### PR TITLE
fix: improve test organization and remove redundant integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,5 +46,5 @@ require (
 	golang.org/x/sys v0.36.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/internal/workflows/cluster_it_test.go
+++ b/internal/workflows/cluster_it_test.go
@@ -4,10 +4,11 @@ package workflows
 
 import (
 	"context"
+	"testing"
+
 	"github.com/automa-saga/automa"
 	"github.com/stretchr/testify/require"
 	"golang.hedera.com/solo-provisioner/internal/workflows/steps"
-	"testing"
 )
 
 func Test_NewSetupClusterWorkflow_Integration(t *testing.T) {

--- a/internal/workflows/steps/bash_steps_it_test.go
+++ b/internal/workflows/steps/bash_steps_it_test.go
@@ -1,12 +1,13 @@
-//go:build integration
+//go:build mock_provisioner
 
 package steps
 
 import (
 	"context"
+	"testing"
+
 	"github.com/automa-saga/automa"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_BashScriptBasedClusterSetupWorkflow_Integration(t *testing.T) {

--- a/pkg/os/swap_unix_it_test.go
+++ b/pkg/os/swap_unix_it_test.go
@@ -1,0 +1,268 @@
+//go:build linux && integration
+
+package os
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwapOff_Integration(t *testing.T) {
+	f := makeTestSwapFile(t)
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+	swapFile := f.Name()
+
+	// swapon
+	out, err := sudo(exec.Command("/usr/sbin/swapon", swapFile)).CombinedOutput()
+	if err != nil {
+		t.Fatalf("swapon failed: %v, output: %s", err, out)
+	}
+
+	// Now call SwapOff
+	err = SwapOff(swapFile)
+	if err != nil {
+		t.Fatalf("SwapOff failed: %v", err)
+	}
+
+	// Confirm swap is off
+	out, err = sudo(exec.Command("/usr/sbin/swapon", "--show=NAME")).CombinedOutput()
+	if err != nil {
+		t.Fatalf("swapon --show failed: %v, output: %s", err, out)
+	}
+	if string(out) != "NAME\n" && !os.IsNotExist(err) {
+		if string(out) != "" && !os.IsNotExist(err) && string(out) != "NAME\n" {
+			t.Errorf("swap file still active: %s", out)
+		}
+	}
+
+	// Cleanup: swapoff and remove file
+	_ = sudo(exec.Command("/usr/sbin/swapoff", swapFile)).Run()
+	_ = os.Remove(swapFile)
+}
+
+func TestSwapOn_Integration(t *testing.T) {
+	h, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	// swapfile needs to be in ext4 or swapoff fails with "swapoff: /path: Invalid argument"
+	f, err := os.CreateTemp(h, "swap-test-")
+	require.NoError(t, err)
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+
+	swapFile := f.Name()
+
+	out, err := exec.Command("dd", "if=/dev/zero", "of="+swapFile, "bs=1M", "count=16").CombinedOutput()
+	require.NoError(t, err, "dd failed: %s", out)
+
+	err = exec.Command("chmod", "0600", swapFile).Run()
+	require.NoError(t, err, "chmod failed")
+
+	out, err = sudo(exec.Command("/usr/sbin/mkswap", swapFile)).CombinedOutput()
+	require.NoError(t, err, "mkswap failed: %s", out)
+
+	// Call sysSwapOn directly (integration with syscall)
+	err = sysSwapOn(swapFile, 0)
+	require.NoError(t, err, "sysSwapOn failed")
+
+	// Confirm swap is active
+	out, err = sudo(exec.Command("/usr/sbin/swapon", "--show=NAME")).CombinedOutput()
+	require.NoError(t, err, "swapon --show failed: %s", out)
+	require.Contains(t, string(out), swapFile, "swap file not active")
+
+	// Cleanup: swapoff and remove file
+	_ = sudo(exec.Command("/usr/sbin/swapoff", swapFile)).Run()
+	_ = os.Remove(swapFile)
+}
+
+func TestSwapOnAll_Integration(t *testing.T) {
+	f := makeTestSwapFile(t)
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+	swapFile := f.Name()
+
+	// Write a temporary fstab with the swap file entry
+	tmpFstab, err := os.CreateTemp("", "fstab")
+	require.NoError(t, err)
+	defer func() {
+		err := os.Remove(tmpFstab.Name())
+		if err != nil {
+			t.Errorf("failed to remove temp fstab: %v", err)
+		}
+	}()
+	_, err = tmpFstab.WriteString(swapFile + " none swap sw 0 0\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFstab.Close())
+
+	// Patch fstabFile for the test
+	fstabFileOrig := fstabFile
+	defer func() { fstabFile = fstabFileOrig }()
+	fstabFile = tmpFstab.Name()
+
+	// Run SwapOnAll
+	err = SwapOnAll()
+	require.NoError(t, err)
+
+	// Confirm swap is active
+	out, err := exec.Command("/usr/sbin/swapon", "--show=NAME").CombinedOutput()
+	require.NoError(t, err, "swapon --show failed: %s", out)
+	require.Contains(t, string(out), swapFile, "swap file not active")
+
+	// Cleanup
+	_ = exec.Command("/usr/sbin/swapoff", swapFile).Run()
+}
+
+func TestSwapOffAll_Integration(t *testing.T) {
+	f := makeTestSwapFile(t)
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+	swapFile := f.Name()
+
+	out, err := exec.Command("/usr/sbin/swapon", swapFile).CombinedOutput()
+	require.NoError(t, err, "swapon failed: %s", out)
+
+	// Write a temporary fstab with the swap file entry
+	tmpFstab, err := os.CreateTemp("", "fstab")
+	require.NoError(t, err)
+	defer func() {
+		err := os.Remove(tmpFstab.Name())
+		if err != nil {
+			t.Errorf("failed to remove temp fstab: %v", err)
+		}
+	}()
+	_, err = tmpFstab.WriteString(swapFile + " none swap sw 0 0\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFstab.Close())
+
+	// Patch fstabFile for the test
+	fstabFileOrig := fstabFile
+	defer func() { fstabFile = fstabFileOrig }()
+	fstabFile = tmpFstab.Name()
+
+	// Run SwapOffAll
+	err = SwapOffAll()
+	require.NoError(t, err)
+
+	// Confirm swap is off
+	out, err = exec.Command("/usr/sbin/swapon", "--show=NAME").CombinedOutput()
+	require.NoError(t, err, "swapon --show failed: %s", out)
+	require.NotContains(t, string(out), swapFile, "swap file still active")
+
+	// Cleanup
+	_ = exec.Command("/usr/sbin/swapoff", swapFile).Run()
+}
+
+func TestDisableSwap_EnableSwap_Integration(t *testing.T) {
+	f := makeTestSwapFile(t)
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+	swapFile := f.Name()
+
+	tmpFstab, err := os.CreateTemp("", "fstab")
+	require.NoError(t, err)
+	defer func() {
+		err := os.Remove(tmpFstab.Name())
+		if err != nil {
+			t.Errorf("failed to remove temp fstab: %v", err)
+		}
+	}()
+
+	fstabContent := swapFile + " none swap sw 0 0\n"
+	_, err = tmpFstab.WriteString(fstabContent)
+	require.NoError(t, err)
+	require.NoError(t, tmpFstab.Close())
+
+	// Patch FSTAB_LOCATION for the test
+	origFstabLocation := FSTAB_LOCATION
+	defer func() { fstabFile = origFstabLocation }()
+	fstabFile = tmpFstab.Name()
+
+	// Enable swap (should uncomment, but file is not commented yet)
+	err = EnableSwap()
+	require.NoError(t, err)
+
+	// Check fstab content is unchanged (no commented lines to uncomment)
+	content, err := os.ReadFile(tmpFstab.Name())
+	require.NoError(t, err)
+	require.Contains(t, string(content), swapFile+" none swap sw 0 0")
+
+	// Disable swap (should comment out swap line)
+	err = DisableSwap()
+	require.NoError(t, err)
+
+	content, err = os.ReadFile(tmpFstab.Name())
+	require.NoError(t, err)
+	require.Contains(t, string(content), SwapCommentPrefix+swapFile+" none swap sw 0 0")
+
+	// Enable swap again (should uncomment swap line)
+	err = EnableSwap()
+	require.NoError(t, err)
+
+	content, err = os.ReadFile(tmpFstab.Name())
+	require.NoError(t, err)
+	require.Contains(t, string(content), swapFile+" none swap sw 0 0")
+}
+
+func TestResolveSpec_Integration(t *testing.T) {
+	h, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	tmpDir, err := os.MkdirTemp(h, "resolve-spec-test-")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	byUUIDDir := tmpDir + "/by-uuid"
+	byLabelDir := tmpDir + "/by-label"
+	require.NoError(t, os.Mkdir(byUUIDDir, 0755))
+	require.NoError(t, os.Mkdir(byLabelDir, 0755))
+
+	uuid := "test-uuid-123"
+	label := "test-label-abc"
+	uuidPath := byUUIDDir + "/" + uuid
+	labelPath := byLabelDir + "/" + label
+	require.NoError(t, os.WriteFile(uuidPath, []byte{}, 0600))
+	require.NoError(t, os.WriteFile(labelPath, []byte{}, 0600))
+
+	// Create dummy device files
+	devFile := tmpDir + "/devtest"
+	require.NoError(t, os.WriteFile(devFile, []byte{}, 0600))
+	devFile2 := tmpDir + "/devtest2"
+
+	require.NoError(t, os.Symlink(devFile, devFile2))
+
+	// Set the lookup path variables for the test
+	origUUIDPath := uuidLookupDir
+	origLabelPath := labelLookupDir
+	uuidLookupDir = byUUIDDir
+	labelLookupDir = byLabelDir
+	defer func() {
+		uuidLookupDir = origUUIDPath
+		labelLookupDir = origLabelPath
+	}()
+
+	res, err := resolveSpec("UUID=" + uuid)
+	require.NoError(t, err)
+	require.Equal(t, uuidPath, res)
+
+	res, err = resolveSpec("LABEL=" + label)
+	require.NoError(t, err)
+	require.Equal(t, labelPath, res)
+
+	res, err = resolveSpec(devFile2)
+	require.NoError(t, err)
+	require.Equal(t, devFile, res)
+
+	_, err = resolveSpec("UUID=doesnotexist")
+	require.Error(t, err)
+	_, err = resolveSpec("LABEL=doesnotexist")
+	require.Error(t, err)
+}

--- a/pkg/os/swap_unix_test.go
+++ b/pkg/os/swap_unix_test.go
@@ -42,7 +42,7 @@ func TestParseProcSwaps_Normal(t *testing.T) {
 	defer func() { swapsFile = swapsFileOrig }()
 	swapsFile = tmp.Name()
 
-	content := "Filename\tType\tSize\tUsed\tPriority\n/dev/sda1 partition 12345 0 -2\n/swapfile file 12345 0 -3\n"
+	content := "Filename\tType\tSize\tUsed\tPriority\n/dev/vda1 partition 12345 0 -2\n/swapfile file 12345 0 -3\n"
 	if _, err := tmp.WriteString(content); err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestParseProcSwaps_Normal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(swaps) != 2 || swaps[0] != "/dev/sda1" || swaps[1] != "/swapfile" {
+	if len(swaps) != 2 || swaps[0] != "/dev/vda1" || swaps[1] != "/swapfile" {
 		t.Errorf("unexpected swaps: %v", swaps)
 	}
 }
@@ -116,8 +116,8 @@ func TestParseFstabSwaps_Normal(t *testing.T) {
 
 	content := fmt.Sprintf(`
 # comment line
-/dev/sda1   none   swap   sw   0   0
-/dev/sda2   /mnt   ext4   defaults   0   0
+/dev/vda1   none   swap   sw   0   0
+/dev/vda2   /mnt   ext4   defaults   0   0
 %s    none   swap   sw   0   0
 `, swapFile)
 	if _, err := tmp.WriteString(content); err != nil {
@@ -129,7 +129,7 @@ func TestParseFstabSwaps_Normal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(swaps) != 2 || swaps[0] != "/dev/sda1" || swaps[1] != swapFile {
+	if len(swaps) != 2 || swaps[0] != "/dev/vda1" || swaps[1] != swapFile {
 		t.Errorf("unexpected swaps: %v", swaps)
 	}
 }
@@ -191,7 +191,7 @@ func TestParseFstabSwaps_CommentAndShortLines(t *testing.T) {
 	content := `
 # just a comment
 not-enough-fields
-/dev/sda1 none swap sw 0 0
+/dev/vda1 none swap sw 0 0
 `
 	if _, err := tmp.WriteString(content); err != nil {
 		t.Fatal(err)
@@ -202,7 +202,7 @@ not-enough-fields
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(swaps) != 1 || swaps[0] != "/dev/sda1" {
+	if len(swaps) != 1 || swaps[0] != "/dev/vda1" {
 		t.Errorf("unexpected swaps: %v", swaps)
 	}
 }
@@ -213,11 +213,11 @@ func TestIsActiveSwap(t *testing.T) {
 		activeSwaps []string
 		want        bool
 	}{
-		{"/dev/sda1", []string{"/dev/sda1", "/swapfile"}, true},
-		{"/swapfile", []string{"/dev/sda1", "/swapfile"}, true},
-		{"/dev/sdb1", []string{"/dev/sda1", "/swapfile"}, false},
+		{"/dev/vda1", []string{"/dev/vda1", "/swapfile"}, true},
+		{"/swapfile", []string{"/dev/vda1", "/swapfile"}, true},
+		{"/dev/vdb1", []string{"/dev/vda1", "/swapfile"}, false},
 		{"", []string{}, false},
-		{"/dev/sda1", []string{}, false},
+		{"/dev/vda1", []string{}, false},
 	}
 
 	for _, tt := range tests {
@@ -298,115 +298,6 @@ func TestHandleSyscallErr(t *testing.T) {
 	}
 }
 
-func TestSwapOff_Integration(t *testing.T) {
-	f := makeTestSwapFile(t)
-	defer func() {
-		_ = os.Remove(f.Name())
-	}()
-	swapFile := f.Name()
-
-	// swapon
-	out, err := sudo(exec.Command("/usr/sbin/swapon", swapFile)).CombinedOutput()
-	if err != nil {
-		t.Fatalf("swapon failed: %v, output: %s", err, out)
-	}
-
-	// Now call SwapOff
-	err = SwapOff(swapFile)
-	if err != nil {
-		t.Fatalf("SwapOff failed: %v", err)
-	}
-
-	// Confirm swap is off
-	out, err = sudo(exec.Command("/usr/sbin/swapon", "--show=NAME")).CombinedOutput()
-	if err != nil {
-		t.Fatalf("swapon --show failed: %v, output: %s", err, out)
-	}
-	if string(out) != "NAME\n" && !os.IsNotExist(err) {
-		if string(out) != "" && !os.IsNotExist(err) && string(out) != "NAME\n" {
-			t.Errorf("swap file still active: %s", out)
-		}
-	}
-
-	// Cleanup: swapoff and remove file
-	_ = sudo(exec.Command("/usr/sbin/swapoff", swapFile)).Run()
-	_ = os.Remove(swapFile)
-}
-
-func TestSwapOn_Integration(t *testing.T) {
-	h, err := os.UserHomeDir()
-	require.NoError(t, err)
-
-	// swapfile needs to be in ext4 or swapoff fails with "swapoff: /path: Invalid argument"
-	f, err := os.CreateTemp(h, "swap-test-")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.Remove(f.Name())
-	}()
-
-	swapFile := f.Name()
-
-	out, err := exec.Command("dd", "if=/dev/zero", "of="+swapFile, "bs=1M", "count=16").CombinedOutput()
-	require.NoError(t, err, "dd failed: %s", out)
-
-	err = exec.Command("chmod", "0600", swapFile).Run()
-	require.NoError(t, err, "chmod failed")
-
-	out, err = sudo(exec.Command("/usr/sbin/mkswap", swapFile)).CombinedOutput()
-	require.NoError(t, err, "mkswap failed: %s", out)
-
-	// Call sysSwapOn directly (integration with syscall)
-	err = sysSwapOn(swapFile, 0)
-	require.NoError(t, err, "sysSwapOn failed")
-
-	// Confirm swap is active
-	out, err = sudo(exec.Command("/usr/sbin/swapon", "--show=NAME")).CombinedOutput()
-	require.NoError(t, err, "swapon --show failed: %s", out)
-	require.Contains(t, string(out), swapFile, "swap file not active")
-
-	// Cleanup: swapoff and remove file
-	_ = sudo(exec.Command("/usr/sbin/swapoff", swapFile)).Run()
-	_ = os.Remove(swapFile)
-}
-
-func TestSwapOnAll_Integration(t *testing.T) {
-	f := makeTestSwapFile(t)
-	defer func() {
-		_ = os.Remove(f.Name())
-	}()
-	swapFile := f.Name()
-
-	// Write a temporary fstab with the swap file entry
-	tmpFstab, err := os.CreateTemp("", "fstab")
-	require.NoError(t, err)
-	defer func() {
-		err := os.Remove(tmpFstab.Name())
-		if err != nil {
-			t.Errorf("failed to remove temp fstab: %v", err)
-		}
-	}()
-	_, err = tmpFstab.WriteString(swapFile + " none swap sw 0 0\n")
-	require.NoError(t, err)
-	require.NoError(t, tmpFstab.Close())
-
-	// Patch fstabFile for the test
-	fstabFileOrig := fstabFile
-	defer func() { fstabFile = fstabFileOrig }()
-	fstabFile = tmpFstab.Name()
-
-	// Run SwapOnAll
-	err = SwapOnAll()
-	require.NoError(t, err)
-
-	// Confirm swap is active
-	out, err := exec.Command("/usr/sbin/swapon", "--show=NAME").CombinedOutput()
-	require.NoError(t, err, "swapon --show failed: %s", out)
-	require.Contains(t, string(out), swapFile, "swap file not active")
-
-	// Cleanup
-	_ = exec.Command("/usr/sbin/swapoff", swapFile).Run()
-}
-
 func makeTestSwapFile(t *testing.T) *os.File {
 	h, err := os.UserHomeDir()
 	require.NoError(t, err)
@@ -429,99 +320,6 @@ func makeTestSwapFile(t *testing.T) *os.File {
 	return f
 }
 
-func TestSwapOffAll_Integration(t *testing.T) {
-	f := makeTestSwapFile(t)
-	defer func() {
-		_ = os.Remove(f.Name())
-	}()
-	swapFile := f.Name()
-
-	out, err := exec.Command("/usr/sbin/swapon", swapFile).CombinedOutput()
-	require.NoError(t, err, "swapon failed: %s", out)
-
-	// Write a temporary fstab with the swap file entry
-	tmpFstab, err := os.CreateTemp("", "fstab")
-	require.NoError(t, err)
-	defer func() {
-		err := os.Remove(tmpFstab.Name())
-		if err != nil {
-			t.Errorf("failed to remove temp fstab: %v", err)
-		}
-	}()
-	_, err = tmpFstab.WriteString(swapFile + " none swap sw 0 0\n")
-	require.NoError(t, err)
-	require.NoError(t, tmpFstab.Close())
-
-	// Patch fstabFile for the test
-	fstabFileOrig := fstabFile
-	defer func() { fstabFile = fstabFileOrig }()
-	fstabFile = tmpFstab.Name()
-
-	// Run SwapOffAll
-	err = SwapOffAll()
-	require.NoError(t, err)
-
-	// Confirm swap is off
-	out, err = exec.Command("/usr/sbin/swapon", "--show=NAME").CombinedOutput()
-	require.NoError(t, err, "swapon --show failed: %s", out)
-	require.NotContains(t, string(out), swapFile, "swap file still active")
-
-	// Cleanup
-	_ = exec.Command("/usr/sbin/swapoff", swapFile).Run()
-}
-
-func TestDisableSwap_EnableSwap_Integration(t *testing.T) {
-	f := makeTestSwapFile(t)
-	defer func() {
-		_ = os.Remove(f.Name())
-	}()
-	swapFile := f.Name()
-
-	tmpFstab, err := os.CreateTemp("", "fstab")
-	require.NoError(t, err)
-	defer func() {
-		err := os.Remove(tmpFstab.Name())
-		if err != nil {
-			t.Errorf("failed to remove temp fstab: %v", err)
-		}
-	}()
-
-	fstabContent := swapFile + " none swap sw 0 0\n"
-	_, err = tmpFstab.WriteString(fstabContent)
-	require.NoError(t, err)
-	require.NoError(t, tmpFstab.Close())
-
-	// Patch FSTAB_LOCATION for the test
-	origFstabLocation := FSTAB_LOCATION
-	defer func() { fstabFile = origFstabLocation }()
-	fstabFile = tmpFstab.Name()
-
-	// Enable swap (should uncomment, but file is not commented yet)
-	err = EnableSwap()
-	require.NoError(t, err)
-
-	// Check fstab content is unchanged (no commented lines to uncomment)
-	content, err := os.ReadFile(tmpFstab.Name())
-	require.NoError(t, err)
-	require.Contains(t, string(content), swapFile+" none swap sw 0 0")
-
-	// Disable swap (should comment out swap line)
-	err = DisableSwap()
-	require.NoError(t, err)
-
-	content, err = os.ReadFile(tmpFstab.Name())
-	require.NoError(t, err)
-	require.Contains(t, string(content), SwapCommentPrefix+swapFile+" none swap sw 0 0")
-
-	// Enable swap again (should uncomment swap line)
-	err = EnableSwap()
-	require.NoError(t, err)
-
-	content, err = os.ReadFile(tmpFstab.Name())
-	require.NoError(t, err)
-	require.Contains(t, string(content), swapFile+" none swap sw 0 0")
-}
-
 func TestUpdateFstabFile(t *testing.T) {
 	// make a temp fstab file for testing
 	fstabFileOrig := fstabFile
@@ -533,7 +331,7 @@ func TestUpdateFstabFile(t *testing.T) {
 	swapLine := "UUID=123 none swap sw 0 0"
 	commentedSwapLine := "#UUID=123 none swap sw 0 0"
 	unrelatedComment := "# swap was on /dev/vda4 during installation"
-	unrelatedLine := "/dev/sda1 / ext4 defaults 0 1"
+	unrelatedLine := "/dev/vda1 / ext4 defaults 0 1"
 
 	cases := []struct {
 		name     string
@@ -584,12 +382,12 @@ func TestUpdateFstabFile(t *testing.T) {
 		{
 			name: "Commented non-swap line remains unchanged",
 			input: []string{
-				"#/dev/sda1 / ext4 defaults 0 1",
+				"#/dev/vda1 / ext4 defaults 0 1",
 				"UUID=123 none swap sw 0 0",
 			},
 			comment: true,
 			expected: []string{
-				"#/dev/sda1 / ext4 defaults 0 1",
+				"#/dev/vda1 / ext4 defaults 0 1",
 				"#UUID=123 none swap sw 0 0",
 			},
 		},
@@ -620,59 +418,4 @@ func TestUpdateFstabFile(t *testing.T) {
 			require.Equal(t, tc.expected, lines)
 		})
 	}
-}
-
-func TestResolveSpec_Integration(t *testing.T) {
-	h, err := os.UserHomeDir()
-	require.NoError(t, err)
-
-	tmpDir, err := os.MkdirTemp(h, "resolve-spec-test-")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	byUUIDDir := tmpDir + "/by-uuid"
-	byLabelDir := tmpDir + "/by-label"
-	require.NoError(t, os.Mkdir(byUUIDDir, 0755))
-	require.NoError(t, os.Mkdir(byLabelDir, 0755))
-
-	uuid := "test-uuid-123"
-	label := "test-label-abc"
-	uuidPath := byUUIDDir + "/" + uuid
-	labelPath := byLabelDir + "/" + label
-	require.NoError(t, os.WriteFile(uuidPath, []byte{}, 0600))
-	require.NoError(t, os.WriteFile(labelPath, []byte{}, 0600))
-
-	// Create dummy device files
-	devFile := tmpDir + "/devtest"
-	require.NoError(t, os.WriteFile(devFile, []byte{}, 0600))
-	devFile2 := tmpDir + "/devtest2"
-
-	require.NoError(t, os.Symlink(devFile, devFile2))
-
-	// Set the lookup path variables for the test
-	origUUIDPath := uuidLookupDir
-	origLabelPath := labelLookupDir
-	uuidLookupDir = byUUIDDir
-	labelLookupDir = byLabelDir
-	defer func() {
-		uuidLookupDir = origUUIDPath
-		labelLookupDir = origLabelPath
-	}()
-
-	res, err := resolveSpec("UUID=" + uuid)
-	require.NoError(t, err)
-	require.Equal(t, uuidPath, res)
-
-	res, err = resolveSpec("LABEL=" + label)
-	require.NoError(t, err)
-	require.Equal(t, labelPath, res)
-
-	res, err = resolveSpec(devFile2)
-	require.NoError(t, err)
-	require.Equal(t, devFile, res)
-
-	_, err = resolveSpec("UUID=doesnotexist")
-	require.Error(t, err)
-	_, err = resolveSpec("LABEL=doesnotexist")
-	require.Error(t, err)
 }


### PR DESCRIPTION
## Description

This pull request basically covers 3 points:
- separates integration tests from unit tests
- fix unit and integration tests failures because it's looking for sda* instead of vda*
- tag bash_steps_it_test.go as mock_provisioner so that it does not run as integration tests and modifies the whole system

### Related Issues

* Closes #118 
