### PR TITLE
feat: implement rollback for kubelet systemd

### DIFF
--- a/internal/kube/kubeadm.go
+++ b/internal/kube/kubeadm.go
@@ -116,6 +116,10 @@ func ConfigureKubeadmInit(kubernetesVersion string) error {
 		return errorx.IllegalState.Wrap(err, "failed to create file manager")
 	}
 
+	err = fm.CreateDirectory(path.Join(core.Paths().SandboxDir, "/etc/provisioner"), true)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to create provisioner directory")
+	}
 	err = fm.WriteFile(path.Join(core.Paths().SandboxDir, "/etc/provisioner/kubeadm-init.yaml"), []byte(rendered))
 	if err != nil {
 		return errorx.IllegalState.Wrap(err, "failed to write kubeadm init configuration file")

--- a/internal/workflows/steps/const.go
+++ b/internal/workflows/steps/const.go
@@ -5,8 +5,14 @@ import "github.com/automa-saga/automa"
 const (
 	LoadedByThisStep = automa.Key("loadedByThisStep")
 
-	AlreadyInstalled     = "alreadyInstalled"
-	AlreadyConfigured    = "alreadyConfigured"
+	AlreadyInstalled      = "alreadyInstalled"
+	AlreadyConfigured     = "alreadyConfigured"
+	ServiceAlreadyEnabled = "serviceAlreadyEnabled"
+	ServiceAlreadyRunning = "serviceAlreadyRunning"
+
+	ServiceEnabledByThisStep = "serviceEnabled"
+	ServiceStartedByThisStep = "serviceStarted"
+
 	DownloadedByThisStep = "downloaded"
 	ExtractedByThisStep  = "extracted"
 	InstalledByThisStep  = "installed"

--- a/internal/workflows/steps/step_helm.go
+++ b/internal/workflows/steps/step_helm.go
@@ -148,7 +148,7 @@ func configureHelm(provider func(opts ...software.InstallerOption) (software.Sof
 					automa.WithError(err))
 			}
 
-			err = installer.RestoreConfiguration()
+			err = installer.RemoveConfiguration()
 			if err != nil {
 				return automa.FailureReport(stp,
 					automa.WithError(err))

--- a/internal/workflows/steps/step_helm_it_test.go
+++ b/internal/workflows/steps/step_helm_it_test.go
@@ -43,7 +43,6 @@ func Test_StepHelm_Fresh_Integration(t *testing.T) {
 	require.Equal(t, "true", report.StepReports[0].Metadata[CleanedUpByThisStep])
 	require.Empty(t, report.StepReports[1].Metadata[AlreadyConfigured])
 	require.Equal(t, "true", report.StepReports[1].Metadata[ConfiguredByThisStep])
-
 }
 
 func Test_StepHelm_AlreadyInstalled_Integration(t *testing.T) {

--- a/internal/workflows/steps/step_k9s.go
+++ b/internal/workflows/steps/step_k9s.go
@@ -148,7 +148,7 @@ func configureK9s(provider func(opts ...software.InstallerOption) (software.Soft
 					automa.WithError(err))
 			}
 
-			err = installer.RestoreConfiguration()
+			err = installer.RemoveConfiguration()
 			if err != nil {
 				return automa.FailureReport(stp,
 					automa.WithError(err))

--- a/internal/workflows/steps/step_kubectl.go
+++ b/internal/workflows/steps/step_kubectl.go
@@ -141,7 +141,7 @@ func configureKubectl(provider func(opts ...software.InstallerOption) (software.
 					automa.WithError(err))
 			}
 
-			err = installer.RestoreConfiguration()
+			err = installer.RemoveConfiguration()
 			if err != nil {
 				return automa.FailureReport(stp,
 					automa.WithError(err))

--- a/internal/workflows/steps/step_kubelet.go
+++ b/internal/workflows/steps/step_kubelet.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/automa-saga/automa"
 	"golang.hedera.com/solo-provisioner/internal/workflows/notify"
@@ -13,7 +14,6 @@ func SetupKubelet() automa.Builder {
 		Steps(
 			installKubelet(software.NewKubeletInstaller),
 			configureKubelet(software.NewKubeletInstaller),
-			SetupSystemdService("kubelet"),
 		).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
 			notify.As().StepStart(ctx, stp, "Setting up kubelet")
@@ -29,6 +29,16 @@ func SetupKubelet() automa.Builder {
 
 func installKubelet(provider func(opts ...software.InstallerOption) (software.Software, error)) automa.Builder {
 	return automa.NewStepBuilder().WithId("install-kubelet").
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Installing kubelet")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to install kubelet")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "kubelet installed successfully")
+		}).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			installer, err := provider()
 			if err != nil {
@@ -36,31 +46,73 @@ func installKubelet(provider func(opts ...software.InstallerOption) (software.So
 					automa.WithError(err))
 			}
 
+			// Prepare metadata for reporting
+			meta := map[string]string{}
+
+			installed, err := installer.IsInstalled()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			if installed {
+				meta[AlreadyInstalled] = "true"
+				return automa.SkippedReport(stp, automa.WithDetail("kubelet is already installed"), automa.WithMetadata(meta))
+			}
+
 			err = installer.Download()
 			if err != nil {
-				return automa.FailureReport(stp,
-					automa.WithError(err))
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
 			}
+			meta[DownloadedByThisStep] = "true"
+
 			err = installer.Install()
 			if err != nil {
-				return automa.FailureReport(stp,
-					automa.WithError(err))
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
 			}
+			meta[InstalledByThisStep] = "true"
+			stp.State().Set(InstalledByThisStep, true)
+
 			err = installer.Cleanup()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			meta[CleanedUpByThisStep] = "true"
+
+			return automa.SuccessReport(stp, automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			installedByThisStep := stp.State().Bool(InstalledByThisStep)
+			if !installedByThisStep {
+				return automa.SkippedReport(stp, automa.WithDetail("kubelet was not installed by this step, skipping rollback"))
+			}
+
+			installer, err := provider()
 			if err != nil {
 				return automa.FailureReport(stp,
 					automa.WithError(err))
 			}
 
-			return automa.SuccessReport(stp)
-		}).
-		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			err = installer.Uninstall()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+
 			return automa.SuccessReport(stp)
 		})
 }
 
 func configureKubelet(provider func(opts ...software.InstallerOption) (software.Software, error)) automa.Builder {
 	return automa.NewStepBuilder().WithId("configure-kubelet").
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Configuring kubelet")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to configure kubelet")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "kubelet configured successfully")
+		}).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			installer, err := provider()
 			if err != nil {
@@ -68,7 +120,42 @@ func configureKubelet(provider func(opts ...software.InstallerOption) (software.
 					automa.WithError(err))
 			}
 
+			// Prepare metadata for reporting
+			meta := map[string]string{}
+
+			configured, err := installer.IsConfigured()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			if configured {
+				meta[AlreadyConfigured] = "true"
+				return automa.SkippedReport(stp, automa.WithDetail("kubelet is already configured"), automa.WithMetadata(meta))
+			}
+
 			err = installer.Configure()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			meta[ConfiguredByThisStep] = "true"
+			stp.State().Set(ConfiguredByThisStep, true)
+
+			return automa.SuccessReport(stp, automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			a := stp.State().Items()
+			fmt.Println(a)
+			configuredByThisStep := stp.State().Bool(ConfiguredByThisStep)
+			if !configuredByThisStep {
+				return automa.SkippedReport(stp, automa.WithDetail("kubelet was not configured by this step, skipping rollback"))
+			}
+
+			installer, err := provider()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+
+			err = installer.RemoveConfiguration()
 			if err != nil {
 				return automa.FailureReport(stp,
 					automa.WithError(err))

--- a/internal/workflows/steps/step_kubelet_it_test.go
+++ b/internal/workflows/steps/step_kubelet_it_test.go
@@ -5,11 +5,15 @@ package steps
 import (
 	"context"
 	"os"
+	"os/exec"
+	"path"
 	"testing"
 
 	"github.com/automa-saga/automa"
+	"github.com/joomcode/errorx"
 	"github.com/stretchr/testify/require"
 	"golang.hedera.com/solo-provisioner/internal/core"
+	"golang.hedera.com/solo-provisioner/pkg/software"
 )
 
 func Test_StepKubelet_Fresh_Integration(t *testing.T) {
@@ -31,6 +35,13 @@ func Test_StepKubelet_Fresh_Integration(t *testing.T) {
 	require.NotNil(t, report)
 	require.NoError(t, report.Error)
 	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	require.Empty(t, report.StepReports[0].Metadata[AlreadyInstalled])
+	require.Equal(t, "true", report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[CleanedUpByThisStep])
+	require.Empty(t, report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Equal(t, "true", report.StepReports[1].Metadata[ConfiguredByThisStep])
 }
 
 func Test_StepKubelet_AlreadyInstalled_Integration(t *testing.T) {
@@ -60,6 +71,15 @@ func Test_StepKubelet_AlreadyInstalled_Integration(t *testing.T) {
 	require.NoError(t, report.Error)
 	require.Equal(t, automa.StatusSuccess, report.Status)
 
+	require.Equal(t, automa.StatusSkipped, report.StepReports[0].Status)
+	require.Equal(t, "true", report.StepReports[0].Metadata[AlreadyInstalled])
+	require.Empty(t, report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Empty(t, report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Empty(t, report.StepReports[0].Metadata[CleanedUpByThisStep])
+
+	require.Equal(t, automa.StatusSkipped, report.StepReports[1].Status)
+	require.Equal(t, "true", report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Empty(t, report.StepReports[1].Metadata[ConfiguredByThisStep])
 }
 
 func Test_StepKubelet_PartiallyInstalled_Integration(t *testing.T) {
@@ -75,20 +95,544 @@ func Test_StepKubelet_PartiallyInstalled_Integration(t *testing.T) {
 	require.NoError(t, report.Error)
 	require.Equal(t, automa.StatusSuccess, report.Status)
 
-	err = os.RemoveAll(core.Paths().TempDir)
+	err = os.RemoveAll("/usr/local/bin/kubelet")
 	require.NoError(t, err)
 
 	//
 	// When
 	//
 	step, err = SetupKubelet().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
 
 	//
 	// Then
 	//
-	require.NoError(t, err)
-	report = step.Execute(context.Background())
 	require.NotNil(t, report)
 	require.NoError(t, report.Error)
 	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	require.Equal(t, automa.StatusSkipped, report.StepReports[0].Status)
+	require.Equal(t, "true", report.StepReports[0].Metadata[AlreadyInstalled])
+	require.Empty(t, report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Empty(t, report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Empty(t, report.StepReports[0].Metadata[CleanedUpByThisStep])
+
+	require.Equal(t, automa.StatusSuccess, report.StepReports[1].Status)
+	require.Empty(t, report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Equal(t, "true", report.StepReports[1].Metadata[ConfiguredByThisStep])
+}
+
+func Test_StepKubelet_Rollback_Fresh_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	//
+	// When
+	//
+	step, err := SetupKubelet().Build()
+
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	require.Equal(t, "true", report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[CleanedUpByThisStep])
+
+	//
+	// When - Rollback
+	//
+	rollbackReport := step.Rollback(context.Background())
+
+	//
+	// Then
+	//
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, rollbackReport.Status)
+
+	// Verify download folder for kubelet is removed
+	_, err = os.Stat("/opt/provisioner/tmp/kubelet")
+	require.Error(t, err)
+
+	// Verify binary files are removed
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/kubelet")
+	require.Error(t, err)
+}
+
+func Test_StepKubelet_Rollback_Setup_DownloadFailed(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	// Make the download directory read-only
+	err := os.MkdirAll(core.Paths().TempDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create download directory")
+	cmd := exec.Command("chattr", "+i", core.Paths().TempDir)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make download directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", core.Paths().TempDir).Run()
+	})
+
+	//
+	// When
+	//
+	step, err := SetupKubelet().Build()
+	require.NoError(t, err)
+
+	//
+	// When - Rollback
+	//
+
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check errorx error type
+	require.Error(t, report.Error)
+
+	// Confirm errorx error type is DownloadError
+	require.True(t, errorx.IsOfType(errorx.Cast(report.Error).Cause(), software.DownloadError))
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	//
+	// Then
+	//
+	rollbackReport := report.StepReports[0].Rollback
+
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSkipped, rollbackReport.Status)
+
+	// Verify download folder for kubelet was not created
+	_, err = os.Stat("/opt/provisioner/tmp/kubelet")
+	require.Error(t, err)
+
+	// Confirm binary files were not created
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/kubelet")
+	require.Error(t, err)
+}
+
+func Test_StepKubelet_Rollback_Setup_InstallFailed(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	// Make the sandbox directory read-only
+	sandboxDir := path.Join(core.Paths().SandboxDir, "bin")
+
+	err := os.MkdirAll(sandboxDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create sandbox bin directory")
+	cmd := exec.Command("chattr", "+i", sandboxDir)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make sandbox binary directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", sandboxDir).Run()
+	})
+
+	//
+	// When
+	//
+	step, err := SetupKubelet().Build()
+	require.NoError(t, err)
+
+	//
+	// When - Rollback
+	//
+
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check errorx error type
+	require.Error(t, report.Error)
+
+	// Confirm errorx error type is InstallationError
+	require.True(t, errorx.IsOfType(errorx.Cast(report.Error).Cause(), software.InstallationError))
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	//
+	// Then
+	//
+	rollbackReport := report.StepReports[0].Rollback
+
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSkipped, rollbackReport.Status)
+
+	// Verify download folder is still around when there is an installation error
+	_, err = os.Stat("/opt/provisioner/tmp/kubelet")
+	require.NoError(t, err)
+
+	// Check there are downloaded files in the kubelet directory
+	files, err := os.ReadDir(path.Join(core.Paths().TempDir, "kubelet"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(files), 1, "Expected at least 1 file in the kubelet directory")
+
+	// Verify binary files were not installed
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/kubelet")
+	require.Error(t, err)
+}
+
+func Test_StepKubelet_Rollback_Setup_CleanupFailed(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	// Create an unremovable directory under download folder
+	unremovableDir := path.Join(core.Paths().TempDir, "kubelet", "unremovable")
+
+	err := os.MkdirAll(unremovableDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create unremovable directory")
+	cmd := exec.Command("chattr", "+i", unremovableDir)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make unremovable directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", unremovableDir).Run()
+	})
+
+	//
+	// When
+	//
+	step, err := SetupKubelet().Build()
+	require.NoError(t, err)
+
+	//
+	// When - Rollback
+	//
+
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check errorx error type
+	require.Error(t, report.Error)
+
+	// Confirm errorx error type is CleanupError
+	require.True(t, errorx.IsOfType(errorx.Cast(report.Error).Cause(), software.CleanupError))
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	//
+	// Then
+	//
+	rollbackReport := report.StepReports[0].Rollback
+
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, rollbackReport.Status)
+
+	// Verify download folder is still around when there is a cleanup error
+	_, err = os.Stat("/opt/provisioner/tmp/kubelet")
+	require.NoError(t, err)
+
+	// Check there are files in the tmp/kubelet directory
+	files, err := os.ReadDir(path.Join(core.Paths().TempDir, "kubelet"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(files), 1, "Expected at least 1 file in the tmp/kubelet directory")
+
+	// Verify binary files were removed
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/kubelet")
+	require.Error(t, err)
+}
+
+func Test_StepKubelet_Rollback_ConfigurationFailed(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	// Make the /usr/local/bin directory read-only to prevent configuration
+	usrLocalBinDir := "/usr/local/bin"
+	err := os.MkdirAll(usrLocalBinDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create /usr/local/bin directory")
+	cmd := exec.Command("chattr", "+i", usrLocalBinDir)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make /usr/local/bin directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", usrLocalBinDir).Run()
+	})
+
+	//
+	// When
+	//
+	step, err := SetupKubelet().Build()
+	require.NoError(t, err)
+
+	//
+	// When - Execute (should fail at configuration step)
+	//
+
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check that it failed
+	require.Error(t, report.Error)
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	// First step (install) should succeed
+	require.Equal(t, automa.StatusSuccess, report.StepReports[0].Status)
+	require.Equal(t, "true", report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[CleanedUpByThisStep])
+
+	// Second step (configure) should fail
+	require.Equal(t, automa.StatusFailed, report.StepReports[1].Status)
+
+	//
+	// Then - Verify rollback
+	//
+	installRollbackReport := report.StepReports[0].Rollback
+	configRollbackReport := report.StepReports[1].Rollback
+
+	require.NoError(t, installRollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, installRollbackReport.Status)
+
+	require.NoError(t, configRollbackReport.Error)
+	require.Equal(t, automa.StatusSkipped, configRollbackReport.Status)
+
+	// Verify installation was rolled back - download folder should be removed
+	_, err = os.Stat("/opt/provisioner/tmp/kubelet")
+	require.Error(t, err)
+
+	// Verify binary files were removed from sandbox
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/kubelet")
+	require.Error(t, err)
+
+	// Verify configuration was not applied - symlinks should not exist
+	_, err = os.Stat("/usr/local/bin/kubelet")
+	require.Error(t, err)
+}
+
+func Test_StepKubelet_ServiceConfiguration_Fresh_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	//
+	// When
+	//
+	step, err := SetupKubelet().Build()
+	require.NoError(t, err)
+
+	report := step.Execute(context.Background())
+
+	//
+	// Then
+	//
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	// Verify kubelet.service was installed in sandbox
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/lib/systemd/system/kubelet.service")
+	require.NoError(t, err, "kubelet.service should exist in sandbox")
+
+	// Verify .latest file was created with modified content
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/lib/systemd/system/kubelet.service.latest")
+	require.NoError(t, err, "kubelet.service.latest should exist")
+
+	// Verify systemd symlink was created
+	linkTarget, err := os.Readlink("/usr/lib/systemd/system/kubelet.service")
+	require.NoError(t, err, "kubelet.service symlink should exist")
+	require.Equal(t, "/opt/provisioner/sandbox/usr/lib/systemd/system/kubelet.service.latest", linkTarget, "symlink should point to .latest file")
+
+	// Verify .latest file contains sandbox binary path
+	content, err := os.ReadFile("/opt/provisioner/sandbox/usr/lib/systemd/system/kubelet.service.latest")
+	require.NoError(t, err, "should be able to read .latest file")
+	contentStr := string(content)
+	require.Contains(t, contentStr, "/opt/provisioner/sandbox/bin/kubelet", ".latest file should contain sandbox kubelet path")
+	require.NotContains(t, contentStr, "/usr/bin/kubelet", ".latest file should not contain original kubelet path")
+}
+
+func Test_StepKubelet_ServiceConfiguration_AlreadyConfigured_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	// First run to configure kubelet
+	step, err := SetupKubelet().Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+
+	//
+	// When - Run again
+	//
+	step, err = SetupKubelet().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+
+	//
+	// Then
+	//
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	// Configuration step should be skipped
+	require.Equal(t, automa.StatusSkipped, report.StepReports[1].Status)
+	require.Equal(t, "true", report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Empty(t, report.StepReports[1].Metadata[ConfiguredByThisStep])
+
+	// Verify service configuration still exists and is valid
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/lib/systemd/system/kubelet.service.latest")
+	require.NoError(t, err, "kubelet.service.latest should still exist")
+
+	linkTarget, err := os.Readlink("/usr/lib/systemd/system/kubelet.service")
+	require.NoError(t, err, "kubelet.service symlink should still exist")
+	require.Equal(t, "/opt/provisioner/sandbox/usr/lib/systemd/system/kubelet.service.latest", linkTarget)
+}
+
+func Test_StepKubelet_ServiceConfiguration_PartiallyConfigured_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	// First run to install and configure kubelet
+	step, err := SetupKubelet().Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+
+	// Remove the systemd symlink but keep the .latest file
+	err = os.RemoveAll("/usr/lib/systemd/system/kubelet.service")
+	require.NoError(t, err)
+
+	//
+	// When - Run again
+	//
+	step, err = SetupKubelet().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+
+	//
+	// Then
+	//
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	// Installation should be skipped (already installed)
+	require.Equal(t, automa.StatusSkipped, report.StepReports[0].Status)
+	require.Equal(t, "true", report.StepReports[0].Metadata[AlreadyInstalled])
+
+	// Configuration should run again (partial configuration)
+	require.Equal(t, automa.StatusSuccess, report.StepReports[1].Status)
+	require.Empty(t, report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Equal(t, "true", report.StepReports[1].Metadata[ConfiguredByThisStep])
+
+	// Verify systemd symlink was recreated
+	linkTarget, err := os.Readlink("/usr/lib/systemd/system/kubelet.service")
+	require.NoError(t, err, "kubelet.service symlink should be recreated")
+	require.Equal(t, "/opt/provisioner/sandbox/usr/lib/systemd/system/kubelet.service.latest", linkTarget)
+}
+
+func Test_StepKubelet_ServiceConfiguration_CorruptedLatestFile_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	// First run to install and configure kubelet
+	step, err := SetupKubelet().Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+
+	// Corrupt the .latest file by writing incorrect content
+	corruptedContent := "This is corrupted content"
+	err = os.WriteFile("/opt/provisioner/sandbox/usr/lib/systemd/system/kubelet.service.latest", []byte(corruptedContent), core.DefaultFilePerm)
+	require.NoError(t, err)
+
+	//
+	// When - Run again
+	//
+	step, err = SetupKubelet().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+
+	//
+	// Then
+	//
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	// Installation should be skipped (already installed)
+	require.Equal(t, automa.StatusSkipped, report.StepReports[0].Status)
+
+	// Configuration should run again (corrupted .latest file detected)
+	require.Equal(t, automa.StatusSuccess, report.StepReports[1].Status)
+	require.Empty(t, report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Equal(t, "true", report.StepReports[1].Metadata[ConfiguredByThisStep])
+
+	// Verify .latest file was fixed
+	content, err := os.ReadFile("/opt/provisioner/sandbox/usr/lib/systemd/system/kubelet.service.latest")
+	require.NoError(t, err)
+	contentStr := string(content)
+	require.Contains(t, contentStr, "/opt/provisioner/sandbox/bin/kubelet", ".latest file should contain correct sandbox path")
+	require.NotEqual(t, corruptedContent, contentStr, ".latest file should be fixed")
+}
+
+func Test_StepKubelet_ServiceConfiguration_RestoreConfiguration_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	cleanUpTempDir(t)
+
+	// Install and configure kubelet
+	step, err := SetupKubelet().Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+
+	// Verify configuration is in place
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/lib/systemd/system/kubelet.service.latest")
+	require.NoError(t, err, "kubelet.service.latest should exist before restoration")
+
+	_, err = os.Stat("/usr/lib/systemd/system/kubelet.service")
+	require.NoError(t, err, "kubelet.service symlink should exist before restoration")
+
+	//
+	// When - Rollback
+	//
+	rollbackReport := step.Rollback(context.Background())
+
+	//
+	// Then
+	//
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, rollbackReport.Status)
+
+	// Verify configuration was restored (removed)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/lib/systemd/system/kubelet.service.latest")
+	require.Error(t, err, "kubelet.service.latest should be removed after rollback")
+
+	_, err = os.Stat("/usr/lib/systemd/system/kubelet.service")
+	require.Error(t, err, "kubelet.service symlink should be removed after rollback")
+
+	// Verify installation was also rolled back
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/kubelet")
+	require.Error(t, err, "kubelet binary should be removed after rollback")
+
+	_, err = os.Stat("/opt/provisioner/tmp/kubelet")
+	require.Error(t, err, "kubelet temp directory should be removed after rollback")
 }

--- a/internal/workflows/steps/step_systemd_service.go
+++ b/internal/workflows/steps/step_systemd_service.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/automa-saga/automa"
 	"golang.hedera.com/solo-provisioner/internal/workflows/notify"
@@ -33,16 +34,71 @@ func SetupSystemdService(serviceName string) automa.Builder {
 					automa.WithError(err))
 			}
 
-			err = os.EnableService(ctx, serviceName)
+			// Prepare metadata for reporting
+			meta := map[string]string{}
+
+			serviceEnabled, err := os.IsServiceEnabled(ctx, serviceName)
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			stp.State().Set(ServiceAlreadyEnabled, serviceEnabled)
+			meta[ServiceAlreadyEnabled] = strconv.FormatBool(serviceEnabled)
+
+			if !serviceEnabled {
+				err = os.EnableService(ctx, serviceName)
+				if err != nil {
+					return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+				}
+				stp.State().Set(ServiceEnabledByThisStep, true)
+				meta[ServiceEnabledByThisStep] = "true"
+			}
+
+			serviceRunning, err := os.IsServiceRunning(ctx, serviceName)
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			stp.State().Set(ServiceAlreadyRunning, serviceRunning)
+			meta[ServiceAlreadyRunning] = strconv.FormatBool(serviceRunning)
+
+			if !serviceRunning {
+				err = os.RestartService(ctx, serviceName)
+				if err != nil {
+					return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+				}
+				stp.State().Set(ServiceStartedByThisStep, true)
+				meta[ServiceStartedByThisStep] = "true"
+			}
+
+			return automa.SuccessReport(stp, automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			serviceAlreadyEnabled := stp.State().Bool(ServiceAlreadyEnabled)
+			serviceAlreadyRunning := stp.State().Bool(ServiceAlreadyRunning)
+
+			if serviceAlreadyEnabled && serviceAlreadyRunning {
+				return automa.SkippedReport(stp, automa.WithDetail("service was not modified by this step, skipping rollback"))
+			}
+
+			err := os.DaemonReload(ctx)
 			if err != nil {
 				return automa.FailureReport(stp,
 					automa.WithError(err))
 			}
 
-			err = os.StartService(ctx, serviceName)
-			if err != nil {
-				return automa.FailureReport(stp,
-					automa.WithError(err))
+			serviceStartedByThisStep := stp.State().Bool(ServiceStartedByThisStep)
+			if serviceStartedByThisStep {
+				err = os.StopService(ctx, serviceName)
+				if err != nil {
+					return automa.FailureReport(stp, automa.WithError(err))
+				}
+			}
+
+			serviceEnabledByThisStep := stp.State().Bool(ServiceEnabledByThisStep)
+			if serviceEnabledByThisStep {
+				err = os.DisableService(ctx, serviceName)
+				if err != nil {
+					return automa.FailureReport(stp, automa.WithError(err))
+				}
 			}
 
 			return automa.SuccessReport(stp)

--- a/internal/workflows/steps/step_systemd_service_it_test.go
+++ b/internal/workflows/steps/step_systemd_service_it_test.go
@@ -1,0 +1,390 @@
+//go:build integration
+
+package steps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/automa-saga/automa"
+	"github.com/stretchr/testify/require"
+	"golang.hedera.com/solo-provisioner/internal/core"
+	osx "golang.hedera.com/solo-provisioner/pkg/os"
+)
+
+// Helper function to reset unit states before and after tests
+func resetSystemdState(t *testing.T, unitName string) {
+	t.Helper()
+
+	err := cleanupSystemdState(t, unitName)
+	require.NoError(t, err)
+
+	// Register cleanup to run after test completes
+	t.Cleanup(func() {
+		_ = cleanupSystemdState(t, unitName)
+	})
+
+	// Make sure unit is not enabled or running
+	enabled, err := osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.False(t, enabled)
+
+	running, err := osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.False(t, running)
+
+	createTempService(t, unitName)
+
+	// Make sure unit is still not enabled or running
+	enabled, err = osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.False(t, enabled)
+
+	running, err = osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.False(t, running)
+}
+
+// Helper function to reset unit states
+func cleanupSystemdState(t *testing.T, unitName string) error {
+	t.Helper()
+
+	ctx := context.Background()
+
+	_ = osx.StopService(ctx, unitName)
+	_ = osx.DisableService(ctx, unitName)
+
+	// Remove unit file from systemd directory
+	systemdDir := "/etc/systemd/system"
+	systemdUnitFile := filepath.Join(systemdDir, unitName)
+	_ = os.Remove(systemdUnitFile)
+
+	// Reload daemon to apply changes
+	return osx.DaemonReload(ctx)
+}
+
+func createTempService(t *testing.T, unitName string) {
+	// Create a temporary test unit file
+	tempDir := t.TempDir()
+	unitFile := filepath.Join(tempDir, unitName)
+	unitContent := `[Unit]
+Description=Test Service for Integration Testing
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+`
+	err := os.WriteFile(unitFile, []byte(unitContent), core.DefaultFilePerm)
+	require.NoError(t, err)
+
+	// Copy to systemd directory
+	systemdDir := "/etc/systemd/system"
+	systemdUnitFile := filepath.Join(systemdDir, unitName)
+	err = os.WriteFile(systemdUnitFile, []byte(unitContent), core.DefaultFilePerm)
+	require.NoError(t, err)
+}
+
+func toBool(s string) bool {
+	b, _ := strconv.ParseBool(s)
+	return b
+}
+
+func Test_StepSystemdService_Fresh_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	unitName := "test-systemd-fresh.service"
+	resetSystemdState(t, unitName)
+
+	//
+	// When
+	//
+	step, err := SetupSystemdService(unitName).Build()
+
+	//
+	// Then
+	//
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	require.False(t, toBool(report.Metadata[ServiceAlreadyEnabled]))
+	require.False(t, toBool(report.Metadata[ServiceAlreadyRunning]))
+	require.True(t, toBool(report.Metadata[ServiceEnabledByThisStep]))
+	require.True(t, toBool(report.Metadata[ServiceStartedByThisStep]))
+
+	enabled, err := osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	running, err := osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, running)
+}
+
+// Test when service is already enabled and running
+func Test_StepSystemdService_AlreadyEnabledRunning_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	unitName := "test-systemd-already-enabled-running.service"
+	resetSystemdState(t, unitName)
+
+	step, err := SetupSystemdService(unitName).Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	enabled, err := osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	running, err := osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, running)
+
+	//
+	// When
+	//
+	step, err = SetupSystemdService(unitName).Build()
+
+	//
+	// Then
+	//
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	require.True(t, toBool(report.Metadata[ServiceAlreadyEnabled]))
+	require.True(t, toBool(report.Metadata[ServiceAlreadyRunning]))
+	require.False(t, toBool(report.Metadata[ServiceEnabledByThisStep]))
+	require.False(t, toBool(report.Metadata[ServiceStartedByThisStep]))
+
+	enabled, err = osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	running, err = osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, running)
+}
+
+// Test when service is already enabled but not running
+func Test_StepSystemdService_AlreadyEnabledNotRunning_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	unitName := "test-systemd-already-enabled-not-running.service"
+	resetSystemdState(t, unitName)
+
+	step, err := SetupSystemdService(unitName).Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	enabled, err := osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	running, err := osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, running)
+
+	err = osx.StopService(context.Background(), unitName)
+	require.NoError(t, err)
+
+	running, err = osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.False(t, running)
+
+	//
+	// When
+	//
+	step, err = SetupSystemdService(unitName).Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+
+	//
+	// Then
+	//
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+	require.True(t, toBool(report.Metadata[ServiceAlreadyEnabled]))
+	require.False(t, toBool(report.Metadata[ServiceAlreadyRunning]))
+	require.False(t, toBool(report.Metadata[ServiceEnabledByThisStep]))
+	require.True(t, toBool(report.Metadata[ServiceStartedByThisStep]))
+
+	enabled, err = osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, enabled)
+	running, err = osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, running)
+}
+
+// Test when service is not enabled but running
+func Test_StepSystemdService_NotEnabledRunning_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	unitName := "test-systemd-not-enabled-running.service"
+	resetSystemdState(t, unitName)
+
+	step, err := SetupSystemdService(unitName).Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	enabled, err := osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	running, err := osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, running)
+
+	err = osx.DisableService(context.Background(), unitName)
+	require.NoError(t, err)
+
+	running, err = osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.False(t, running)
+
+	//
+	// When
+	//
+	step, err = SetupSystemdService(unitName).Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+
+	//
+	// Then
+	//
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+	require.False(t, toBool(report.Metadata[ServiceAlreadyEnabled]))
+	require.True(t, toBool(report.Metadata[ServiceAlreadyRunning]))
+	require.True(t, toBool(report.Metadata[ServiceEnabledByThisStep]))
+	require.False(t, toBool(report.Metadata[ServiceStartedByThisStep]))
+
+	enabled, err = osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, enabled)
+	running, err = osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, running)
+}
+
+// Test full rollback
+func Test_StepSystemdService_Rollback_Fresh_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	unitName := "test-systemd-rollback-fresh.service"
+	resetSystemdState(t, unitName)
+
+	step, err := SetupSystemdService(unitName).Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	enabled, err := osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	running, err := osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, running)
+
+	//
+	// When
+	//
+	rollbackReport := step.Rollback(context.Background())
+
+	//
+	// Then
+	//
+	require.NotNil(t, rollbackReport)
+	require.Equal(t, automa.StatusSuccess, rollbackReport.Status)
+
+	enabled, err = osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.False(t, enabled)
+
+	running, err = osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.False(t, running)
+}
+
+// Test rollback when service was already enabled and running
+func Test_StepSystemdService_Rollback_AlreadyEnabledRunning_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	unitName := "test-systemd-rollback-already-enabled-running.service"
+	resetSystemdState(t, unitName)
+
+	step, err := SetupSystemdService(unitName).Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	enabled, err := osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	running, err := osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, running)
+
+	// Call it a second time so that it detects service is already enabled and running
+	step, err = SetupSystemdService(unitName).Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	//
+	// When
+	//
+	rollbackReport := step.Rollback(context.Background())
+
+	//
+	// Then
+	//
+	require.NotNil(t, rollbackReport)
+	require.Equal(t, automa.StatusSkipped, rollbackReport.Status)
+
+	enabled, err = osx.IsServiceEnabled(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	running, err = osx.IsServiceRunning(context.Background(), unitName)
+	require.NoError(t, err)
+	require.True(t, running)
+}

--- a/pkg/software/base_installer_test.go
+++ b/pkg/software/base_installer_test.go
@@ -1313,7 +1313,7 @@ func Test_BaseInstaller_Uninstall_SymlinkPointsToOurBinary(t *testing.T) {
 	})
 }
 
-// Tests for RestoreConfiguration method
+// Tests for RemoveConfiguration method
 func Test_BaseInstaller_RestoreConfiguration_Success(t *testing.T) {
 	resetTestEnvironment(t)
 
@@ -1356,9 +1356,9 @@ func Test_BaseInstaller_RestoreConfiguration_Success(t *testing.T) {
 	err = os.Symlink(sandboxBinary, systemBinary)
 	require.NoError(t, err)
 
-	// Verify symlink exists and points to our binary before RestoreConfiguration
+	// Verify symlink exists and points to our binary before RemoveConfiguration
 	_, err = os.Lstat(systemBinary)
-	require.NoError(t, err, "Symlink should exist before RestoreConfiguration")
+	require.NoError(t, err, "Symlink should exist before RemoveConfiguration")
 	linkTarget, err := os.Readlink(systemBinary)
 	require.NoError(t, err)
 	require.Equal(t, sandboxBinary, linkTarget)
@@ -1367,8 +1367,8 @@ func Test_BaseInstaller_RestoreConfiguration_Success(t *testing.T) {
 	// When
 	//
 
-	// Execute RestoreConfiguration
-	err = installer.RestoreConfiguration()
+	// Execute RemoveConfiguration
+	err = installer.RemoveConfiguration()
 	require.NoError(t, err)
 
 	//
@@ -1377,11 +1377,11 @@ func Test_BaseInstaller_RestoreConfiguration_Success(t *testing.T) {
 
 	// Verify symlink is removed
 	_, err = os.Lstat(systemBinary)
-	require.True(t, os.IsNotExist(err), "Symlink should be removed after RestoreConfiguration")
+	require.True(t, os.IsNotExist(err), "Symlink should be removed after RemoveConfiguration")
 
-	// Verify sandbox binary still exists (RestoreConfiguration doesn't remove it)
+	// Verify sandbox binary still exists (RemoveConfiguration doesn't remove it)
 	_, err = os.Stat(sandboxBinary)
-	require.NoError(t, err, "Sandbox binary should still exist after RestoreConfiguration")
+	require.NoError(t, err, "Sandbox binary should still exist after RemoveConfiguration")
 }
 
 func Test_BaseInstaller_RestoreConfiguration_SymlinkPointsToOtherBinary(t *testing.T) {
@@ -1440,8 +1440,8 @@ func Test_BaseInstaller_RestoreConfiguration_SymlinkPointsToOtherBinary(t *testi
 	// When
 	//
 
-	// Execute RestoreConfiguration
-	err = installer.RestoreConfiguration()
+	// Execute RemoveConfiguration
+	err = installer.RemoveConfiguration()
 
 	//
 	// Then
@@ -1528,8 +1528,8 @@ func Test_BaseInstaller_RestoreConfiguration_MultipleBinaries(t *testing.T) {
 	// When
 	//
 
-	// Execute RestoreConfiguration
-	err = installer.RestoreConfiguration()
+	// Execute RemoveConfiguration
+	err = installer.RemoveConfiguration()
 
 	//
 	// Then
@@ -1610,8 +1610,8 @@ func Test_BaseInstaller_RestoreConfiguration_SymlinkError(t *testing.T) {
 	// When
 	//
 
-	// Execute RestoreConfiguration - should fail due to read-only system bin directory
-	err = installer.RestoreConfiguration()
+	// Execute RemoveConfiguration - should fail due to read-only system bin directory
+	err = installer.RemoveConfiguration()
 
 	//
 	// Then
@@ -1652,8 +1652,8 @@ func Test_BaseInstaller_RestoreConfiguration_VersionNotFound(t *testing.T) {
 	// When
 	//
 
-	// Execute RestoreConfiguration with non-existent version
-	err = installer.RestoreConfiguration()
+	// Execute RemoveConfiguration with non-existent version
+	err = installer.RemoveConfiguration()
 
 	//
 	// Then
@@ -1705,8 +1705,8 @@ func Test_BaseInstaller_RestoreConfiguration_NoSymlinks(t *testing.T) {
 	// When
 	//
 
-	// Execute RestoreConfiguration - should succeed even with no symlinks
-	err = installer.RestoreConfiguration()
+	// Execute RemoveConfiguration - should succeed even with no symlinks
+	err = installer.RemoveConfiguration()
 
 	//
 	// Then

--- a/pkg/software/interface.go
+++ b/pkg/software/interface.go
@@ -37,8 +37,8 @@ type Software interface {
 	// It also fills the configuration files
 	Configure() error
 
-	// RestoreConfiguration restores removes symlinks and restores the configuration files
-	RestoreConfiguration() error
+	// RemoveConfiguration removes symlinks and restores the configuration files
+	RemoveConfiguration() error
 
 	// IsConfigured checks if the configuration has been done
 	IsConfigured() (bool, error)

--- a/pkg/software/kubelet_installer.go
+++ b/pkg/software/kubelet_installer.go
@@ -2,12 +2,15 @@ package software
 
 import (
 	"path"
+	"strings"
 
 	"github.com/joomcode/errorx"
 	"golang.hedera.com/solo-provisioner/internal/core"
 )
 
 const KubeletServiceName = "kubelet"
+const kubeletServiceFileName = "kubelet.service"
+const latestFileSuffix = ".latest"
 
 type kubeletInstaller struct {
 	*baseInstaller
@@ -26,14 +29,20 @@ func NewKubeletInstaller(opts ...InstallerOption) (Software, error) {
 
 // Install installs the kubelet binary and configuration files in the sandbox folder
 func (ki *kubeletInstaller) Install() error {
-	// Install the kubeadm binary using the common logic
+	// Validate critical paths before proceeding
+	if err := ki.validateCriticalPaths(); err != nil {
+		return errorx.IllegalState.Wrap(err, "kubelet installation failed due to invalid paths")
+	}
+
+	// Install the kubelet binary using the common logic
 	err := ki.baseInstaller.Install()
 	if err != nil {
 		return err
 	}
 
 	// Install the kubelet configuration files
-	err = ki.installConfig(path.Join(core.Paths().SandboxDir, core.SystemdUnitFilesDir))
+	configDir := path.Join(core.Paths().SandboxDir, core.SystemdUnitFilesDir)
+	err = ki.installConfig(configDir)
 	if err != nil {
 		return err
 	}
@@ -41,30 +50,234 @@ func (ki *kubeletInstaller) Install() error {
 	return nil
 }
 
+// Uninstall removes the kubelet binary and configuration files from the sandbox folder
+func (ki *kubeletInstaller) Uninstall() error {
+	err := ki.baseInstaller.Uninstall()
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to uninstall kubelet binary")
+	}
+
+	// Remove the kubelet configuration file
+	configDir := path.Join(core.Paths().SandboxDir, core.SystemdUnitFilesDir)
+	err = ki.baseInstaller.uninstallConfig(configDir)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to uninstall kubelet configuration files from %s", configDir)
+	}
+
+	return nil
+}
+
 // Configure configures the kubelet binary,
-// updates kubelet.service and create symlink in systemd unit directory
+// creates a copy of kubelet.service with updated paths in the sandbox folder,
+// and creates symlink in systemd unit directory
 func (ki *kubeletInstaller) Configure() error {
 	// Create the symlink for the kubelet binary
 	err := ki.baseInstaller.Configure()
 	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to configure kubelet binary")
+	}
+
+	// Create the latest service file with updated paths
+	err = ki.createLatestServiceFile()
+	if err != nil {
 		return err
 	}
 
-	fileManager := ki.fileManager
-
-	// Replace strings in configuration file and create symlink
-	sandboxKubeletServiceDir := path.Join(core.Paths().SandboxDir, core.SystemdUnitFilesDir)
-	kubeadmConfDest := path.Join(sandboxKubeletServiceDir, "kubelet.service")
-
-	err = ki.replaceAllInFile(kubeadmConfDest, "/usr/bin/kubelet", path.Join(core.Paths().SandboxBinDir, "kubelet"))
+	// Create symlink in systemd directory
+	err = ki.createSystemdSymlink()
 	if err != nil {
-		return errorx.IllegalState.Wrap(err, "failed to replace kubelet path in kubelet.service")
-	}
-
-	err = fileManager.CreateSymbolicLink(kubeadmConfDest, path.Join(core.SystemdUnitFilesDir, "kubelet.service"), true)
-	if err != nil {
-		return errorx.IllegalState.Wrap(err, "failed to create symlink for kubelet service directory")
+		return err
 	}
 
 	return nil
+}
+
+// RestoreConfiguration restores the kubelet binary and configuration files to their original state
+func (ki *kubeletInstaller) RemoveConfiguration() error {
+	err := ki.baseInstaller.RemoveConfiguration()
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to restore kubelet binary configuration")
+	}
+
+	// Remove the latest file
+	latestServicePath := ki.getLatestKubeletServicePath()
+	err = ki.fileManager.RemoveAll(latestServicePath)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to remove latest kubelet.service file at %s", latestServicePath)
+	}
+
+	// Remove the symlink for kubelet.service config file
+	systemdUnitPath := ki.getSystemdUnitPath()
+	err = ki.fileManager.RemoveAll(systemdUnitPath)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to remove symlink for kubelet service file at %s", systemdUnitPath)
+	}
+
+	return nil
+}
+
+// Overrides IsInstalled() to check if both binaries and config files are installed
+func (ki *kubeletInstaller) IsInstalled() (bool, error) {
+	binariesInstalled, err := ki.baseInstaller.IsInstalled()
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to check if kubelet binaries are installed")
+	}
+
+	configDir := path.Join(core.Paths().SandboxDir, core.SystemdUnitFilesDir)
+	configsInstalled, err := ki.isConfigInstalled(configDir)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to check if kubelet configuration files are installed in %s", configDir)
+	}
+
+	return binariesInstalled && configsInstalled, nil
+}
+
+// Overrides IsConfigured() to check if the kubelet is properly configured.
+// This includes checking if the binaries are configured, the .latest service file is valid,
+// and the systemd symlink for kubelet.service is present.
+func (ki *kubeletInstaller) IsConfigured() (bool, error) {
+	// First check if binaries are configured
+	binariesConfigured, err := ki.baseInstaller.IsConfigured()
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to check if kubelet binaries are configured")
+	}
+	if !binariesConfigured {
+		return false, nil
+	}
+
+	// Check if the .latest service file is valid
+	latestFileValid, err := ki.isLatestServiceFileValid()
+	if err != nil {
+		return false, err
+	}
+	if !latestFileValid {
+		return false, nil
+	}
+
+	// Check if the systemd symlink is present
+	symlinkPresent, err := ki.isSystemdSymlinkPresent()
+	if err != nil {
+		return false, err
+	}
+
+	return symlinkPresent, nil
+}
+
+// getKubeletServicePath returns the path to the kubelet.service file in the sandbox
+func (ki *kubeletInstaller) getKubeletServicePath() string {
+	return path.Join(core.Paths().SandboxDir, core.SystemdUnitFilesDir, kubeletServiceFileName)
+}
+
+// getLatestKubeletServicePath returns the path to the .latest kubelet.service file in the sandbox
+func (ki *kubeletInstaller) getLatestKubeletServicePath() string {
+	return ki.getKubeletServicePath() + latestFileSuffix
+}
+
+// getSystemdUnitPath returns the path to the kubelet.service file in the systemd directory
+func (ki *kubeletInstaller) getSystemdUnitPath() string {
+	return path.Join(core.SystemdUnitFilesDir, kubeletServiceFileName)
+}
+
+// getSandboxKubeletBinPath returns the path to the kubelet binary in the sandbox
+func (ki *kubeletInstaller) getSandboxKubeletBinPath() string {
+	return path.Join(core.Paths().SandboxBinDir, "kubelet")
+}
+
+// validateCriticalPaths performs basic validation on critical paths used by the installer
+func (ki *kubeletInstaller) validateCriticalPaths() error {
+	paths := []string{
+		core.Paths().SandboxDir,
+		core.Paths().SandboxBinDir,
+		core.SystemdUnitFilesDir,
+	}
+
+	for _, p := range paths {
+		if p == "" {
+			return errorx.IllegalArgument.New("critical path cannot be empty: %s", p)
+		}
+		if !path.IsAbs(p) {
+			return errorx.IllegalArgument.New("critical path must be absolute: %s", p)
+		}
+	}
+	return nil
+}
+
+// createLatestServiceFile creates a copy of kubelet.service with updated paths
+func (ki *kubeletInstaller) createLatestServiceFile() error {
+	kubeletServicePath := ki.getKubeletServicePath()
+	latestServicePath := ki.getLatestKubeletServicePath()
+
+	// Create latest file which will have some strings replaced
+	err := ki.fileManager.CopyFile(kubeletServicePath, latestServicePath, true)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to create latest kubelet.service file at %s", latestServicePath)
+	}
+
+	// Replace the kubelet binary path with sandbox path
+	sandboxKubeletPath := ki.getSandboxKubeletBinPath()
+	err = ki.replaceAllInFile(latestServicePath, "/usr/bin/kubelet", sandboxKubeletPath)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to replace kubelet path in kubelet.service file")
+	}
+
+	return nil
+}
+
+// createSystemdSymlink creates a symlink for the kubelet service in the systemd directory
+func (ki *kubeletInstaller) createSystemdSymlink() error {
+	latestServicePath := ki.getLatestKubeletServicePath()
+	systemdUnitPath := ki.getSystemdUnitPath()
+
+	err := ki.fileManager.CreateSymbolicLink(latestServicePath, systemdUnitPath, true)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to create symlink for kubelet service from %s to %s", latestServicePath, systemdUnitPath)
+	}
+
+	return nil
+}
+
+// isLatestServiceFileValid checks if the .latest service file exists and has the correct content
+func (ki *kubeletInstaller) isLatestServiceFileValid() (bool, error) {
+	latestServicePath := ki.getLatestKubeletServicePath()
+
+	// Check if the .latest file exists
+	fi, exists, err := ki.fileManager.PathExists(latestServicePath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to check if latest service file exists at %s", latestServicePath)
+	}
+	if !exists || !ki.fileManager.IsRegularFileByFileInfo(fi) {
+		return false, nil
+	}
+
+	// Read the original service file to create expected content
+	originalServicePath := ki.getKubeletServicePath()
+	originalContent, err := ki.fileManager.ReadFile(originalServicePath, -1)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to read original kubelet.service file at %s", originalServicePath)
+	}
+
+	// Generate expected content with replaced paths
+	sandboxKubeletPath := ki.getSandboxKubeletBinPath()
+	expectedContent := strings.ReplaceAll(string(originalContent), "/usr/bin/kubelet", sandboxKubeletPath)
+
+	// Read the actual latest file content
+	actualContent, err := ki.fileManager.ReadFile(latestServicePath, -1)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to read latest kubelet.service file at %s", latestServicePath)
+	}
+
+	// Compare contents
+	return string(actualContent) == expectedContent, nil
+}
+
+// isSystemdSymlinkPresent checks if the kubelet.service symlink exists in the systemd directory
+func (ki *kubeletInstaller) isSystemdSymlinkPresent() (bool, error) {
+	systemdUnitPath := ki.getSystemdUnitPath()
+
+	_, exists, err := ki.fileManager.PathExists(systemdUnitPath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to check if systemd symlink exists at %s", systemdUnitPath)
+	}
+
+	return exists, nil
 }


### PR DESCRIPTION
## Description

This pull request introduces improved handling and reporting for systemd service steps, adds comprehensive integration tests for systemd service management, and enhances the kubelet installation/configuration steps with more robust status tracking and notifications. The changes focus on making service state transitions explicit, improving rollback logic, and ensuring that metadata about service actions is consistently reported.

Key changes include:

**Systemd Service Management Enhancements:**

- Added new metadata keys (`ServiceAlreadyEnabled`, `ServiceAlreadyRunning`, `ServiceEnabledByThisStep`, `ServiceStartedByThisStep`) to track and report the state of systemd services before and after step execution. The step now checks if a service is enabled or running and only performs enable/start actions if needed, recording these actions for accurate rollback and reporting. Rollback logic is improved to only undo actions performed by the step, and to skip rollback if nothing was changed. (`internal/workflows/steps/const.go` [[1]](diffhunk://#diff-fd83849c198c65d02fc2921c35802475218e449aaa4d20943860796e99faa4b9R10-R15) `internal/workflows/steps/step_systemd_service.go` [[2]](diffhunk://#diff-23573cb3acee50e24587ce0f99ec25ada0284c7e9ebc96fbfefe935dfc9c22c8R37-R103)

- Introduced new helper functions in the OS package: `IsServiceEnabled` and `IsServiceRunning` for checking the current state of systemd services, and refactored the service start logic to use `RestartService` for idempotent behavior. (`pkg/os/systemd.go` [[1]](diffhunk://#diff-c808142ba652967f7e282db53d7e50120efc1fb4c80657c82f792e5fd98ab4c5L73-R103) [[2]](diffhunk://#diff-c808142ba652967f7e282db53d7e50120efc1fb4c80657c82f792e5fd98ab4c5L91-R117) [[3]](diffhunk://#diff-c808142ba652967f7e282db53d7e50120efc1fb4c80657c82f792e5fd98ab4c5R177-R196)

**Integration Testing Improvements:**

- Added a comprehensive integration test suite for systemd service steps, covering scenarios where the service is fresh, already enabled/running, already enabled but not running, not enabled but running, and rollback behaviors. These tests ensure that service state transitions and metadata reporting behave as expected in all cases. (`internal/workflows/steps/step_systemd_service_it_test.go` [internal/workflows/steps/step_systemd_service_it_test.goR1-R390](diffhunk://#diff-da7ce86961049f2e4ff0c5c20a05f9f0191619c3a9ffe5ca9441b48f9afaf4e6R1-R390))

- Removed redundant helper functions for checking unit state in the systemd OS integration tests, now replaced by the new public helpers. (`pkg/os/systemd_it_test.go` [pkg/os/systemd_it_test.goL17-L58](diffhunk://#diff-aca6d32c59a995e5ca977ca03e789d7e4634b04d10c618d525f7bf9e29afe041L17-L58))

**Kubelet Step Improvements:**

- Enhanced the kubelet installation and configuration steps to include detailed metadata reporting, explicit notifications for step start/failure/completion, and robust error handling. Rollback logic is improved to cleanly uninstall or restore configuration only when necessary. (`internal/workflows/steps/step_kubelet.go` [internal/workflows/steps/step_kubelet.goR32-R145](diffhunk://#diff-c2e0fbabe602ac92bf56e23ec15c98bcc790fa567cd9f76a803c15cc0e19e9caR32-R145))

These changes collectively improve the reliability, observability, and testability of service management workflows.

### Manual Test Results

<img width="1277" height="2042" alt="image" src="https://github.com/user-attachments/assets/bce4a245-a326-4ae8-8199-21f261b3a923" />

### Related Issues

* Closes #168 
