### PR TITLE
feat: remove containerd dependency from system packages

### DIFF
--- a/internal/workflows/setup.go
+++ b/internal/workflows/setup.go
@@ -22,7 +22,7 @@ func NewNodeSetupWorkflow(nodeType string) automa.Builder {
 		steps.InstallSystemPackage("socat", software.NewSocat),
 		steps.InstallSystemPackage("nftables", software.NewNftables),
 		//steps.InstallKernelModules(),
-		//steps.RemoveExistingContainerd(),
+		steps.RemoveSystemPackage("containerd", software.NewContainerd),
 		//steps.RemoveUnusedSystemPackages(),
 	)
 }

--- a/internal/workflows/steps/system_package.go
+++ b/internal/workflows/steps/system_package.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"golang.hedera.com/solo-provisioner/pkg/software"
@@ -70,7 +71,7 @@ func InstallSystemPackage(name string, installer func() (software.Package, error
 					Str("version", info.Version).
 					Str("status", string(info.Status)).
 					Interface("package", info).
-					Msgf("Package %q is installedByThisStep successfully", pkg.Name())
+					Msgf("Package %q is installed by this step successfully", pkg.Name())
 				installedByThisStep = true
 			} else {
 				logx.As().Info().Msgf("Package %q is already installed, skipping installation", pkg.Name())
@@ -100,6 +101,90 @@ func InstallSystemPackage(name string, installer func() (software.Package, error
 					Msgf("Package %q is uninstalled successfully", pkg.Name())
 			} else {
 				logx.As().Info().Msgf("Package %q is not installed, skipping uninstallation", pkg.Name())
+			}
+
+			return automa.StepSuccessReport(stepId), nil
+		}))
+}
+
+// RemoveSystemPackage removes a system package using the provided installer function.
+// The installer function should return a software.Package instance that knows how to uninstall the package.
+// If the package is not installed, it will skip the removal.
+func RemoveSystemPackage(name string, installer func() (software.Package, error)) automa.Builder {
+	var removedByThisStep bool
+	stepId := fmt.Sprintf("remove-%s", name)
+	validateInstaller := func() (software.Package, error) {
+		if name == "" {
+			return nil, fmt.Errorf("package name cannot be empty")
+		}
+
+		if installer == nil {
+			return nil, fmt.Errorf("installer function cannot be nil")
+		}
+
+		pkg, err := installer()
+		if err != nil {
+			return nil, err
+		}
+
+		if pkg.Name() != name {
+			return nil, fmt.Errorf("installer returned package with unexpected name: got %q, want %q",
+				pkg.Name(), name)
+		}
+
+		return pkg, nil
+	}
+
+	return automa.NewStepBuilder(stepId,
+		automa.WithOnExecute(func(ctx context.Context) (*automa.Report, error) {
+			pkg, err := validateInstaller()
+			if err != nil {
+				return nil, err
+			}
+
+			if pkg.IsInstalled() {
+				logx.As().Debug().Msgf("Removing %s...", pkg.Name())
+
+				info, err := pkg.Uninstall()
+				if err != nil {
+					return nil, err
+				}
+
+				logx.As().Info().
+					Str("name", info.Name).
+					Str("version", info.Version).
+					Str("status", string(info.Status)).
+					Interface("package", info).
+					Msgf("Package %q is uninstalled successfully", pkg.Name())
+				removedByThisStep = true
+			} else {
+				logx.As().Info().Msgf("Package %q is not installed, skipping removal", pkg.Name())
+			}
+
+			return automa.StepSuccessReport(stepId), nil
+		}),
+		automa.WithOnRollback(func(ctx context.Context) (*automa.Report, error) {
+			pkg, err := validateInstaller()
+			if err != nil {
+				return nil, err
+			}
+
+			if !pkg.IsInstalled() && removedByThisStep {
+				// Only reinstall if it was removed in this step
+				logx.As().Debug().Msgf("Reinstalling %s...", pkg.Name())
+				info, err := pkg.Install()
+				if err != nil {
+					return nil, err
+				}
+
+				logx.As().Info().
+					Str("name", info.Name).
+					Str("version", info.Version).
+					Str("status", string(info.Status)).
+					Interface("package", info).
+					Msgf("Package %q is installed successfully", pkg.Name())
+			} else {
+				logx.As().Info().Msgf("Package %q is already installed, skipping reinstallation", pkg.Name())
 			}
 
 			return automa.StepSuccessReport(stepId), nil

--- a/pkg/software/system_packages.go
+++ b/pkg/software/system_packages.go
@@ -30,3 +30,7 @@ func NewEbtables() (Package, error) {
 func NewNftables() (Package, error) {
 	return NewPackageInstaller(WithPackageName("nftables"), WithPackageOptions(manager.Options{AssumeYes: true}))
 }
+
+func NewContainerd() (Package, error) {
+	return NewPackageInstaller(WithPackageName("containerd"), WithPackageOptions(manager.Options{AssumeYes: true}))
+}

--- a/pkg/software/system_packages_test.go
+++ b/pkg/software/system_packages_test.go
@@ -126,6 +126,10 @@ func TestNftablesInstallUninstall(t *testing.T) {
 	testPackageInstallUninstall(t, NewNftables, "nftables")
 }
 
+func TestContainerdInstallUninstall(t *testing.T) {
+	testPackageInstallUninstall(t, NewContainerd, "containerd")
+}
+
 // Test package creation without installation
 func TestPackageCreation(t *testing.T) {
 	requireLinux(t) // This will skip the test on non-Linux systems
@@ -140,6 +144,7 @@ func TestPackageCreation(t *testing.T) {
 		{"socat", NewSocat},
 		{"ebtables", NewEbtables},
 		{"nftables", NewNftables},
+		{"containerd", NewContainerd},
 	}
 
 	for _, pkg := range packages {


### PR DESCRIPTION
This pull request introduces the ability to remove system packages as part of the node setup workflow, with a particular focus on supporting the removal of `containerd`. It adds a reusable `RemoveSystemPackage` step, implements a package installer for `containerd`, and includes corresponding tests to ensure correct behavior.

**System package removal enhancements:**

* Added a new `RemoveSystemPackage` function in `internal/workflows/steps/system_package.go` to support the removal (and rollback reinstallation) of system packages using installer functions. This ensures packages like `containerd` can be removed or restored as needed in workflow steps.
* Updated the node setup workflow in `internal/workflows/setup.go` to remove `containerd` using the new `RemoveSystemPackage` step, replacing the previous commented-out placeholder.

**Support for containerd package:**

* Added a `NewContainerd` installer function in `pkg/software/system_packages.go` to create a package installer for `containerd`, enabling consistent management alongside other system packages.

**Testing improvements:**

* Added a test for installing and uninstalling `containerd` in `pkg/software/system_packages_test.go` to verify the new installer and removal logic.
* Included `containerd` in the generic package creation test suite to ensure it is covered by standard package tests.


- Update system package installation workflow
- Modify system package handling logic
- Remove containerd-related package installations
- Update corresponding unit tests

### Related Issues

* Closes #105 
