### PR TITLE
fix: support wildcard patterns for sysctl properties

### DIFF
--- a/internal/sysctl/sysctl_it_test.go
+++ b/internal/sysctl/sysctl_it_test.go
@@ -106,6 +106,10 @@ func Test_PathFromKey(t *testing.T) {
 		}
 	}
 
+	results, err = PathFromKey("net.ipv4.conf.invalid*.rp_filter")
+	require.NoError(t, err)
+	require.Empty(t, results)
+
 	results, err = PathFromKey("-net.ipv4.ip_forward")
 	require.NoError(t, err)
 	require.Equal(t, []string{"/proc/sys/net/ipv4/ip_forward"}, results)


### PR DESCRIPTION
## Description
Now we support sysctl config patterns with '*' for interface names, e.g. `net.ipv4.conf.lxc*.rp_filter`

This pull request adds new helper functions and improves sysctl configuration handling in the `internal/sysctl` package. The main changes introduce more flexible sysctl key resolution, allow updating sysctl values programmatically, and improve test coverage for these features.

### Sysctl key resolution and update helpers

* Added the `PathFromKey` function to resolve sysctl key patterns (including wildcards like `lxc*`) into corresponding file paths, supporting more flexible sysctl configuration management.
* Added the `Set` function to update sysctl values directly by writing to the resolved sysctl file paths.

### Refactoring and improved configuration application

* Refactored configuration loading logic: replaced the direct call to `sysctl.LoadConfigAndApply` with a new `applyConfigs` helper, which loads and applies sysctl values from a list of configuration files.

### Test coverage improvements

* Added integration and unit tests for the new `PathFromKey` and configuration loading logic in `internal/sysctl/sysctl_it_test.go`, ensuring correct path resolution and application of configuration files.

### Minor codebase improvements

* Updated imports to include `fmt` and `filepath`, and exposed the `DefaultPath` constant for use in helper functions. [[1]](diffhunk://#diff-da065df3228e57db93e949c4d1bf0b2466cda04d71ef9cea011d1703a7eb734cR4-R7) [[2]](diffhunk://#diff-da065df3228e57db93e949c4d1bf0b2466cda04d71ef9cea011d1703a7eb734cR17)

### Related Issues

* Closes #170 
