### PR TITLE
fix: update SwapOnAll and SwapOffAll to mimic util-linux semantics

### DIFF
--- a/pkg/os/errors.go
+++ b/pkg/os/errors.go
@@ -8,6 +8,7 @@ var (
 	SwapErrTrait = errorx.RegisterTrait("swap_error")
 	FileErrTrait = errorx.RegisterTrait("file_error")
 
+	ErrSwapBusy           = ErrNamespace.NewType("device_busy", SwapErrTrait)
 	ErrSwapOutOfMemory    = ErrNamespace.NewType("out_of_memory", SwapErrTrait)
 	ErrSwapUnknownSyscall = ErrNamespace.NewType("unknown_syscall", SwapErrTrait)
 	ErrNonSyscall         = ErrNamespace.NewType("non_syscall", SwapErrTrait)


### PR DESCRIPTION
## Description

This pull request improves swap device management by making swap-on and swap-off operations more robust and user-friendly. The main enhancements include better error handling for busy devices, returning aggregated errors when all attempts fail, and following symlinks for device resolution. These changes ensure that operations mimic the behavior of standard Linux utilities, handling partial failures gracefully.

**Swap operation robustness and error handling:**

* [`pkg/os/swap_unix.go`](diffhunk://#diff-1353fe2f01e3adc3bb2a0cd1bfc4236497d3a1a82e48c136b8aad3338a63cf49L258-R316): Updated `SwapOffAll` to attempt disabling all swap devices/files, skip `EBUSY` errors (device busy), and return aggregated errors only if all attempts fail. This mimics `swapoff -a` behavior and ensures partial success is not treated as a failure.
* [`pkg/os/swap_unix.go`](diffhunk://#diff-1353fe2f01e3adc3bb2a0cd1bfc4236497d3a1a82e48c136b8aad3338a63cf49R325-R360): Added `SwapOnAll` to enable all swap devices/files listed in `/etc/fstab`, returning success if at least one succeeds, and aggregating errors if all fail.
* [`pkg/os/swap_unix.go`](diffhunk://#diff-1353fe2f01e3adc3bb2a0cd1bfc4236497d3a1a82e48c136b8aad3338a63cf49L222-R247): Improved error handling in `handleSyscallErr` to specifically handle `EBUSY` (device busy) errors, wrapping them with the new error type and not treating them as fatal for bulk operations. [[1]](diffhunk://#diff-1353fe2f01e3adc3bb2a0cd1bfc4236497d3a1a82e48c136b8aad3338a63cf49L222-R247) [[2]](diffhunk://#diff-38898f454c73a203fcd31a0efd4580800438a4de7bb30f32259cf4d928d10605R11)

**Device resolution improvements:**

* [`pkg/os/swap_unix.go`](diffhunk://#diff-1353fe2f01e3adc3bb2a0cd1bfc4236497d3a1a82e48c136b8aad3338a63cf49L96-R97): Modified device resolution for `UUID=` and `LABEL=` specifications to follow symlinks using `filepath.EvalSymlinks`, ensuring the actual device path is used. [[1]](diffhunk://#diff-1353fe2f01e3adc3bb2a0cd1bfc4236497d3a1a82e48c136b8aad3338a63cf49L96-R97) [[2]](diffhunk://#diff-1353fe2f01e3adc3bb2a0cd1bfc4236497d3a1a82e48c136b8aad3338a63cf49L106-R107)

**Error type additions:**

* [`pkg/os/errors.go`](diffhunk://#diff-38898f454c73a203fcd31a0efd4580800438a4de7bb30f32259cf4d928d10605R11): Added a new error type `ErrSwapBusy` for handling busy swap device situations.

### Related Issues

* Closes #112 
