### PR TITLE
feat: implement download and extract for crio

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -214,7 +214,7 @@ tasks:
     deps:
       - "generate"
     cmds:
-      - "go test -v -race -cover -tags='integration' ./internal/... ./pkg/... ./cmd/..."
+      - "go test -p 1 -v -race -cover -tags='integration' ./internal/... ./pkg/... ./cmd/..."
 
   test:coverage:
     cmds:
@@ -270,6 +270,9 @@ tasks:
       - "echo 'PATH=\"${PATH}:/usr/local/go/bin:$HOME/go/bin\"' | sudo tee /etc/profile.d/go.sh >/dev/null 2>&1"
       - "source /etc/profile.d/go.sh"
       - "source /etc/profile.d/go.sh && go install github.com/go-delve/delve/cmd/dlv@latest"
+      # Set the Go toolchain to auto-upgrade to the latest version due to https://github.com/golang/go/issues/75031
+      - "/usr/local/go/bin/go env -w GOTOOLCHAIN=go1.25.0+auto"
+      - "sudo /usr/local/go/bin/go env -w GOTOOLCHAIN=go1.25.0+auto"
     generates:
       - "/usr/local/go/**"
 

--- a/internal/core/const.go
+++ b/internal/core/const.go
@@ -5,10 +5,11 @@ import (
 )
 
 const (
-	DefaultFilePerm        = 0755
-	DefaultProvisionerHome = "/opt/provisioner"
-	DefaultKubernetesDir   = "/etc/kubernetes"
-	DefaultKubeletDir      = "/var/lib/kubelet"
+	DefaultFilePerm         = 0755
+	DefaultProvisionerHome  = "/opt/provisioner"
+	DefaultKubernetesDir    = "/etc/kubernetes"
+	DefaultKubeletDir       = "/var/lib/kubelet"
+	DefaultUnpackFolderName = "unpack"
 )
 
 var (

--- a/internal/workflows/cluster.go
+++ b/internal/workflows/cluster.go
@@ -11,7 +11,7 @@ func NewSetupClusterWorkflow(nodeType string) automa.Builder {
 		NewNodeSetupWorkflow(nodeType),
 		steps.DisableSwap(),
 		//steps.ConfigureSysctlForKubernetes(),
-		//steps.InstallCrio(),
+		steps.SetupCrio(),
 		//steps.InstallCilium(),
 		//steps.InstallKubelet(),
 		//steps.InstallKubeadm(),

--- a/internal/workflows/steps/step_crio.go
+++ b/internal/workflows/steps/step_crio.go
@@ -2,26 +2,72 @@ package steps
 
 import (
 	"context"
+
 	"github.com/automa-saga/automa"
+	"golang.hedera.com/solo-provisioner/pkg/software"
 )
 
-func InstallCrio() automa.Builder {
+func SetupCrio() automa.Builder {
+	crioInstaller, err := software.NewCrioInstaller()
+	if err != nil {
+		panic(err)
+	}
+
+	return automa.NewWorkflowBuilder().WithId("setup-crio").Steps(
+		installCrio(crioInstaller),
+		configureCrio(crioInstaller),
+		enableAndStartCrio(crioInstaller),
+	)
+}
+
+func installCrio(installer software.Software) automa.Builder {
 	return automa.NewStepBuilder().WithId("install-crio").
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			err := installer.Download()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+			err = installer.Extract()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+			err = installer.Install()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
 			return automa.SuccessReport(stp)
 		})
 }
 
-func ConfigureCrio() automa.Builder {
+func configureCrio(installer software.Software) automa.Builder {
 	return automa.NewStepBuilder().WithId("configure-crio").
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			err := installer.Configure()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+
 			return automa.SuccessReport(stp)
 		})
 }
 
-func EnableAndStartCrio() automa.Builder {
+func enableAndStartCrio(installer software.Software) automa.Builder {
 	return automa.NewStepBuilder().WithId("start-crio").
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			err := installer.Configure()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+
 			return automa.SuccessReport(stp)
 		})
 }

--- a/internal/workflows/steps/step_crio_it_test.go
+++ b/internal/workflows/steps/step_crio_it_test.go
@@ -1,0 +1,99 @@
+package steps
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/automa-saga/automa"
+	"github.com/stretchr/testify/require"
+	"golang.hedera.com/solo-provisioner/internal/core"
+)
+
+func cleanUpCrio(t *testing.T) {
+	t.Helper()
+
+	err := os.RemoveAll(core.Paths().TempDir)
+	require.NoError(t, err)
+}
+
+func TestSetupCrio_Fresh_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpCrio(t)
+
+	//
+	// When
+	//
+	step, err := SetupCrio().Build()
+
+	//
+	// Then
+	//
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+}
+
+func TestSetupCrio_AlreadyInstalled_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpCrio(t)
+
+	step, err := SetupCrio().Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	//
+	// When
+	//
+	step, err = SetupCrio().Build()
+
+	//
+	// Then
+	//
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+}
+
+func TestSetupCrio_PartiallyInstalled_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpCrio(t)
+
+	step, err := SetupCrio().Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	err = os.RemoveAll(core.Paths().TempDir)
+	require.NoError(t, err)
+
+	//
+	// When
+	//
+	step, err = SetupCrio().Build()
+
+	//
+	// Then
+	//
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+}

--- a/pkg/software/config.go
+++ b/pkg/software/config.go
@@ -1,0 +1,188 @@
+package software
+
+import (
+	"bytes"
+	"embed"
+	"runtime"
+	"sort"
+	"text/template"
+
+	"golang.hedera.com/solo-provisioner/pkg/semver"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed software.yaml
+var softwareConfigFS embed.FS
+
+// Semantic types + enums
+
+type Version string
+type OS string
+type Arch string
+
+const (
+	OSLinux   OS = "linux"
+	OSDarwin  OS = "darwin"
+	OSWindows OS = "windows"
+
+	ArchAMD64 Arch = "amd64"
+	ArchARM64 Arch = "arm64"
+)
+
+// SoftwareConfig represents the root configuration structure
+type SoftwareConfig struct {
+	Software []SoftwareItem `yaml:"software"`
+}
+
+// SoftwareItem represents a single software package configuration
+// with its versions
+type SoftwareItem struct {
+	Name     string                `yaml:"name"`
+	URL      string                `yaml:"url"`
+	Filename string                `yaml:"filename"`
+	Versions map[Version]Platforms `yaml:"versions"`
+}
+
+// Platforms represents the platform-specific information for a version
+type Platforms map[OS]map[Arch]Checksum
+
+// Checksum contains platform-specific checksum information
+type Checksum struct {
+	Algorithm string `yaml:"algorithm"`
+	Value     string `yaml:"checksum"`
+}
+
+// TemplateData contains the variables used in template substitution
+type TemplateData struct {
+	VERSION string
+	OS      string
+	ARCH    string
+}
+
+// LoadSoftwareConfig loads and parses the software.yaml configuration
+func LoadSoftwareConfig() (*SoftwareConfig, error) {
+	data, err := softwareConfigFS.ReadFile("software.yaml")
+	if err != nil {
+		return nil, NewConfigLoadError(err)
+	}
+
+	var config SoftwareConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, NewConfigLoadError(err)
+	}
+
+	return &config, nil
+}
+
+// GetSoftwareByName finds a software item by name
+func (sc *SoftwareConfig) GetSoftwareByName(name string) (*SoftwareItem, error) {
+	for _, item := range sc.Software {
+		if item.Name == name {
+			return &item, nil
+		}
+	}
+	return nil, NewSoftwareNotFoundError(name)
+}
+
+// GetChecksum retrieves the checksum for a specific version, OS, and architecture
+func (si *SoftwareItem) GetChecksum(version string) (Checksum, error) {
+	versionInfo, exists := si.Versions[Version(version)]
+	if !exists {
+		return Checksum{}, NewVersionNotFoundError(si.Name, version)
+	}
+
+	os := runtime.GOOS
+	osInfo, exists := versionInfo[OS(os)]
+	if !exists {
+		return Checksum{}, NewPlatformNotFoundError(si.Name, version, os, "")
+	}
+
+	arch := runtime.GOARCH
+	checksum, exists := osInfo[Arch(arch)]
+	if !exists {
+		return Checksum{}, NewPlatformNotFoundError(si.Name, version, os, arch)
+	}
+
+	return checksum, nil
+}
+
+// executeTemplate executes a template string with the given data
+func executeTemplate(templateStr string, data TemplateData) (string, error) {
+	tmpl, err := template.New("software").Parse(templateStr)
+	if err != nil {
+		return "", NewTemplateError(err, "")
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", NewTemplateError(err, "")
+	}
+
+	return buf.String(), nil
+}
+
+// GetDownloadURL returns the download URL with template variables replaced
+func (si *SoftwareItem) GetDownloadURL(version string) (string, error) {
+	data := TemplateData{
+		VERSION: version,
+		OS:      runtime.GOOS,
+		ARCH:    runtime.GOARCH,
+	}
+	result, err := executeTemplate(si.URL, data)
+	if err != nil {
+		return "", NewTemplateError(err, si.Name)
+	}
+	return result, nil
+}
+
+// GetFilename returns the filename with template variables replaced
+func (si *SoftwareItem) GetFilename(version string) (string, error) {
+	data := TemplateData{
+		VERSION: version,
+		OS:      runtime.GOOS,
+		ARCH:    runtime.GOARCH,
+	}
+	result, err := executeTemplate(si.Filename, data)
+	if err != nil {
+		return "", NewTemplateError(err, si.Name)
+	}
+	return result, nil
+}
+
+// GetLatestVersion returns the latest version available for this software item
+func (si *SoftwareItem) GetLatestVersion() (string, error) {
+	if len(si.Versions) == 0 {
+		return "", NewVersionNotFoundError(si.Name, "any")
+	}
+
+	// If there's only one version, return it
+	if len(si.Versions) == 1 {
+		for version := range si.Versions {
+			return string(version), nil
+		}
+	}
+
+	// Collect all version strings
+	versions := make([]string, 0, len(si.Versions))
+	for version := range si.Versions {
+		versions = append(versions, string(version))
+	}
+
+	// Sort versions using semantic version comparison
+	sort.Slice(versions, func(i, j int) bool {
+		// Parse versions and compare - newer versions come first (descending order)
+		versionI, errI := semver.NewSemver(versions[i])
+		versionJ, errJ := semver.NewSemver(versions[j])
+
+		// If parsing fails for either version, fall back to string comparison
+		if errI != nil || errJ != nil {
+			return versions[i] > versions[j]
+		}
+
+		// Return true if versionI is greater than versionJ (for descending sort)
+		return versionI.GreaterThan(versionJ)
+	})
+
+	// Return the first (latest) version
+	return versions[0], nil
+}

--- a/pkg/software/config_test.go
+++ b/pkg/software/config_test.go
@@ -1,0 +1,223 @@
+package software
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSoftwareItem_GetLatestVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		item     SoftwareItem
+		expected string
+		wantErr  bool
+	}{
+		{
+			name: "single version",
+			item: SoftwareItem{
+				Name: "test-software",
+				Versions: map[Version]Platforms{
+					"1.0.0": {},
+				},
+			},
+			expected: "1.0.0",
+			wantErr:  false,
+		},
+		{
+			name: "multiple versions - semantic ordering",
+			item: SoftwareItem{
+				Name: "test-software",
+				Versions: map[Version]Platforms{
+					"1.0.0":  {},
+					"1.1.0":  {},
+					"1.0.1":  {},
+					"2.0.0":  {},
+					"1.10.0": {},
+				},
+			},
+			expected: "2.0.0",
+			wantErr:  false,
+		},
+		{
+			name: "versions with patch releases",
+			item: SoftwareItem{
+				Name: "test-software",
+				Versions: map[Version]Platforms{
+					"1.33.4": {},
+					"1.33.5": {},
+					"1.34.0": {},
+					"1.33.6": {},
+				},
+			},
+			expected: "1.34.0",
+			wantErr:  false,
+		},
+		{
+			name: "no versions available",
+			item: SoftwareItem{
+				Name:     "test-software",
+				Versions: map[Version]Platforms{},
+			},
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name: "versions with non-semantic format fallback to string comparison",
+			item: SoftwareItem{
+				Name: "test-software",
+				Versions: map[Version]Platforms{
+					"latest": {},
+					"stable": {},
+					"v1.0.0": {},
+					"z":      {},
+					"1.0.0":  {},
+					"0.0.0":  {},
+					"v0.1.0": {},
+				},
+			},
+			// The latest version should be "z"
+			expected: "z",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.item.GetLatestVersion()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestCrioInstaller_UsesLatestVersion(t *testing.T) {
+
+	//
+	// Given
+	//
+
+	// Create a mock software item with multiple versions to test version selection
+	mockSoftwareItem := &SoftwareItem{
+		Name:     "cri-o",
+		URL:      "https://example.com/crio-{{.VERSION}}.tar.gz",
+		Filename: "crio-{{.VERSION}}.tar.gz",
+		Versions: map[Version]Platforms{
+			"1.25.0": {
+				"linux": {
+					"amd64": {
+						Algorithm: "sha256",
+						Value:     "abc123",
+					},
+				},
+				"darwin": {
+					"amd64": {
+						Algorithm: "sha256",
+						Value:     "def456",
+					},
+					"arm64": {
+						Algorithm: "sha256",
+						Value:     "ghi789",
+					},
+				},
+			},
+			"1.27.0": {
+				"linux": {
+					"amd64": {
+						Algorithm: "sha256",
+						Value:     "stu901",
+					},
+					"arm64": {
+						Algorithm: "sha256",
+						Value:     "opq234",
+					},
+				},
+				"darwin": {
+					"amd64": {
+						Algorithm: "sha256",
+						Value:     "vwx234",
+					},
+					"arm64": {
+						Algorithm: "sha256",
+						Value:     "yzx567",
+					},
+				},
+			},
+			"1.26.1": {
+				"linux": {
+					"amd64": {
+						Algorithm: "sha256",
+						Value:     "jkl012",
+					},
+				},
+				"darwin": {
+					"amd64": {
+						Algorithm: "sha256",
+						Value:     "mno345",
+					},
+					"arm64": {
+						Algorithm: "sha256",
+						Value:     "pqr678",
+					},
+				},
+			},
+		},
+	}
+
+	// Test that GetLatestVersion returns the expected latest version
+	latestVersion, err := mockSoftwareItem.GetLatestVersion()
+	require.NoError(t, err, "GetLatestVersion should not return an error")
+	assert.Equal(t, "1.27.0", latestVersion, "GetLatestVersion should return 1.27.0 as the latest version")
+
+	//
+	// When
+	//
+
+	// Create a mock crio installer with our test software item
+	installer := &crioInstaller{
+		downloader:            NewDownloader(),
+		softwareToBeInstalled: mockSoftwareItem,
+		version:               latestVersion,
+	}
+
+	//
+	// Then
+	//
+
+	// Verify that the version is valid (exists in the configuration and has checksums available)
+	checksum, err := installer.softwareToBeInstalled.GetChecksum(installer.version)
+	require.NoError(t, err, "Selected version should be valid and have checksums available for current platform")
+	assert.NotEmpty(t, checksum, "Checksum for the selected version should not be empty")
+
+	// Verify that the installer uses the latest version
+	assert.Equal(t, "1.27.0", installer.version, "Installer should use the latest version (1.27.0)")
+
+	// Additional verification: ensure the version selection is semantic, not alphabetical
+	// Test with a version that would be "latest" alphabetically but not semantically
+	mockItemWithNonSemanticOrder := &SoftwareItem{
+		Name: "cri-o",
+		Versions: map[Version]Platforms{
+			"1.9.0": {
+				"darwin": {
+					"arm64": {Algorithm: "sha256", Value: "test1"},
+				},
+			},
+			"1.10.0": {
+				"darwin": {
+					"arm64": {Algorithm: "sha256", Value: "test2"},
+				},
+			},
+		},
+	}
+
+	semanticLatest, err := mockItemWithNonSemanticOrder.GetLatestVersion()
+	require.NoError(t, err)
+	assert.Equal(t, "1.10.0", semanticLatest, "Should choose 1.10.0 over 1.9.0 (semantic ordering, not alphabetical)")
+}

--- a/pkg/software/crio_installer.go
+++ b/pkg/software/crio_installer.go
@@ -1,15 +1,139 @@
 package software
 
+import (
+	"os"
+	"path"
+
+	"golang.hedera.com/solo-provisioner/internal/core"
+)
+
 type crioInstaller struct {
+	downloader            *Downloader
+	softwareToBeInstalled *SoftwareItem
+	version               string
+}
+
+var _ Software = (*crioInstaller)(nil)
+
+func NewCrioInstaller() (Software, error) {
+	config, err := LoadSoftwareConfig()
+	if err != nil {
+		return nil, NewConfigLoadError(err)
+	}
+
+	item, err := config.GetSoftwareByName("cri-o")
+	if err != nil {
+		return nil, err // Already using NewSoftwareNotFoundError
+	}
+
+	// Get latest version
+	version, err := item.GetLatestVersion()
+	if err != nil {
+		return nil, err // Already using NewVersionNotFoundError
+	}
+
+	return &crioInstaller{
+		downloader:            NewDownloader(),
+		softwareToBeInstalled: item,
+		version:               version,
+	}, nil
 }
 
 func (ci *crioInstaller) Download() error {
-	// Downloads and check the integrity of the downloaded package
+	_, err := ci.softwareToBeInstalled.GetFilename(ci.version)
+	if err != nil {
+		return err // Already using NewTemplateError
+	}
+
+	downloadFolder := ci.getDownloadFolder()
+
+	downloadURL, err := ci.softwareToBeInstalled.GetDownloadURL(ci.version)
+	if err != nil {
+		return err // Already using NewTemplateError
+	}
+
+	destinationFile, err := ci.getDestinationFile()
+	if err != nil {
+		return err // Already using NewTemplateError
+	}
+
+	// Get expected checksum and algorithm from configuration
+	expectedChecksum, err := ci.softwareToBeInstalled.GetChecksum(ci.version)
+	if err != nil {
+		return err // Already using structured errors
+	}
+
+	// Create download folder if it doesn't exist
+	if err := os.MkdirAll(downloadFolder, core.DefaultFilePerm); err != nil {
+		return NewDownloadError(err, downloadURL, 0)
+	}
+
+	// Check if file already exists and is valid
+	if _, err := os.Stat(destinationFile); err == nil {
+		// File exists, verify checksum
+		if err := ci.downloader.VerifyChecksum(destinationFile, expectedChecksum.Value, expectedChecksum.Algorithm); err == nil {
+			// File is already downloaded and valid
+			return nil
+		}
+		// File exists but invalid checksum, remove it and re-download
+		if err := os.Remove(destinationFile); err != nil {
+			return NewDownloadError(err, downloadURL, 0)
+		}
+	}
+
+	// Download the file
+	if err := ci.downloader.Download(downloadURL, destinationFile); err != nil {
+		return err // Already using NewDownloadError
+	}
+
+	// Verify the downloaded file's checksum using the dynamic algorithm
+	if err := ci.downloader.VerifyChecksum(destinationFile, expectedChecksum.Value, expectedChecksum.Algorithm); err != nil {
+		return err // Already using NewChecksumError
+	}
 
 	return nil
 }
 
 func (ci *crioInstaller) Extract() error {
+	downloadFolder := ci.getDownloadFolder()
+
+	compressedFile, err := ci.getDestinationFile()
+	if err != nil {
+		return err // Already using NewTemplateError
+	}
+
+	extractFolder := path.Join(downloadFolder, core.DefaultUnpackFolderName)
+
+	// Verify that the compressed file exists
+	if _, err := os.Stat(compressedFile); os.IsNotExist(err) {
+		return NewFileNotFoundError(compressedFile)
+	}
+
+	// Check if extraction folder already exists and has content
+	if entries, err := os.ReadDir(extractFolder); err == nil && len(entries) > 0 {
+		// Already extracted, skip
+		return nil
+	}
+
+	// Create extraction folder if it doesn't exist
+	if err := os.MkdirAll(extractFolder, core.DefaultFilePerm); err != nil {
+		return NewExtractionError(err, compressedFile, extractFolder)
+	}
+
+	// Extract the compressed file
+	if err := ci.downloader.Extract(compressedFile, extractFolder); err != nil {
+		return err // Already using NewExtractionError
+	}
+
+	// Verify that extraction was successful by checking if we have files
+	entries, err := os.ReadDir(extractFolder)
+	if err != nil {
+		return NewExtractionError(err, compressedFile, extractFolder)
+	}
+	if len(entries) == 0 {
+		return NewExtractionError(nil, compressedFile, extractFolder)
+	}
+
 	return nil
 }
 
@@ -52,4 +176,18 @@ func (ci *crioInstaller) Configure() error {
 // Checks default, service, application and configuration service symlinks
 func (ci *crioInstaller) IsConfigured() (bool, error) {
 	return false, nil
+}
+
+// getDownloadFolder returns the download folder path for cri-o
+func (ci *crioInstaller) getDownloadFolder() string {
+	return path.Join(core.Paths().TempDir, "cri-o")
+}
+
+// getDestinationFile returns the full path where the downloaded file will be stored
+func (ci *crioInstaller) getDestinationFile() (string, error) {
+	filename, err := ci.softwareToBeInstalled.GetFilename(ci.version)
+	if err != nil {
+		return "", err
+	}
+	return path.Join(ci.getDownloadFolder(), filename), nil
 }

--- a/pkg/software/crio_installer_it_test.go
+++ b/pkg/software/crio_installer_it_test.go
@@ -1,0 +1,242 @@
+//go:build integration
+
+package software
+
+import (
+	"os"
+	"testing"
+
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/require"
+	"golang.hedera.com/solo-provisioner/internal/core"
+)
+
+const (
+	tmpFolder = "/opt/provisioner/tmp"
+)
+
+// setupTestEnvironment creates a clean test environment and registers cleanup
+func setupTestEnvironment(t *testing.T) {
+	t.Helper()
+
+	// Clean up any existing test artifacts
+	_ = os.RemoveAll(tmpFolder)
+
+	// Register cleanup to run after test completes
+	t.Cleanup(func() {
+		_ = os.RemoveAll(tmpFolder)
+	})
+}
+
+func TestCrioInstaller_Download_Success(t *testing.T) {
+	setupTestEnvironment(t)
+
+	//
+	// When
+	//
+	installer, err := NewCrioInstaller()
+	require.NoError(t, err, "Failed to create crio installer")
+
+	//
+	// Given
+	//
+	err = installer.Download()
+
+	//
+	// Then
+	//
+	require.NoError(t, err, "Failed to download crio")
+}
+
+// Test when permission to create file is denied
+func TestCrioInstaller_Download_PermissionError(t *testing.T) {
+	setupTestEnvironment(t)
+
+	// Create a regular file where the directory should be created
+	// This will cause MkdirAll to fail with permission/file exists error
+	conflictingFile := tmpFolder
+	err := os.WriteFile(conflictingFile, []byte("blocking file"), 0644)
+	require.NoError(t, err, "Failed to create blocking file")
+
+	// Override cleanup to remove the file we created
+	t.Cleanup(func() {
+		_ = os.Remove(conflictingFile)
+	})
+
+	//
+	// When
+	//
+	installer, err := NewCrioInstaller()
+	require.NoError(t, err, "Failed to create crio installer")
+
+	//
+	// Given
+	//
+	err = installer.Download()
+
+	//
+	// Then
+	//
+	require.Error(t, err, "Download should fail due to permission error")
+	require.True(t, errorx.IsOfType(err, DownloadError), "Error should be of type DownloadError")
+}
+
+// Test when download fails due to invalid configuration
+func TestCrioInstaller_Download_Fails(t *testing.T) {
+	setupTestEnvironment(t)
+
+	//
+	// When
+	// Create an installer with invalid configuration by manipulating the struct directly
+	config, err := LoadSoftwareConfig()
+	require.NoError(t, err, "Failed to load software config")
+
+	item, err := config.GetSoftwareByName("cri-o")
+	require.NoError(t, err, "Failed to find cri-o in config")
+
+	wrongInstaller := &crioInstaller{
+		downloader:            NewDownloader(),
+		softwareToBeInstalled: item,
+		version:               "invalidversion", // This version doesn't exist in config
+	}
+
+	//
+	// Given
+	//
+	err = wrongInstaller.Download()
+
+	//
+	// Then
+	//
+	require.Error(t, err, "Download should fail")
+	require.True(t, errorx.IsOfType(err, VersionNotFoundError), "Error should be of type VersionNotFoundError")
+}
+
+// Test when checksum fails (this test might need adjustment based on actual config)
+func TestCrioInstaller_Download_ChecksumFails(t *testing.T) {
+	setupTestEnvironment(t)
+
+	//
+	// When
+	// Create an installer with a version that has wrong checksum
+	config, err := LoadSoftwareConfig()
+	require.NoError(t, err, "Failed to load software config")
+
+	item, err := config.GetSoftwareByName("cri-o")
+	require.NoError(t, err, "Failed to find cri-o in config")
+	item.Versions["1.33.4"] = Platforms{
+		"linux": {
+			"arm64": {
+				Algorithm: "sha256",
+				Value:     "invalidchecksum",
+			},
+		},
+	}
+
+	wrongInstaller := &crioInstaller{
+		downloader:            NewDownloader(),
+		softwareToBeInstalled: item,
+		version:               "1.33.4", // This version might not exist or have wrong checksum
+	}
+
+	//
+	// Given
+	//
+	err = wrongInstaller.Download()
+
+	//
+	// Then
+	//
+	require.Error(t, err, "Download should fail")
+	require.True(t, errorx.IsOfType(err, ChecksumError), "Error should be of type ChecksumError")
+
+}
+
+// Test idempotency with existing valid file
+func TestCrioInstaller_Download_Idempotency_ExistingFile(t *testing.T) {
+	setupTestEnvironment(t)
+
+	//
+	// When
+	//
+	installer, err := NewCrioInstaller()
+	require.NoError(t, err, "Failed to create crio installer")
+
+	err = installer.Download()
+	require.NoError(t, err, "Failed to download crio")
+
+	//
+	// Given
+	//
+
+	// Trigger Download again
+	err = installer.Download()
+
+	//
+	// Then
+	//
+	require.NoError(t, err, "Download should succeed again due to idempotency")
+}
+
+func TestCrioInstaller_Download_Idempotency_ExistingFile_WrongChecksum(t *testing.T) {
+	setupTestEnvironment(t)
+
+	//
+	// When
+	//
+	installerInterface, err := NewCrioInstaller()
+	require.NoError(t, err, "Failed to create crio installer")
+
+	installer := installerInterface.(*crioInstaller) // cast to crioInstaller to access private fields
+
+	// create empty file to emulate first download with wrong checksum
+	err = os.MkdirAll(installer.getDownloadFolder(), core.DefaultFilePerm)
+	require.NoError(t, err, "Failed to create download folder")
+
+	destinationFile, err := installer.getDestinationFile()
+	require.NoError(t, err, "Failed to get destination file path")
+
+	err = os.WriteFile(destinationFile, []byte(""), core.DefaultFilePerm)
+	require.NoError(t, err, "Failed to create empty file")
+
+	//
+	// Given
+	//
+	err = installer.Download()
+
+	//
+	// Then
+	//
+	require.NoError(t, err, "Download should succeed again due to idempotency")
+	// Check that the file exists
+	_, err = os.Stat(destinationFile)
+	require.NoError(t, err, "File should exist after download")
+}
+
+func TestCrioInstaller_Extract_Success(t *testing.T) {
+	setupTestEnvironment(t)
+
+	//
+	// When
+	//
+	installer, err := NewCrioInstaller()
+	require.NoError(t, err, "Failed to create crio installer")
+
+	//
+	// Given
+	//
+	err = installer.Download()
+	require.NoError(t, err, "Failed to download crio")
+
+	err = installer.Extract()
+
+	//
+	// Then
+	//
+	require.NoError(t, err, "Failed to extract crio")
+	// validate there are multiple files under extracted folder
+	extractedFolder := tmpFolder + "/cri-o/unpack"
+	files, err := os.ReadDir(extractedFolder)
+	require.NoError(t, err, "Failed to read extracted folder")
+	require.Greater(t, len(files), 0, "No files found in extracted folder")
+}

--- a/pkg/software/errors.go
+++ b/pkg/software/errors.go
@@ -1,0 +1,174 @@
+package software
+
+import (
+	"strconv"
+
+	"github.com/joomcode/errorx"
+)
+
+var (
+	ErrorsNamespace       = errorx.NewNamespace("software")
+	ConfigLoadError       = ErrorsNamespace.NewType("config_load_error")
+	SoftwareNotFoundError = ErrorsNamespace.NewType("software_not_found")
+	VersionNotFoundError  = ErrorsNamespace.NewType("version_not_found")
+	PlatformNotFoundError = ErrorsNamespace.NewType("platform_not_found")
+	DownloadError         = ErrorsNamespace.NewType("download_error")
+	ChecksumError         = ErrorsNamespace.NewType("checksum_error")
+	ExtractionError       = ErrorsNamespace.NewType("extraction_error")
+	FileNotFoundError     = ErrorsNamespace.NewType("file_not_found")
+	InstallationError     = ErrorsNamespace.NewType("installation_error")
+	ConfigurationError    = ErrorsNamespace.NewType("configuration_error")
+	TemplateError         = ErrorsNamespace.NewType("template_error")
+
+	softwareNameProperty = errorx.RegisterPrintableProperty("software_name")
+	versionProperty      = errorx.RegisterPrintableProperty("version")
+	urlProperty          = errorx.RegisterPrintableProperty("url")
+	filePathProperty     = errorx.RegisterPrintableProperty("file_path")
+	osProperty           = errorx.RegisterPrintableProperty("os")
+	archProperty         = errorx.RegisterPrintableProperty("arch")
+	algorithmProperty    = errorx.RegisterPrintableProperty("algorithm")
+	expectedHashProperty = errorx.RegisterPrintableProperty("expected_hash")
+	actualHashProperty   = errorx.RegisterPrintableProperty("actual_hash")
+	statusCodeProperty   = errorx.RegisterPrintableProperty("status_code")
+)
+
+const (
+	configLoadErrorMsg       = "failed to load software configuration"
+	softwareNotFoundErrorMsg = "software '%s' not found in configuration"
+	versionNotFoundErrorMsg  = "version '%s' not found for software '%s'"
+	platformNotFoundErrorMsg = "platform '%s/%s' not supported for software '%s' version '%s'"
+	downloadErrorMsg         = "failed to download from URL '%s'"
+	checksumErrorMsg         = "checksum verification failed for file '%s' using algorithm '%s' [ expected = '%s', actual = '%s' ]"
+	extractionErrorMsg       = "failed to extract file '%s' to '%s'"
+	fileNotFoundErrorMsg     = "file not found: '%s'"
+	installationErrorMsg     = "failed to install software '%s' version '%s'"
+	configurationErrorMsg    = "failed to configure software '%s'"
+	templateErrorMsg         = "failed to execute template for software '%s'"
+)
+
+func NewConfigLoadError(cause error) *errorx.Error {
+	if cause == nil {
+		return ConfigLoadError.New(configLoadErrorMsg)
+	}
+
+	return ConfigLoadError.New(configLoadErrorMsg).
+		WithUnderlyingErrors(cause)
+}
+
+func NewSoftwareNotFoundError(softwareName string) *errorx.Error {
+	return SoftwareNotFoundError.New(softwareNotFoundErrorMsg, softwareName).
+		WithProperty(softwareNameProperty, softwareName)
+}
+
+func NewVersionNotFoundError(softwareName, version string) *errorx.Error {
+	return VersionNotFoundError.New(versionNotFoundErrorMsg, version, softwareName).
+		WithProperty(softwareNameProperty, softwareName).
+		WithProperty(versionProperty, version)
+}
+
+func NewPlatformNotFoundError(softwareName, version, os, arch string) *errorx.Error {
+	return PlatformNotFoundError.New(platformNotFoundErrorMsg, os, arch, softwareName, version).
+		WithProperty(softwareNameProperty, softwareName).
+		WithProperty(versionProperty, version).
+		WithProperty(osProperty, os).
+		WithProperty(archProperty, arch)
+}
+
+func NewDownloadError(cause error, url string, statusCode int) *errorx.Error {
+	err := DownloadError.New(downloadErrorMsg, url).
+		WithProperty(urlProperty, url)
+
+	if statusCode > 0 {
+		err = err.WithProperty(statusCodeProperty, statusCode)
+	}
+
+	if cause != nil {
+		err = err.WithUnderlyingErrors(cause)
+	}
+
+	return err
+}
+
+func NewChecksumError(filePath, algorithm, expectedHash, actualHash string) *errorx.Error {
+	return ChecksumError.New(checksumErrorMsg, filePath, algorithm, expectedHash, actualHash).
+		WithProperty(filePathProperty, filePath).
+		WithProperty(algorithmProperty, algorithm).
+		WithProperty(expectedHashProperty, expectedHash).
+		WithProperty(actualHashProperty, actualHash)
+}
+
+func NewExtractionError(cause error, filePath, destPath string) *errorx.Error {
+	err := ExtractionError.New(extractionErrorMsg, filePath, destPath).
+		WithProperty(filePathProperty, filePath)
+
+	if cause != nil {
+		err = err.WithUnderlyingErrors(cause)
+	}
+
+	return err
+}
+
+func NewFileNotFoundError(filePath string) *errorx.Error {
+	return FileNotFoundError.New(fileNotFoundErrorMsg, filePath).
+		WithProperty(filePathProperty, filePath)
+}
+
+func NewInstallationError(cause error, softwareName, version string) *errorx.Error {
+	err := InstallationError.New(installationErrorMsg, softwareName, version).
+		WithProperty(softwareNameProperty, softwareName).
+		WithProperty(versionProperty, version)
+
+	if cause != nil {
+		err = err.WithUnderlyingErrors(cause)
+	}
+
+	return err
+}
+
+func NewConfigurationError(cause error, softwareName string) *errorx.Error {
+	err := ConfigurationError.New(configurationErrorMsg, softwareName).
+		WithProperty(softwareNameProperty, softwareName)
+
+	if cause != nil {
+		err = err.WithUnderlyingErrors(cause)
+	}
+
+	return err
+}
+
+func NewTemplateError(cause error, softwareName string) *errorx.Error {
+	err := TemplateError.New(templateErrorMsg, softwareName).
+		WithProperty(softwareNameProperty, softwareName)
+
+	if cause != nil {
+		err = err.WithUnderlyingErrors(cause)
+	}
+
+	return err
+}
+
+// SafeErrorDetails emits a PII-safe slice of error details.
+func SafeErrorDetails(err *errorx.Error) []string {
+	var safeDetails []string
+	if err == nil {
+		return safeDetails
+	}
+
+	for _, prop := range []errorx.Property{
+		softwareNameProperty, versionProperty, urlProperty, filePathProperty,
+		osProperty, archProperty, algorithmProperty, expectedHashProperty,
+		actualHashProperty, statusCodeProperty,
+	} {
+		if val, ok := err.Property(prop); ok {
+			switch prop {
+			case softwareNameProperty, versionProperty, urlProperty, filePathProperty,
+				osProperty, archProperty, algorithmProperty, expectedHashProperty, actualHashProperty:
+				safeDetails = append(safeDetails, val.(string))
+			case statusCodeProperty:
+				safeDetails = append(safeDetails, strconv.Itoa(val.(int)))
+			}
+		}
+	}
+
+	return safeDetails
+}

--- a/pkg/software/interface.go
+++ b/pkg/software/interface.go
@@ -12,16 +12,6 @@ type Package interface {
 	IsInstalled() bool
 }
 
-// Downloader interface for downloading and verifying software packages
-type Downloader interface {
-	Download(url, destination string) error
-	VerifyMD5(filePath, expectedMD5 string) error
-	VerifySHA256(filePath, expectedSHA256 string) error
-	VerifySHA512(filePath, expectedSHA512 string) error
-	ExtractTarGz(gzPath, destDir string) error
-	ExtractZip(zipPath, destDir string) error
-}
-
 type Software interface {
 	Download() error
 

--- a/pkg/software/software.yaml
+++ b/pkg/software/software.yaml
@@ -1,0 +1,27 @@
+software:
+
+- name: cri-o
+  url: 'https://storage.googleapis.com/cri-o/artifacts/cri-o.{{.ARCH}}.v{{.VERSION}}.tar.gz'
+  filename: 'cri-o.{{.ARCH}}.v{{.VERSION}}.tar.gz'
+  versions:
+    1.33.4:
+      linux:
+        amd64:
+          algorithm: 'sha256'
+          checksum: '8f6d14828659b85da7c83bad798d50c2f7e0311742615fb7ed305f77bab54e50'
+        arm64:
+          algorithm: 'sha256'
+          checksum: '6a04cb1ab2020508927d7237ff1174bb330211a1076683417b30642a9c8e4996'
+
+- name: kubeadm
+  url: 'https://dl.k8s.io/release/v{{.VERSION}}/bin/{{.OS}}/{{.ARCH}}/kubeadm'
+  filename: 'kubeadm'
+  versions:
+    1.33.4:
+      linux:
+        amd64:
+          algorithm: 'sha256'
+          checksum: '8f6d14828659b85da7c83bad798d50c2f7e0311742615fb7ed305f77bab54e50'
+        arm64:
+          algorithm: 'sha256'
+          checksum: '6a04cb1ab2020508927d7237ff1174bb330211a1076683417b30642a9c8e4996'

--- a/pkg/software/system_packages_test.go
+++ b/pkg/software/system_packages_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/bluet/syspkg/manager"
+	"github.com/joomcode/errorx"
 	"github.com/stretchr/testify/require"
 	"golang.hedera.com/solo-provisioner/pkg/hardware"
 )
@@ -99,7 +100,8 @@ func testPackageInstallUninstall(t *testing.T, createPackage func() (Package, er
 	// Test verification after uninstall
 	err = pkg.Verify()
 	require.Error(t, err, "package verification should fail after uninstallation")
-
+	// Check if it's an installation error when package is not installed
+	require.True(t, errorx.IsOfType(err, InstallationError), "Error should be of type InstallationError when package is not installed")
 }
 
 func TestIptablesInstallUninstall(t *testing.T) {


### PR DESCRIPTION
## Description

This pull request introduces a new, configurable, and testable approach for installing CRI-O, replacing the previous hardcoded step with a data-driven installer. The main changes include implementing a configuration-driven software installer framework, adding integration tests for the CRI-O setup workflow, and refactoring helper functions for better code reuse and maintainability.

**Cluster Workflow Improvements**
- The cluster setup workflow now uses the new `SetupCrio` step instead of the old hardcoded `InstallCrio`, enabling configuration-driven installation and improved flexibility.

**Software Installer Framework**
- Introduced a new configuration system in `pkg/software/config.go` for managing software installation metadata, including templated URLs, filenames, versions, and checksums, all loaded from an embedded YAML file.
- Implemented a new `crioInstaller` in `pkg/software/crio_installer.go` that uses the configuration to download, verify, extract, and install the latest version of CRI-O for the detected OS and architecture. [[1]](diffhunk://#diff-12eb6d2dd664cfc78803ee6b46bcf564e348b461766d3b46a8c188d2b5a34ac2R3-R136) [[2]](diffhunk://#diff-12eb6d2dd664cfc78803ee6b46bcf564e348b461766d3b46a8c188d2b5a34ac2R180-R193)
- Added a test suite in `pkg/software/config_test.go` to verify semantic version selection and correct configuration handling for software installers.

**Workflow Step Refactoring**
- Refactored the CRI-O workflow step in `internal/workflows/steps/step_crio.go` to use the new installer, making the workflow modular and idempotent, and supporting rollback.
- Added integration tests for the new CRI-O setup workflow in `internal/workflows/steps/step_crio_it_test.go`, covering fresh, already installed, and partially installed scenarios.

**Helper Function Consolidation**
- Moved the `sudo` helper function to a central location in `internal/workflows/steps/helpers.go` for reuse across tests and steps, removing duplicate definitions from test files. [[1]](diffhunk://#diff-7ad4ec7eeff1dc584dd03246cd24d4b5ff6704cfd3034578ffd2d5e9834d3b87R4-R24) [[2]](diffhunk://#diff-dc67a875fb1bfb4f36815659b7a491e64dd52d83f1da0885aa415142742416f7L17-L30) [[3]](diffhunk://#diff-4de8083bf15e26d5d87dc4bc4a604ef2249aa5038a0209383a53bd31c2e69122L18-L31)

### Related Issues

* Closes #61 
