### PR TITLE
fix: load helm settings after setting namespace in env

### DIFF
--- a/pkg/helm/manager_it_test.go
+++ b/pkg/helm/manager_it_test.go
@@ -1,4 +1,4 @@
-//go:build helm_integration || cluster_e2e
+//go:build helm_integration || require_cluster
 
 package helm
 
@@ -9,7 +9,6 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/cli/values"
 )
 
@@ -37,8 +36,7 @@ var testChart = testChartInfo{
 // helper to create Helm manager
 func newTestManager(t *testing.T) Manager {
 	log := zerolog.Nop()
-	settings := cli.New()
-	manager, err := NewManager(WithLogger(log), WithSettings(settings))
+	manager, err := NewManager(WithLogger(log))
 	require.NoError(t, err)
 	return manager
 }


### PR DESCRIPTION
## Description
This pull request refactors the way Helm environment settings are managed within the `helmManager` implementation. The main change is the removal of the internal `settings` field and its associated option, shifting to a more stateless approach that relies on environment variables and fresh instantiation of settings when needed. This simplifies the manager's usage and avoids potential issues with stale or shared state.

Refactor of Helm environment settings management:

* Removed the `settings` field from the `helmManager` struct and eliminated the `WithSettings` option, making the manager stateless with respect to Helm environment settings. [[1]](diffhunk://#diff-a66e5701ccd78e997025e2722919d5353c2fb8aeb57d9a2da215e29ef52f3af7L28) [[2]](diffhunk://#diff-a66e5701ccd78e997025e2722919d5353c2fb8aeb57d9a2da215e29ef52f3af7L39-L44)
* Updated the `NewManager` constructor to no longer require or initialize `settings`, further simplifying manager creation.
* Refactored the `WithNamespace` method to set the namespace via environment variable and always instantiate a new `cli.EnvSettings`, ensuring the correct namespace is picked up.
* Updated the integration test helper `newTestManager` to remove the dependency on the `WithSettings` option, reflecting the simplified manager API.
* Cleaned up unused imports in `manager_it_test.go` that were only needed for the previous `settings` handling.
### Related Issues

* Closes #
