### PR TITLE
feat: rollback verification for k9s deployment

### DIFF
--- a/internal/workflows/steps/step_k9s.go
+++ b/internal/workflows/steps/step_k9s.go
@@ -4,19 +4,41 @@ import (
 	"context"
 
 	"github.com/automa-saga/automa"
+	"golang.hedera.com/solo-provisioner/internal/workflows/notify"
 	"golang.hedera.com/solo-provisioner/pkg/software"
 )
 
 func SetupK9s() automa.Builder {
 
-	return automa.NewWorkflowBuilder().WithId("setup-k9s").Steps(
-		installK9s(software.NewK9sInstaller),
-		configureK9s(software.NewK9sInstaller),
-	)
+	return automa.NewWorkflowBuilder().WithId("setup-k9s").
+		Steps(
+			installK9s(software.NewK9sInstaller),
+			configureK9s(software.NewK9sInstaller),
+		).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Setting up K9s")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to setup K9s")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "K9s setup successfully")
+		})
 }
 
 func installK9s(provider func(opts ...software.InstallerOption) (software.Software, error)) automa.Builder {
 	return automa.NewStepBuilder().WithId("install-k9s").
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Installing K9s")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to install K9s")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "K9s installed successfully")
+		}).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			installer, err := provider()
 			if err != nil {
@@ -24,36 +46,73 @@ func installK9s(provider func(opts ...software.InstallerOption) (software.Softwa
 					automa.WithError(err))
 			}
 
+			// Prepare metadata for reporting
+			meta := map[string]string{}
+
+			installed, err := installer.IsInstalled()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			if installed {
+				meta[AlreadyInstalled] = "true"
+				return automa.SkippedReport(stp, automa.WithDetail("K9s is already installed"), automa.WithMetadata(meta))
+			}
+
 			err = installer.Download()
 			if err != nil {
-				return automa.FailureReport(stp,
-					automa.WithError(err))
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
 			}
+			meta[DownloadedByThisStep] = "true"
+
 			err = installer.Extract()
 			if err != nil {
-				return automa.FailureReport(stp,
-					automa.WithError(err))
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
 			}
+			meta[ExtractedByThisStep] = "true"
+
 			err = installer.Install()
 			if err != nil {
-				return automa.FailureReport(stp,
-					automa.WithError(err))
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
 			}
+			meta[InstalledByThisStep] = "true"
+
 			err = installer.Cleanup()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			meta[CleanedUpByThisStep] = "true"
+
+			return automa.SuccessReport(stp, automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			installer, err := provider()
 			if err != nil {
 				return automa.FailureReport(stp,
 					automa.WithError(err))
 			}
 
-			return automa.SuccessReport(stp)
-		}).
-		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			err = installer.Uninstall()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+
 			return automa.SuccessReport(stp)
 		})
 }
 
 func configureK9s(provider func(opts ...software.InstallerOption) (software.Software, error)) automa.Builder {
 	return automa.NewStepBuilder().WithId("configure-k9s").
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Configuring K9s")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to configure K9s")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "K9s configured successfully")
+		}).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			installer, err := provider()
 			if err != nil {
@@ -61,7 +120,35 @@ func configureK9s(provider func(opts ...software.InstallerOption) (software.Soft
 					automa.WithError(err))
 			}
 
+			// Prepare metadata for reporting
+			meta := map[string]string{}
+
+			configured, err := installer.IsConfigured()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			if configured {
+				meta[AlreadyConfigured] = "true"
+				return automa.SkippedReport(stp, automa.WithDetail("K9s is already configured"), automa.WithMetadata(meta))
+			}
+
 			err = installer.Configure()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+
+			meta[ConfiguredByThisStep] = "true"
+
+			return automa.SuccessReport(stp, automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			installer, err := provider()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+
+			err = installer.RestoreConfiguration()
 			if err != nil {
 				return automa.FailureReport(stp,
 					automa.WithError(err))


### PR DESCRIPTION
## Description

This pull request enhances the `setup-k9s` workflow in `step_k9s.go` by adding robust notification hooks, improved metadata reporting, and more comprehensive error handling for each step in the K9s setup process. The changes increase observability and reliability, making it easier to track the progress and outcome of each step and to recover from failures.

Key improvements:

**Notification and Observability Enhancements:**
- Integrated the `notify` package to provide step-level notifications for start, failure, and completion events in the main workflow and individual steps, improving visibility into the workflow execution.

**Metadata and Reporting Improvements:**
- Added detailed metadata to step reports (such as installation and configuration status) to facilitate better tracking and debugging of each operation's outcome.

**Error Handling and Step Skipping:**
- Improved error handling by checking if K9s is already installed or configured, and skipping steps with appropriate reporting when no action is needed.

**Rollback and Cleanup Enhancements:**
- Enhanced rollback logic: `installK9s` now calls `Uninstall` on rollback, and `configureK9s` attempts to restore previous configuration, providing safer recovery from failures.

### Related Issues

* Closes #165 
