### PR TITLE
fix: ignore swapoff error if swap device not found or swap file is invalid

### DIFF
--- a/pkg/os/errors.go
+++ b/pkg/os/errors.go
@@ -10,6 +10,7 @@ var (
 	SystemdErrTrait = errorx.RegisterTrait("systemd_error")
 
 	ErrSwapOutOfMemory    = ErrNamespace.NewType("out_of_memory", SwapErrTrait)
+	ErrInvalidSwapFile    = ErrNamespace.NewType("invalid_swap_file", SwapErrTrait)
 	ErrSwapUnknownSyscall = ErrNamespace.NewType("unknown_syscall", SwapErrTrait)
 	ErrNonSyscall         = ErrNamespace.NewType("non_syscall", SwapErrTrait)
 	ErrSwapNotSuperUser   = ErrNamespace.NewType("not_super_user", SwapErrTrait)


### PR DESCRIPTION
## Description

This PR updates the swapoff logic to gracefully ignore errors when the swap device is not found or the swap file is invalid. Previously, such errors could cause unnecessary failures during provisioning or cleanup. With this change, only critical swapoff errors will be reported, improving robustness in environments where swap may be misconfigured or absent

The main change is the addition of a new error type to distinguish invalid swap files, and updates to the swap management logic to safely ignore this specific error during swap-off operations.

Error handling improvements:

* Added a new error type `ErrInvalidSwapFile` in `pkg/os/errors.go` to represent invalid swap file errors.
* Updated `handleSyscallErr` in `pkg/os/swap_unix.go` to wrap `syscall.EINVAL` errors as `ErrInvalidSwapFile`, providing clearer error context when swap file validation fails.

Swap management logic:

* Modified `SwapOffAll` in `pkg/os/swap_unix.go` to safely ignore both `ErrSwapDeviceNotFound` and the new `ErrInvalidSwapFile` errors, preventing unnecessary failures when encountering these conditions.
### Related Issues

* Closes #
