### PR TITLE
feat: rollback verification for helm deployment

### DIFF
--- a/internal/workflows/steps/step_helm_it_test.go
+++ b/internal/workflows/steps/step_helm_it_test.go
@@ -123,7 +123,7 @@ func Test_StepHelm_PartiallyInstalled_Integration(t *testing.T) {
 	require.Empty(t, report.StepReports[0].Metadata[CleanedUpByThisStep])
 
 	require.Equal(t, automa.StatusSuccess, report.StepReports[1].Status)
-	require.Empty(t, report.StepReports[1].Metadata[AlreadyInstalled])
+	require.Empty(t, report.StepReports[1].Metadata[AlreadyConfigured])
 	require.Equal(t, "true", report.StepReports[1].Metadata[ConfiguredByThisStep])
 }
 
@@ -428,7 +428,7 @@ func Test_StepHelm_Rollback_Setup_CleanupFailed(t *testing.T) {
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(files), 1, "Expected at least 1 file in the unpack directory")
 
-	// Verify binary files were removed installed
+	// Verify binary files were removed
 	_, err = os.Stat("/opt/provisioner/sandbox/bin/helm")
 	require.Error(t, err)
 }
@@ -501,7 +501,7 @@ func Test_StepHelm_Rollback_ConfigurationFailed(t *testing.T) {
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(files), 1, "Expected at least 1 file in the unpack directory")
 
-	// Verify binary files were removed installed
+	// Verify binary files were removed
 	_, err = os.Stat("/opt/provisioner/sandbox/bin/helm")
 	require.Error(t, err)
 }

--- a/internal/workflows/steps/step_kubectl.go
+++ b/internal/workflows/steps/step_kubectl.go
@@ -28,6 +28,16 @@ func SetupKubectl() automa.Builder {
 
 func installKubectl(provider func(opts ...software.InstallerOption) (software.Software, error)) automa.Builder {
 	return automa.NewStepBuilder().WithId("install-kubectl").
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Installing kubectl")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to install kubectl")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "kubectl installed successfully")
+		}).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			installer, err := provider()
 			if err != nil {
@@ -35,31 +45,67 @@ func installKubectl(provider func(opts ...software.InstallerOption) (software.So
 					automa.WithError(err))
 			}
 
+			// Prepare metadata for reporting
+			meta := map[string]string{}
+
+			installed, err := installer.IsInstalled()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			if installed {
+				meta[AlreadyInstalled] = "true"
+				return automa.SkippedReport(stp, automa.WithDetail("kubectl is already installed"), automa.WithMetadata(meta))
+			}
+
 			err = installer.Download()
 			if err != nil {
-				return automa.FailureReport(stp,
-					automa.WithError(err))
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
 			}
+			meta[DownloadedByThisStep] = "true"
+
 			err = installer.Install()
 			if err != nil {
-				return automa.FailureReport(stp,
-					automa.WithError(err))
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
 			}
+			meta[InstalledByThisStep] = "true"
+
 			err = installer.Cleanup()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			meta[CleanedUpByThisStep] = "true"
+
+			return automa.SuccessReport(stp, automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			installer, err := provider()
 			if err != nil {
 				return automa.FailureReport(stp,
 					automa.WithError(err))
 			}
 
-			return automa.SuccessReport(stp)
-		}).
-		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			err = installer.Uninstall()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+
 			return automa.SuccessReport(stp)
 		})
 }
 
 func configureKubectl(provider func(opts ...software.InstallerOption) (software.Software, error)) automa.Builder {
 	return automa.NewStepBuilder().WithId("configure-kubectl").
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Configuring kubectl")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to configure kubectl")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "kubectl configured successfully")
+		}).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			installer, err := provider()
 			if err != nil {
@@ -67,7 +113,35 @@ func configureKubectl(provider func(opts ...software.InstallerOption) (software.
 					automa.WithError(err))
 			}
 
+			// Prepare metadata for reporting
+			meta := map[string]string{}
+
+			configured, err := installer.IsConfigured()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			if configured {
+				meta[AlreadyConfigured] = "true"
+				return automa.SkippedReport(stp, automa.WithDetail("kubectl is already configured"), automa.WithMetadata(meta))
+			}
+
 			err = installer.Configure()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+
+			meta[ConfiguredByThisStep] = "true"
+
+			return automa.SuccessReport(stp, automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			installer, err := provider()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+
+			err = installer.RestoreConfiguration()
 			if err != nil {
 				return automa.FailureReport(stp,
 					automa.WithError(err))

--- a/internal/workflows/steps/step_kubectl_it_test.go
+++ b/internal/workflows/steps/step_kubectl_it_test.go
@@ -5,11 +5,15 @@ package steps
 import (
 	"context"
 	"os"
+	"os/exec"
+	"path"
 	"testing"
 
 	"github.com/automa-saga/automa"
+	"github.com/joomcode/errorx"
 	"github.com/stretchr/testify/require"
 	"golang.hedera.com/solo-provisioner/internal/core"
+	"golang.hedera.com/solo-provisioner/pkg/software"
 )
 
 func Test_StepKubectl_Fresh_Integration(t *testing.T) {
@@ -31,6 +35,14 @@ func Test_StepKubectl_Fresh_Integration(t *testing.T) {
 	require.NotNil(t, report)
 	require.NoError(t, report.Error)
 	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	require.Empty(t, report.StepReports[0].Metadata[AlreadyInstalled])
+	require.Equal(t, "true", report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[CleanedUpByThisStep])
+	require.Empty(t, report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Equal(t, "true", report.StepReports[1].Metadata[ConfiguredByThisStep])
+
 }
 
 func Test_StepKubectl_AlreadyInstalled_Integration(t *testing.T) {
@@ -60,6 +72,15 @@ func Test_StepKubectl_AlreadyInstalled_Integration(t *testing.T) {
 	require.NoError(t, report.Error)
 	require.Equal(t, automa.StatusSuccess, report.Status)
 
+	require.Equal(t, automa.StatusSkipped, report.StepReports[0].Status)
+	require.Equal(t, "true", report.StepReports[0].Metadata[AlreadyInstalled])
+	require.Empty(t, report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Empty(t, report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Empty(t, report.StepReports[0].Metadata[CleanedUpByThisStep])
+
+	require.Equal(t, automa.StatusSkipped, report.StepReports[1].Status)
+	require.Equal(t, "true", report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Empty(t, report.StepReports[1].Metadata[ConfiguredByThisStep])
 }
 
 func Test_StepKubectl_PartiallyInstalled_Integration(t *testing.T) {
@@ -75,20 +96,335 @@ func Test_StepKubectl_PartiallyInstalled_Integration(t *testing.T) {
 	require.NoError(t, report.Error)
 	require.Equal(t, automa.StatusSuccess, report.Status)
 
-	err = os.RemoveAll(core.Paths().TempDir)
+	err = os.RemoveAll("/usr/local/bin/kubectl")
 	require.NoError(t, err)
 
 	//
 	// When
 	//
 	step, err = SetupKubectl().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
 
 	//
 	// Then
 	//
-	require.NoError(t, err)
-	report = step.Execute(context.Background())
 	require.NotNil(t, report)
 	require.NoError(t, report.Error)
 	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	require.Equal(t, automa.StatusSkipped, report.StepReports[0].Status)
+	require.Equal(t, "true", report.StepReports[0].Metadata[AlreadyInstalled])
+	require.Empty(t, report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Empty(t, report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Empty(t, report.StepReports[0].Metadata[CleanedUpByThisStep])
+
+	require.Equal(t, automa.StatusSuccess, report.StepReports[1].Status)
+	require.Empty(t, report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Equal(t, "true", report.StepReports[1].Metadata[ConfiguredByThisStep])
+}
+
+func Test_StepKubectl_Rollback_Fresh_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	//
+	// When
+	//
+	step, err := SetupKubectl().Build()
+
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	require.Equal(t, "true", report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[CleanedUpByThisStep])
+
+	//
+	// When - Rollback
+	//
+	rollbackReport := step.Rollback(context.Background())
+
+	//
+	// Then
+	//
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, rollbackReport.Status)
+
+	// Verify download folder for kubectl is removed
+	_, err = os.Stat("/opt/provisioner/tmp/kubectl")
+	require.Error(t, err)
+
+	// Verify binary files are removed
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/kubectl")
+	require.Error(t, err)
+}
+
+func Test_StepKubectl_Rollback_Setup_DownloadFailed(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	// Make the download directory read-only
+	err := os.MkdirAll(core.Paths().TempDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create download directory")
+	cmd := exec.Command("chattr", "+i", core.Paths().TempDir)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make download directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", core.Paths().TempDir).Run()
+	})
+
+	//
+	// When
+	//
+	step, err := SetupKubectl().Build()
+	require.NoError(t, err)
+
+	//
+	// When - Rollback
+	//
+
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check errorx error type
+	require.Error(t, report.Error)
+
+	// Confirm errorx error type is DownloadError
+	require.True(t, errorx.IsOfType(errorx.Cast(report.Error).Cause(), software.DownloadError))
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	//
+	// Then
+	//
+	rollbackReport := report.StepReports[0].Rollback
+
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, rollbackReport.Status)
+
+	// Verify download folder for kubectl was not created
+	_, err = os.Stat("/opt/provisioner/tmp/kubectl")
+	require.Error(t, err)
+
+	// Confirm binary files were not created
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/kubectl")
+	require.Error(t, err)
+}
+
+func Test_StepKubectl_Rollback_Setup_InstallFailed(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	// Make the sandbox directory read-only
+	sandboxDir := path.Join(core.Paths().SandboxDir, "bin")
+
+	err := os.MkdirAll(sandboxDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create sandbox bin directory")
+	cmd := exec.Command("chattr", "+i", sandboxDir)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make sandbox binary directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", sandboxDir).Run()
+	})
+
+	//
+	// When
+	//
+	step, err := SetupKubectl().Build()
+	require.NoError(t, err)
+
+	//
+	// When - Rollback
+	//
+
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check errorx error type
+	require.Error(t, report.Error)
+
+	// Confirm errorx error type is DownloadError
+	require.True(t, errorx.IsOfType(errorx.Cast(report.Error).Cause(), software.InstallationError))
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	//
+	// Then
+	//
+	rollbackReport := report.StepReports[0].Rollback
+
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, rollbackReport.Status)
+
+	// Verify download folder is still around when there is an error
+	_, err = os.Stat("/opt/provisioner/tmp/kubectl")
+	require.NoError(t, err)
+
+	// Verify downloaded binary is still around
+	_, err = os.Stat("/opt/provisioner/tmp/kubectl/kubectl")
+	require.NoError(t, err)
+
+	// Verify binary files were not installed
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/kubectl")
+	require.Error(t, err)
+}
+
+func Test_StepKubectl_Rollback_Setup_CleanupFailed(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	// Create an unremovable directory under download folder
+	unremovableDir := path.Join(core.Paths().TempDir, "kubectl", "unremovable")
+
+	err := os.MkdirAll(unremovableDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create unremovable directory")
+	cmd := exec.Command("chattr", "+i", unremovableDir)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make unremovable directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", unremovableDir).Run()
+	})
+
+	//
+	// When
+	//
+	step, err := SetupKubectl().Build()
+	require.NoError(t, err)
+
+	//
+	// When - Rollback
+	//
+
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check errorx error type
+	require.Error(t, report.Error)
+
+	// Confirm errorx error type is DownloadError
+	require.True(t, errorx.IsOfType(errorx.Cast(report.Error).Cause(), software.CleanupError))
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	//
+	// Then
+	//
+	rollbackReport := report.StepReports[0].Rollback
+
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, rollbackReport.Status)
+
+	// Verify download folder is still around when there is an extraction error
+	_, err = os.Stat("/opt/provisioner/tmp/kubectl")
+	require.NoError(t, err)
+
+	// Check there is a tar.gz file in the unpack directory by counting the number of files
+	files, err := os.ReadDir(path.Join(core.Paths().TempDir, "kubectl"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(files), 1, "Expected 1 file in the tmp/kubectl directory")
+
+	// Verify unpack folder is not around because the cleanup tried to remove it
+	_, err = os.Stat("/opt/provisioner/tmp/kubectl/unpack")
+	require.Error(t, err)
+
+	// Check there are unpacked files
+	files, err = os.ReadDir(path.Join(core.Paths().TempDir, "kubectl"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(files), 1, "Expected at least 1 file in the unpack directory")
+
+	// Verify binary files were removed
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/kubectl")
+	require.Error(t, err)
+}
+
+func Test_StepKubectl_Rollback_ConfigurationFailed(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	// Create an unremovable directory under download folder
+	unremovableDir := path.Join(core.Paths().TempDir, "kubectl", "unremovable")
+
+	err := os.MkdirAll(unremovableDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create unremovable directory")
+	cmd := exec.Command("chattr", "+i", unremovableDir)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make unremovable directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", unremovableDir).Run()
+	})
+
+	//
+	// When
+	//
+	step, err := SetupKubectl().Build()
+	require.NoError(t, err)
+
+	//
+	// When - Rollback
+	//
+
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check errorx error type
+	require.Error(t, report.Error)
+
+	// Confirm errorx error type is DownloadError
+
+	require.True(t, errorx.IsOfType(errorx.Cast(report.Error).Cause(), software.CleanupError))
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	//
+	// Then
+	//
+	rollbackReport := report.StepReports[0].Rollback
+
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, rollbackReport.Status)
+
+	// Verify download folder is still around when there is an extraction error
+	_, err = os.Stat("/opt/provisioner/tmp/kubectl")
+	require.NoError(t, err)
+
+	// Check there is a tar.gz file in the unpack directory by counting the number of files
+	files, err := os.ReadDir(path.Join(core.Paths().TempDir, "kubectl"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(files), 1, "Expected 1 file in the tmp/kubectl directory")
+
+	// Verify unpack folder is not around because the cleanup tried to remove it
+	_, err = os.Stat("/opt/provisioner/tmp/kubectl/unpack")
+	require.Error(t, err)
+
+	// Check there are unpacked files
+	files, err = os.ReadDir(path.Join(core.Paths().TempDir, "kubectl"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(files), 1, "Expected at least 1 file in the unpack directory")
+
+	// Verify binary files were removed
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/kubectl")
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Description

This pull request significantly enhances the robustness, observability, and test coverage of the `kubectl` setup and configuration workflow. The main improvements include adding detailed metadata reporting, user notifications for step progress, more comprehensive error handling, and a suite of integration tests covering various success and failure scenarios, including rollback logic.

**Enhancements to Step Logic and Observability:**

- Added metadata tracking to each step of the `kubectl` installation and configuration process, capturing whether actions like download, install, cleanup, and configuration were performed or skipped. This metadata is included in the step reports for better traceability.
- Integrated user notifications to indicate when each step starts, fails, or completes, improving transparency for users running the workflow.

**Error Handling and Rollback Improvements:**

- Expanded error handling throughout the installation and configuration steps, ensuring that errors at any stage (download, install, cleanup, configure) are reported with contextual metadata and that rollback logic is invoked when needed.
- Implemented rollback handlers for both installation and configuration steps, calling `Uninstall` or `RestoreConfiguration` respectively to clean up after failures.

**Comprehensive Integration Testing:**

- Greatly expanded integration tests in `step_kubectl_it_test.go` to cover:
  - Fresh installations, already installed/configured scenarios, and partial installations. [[1]](diffhunk://#diff-61ccb77078afa34f2c1120f85ac0cb0db0aff8901b6b97ef3d0ae0029b5c8006R38-R45) [[2]](diffhunk://#diff-61ccb77078afa34f2c1120f85ac0cb0db0aff8901b6b97ef3d0ae0029b5c8006R75-R83) [[3]](diffhunk://#diff-61ccb77078afa34f2c1120f85ac0cb0db0aff8901b6b97ef3d0ae0029b5c8006L78-R429)
  - Rollback behavior for failures during download, install, and cleanup phases, including manipulation of file system permissions to simulate errors.
  - Verification that relevant files and directories are created or removed as expected after rollback.
- Tests now assert on the new metadata fields and check the correct status (success, skipped, failed) for each sub-step, ensuring the workflow behaves as intended in all edge cases. [[1]](diffhunk://#diff-61ccb77078afa34f2c1120f85ac0cb0db0aff8901b6b97ef3d0ae0029b5c8006R38-R45) [[2]](diffhunk://#diff-61ccb77078afa34f2c1120f85ac0cb0db0aff8901b6b97ef3d0ae0029b5c8006R75-R83) [[3]](diffhunk://#diff-61ccb77078afa34f2c1120f85ac0cb0db0aff8901b6b97ef3d0ae0029b5c8006L78-R429)

**Test Utility Improvements:**

- Added helper logic to clean up temporary directories and restore file system permissions after tests, ensuring test isolation and repeatability.

These changes collectively make the setup process for `kubectl` more reliable, observable, and maintainable, and provide strong guarantees through comprehensive automated testing.

**References:** [[1]](diffhunk://#diff-068b9781c21c9aede106773ad1681ca83a9b20240f0ed78447620480828d57b4R31-R144) [[2]](diffhunk://#diff-61ccb77078afa34f2c1120f85ac0cb0db0aff8901b6b97ef3d0ae0029b5c8006R8-R16) [[3]](diffhunk://#diff-61ccb77078afa34f2c1120f85ac0cb0db0aff8901b6b97ef3d0ae0029b5c8006R38-R45) [[4]](diffhunk://#diff-61ccb77078afa34f2c1120f85ac0cb0db0aff8901b6b97ef3d0ae0029b5c8006R75-R83) [[5]](diffhunk://#diff-61ccb77078afa34f2c1120f85ac0cb0db0aff8901b6b97ef3d0ae0029b5c8006L78-R429)

### Related Issues

* Closes #164 
