### PR TITLE
feat: implement CRI-O rollback support with comprehensive validation

### DIFF
--- a/internal/tomlx/tomlx.go
+++ b/internal/tomlx/tomlx.go
@@ -1,0 +1,182 @@
+// Package tomlx provides utilities for managing TOML configuration files.
+//
+// This package offers a TomlConfigManager that can:
+// - Read and update existing TOML files while preserving structure
+// - Merge configuration maps recursively
+// - Set nested configuration values using dot notation paths
+// - Validate TOML configurations against expected values
+//
+// It is primarily used by software installers to patch configuration files
+// with sandbox-specific paths while maintaining the original structure.
+package tomlx
+
+import (
+	"os"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// TomlConfigManager provides utilities for managing TOML configuration files
+type TomlConfigManager struct{}
+
+// NewTomlConfigManager creates a new TOML configuration manager
+func NewTomlConfigManager() *TomlConfigManager {
+	return &TomlConfigManager{}
+}
+
+// UpdateTomlFile reads a TOML file, applies configuration updates, and writes it back
+func (tcm *TomlConfigManager) UpdateTomlFile(filePath string, configUpdates map[string]interface{}) error {
+	// Read the existing TOML file
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	// Parse the TOML content into a generic map to preserve all existing configuration
+	var config map[string]interface{}
+	err = toml.Unmarshal(data, &config)
+	if err != nil {
+		return err
+	}
+
+	// Merge the updates into the existing config
+	tcm.MergeConfigMaps(config, configUpdates)
+
+	// Marshal back to TOML and write to file
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	encoder := toml.NewEncoder(file)
+	err = encoder.Encode(config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// MergeConfigMaps recursively merges the source config into the target config
+func (tcm *TomlConfigManager) MergeConfigMaps(target, source map[string]interface{}) {
+	for key, value := range source {
+		switch val := value.(type) {
+		case map[string]interface{}:
+			// If the target doesn't have this key, create it
+			if _, exists := target[key]; !exists {
+				target[key] = make(map[string]interface{})
+			}
+			// If target exists and is a map, merge recursively
+			if targetMap, ok := target[key].(map[string]interface{}); ok {
+				tcm.MergeConfigMaps(targetMap, val)
+			} else {
+				// Replace if target exists but isn't a map
+				target[key] = val
+			}
+		default:
+			// Direct assignment for non-map values
+			target[key] = value
+		}
+	}
+}
+
+// SetNestedValue safely sets nested values in a map, creating intermediate maps as needed
+// The value can be a string, slice, or any other type
+func (tcm *TomlConfigManager) SetNestedValue(config map[string]interface{}, path string, value interface{}) {
+	keys := strings.Split(path, ".")
+	m := config
+
+	// Navigate/create the nested structure
+	for i := 0; i < len(keys)-1; i++ {
+		key := keys[i]
+		if _, exists := m[key]; !exists {
+			m[key] = make(map[string]interface{})
+		}
+		// Type assertion to continue navigating
+		if nextMap, ok := m[key].(map[string]interface{}); ok {
+			m = nextMap
+		} else {
+			// If the existing value isn't a map, replace it
+			newMap := make(map[string]interface{})
+			m[key] = newMap
+			m = newMap
+		}
+	}
+	// Set the final value
+	m[keys[len(keys)-1]] = value
+}
+
+// ValidateConfigValues recursively validates that the actual TOML config matches the expected config
+func (tcm *TomlConfigManager) ValidateConfigValues(actual map[string]any, expected map[string]interface{}) bool {
+	return tcm.validateConfigMap(actual, expected, "")
+}
+
+// validateConfigMap recursively compares actual vs expected configuration maps
+func (tcm *TomlConfigManager) validateConfigMap(actual map[string]any, expected map[string]interface{}, pathPrefix string) bool {
+	for key, expectedValue := range expected {
+		currentPath := tcm.buildCurrentPath(pathPrefix, key)
+
+		actualValue, exists := actual[key]
+		if !exists {
+			return false
+		}
+
+		if !tcm.validateSingleConfigValue(actualValue, expectedValue, currentPath) {
+			return false
+		}
+	}
+	return true
+}
+
+// buildCurrentPath constructs the current configuration path for debugging
+func (tcm *TomlConfigManager) buildCurrentPath(pathPrefix, key string) string {
+	if pathPrefix == "" {
+		return key
+	}
+	return pathPrefix + "." + key
+}
+
+// validateSingleConfigValue validates a single configuration value against expected value
+func (tcm *TomlConfigManager) validateSingleConfigValue(actualValue any, expectedValue interface{}, currentPath string) bool {
+	switch expectedVal := expectedValue.(type) {
+	case map[string]interface{}:
+		return tcm.validateNestedMap(actualValue, expectedVal, currentPath)
+	case []interface{}:
+		return tcm.validateArray(actualValue, expectedVal)
+	default:
+		return actualValue == expectedValue
+	}
+}
+
+// validateNestedMap validates nested configuration maps
+func (tcm *TomlConfigManager) validateNestedMap(actualValue any, expectedVal map[string]interface{}, currentPath string) bool {
+	if actualMap, ok := actualValue.(map[string]interface{}); ok {
+		return tcm.validateConfigMap(actualMap, expectedVal, currentPath)
+	}
+	return false
+}
+
+// validateArray validates configuration arrays
+func (tcm *TomlConfigManager) validateArray(actualValue any, expectedVal []interface{}) bool {
+	actualArray, ok := actualValue.([]interface{})
+	if !ok {
+		return false
+	}
+
+	if len(actualArray) != len(expectedVal) {
+		return false
+	}
+
+	for i, expectedItem := range expectedVal {
+		if i >= len(actualArray) || actualArray[i] != expectedItem {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tomlx/tomlx_test.go
+++ b/internal/tomlx/tomlx_test.go
@@ -1,0 +1,507 @@
+package tomlx
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func Test_NewTomlConfigManager(t *testing.T) {
+	manager := NewTomlConfigManager()
+	if manager == nil {
+		t.Fatal("Expected non-nil TomlConfigManager")
+	}
+}
+
+func Test_UpdateTomlFile(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.toml")
+
+	// Test case 1: Create new TOML file
+	t.Run("CreateNewFile", func(t *testing.T) {
+		manager := NewTomlConfigManager()
+
+		// Initial content
+		initialContent := `[database]
+host = "localhost"
+port = 5432
+
+[logging]
+level = "info"`
+
+		err := os.WriteFile(testFile, []byte(initialContent), 0644)
+		if err != nil {
+			t.Fatalf("Failed to write initial test file: %v", err)
+		}
+
+		// Updates to apply
+		updates := map[string]interface{}{
+			"database": map[string]interface{}{
+				"port": 3306,
+				"user": "admin",
+			},
+			"logging": map[string]interface{}{
+				"level": "debug",
+			},
+			"newSection": map[string]interface{}{
+				"enabled": true,
+			},
+		}
+
+		err = manager.UpdateTomlFile(testFile, updates)
+		if err != nil {
+			t.Fatalf("UpdateTomlFile failed: %v", err)
+		}
+
+		// Verify the file was updated correctly
+		data, err := os.ReadFile(testFile)
+		if err != nil {
+			t.Fatalf("Failed to read updated file: %v", err)
+		}
+
+		// The exact format may vary, but we can check that our values are present
+		content := string(data)
+		if !contains(content, "port = 3306") {
+			t.Error("Expected port to be updated to 3306")
+		}
+		if !contains(content, "user = \"admin\"") {
+			t.Error("Expected user to be added")
+		}
+		if !contains(content, "level = \"debug\"") {
+			t.Error("Expected logging level to be updated to debug")
+		}
+		if !contains(content, "enabled = true") {
+			t.Error("Expected newSection to be added")
+		}
+	})
+
+	// Test case 2: File doesn't exist
+	t.Run("FileNotExists", func(t *testing.T) {
+		manager := NewTomlConfigManager()
+		nonExistentFile := filepath.Join(tmpDir, "nonexistent.toml")
+
+		updates := map[string]interface{}{
+			"test": "value",
+		}
+
+		err := manager.UpdateTomlFile(nonExistentFile, updates)
+		if err == nil {
+			t.Error("Expected error when file doesn't exist")
+		}
+	})
+
+	// Test case 3: Invalid TOML content
+	t.Run("InvalidToml", func(t *testing.T) {
+		manager := NewTomlConfigManager()
+		invalidFile := filepath.Join(tmpDir, "invalid.toml")
+
+		// Write invalid TOML content
+		err := os.WriteFile(invalidFile, []byte("invalid toml [[["), 0644)
+		if err != nil {
+			t.Fatalf("Failed to write invalid test file: %v", err)
+		}
+
+		updates := map[string]interface{}{
+			"test": "value",
+		}
+
+		err = manager.UpdateTomlFile(invalidFile, updates)
+		if err == nil {
+			t.Error("Expected error when parsing invalid TOML")
+		}
+	})
+}
+
+func Test_MergeConfigMaps(t *testing.T) {
+	manager := NewTomlConfigManager()
+
+	// Test case 1: Basic merge
+	t.Run("BasicMerge", func(t *testing.T) {
+		target := map[string]interface{}{
+			"existing": "value",
+			"database": map[string]interface{}{
+				"host": "localhost",
+				"port": 5432,
+			},
+		}
+
+		source := map[string]interface{}{
+			"new": "value",
+			"database": map[string]interface{}{
+				"port": 3306,
+				"user": "admin",
+			},
+		}
+
+		manager.MergeConfigMaps(target, source)
+
+		// Check that existing values are preserved
+		if target["existing"] != "value" {
+			t.Error("Expected existing value to be preserved")
+		}
+
+		// Check that new values are added
+		if target["new"] != "value" {
+			t.Error("Expected new value to be added")
+		}
+
+		// Check that nested maps are merged correctly
+		dbConfig, ok := target["database"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected database to be a map")
+		}
+
+		if dbConfig["host"] != "localhost" {
+			t.Error("Expected existing nested value to be preserved")
+		}
+		if dbConfig["port"] != 3306 {
+			t.Error("Expected nested value to be updated")
+		}
+		if dbConfig["user"] != "admin" {
+			t.Error("Expected new nested value to be added")
+		}
+	})
+
+	// Test case 2: Replace non-map with map
+	t.Run("ReplaceNonMapWithMap", func(t *testing.T) {
+		target := map[string]interface{}{
+			"config": "simple_value",
+		}
+
+		source := map[string]interface{}{
+			"config": map[string]interface{}{
+				"nested": "value",
+			},
+		}
+
+		manager.MergeConfigMaps(target, source)
+
+		configMap, ok := target["config"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected config to be replaced with a map")
+		}
+		if configMap["nested"] != "value" {
+			t.Error("Expected nested value to be set correctly")
+		}
+	})
+
+	// Test case 3: Empty maps
+	t.Run("EmptyMaps", func(t *testing.T) {
+		target := map[string]interface{}{}
+		source := map[string]interface{}{}
+
+		manager.MergeConfigMaps(target, source)
+
+		if len(target) != 0 {
+			t.Error("Expected target to remain empty")
+		}
+	})
+}
+
+func Test_SetNestedValue(t *testing.T) {
+	manager := NewTomlConfigManager()
+
+	// Test case 1: Set value in new nested structure
+	t.Run("SetInNewStructure", func(t *testing.T) {
+		config := make(map[string]interface{})
+		manager.SetNestedValue(config, "database.connection.host", "localhost")
+
+		// Navigate to the value
+		db, ok := config["database"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected database to be created as a map")
+		}
+
+		conn, ok := db["connection"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected connection to be created as a map")
+		}
+
+		if conn["host"] != "localhost" {
+			t.Error("Expected host to be set to localhost")
+		}
+	})
+
+	// Test case 2: Set value in existing structure
+	t.Run("SetInExistingStructure", func(t *testing.T) {
+		config := map[string]interface{}{
+			"database": map[string]interface{}{
+				"connection": map[string]interface{}{
+					"port": 5432,
+				},
+			},
+		}
+
+		manager.SetNestedValue(config, "database.connection.host", "localhost")
+
+		// Navigate to the value
+		db := config["database"].(map[string]interface{})
+		conn := db["connection"].(map[string]interface{})
+
+		if conn["host"] != "localhost" {
+			t.Error("Expected host to be added to existing structure")
+		}
+		if conn["port"] != 5432 {
+			t.Error("Expected existing port value to be preserved")
+		}
+	})
+
+	// Test case 3: Replace non-map with map in path
+	t.Run("ReplaceNonMapInPath", func(t *testing.T) {
+		config := map[string]interface{}{
+			"database": "simple_string",
+		}
+
+		manager.SetNestedValue(config, "database.connection.host", "localhost")
+
+		// Database should now be a map
+		db, ok := config["database"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected database to be replaced with a map")
+		}
+
+		conn, ok := db["connection"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected connection to be created as a map")
+		}
+
+		if conn["host"] != "localhost" {
+			t.Error("Expected host to be set correctly")
+		}
+	})
+
+	// Test case 4: Single level path
+	t.Run("SingleLevelPath", func(t *testing.T) {
+		config := make(map[string]interface{})
+		manager.SetNestedValue(config, "simple", "value")
+
+		if config["simple"] != "value" {
+			t.Error("Expected simple value to be set correctly")
+		}
+	})
+
+	// Test case 5: Set array value
+	t.Run("SetArrayValue", func(t *testing.T) {
+		config := make(map[string]interface{})
+		arrayValue := []string{"item1", "item2"}
+		manager.SetNestedValue(config, "list.items", arrayValue)
+
+		list, ok := config["list"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected list to be created as a map")
+		}
+
+		items, ok := list["items"].([]string)
+		if !ok {
+			t.Fatal("Expected items to be an array")
+		}
+
+		if !reflect.DeepEqual(items, arrayValue) {
+			t.Error("Expected array value to be set correctly")
+		}
+	})
+}
+
+func Test_ValidateConfigValues(t *testing.T) {
+	manager := NewTomlConfigManager()
+
+	// Test case 1: Valid configuration
+	t.Run("ValidConfiguration", func(t *testing.T) {
+		actual := map[string]any{
+			"database": map[string]interface{}{
+				"host": "localhost",
+				"port": 5432,
+			},
+			"logging": map[string]interface{}{
+				"level": "info",
+			},
+		}
+
+		expected := map[string]interface{}{
+			"database": map[string]interface{}{
+				"host": "localhost",
+				"port": 5432,
+			},
+			"logging": map[string]interface{}{
+				"level": "info",
+			},
+		}
+
+		if !manager.ValidateConfigValues(actual, expected) {
+			t.Error("Expected validation to pass for matching configurations")
+		}
+	})
+
+	// Test case 2: Missing key
+	t.Run("MissingKey", func(t *testing.T) {
+		actual := map[string]any{
+			"database": map[string]interface{}{
+				"host": "localhost",
+			},
+		}
+
+		expected := map[string]interface{}{
+			"database": map[string]interface{}{
+				"host": "localhost",
+				"port": 5432,
+			},
+		}
+
+		if manager.ValidateConfigValues(actual, expected) {
+			t.Error("Expected validation to fail for missing key")
+		}
+	})
+
+	// Test case 3: Wrong value
+	t.Run("WrongValue", func(t *testing.T) {
+		actual := map[string]any{
+			"database": map[string]interface{}{
+				"host": "localhost",
+				"port": 3306,
+			},
+		}
+
+		expected := map[string]interface{}{
+			"database": map[string]interface{}{
+				"host": "localhost",
+				"port": 5432,
+			},
+		}
+
+		if manager.ValidateConfigValues(actual, expected) {
+			t.Error("Expected validation to fail for wrong value")
+		}
+	})
+
+	// Test case 4: Array validation
+	t.Run("ArrayValidation", func(t *testing.T) {
+		actual := map[string]any{
+			"servers": []interface{}{"server1", "server2"},
+		}
+
+		expected := map[string]interface{}{
+			"servers": []interface{}{"server1", "server2"},
+		}
+
+		if !manager.ValidateConfigValues(actual, expected) {
+			t.Error("Expected validation to pass for matching arrays")
+		}
+
+		// Test wrong array length
+		expectedWrongLength := map[string]interface{}{
+			"servers": []interface{}{"server1"},
+		}
+
+		if manager.ValidateConfigValues(actual, expectedWrongLength) {
+			t.Error("Expected validation to fail for array length mismatch")
+		}
+
+		// Test wrong array content
+		expectedWrongContent := map[string]interface{}{
+			"servers": []interface{}{"server1", "server3"},
+		}
+
+		if manager.ValidateConfigValues(actual, expectedWrongContent) {
+			t.Error("Expected validation to fail for array content mismatch")
+		}
+	})
+
+	// Test case 5: Type mismatch
+	t.Run("TypeMismatch", func(t *testing.T) {
+		actual := map[string]any{
+			"config": "string_value",
+		}
+
+		expected := map[string]interface{}{
+			"config": map[string]interface{}{
+				"nested": "value",
+			},
+		}
+
+		if manager.ValidateConfigValues(actual, expected) {
+			t.Error("Expected validation to fail for type mismatch")
+		}
+	})
+
+	// Test case 6: Empty configurations
+	t.Run("EmptyConfigurations", func(t *testing.T) {
+		actual := map[string]any{}
+		expected := map[string]interface{}{}
+
+		if !manager.ValidateConfigValues(actual, expected) {
+			t.Error("Expected validation to pass for empty configurations")
+		}
+	})
+}
+
+func Test_BuildCurrentPath(t *testing.T) {
+	manager := NewTomlConfigManager()
+
+	// Test case 1: Empty prefix
+	t.Run("EmptyPrefix", func(t *testing.T) {
+		path := manager.buildCurrentPath("", "key")
+		if path != "key" {
+			t.Errorf("Expected 'key', got '%s'", path)
+		}
+	})
+
+	// Test case 2: With prefix
+	t.Run("WithPrefix", func(t *testing.T) {
+		path := manager.buildCurrentPath("database", "host")
+		if path != "database.host" {
+			t.Errorf("Expected 'database.host', got '%s'", path)
+		}
+	})
+}
+
+func Test_ValidateArray(t *testing.T) {
+	manager := NewTomlConfigManager()
+
+	// Test case 1: Valid array
+	t.Run("ValidArray", func(t *testing.T) {
+		actual := []interface{}{"a", "b", "c"}
+		expected := []interface{}{"a", "b", "c"}
+
+		if !manager.validateArray(actual, expected) {
+			t.Error("Expected validation to pass for matching arrays")
+		}
+	})
+
+	// Test case 2: Wrong type
+	t.Run("WrongType", func(t *testing.T) {
+		actual := "not_an_array"
+		expected := []interface{}{"a", "b", "c"}
+
+		if manager.validateArray(actual, expected) {
+			t.Error("Expected validation to fail for wrong type")
+		}
+	})
+
+	// Test case 3: Different lengths
+	t.Run("DifferentLengths", func(t *testing.T) {
+		actual := []interface{}{"a", "b"}
+		expected := []interface{}{"a", "b", "c"}
+
+		if manager.validateArray(actual, expected) {
+			t.Error("Expected validation to fail for different lengths")
+		}
+	})
+
+	// Test case 4: Different content
+	t.Run("DifferentContent", func(t *testing.T) {
+		actual := []interface{}{"a", "x", "c"}
+		expected := []interface{}{"a", "b", "c"}
+
+		if manager.validateArray(actual, expected) {
+			t.Error("Expected validation to fail for different content")
+		}
+	})
+}
+
+// Helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return strings.Contains(s, substr)
+}

--- a/internal/workflows/steps/helpers_test.go
+++ b/internal/workflows/steps/helpers_test.go
@@ -1,12 +1,14 @@
 package steps
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"golang.hedera.com/solo-provisioner/internal/core"
+	"golang.hedera.com/solo-provisioner/pkg/software"
 )
 
 func sudo(cmd *exec.Cmd) *exec.Cmd {
@@ -50,5 +52,191 @@ func cleanUpTempDir(t *testing.T) {
 		for _, file := range files {
 			_ = os.Remove("/usr/local/bin/" + file.Name())
 		}
+	}
+}
+
+// reset performs a complete cleanup of the Kubernetes environment
+func reset(t *testing.T) {
+	t.Helper()
+
+	// Reset kubeadm with custom CRI socket
+	_ = sudo(exec.Command("kubeadm", "reset",
+		"--cri-socket", "unix:///opt/provisioner/sandbox/var/run/crio/crio.sock",
+		"--force")).Run()
+
+	// Stop CRI-O service
+	_ = sudo(exec.Command("systemctl", "stop", "crio")).Run()
+
+	// Unmount kubernetes directories
+	_ = sudo(exec.Command("umount", "/etc/kubernetes")).Run()
+	_ = sudo(exec.Command("umount", "/var/lib/kubelet")).Run()
+	_ = sudo(exec.Command("umount", "-R", "/var/run/cilium")).Run()
+
+	// Remove provisioner directory
+	_ = sudo(exec.Command("rm", "-rf", "/opt/provisioner")).Run()
+
+	// Remove /usr/lib/systemd/system
+	_ = sudo(exec.Command("rm", "-rf", "/usr/lib/systemd/system/crio.service")).Run()
+	_ = sudo(exec.Command("rm", "-rf", "/usr/lib/systemd/system/kubelet.service.d")).Run()
+	_ = sudo(exec.Command("rm", "-rf", "/usr/lib/systemd/system/kubelet.service")).Run()
+
+	// Remove etc/containers directory
+	_ = sudo(exec.Command("rm", "-rf", "/etc/containers")).Run()
+
+	// Remove crio directory
+	_ = sudo(exec.Command("rm", "-rf", "/etc/crio")).Run()
+
+	// Clean up temp directory (from existing tests)
+	cleanUpTempDir(t)
+}
+
+type SetupLevel int
+
+const (
+	SetupBasicLevel SetupLevel = iota
+	SetupKubeletLevel
+	SetupCrioLevel
+	SetupCKubeadmLevel
+)
+
+// setupPrerequisitesToLevel sets up all the required components before cluster initialization
+func setupPrerequisitesToLevel(t *testing.T, level SetupLevel) {
+	t.Helper()
+
+	// preflight & basic setup
+	step, err := SetupHomeDirectoryStructure(core.Paths()).Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to setup home directory structure")
+
+	step, err = RefreshSystemPackageIndex().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to refresh system package index")
+
+	step, err = InstallSystemPackage("iptables", software.NewIptables).Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to install iptables")
+
+	step, err = InstallSystemPackage("gpg", software.NewGpg).Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to install gpg")
+
+	step, err = InstallSystemPackage("conntrack", software.NewConntrack).Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to install conntrack")
+
+	step, err = InstallSystemPackage("ebtables", software.NewEbtables).Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to install ebtables")
+
+	step, err = InstallSystemPackage("socat", software.NewSocat).Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to install socat")
+
+	step, err = InstallSystemPackage("nftables", software.NewNftables).Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to install nftables")
+
+	step, err = SetupSystemdService("nftables").Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to setup nftables service")
+
+	step, err = InstallKernelModule("overlay").Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to install overlay kernel module")
+
+	step, err = InstallKernelModule("br_netfilter").Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to install br_netfilter kernel module")
+
+	step, err = AutoRemoveOrphanedPackages().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to auto-remove orphaned packages")
+
+	// Disable swap
+	step, err = DisableSwap().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to disable swap")
+
+	// Configure sysctl for Kubernetes
+	step, err = ConfigureSysctlForKubernetes().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to configure sysctl")
+
+	// Setup bind mounts
+	step, err = SetupBindMounts().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to setup bind mounts")
+
+	// Setup kubectl
+	step, err = SetupKubectl().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to setup kubectl")
+
+	if level == SetupBasicLevel {
+		return
+	}
+
+	// Setup kubelet
+	step, err = SetupKubelet().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to setup kubelet")
+
+	// Setup kubelet systemd service
+	step, err = SetupSystemdService(software.KubeletServiceName).Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to setup kubelet service")
+
+	if level == SetupKubeletLevel {
+		return
+	}
+
+	// Setup CRI-O
+	step, err = SetupCrio().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to setup CRI-O")
+
+	// Setup CRI-O systemd service
+	step, err = SetupSystemdService(software.CrioServiceName).Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to setup CRI-O service")
+
+	if level == SetupCrioLevel {
+		return
+	}
+
+	// Setup Kubeadm
+	step, err = SetupKubeadm().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to setup Kubeadm")
+
+	// Initialize cluster
+	step, err = InitializeCluster().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to initialize cluster")
+
+	if level == SetupCKubeadmLevel {
+		return
 	}
 }

--- a/internal/workflows/steps/step_crio.go
+++ b/internal/workflows/steps/step_crio.go
@@ -10,14 +10,11 @@ import (
 
 func SetupCrio() automa.Builder {
 
-	return automa.NewWorkflowBuilder().WithId("setup-crio").Steps(
-		installCrio(software.NewCrioInstaller),
-		configureCrio(software.NewCrioInstaller),
-	)
-}
-
-func installCrio(provider func(opts ...software.InstallerOption) (software.Software, error)) automa.Builder {
-	return automa.NewStepBuilder().WithId("install-crio").
+	return automa.NewWorkflowBuilder().WithId("setup-crio").
+		Steps(
+			installCrio(software.NewCrioInstaller),
+			configureCrio(software.NewCrioInstaller),
+		).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
 			notify.As().StepStart(ctx, stp, "Setting up cri-o")
 			return ctx, nil
@@ -27,6 +24,20 @@ func installCrio(provider func(opts ...software.InstallerOption) (software.Softw
 		}).
 		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
 			notify.As().StepCompletion(ctx, stp, rpt, "Cri-o setup successfully")
+		})
+}
+
+func installCrio(provider func(opts ...software.InstallerOption) (software.Software, error)) automa.Builder {
+	return automa.NewStepBuilder().WithId("install-crio").
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Installing cri-o")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to install cri-o")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Cri-o installed successfully")
 		}).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			installer, err := provider()
@@ -35,30 +46,63 @@ func installCrio(provider func(opts ...software.InstallerOption) (software.Softw
 					automa.WithError(err))
 			}
 
+			// Prepare metadata for reporting
+			meta := map[string]string{}
+
+			installed, err := installer.IsInstalled()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			if installed {
+				meta[AlreadyInstalled] = "true"
+				return automa.SkippedReport(stp, automa.WithDetail("cri-o is already installed"), automa.WithMetadata(meta))
+			}
+
 			err = installer.Download()
 			if err != nil {
-				return automa.FailureReport(stp,
-					automa.WithError(err))
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
 			}
+			meta[DownloadedByThisStep] = "true"
+
 			err = installer.Extract()
 			if err != nil {
-				return automa.FailureReport(stp,
-					automa.WithError(err))
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
 			}
+			meta[ExtractedByThisStep] = "true"
+
 			err = installer.Install()
 			if err != nil {
-				return automa.FailureReport(stp,
-					automa.WithError(err))
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
 			}
+			meta[InstalledByThisStep] = "true"
+			stp.State().Set(InstalledByThisStep, true)
+
 			err = installer.Cleanup()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			meta[CleanedUpByThisStep] = "true"
+
+			return automa.SuccessReport(stp, automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			installedByThisStep := stp.State().Bool(InstalledByThisStep)
+			if !installedByThisStep {
+				return automa.SkippedReport(stp, automa.WithDetail("cri-o was not installed by this step, skipping rollback"))
+			}
+
+			installer, err := provider()
 			if err != nil {
 				return automa.FailureReport(stp,
 					automa.WithError(err))
 			}
 
-			return automa.SuccessReport(stp)
-		}).
-		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			err = installer.Uninstall()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+
 			return automa.SuccessReport(stp)
 		})
 }
@@ -82,7 +126,41 @@ func configureCrio(provider func(opts ...software.InstallerOption) (software.Sof
 					automa.WithError(err))
 			}
 
+			// Prepare metadata for reporting
+			meta := map[string]string{}
+
+			configured, err := installer.IsConfigured()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+			if configured {
+				meta[AlreadyConfigured] = "true"
+				return automa.SkippedReport(stp, automa.WithDetail("cri-o is already configured"), automa.WithMetadata(meta))
+			}
+
 			err = installer.Configure()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err), automa.WithMetadata(meta))
+			}
+
+			meta[ConfiguredByThisStep] = "true"
+			stp.State().Set(ConfiguredByThisStep, true)
+
+			return automa.SuccessReport(stp, automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			configuredByThisStep := stp.State().Bool(ConfiguredByThisStep)
+			if !configuredByThisStep {
+				return automa.SkippedReport(stp, automa.WithDetail("cri-o was not configured by this step, skipping rollback"))
+			}
+
+			installer, err := provider()
+			if err != nil {
+				return automa.FailureReport(stp,
+					automa.WithError(err))
+			}
+
+			err = installer.RemoveConfiguration()
 			if err != nil {
 				return automa.FailureReport(stp,
 					automa.WithError(err))

--- a/internal/workflows/steps/step_crio_it_test.go
+++ b/internal/workflows/steps/step_crio_it_test.go
@@ -5,18 +5,22 @@ package steps
 import (
 	"context"
 	"os"
+	"os/exec"
+	"path"
 	"testing"
 
 	"github.com/automa-saga/automa"
+	"github.com/joomcode/errorx"
 	"github.com/stretchr/testify/require"
 	"golang.hedera.com/solo-provisioner/internal/core"
+	"golang.hedera.com/solo-provisioner/pkg/software"
 )
 
 func Test_StepCrio_Fresh_Integration(t *testing.T) {
 	//
 	// Given
 	//
-	cleanUpTempDir(t)
+	reset(t)
 
 	//
 	// When
@@ -31,13 +35,20 @@ func Test_StepCrio_Fresh_Integration(t *testing.T) {
 	require.NotNil(t, report)
 	require.NoError(t, report.Error)
 	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	require.Empty(t, report.StepReports[0].Metadata[AlreadyInstalled])
+	require.Equal(t, "true", report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[CleanedUpByThisStep])
+	require.Empty(t, report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Equal(t, "true", report.StepReports[1].Metadata[ConfiguredByThisStep])
 }
 
 func Test_StepCrio_AlreadyInstalled_Integration(t *testing.T) {
 	//
 	// Given
 	//
-	cleanUpTempDir(t)
+	reset(t)
 
 	step, err := SetupCrio().Build()
 	require.NoError(t, err)
@@ -60,13 +71,22 @@ func Test_StepCrio_AlreadyInstalled_Integration(t *testing.T) {
 	require.NoError(t, report.Error)
 	require.Equal(t, automa.StatusSuccess, report.Status)
 
+	require.Equal(t, automa.StatusSkipped, report.StepReports[0].Status)
+	require.Equal(t, "true", report.StepReports[0].Metadata[AlreadyInstalled])
+	require.Empty(t, report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Empty(t, report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Empty(t, report.StepReports[0].Metadata[CleanedUpByThisStep])
+
+	require.Equal(t, automa.StatusSkipped, report.StepReports[1].Status)
+	require.Equal(t, "true", report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Empty(t, report.StepReports[1].Metadata[ConfiguredByThisStep])
 }
 
 func Test_StepCrio_PartiallyInstalled_Integration(t *testing.T) {
 	//
 	// Given
 	//
-	cleanUpTempDir(t)
+	reset(t)
 
 	step, err := SetupCrio().Build()
 	require.NoError(t, err)
@@ -82,13 +102,657 @@ func Test_StepCrio_PartiallyInstalled_Integration(t *testing.T) {
 	// When
 	//
 	step, err = SetupCrio().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
 
 	//
 	// Then
 	//
-	require.NoError(t, err)
-	report = step.Execute(context.Background())
 	require.NotNil(t, report)
 	require.NoError(t, report.Error)
 	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	require.Equal(t, automa.StatusSkipped, report.StepReports[0].Status)
+	require.Equal(t, "true", report.StepReports[0].Metadata[AlreadyInstalled])
+	require.Empty(t, report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Empty(t, report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Empty(t, report.StepReports[0].Metadata[CleanedUpByThisStep])
+
+	require.Equal(t, automa.StatusSkipped, report.StepReports[1].Status)
+	require.Equal(t, "true", report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Empty(t, report.StepReports[1].Metadata[ConfiguredByThisStep])
+}
+
+func Test_StepCrio_Rollback_Fresh_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	reset(t)
+
+	//
+	// When
+	//
+	step, err := SetupCrio().Build()
+
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	require.Equal(t, "true", report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[CleanedUpByThisStep])
+
+	//
+	// When - Rollback
+	//
+	rollbackReport := step.Rollback(context.Background())
+
+	//
+	// Then
+	//
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, rollbackReport.Status)
+
+	// Verify download folder for crio is removed
+	_, err = os.Stat("/opt/provisioner/tmp/crio")
+	require.Error(t, err)
+
+	// Verify binary files are removed (from Uninstall method)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/local/bin/crio")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/local/bin/pinns")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/local/bin/crictl")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/libexec/crio/conmon")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/libexec/crio/conmonrs")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/libexec/crio/crun")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/libexec/crio/runc")
+	require.Error(t, err)
+
+	// Verify CNI plugins directory is removed
+	_, err = os.Stat("/opt/provisioner/sandbox/opt/cni/bin")
+	require.Error(t, err)
+
+	// Verify configuration files are removed (from Uninstall method)
+	_, err = os.Stat("/opt/provisioner/sandbox/etc/cni/net.d/10-crio-bridge.conflist.disabled")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/etc/crictl.yaml")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/share/oci-umount/oci-umount.d/crio-umount.conf")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/etc/crio/policy.json")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/etc/crio/crio.conf.d/10-crio.conf")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/local/share/man/man5/crio.conf.5")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/local/share/man/man5/crio.conf.d.5")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/local/share/man/man8/crio.8")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/local/share/bash-completion/completions/crio")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/local/share/fish/completions/crio.fish")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/local/share/zsh/site-functions/_crio")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/lib/systemd/system/crio.service")
+	require.Error(t, err)
+	_, err = os.Stat("/opt/provisioner/sandbox/etc/containers/registries.conf.d/registries.conf")
+	require.Error(t, err)
+
+	// Verify symlinks and configuration files removed (from RemoveConfiguration method)
+	_, err = os.Stat("/usr/lib/systemd/system/crio.service")
+	require.Error(t, err)
+	_, err = os.Stat("/etc/containers")
+	require.Error(t, err)
+
+	// Check that .crio-install file is removed
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	_, err = os.Stat(path.Join(homeDir, ".crio-install"))
+	require.Error(t, err)
+}
+
+func Test_StepCrio_Rollback_Setup_DownloadFailed(t *testing.T) {
+	//
+	// Given
+	//
+	reset(t)
+
+	// Make the download directory read-only
+	err := os.MkdirAll(core.Paths().TempDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create download directory")
+	cmd := exec.Command("chattr", "+i", core.Paths().TempDir)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make download directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", core.Paths().TempDir).Run()
+	})
+
+	//
+	// When
+	//
+	step, err := SetupCrio().Build()
+	require.NoError(t, err)
+
+	//
+	// When - Execute (should fail at download)
+	//
+
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check errorx error type
+	require.Error(t, report.Error)
+
+	// Confirm errorx error type is DownloadError
+	require.True(t, errorx.IsOfType(errorx.Cast(report.Error).Cause(), software.DownloadError))
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	//
+	// Then
+	//
+	rollbackReport := report.StepReports[0].Rollback
+
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSkipped, rollbackReport.Status)
+
+	// Verify download folder for crio was not created
+	_, err = os.Stat("/opt/provisioner/tmp/crio")
+	require.Error(t, err)
+
+	// Confirm binary files were not created
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/crio")
+	require.Error(t, err)
+}
+
+func Test_StepCrio_Rollback_Setup_ExtractFailed(t *testing.T) {
+	//
+	// Given
+	//
+	reset(t)
+
+	// First, let the download succeed, then make the extraction fail
+	// by making the unpack directory read-only after download
+	step, err := SetupCrio().Build()
+	require.NoError(t, err)
+
+	// Download first to create the download folder
+	installer, err := software.NewCrioInstaller()
+	require.NoError(t, err)
+
+	err = installer.Download()
+	require.NoError(t, err)
+
+	// Now make the download folder read-only to prevent extraction
+	downloadDir := path.Join(core.Paths().TempDir, "cri-o")
+	cmd := exec.Command("chattr", "+i", downloadDir)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make download directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", downloadDir).Run()
+	})
+
+	//
+	// When - Execute (should fail at extraction)
+	//
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check errorx error type
+	require.Error(t, report.Error)
+
+	// Confirm errorx error type is ExtractionError
+	require.True(t, errorx.IsOfType(errorx.Cast(report.Error).Cause(), software.ExtractionError))
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	//
+	// Then
+	//
+	rollbackReport := report.StepReports[0].Rollback
+
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSkipped, rollbackReport.Status)
+
+	// Verify download folder is still around when there is an extraction error
+	_, err = os.Stat("/opt/provisioner/tmp/cri-o")
+	require.NoError(t, err)
+
+	// Check there are downloaded files in the crio directory
+	files, err := os.ReadDir(path.Join(core.Paths().TempDir, "cri-o"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(files), 1, "Expected at least 1 file in the crio directory")
+
+	// Verify binary files were not installed (since extraction failed)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/local/bin/crio")
+	require.Error(t, err)
+}
+
+func Test_StepCrio_Rollback_Setup_InstallFailed(t *testing.T) {
+	//
+	// Given
+	//
+	reset(t)
+
+	// Make subfolder in sandbox directory read-only
+	sandboxSubFolder := path.Join(core.Paths().SandboxDir, "opt")
+
+	err := os.MkdirAll(sandboxSubFolder, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create sandbox bin directory")
+	cmd := exec.Command("chattr", "+i", sandboxSubFolder)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make sandbox binary directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", sandboxSubFolder).Run()
+	})
+
+	//
+	// When
+	//
+	step, err := SetupCrio().Build()
+	require.NoError(t, err)
+
+	//
+	// When - Execute (should fail at install)
+	//
+
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check errorx error type
+	require.Error(t, report.Error)
+
+	// Confirm errorx error type is InstallationError
+	require.True(t, errorx.IsOfType(errorx.Cast(report.Error).Cause(), software.InstallationError))
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	//
+	// Then
+	//
+	rollbackReport := report.StepReports[0].Rollback
+
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSkipped, rollbackReport.Status)
+
+	// Verify download folder is still around when there is an installation error
+	_, err = os.Stat("/opt/provisioner/tmp/cri-o")
+	require.NoError(t, err)
+
+	// Check there are downloaded files in the crio directory
+	files, err := os.ReadDir(path.Join(core.Paths().TempDir, "cri-o"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(files), 1, "Expected at least 1 file in the crio directory")
+
+	// Verify binary files were not installed
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/crio")
+	require.Error(t, err)
+}
+
+func Test_StepCrio_Rollback_Setup_CleanupFailed(t *testing.T) {
+	//
+	// Given
+	//
+	reset(t)
+
+	// Create an unremovable directory under download folder
+	unremovableDir := path.Join(core.Paths().TempDir, "cri-o", "unremovable")
+
+	err := os.MkdirAll(unremovableDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create unremovable directory")
+	cmd := exec.Command("chattr", "+i", unremovableDir)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make unremovable directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", unremovableDir).Run()
+	})
+
+	//
+	// When
+	//
+	step, err := SetupCrio().Build()
+	require.NoError(t, err)
+
+	//
+	// When - Execute (should fail at cleanup)
+	//
+
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check errorx error type
+	require.Error(t, report.Error)
+
+	// Confirm errorx error type is CleanupError
+	require.True(t, errorx.IsOfType(errorx.Cast(report.Error).Cause(), software.CleanupError))
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	//
+	// Then
+	//
+	rollbackReport := report.StepReports[0].Rollback
+
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, rollbackReport.Status)
+
+	// Verify download folder is still around when there is a cleanup error
+	_, err = os.Stat("/opt/provisioner/tmp/cri-o")
+	require.NoError(t, err)
+
+	// Check there are files in the tmp/crio directory
+	files, err := os.ReadDir(path.Join(core.Paths().TempDir, "cri-o"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(files), 1, "Expected at least 1 file in the tmp/crio directory")
+
+	// Verify binary files were removed
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/crio")
+	require.Error(t, err)
+}
+
+func Test_StepCrio_Rollback_ConfigurationFailed(t *testing.T) {
+	//
+	// Given
+	//
+	reset(t)
+
+	// Make the /etc/containers directory read-only to prevent configuration
+	etcCrioDir := "/etc/containers"
+	err := os.MkdirAll(etcCrioDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create /etc/containers directory")
+	cmd := exec.Command("chattr", "+i", etcCrioDir)
+	err = cmd.Run()
+	require.NoError(t, err, "Failed to make /etc/containers directory read-only")
+
+	// Restore permissions after test
+	t.Cleanup(func() {
+		_ = exec.Command("chattr", "-i", etcCrioDir).Run()
+	})
+
+	//
+	// When
+	//
+	step, err := SetupCrio().Build()
+	require.NoError(t, err)
+
+	//
+	// When - Execute (should fail at configuration step)
+	//
+
+	report := step.Execute(context.Background())
+
+	require.NotNil(t, report)
+
+	// Check that it failed
+	require.Error(t, report.Error)
+	require.Equal(t, automa.StatusFailed, report.Status)
+
+	// First step (install) should succeed
+	require.Equal(t, automa.StatusSuccess, report.StepReports[0].Status)
+	require.Equal(t, "true", report.StepReports[0].Metadata[DownloadedByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[InstalledByThisStep])
+	require.Equal(t, "true", report.StepReports[0].Metadata[CleanedUpByThisStep])
+
+	// Second step (configure) should fail
+	require.Equal(t, automa.StatusFailed, report.StepReports[1].Status)
+
+	//
+	// Then - Verify rollback
+	//
+	installRollbackReport := report.StepReports[0].Rollback
+	configRollbackReport := report.StepReports[1].Rollback
+
+	require.NoError(t, installRollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, installRollbackReport.Status)
+
+	require.NoError(t, configRollbackReport.Error)
+	require.Equal(t, automa.StatusSkipped, configRollbackReport.Status)
+
+	// Verify installation was rolled back - download folder should be removed
+	_, err = os.Stat("/opt/provisioner/tmp/cri-o")
+	require.Error(t, err)
+
+	// Verify binary files were removed from sandbox
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/crio")
+	require.Error(t, err)
+
+	// Verify configuration was not applied
+	_, err = os.Stat("/usr/lib/systemd/system/crio.service")
+	require.Error(t, err)
+}
+
+func Test_StepCrio_ServiceConfiguration_Fresh_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	reset(t)
+
+	//
+	// When
+	//
+	step, err := SetupCrio().Build()
+	require.NoError(t, err)
+
+	report := step.Execute(context.Background())
+
+	//
+	// Then
+	//
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	// Verify crio.service was installed in sandbox
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/lib/systemd/system/crio.service")
+	require.NoError(t, err, "crio.service should exist in sandbox")
+
+	// Verify .latest file was created with modified content
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/lib/systemd/system/crio.service.latest")
+	require.NoError(t, err, "crio.service.latest should exist")
+
+	// Verify systemd symlink was created
+	linkTarget, err := os.Readlink("/usr/lib/systemd/system/crio.service")
+	require.NoError(t, err, "crio.service symlink should exist")
+	require.Equal(t, "/opt/provisioner/sandbox/usr/lib/systemd/system/crio.service.latest", linkTarget, "symlink should point to .latest file")
+
+	// Verify .latest file contains sandbox binary path
+	content, err := os.ReadFile("/opt/provisioner/sandbox/usr/lib/systemd/system/crio.service.latest")
+	require.NoError(t, err, "should be able to read .latest file")
+	contentStr := string(content)
+	require.Contains(t, contentStr, "/opt/provisioner/sandbox/usr/local/bin/crio", ".latest file should contain sandbox crio path")
+}
+
+func Test_StepCrio_ServiceConfiguration_AlreadyConfigured_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	reset(t)
+
+	// First run to configure crio
+	step, err := SetupCrio().Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+
+	//
+	// When - Run again
+	//
+	step, err = SetupCrio().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+
+	//
+	// Then
+	//
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	// Configuration step should be skipped
+	require.Equal(t, automa.StatusSkipped, report.StepReports[1].Status)
+	require.Equal(t, "true", report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Empty(t, report.StepReports[1].Metadata[ConfiguredByThisStep])
+
+	// Verify service configuration still exists and is valid
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/lib/systemd/system/crio.service.latest")
+	require.NoError(t, err, "crio.service.latest should still exist")
+
+	linkTarget, err := os.Readlink("/usr/lib/systemd/system/crio.service")
+	require.NoError(t, err, "crio.service symlink should still exist")
+	require.Equal(t, "/opt/provisioner/sandbox/usr/lib/systemd/system/crio.service.latest", linkTarget)
+}
+
+func Test_StepCrio_ServiceConfiguration_PartiallyConfigured_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	reset(t)
+
+	// First run to install and configure crio
+	step, err := SetupCrio().Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+
+	// Remove the systemd symlink but keep the .latest file
+	err = os.RemoveAll("/usr/lib/systemd/system/crio.service")
+	require.NoError(t, err)
+
+	//
+	// When - Run again
+	//
+	step, err = SetupCrio().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+
+	//
+	// Then
+	//
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	// Installation should be skipped (already installed)
+	require.Equal(t, automa.StatusSkipped, report.StepReports[0].Status)
+	require.Equal(t, "true", report.StepReports[0].Metadata[AlreadyInstalled])
+
+	// Configuration should run again (partial configuration)
+	require.Equal(t, automa.StatusSuccess, report.StepReports[1].Status)
+	require.Empty(t, report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Equal(t, "true", report.StepReports[1].Metadata[ConfiguredByThisStep])
+
+	// Verify systemd symlink was recreated
+	linkTarget, err := os.Readlink("/usr/lib/systemd/system/crio.service")
+	require.NoError(t, err, "crio.service symlink should be recreated")
+	require.Equal(t, "/opt/provisioner/sandbox/usr/lib/systemd/system/crio.service.latest", linkTarget)
+}
+
+func Test_StepCrio_ServiceConfiguration_CorruptedLatestFile_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	reset(t)
+
+	// First run to install and configure crio
+	step, err := SetupCrio().Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+
+	// Corrupt the .latest file by writing incorrect content
+	corruptedContent := "This is corrupted content"
+	err = os.WriteFile("/opt/provisioner/sandbox/usr/lib/systemd/system/crio.service.latest", []byte(corruptedContent), core.DefaultFilePerm)
+	require.NoError(t, err)
+
+	//
+	// When - Run again
+	//
+	step, err = SetupCrio().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+
+	//
+	// Then
+	//
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	// Installation should be skipped (already installed)
+	require.Equal(t, automa.StatusSkipped, report.StepReports[0].Status)
+
+	// Configuration should run again (corrupted .latest file detected)
+	require.Equal(t, automa.StatusSuccess, report.StepReports[1].Status)
+	require.Empty(t, report.StepReports[1].Metadata[AlreadyConfigured])
+	require.Equal(t, "true", report.StepReports[1].Metadata[ConfiguredByThisStep])
+
+	// Verify .latest file was fixed
+	content, err := os.ReadFile("/opt/provisioner/sandbox/usr/lib/systemd/system/crio.service.latest")
+	require.NoError(t, err)
+	contentStr := string(content)
+	require.Contains(t, contentStr, "/opt/provisioner/sandbox/usr/local/bin/crio", ".latest file should contain correct sandbox path")
+	require.NotEqual(t, corruptedContent, contentStr, ".latest file should be fixed")
+}
+
+func Test_StepCrio_ServiceConfiguration_RestoreConfiguration_Integration(t *testing.T) {
+	//
+	// Given
+	//
+	reset(t)
+
+	// Install and configure crio
+	step, err := SetupCrio().Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+
+	// Verify configuration is in place
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/lib/systemd/system/crio.service.latest")
+	require.NoError(t, err, "crio.service.latest should exist before restoration")
+
+	_, err = os.Stat("/usr/lib/systemd/system/crio.service")
+	require.NoError(t, err, "crio.service symlink should exist before restoration")
+
+	//
+	// When - Rollback
+	//
+	rollbackReport := step.Rollback(context.Background())
+
+	//
+	// Then
+	//
+	require.NoError(t, rollbackReport.Error)
+	require.Equal(t, automa.StatusSuccess, rollbackReport.Status)
+
+	// Verify configuration was restored (removed)
+	_, err = os.Stat("/opt/provisioner/sandbox/usr/lib/systemd/system/crio.service.latest")
+	require.Error(t, err, "crio.service.latest should be removed after rollback")
+
+	_, err = os.Stat("/usr/lib/systemd/system/crio.service")
+	require.Error(t, err, "crio.service symlink should be removed after rollback")
+
+	// Verify installation was also rolled back
+	_, err = os.Stat("/opt/provisioner/sandbox/bin/crio")
+	require.Error(t, err, "crio binary should be removed after rollback")
+
+	_, err = os.Stat("/opt/provisioner/tmp/crio")
+	require.Error(t, err, "crio temp directory should be removed after rollback")
 }

--- a/pkg/software/base_installer.go
+++ b/pkg/software/base_installer.go
@@ -1105,8 +1105,16 @@ func (b *baseInstaller) cleanupSymlinks() error {
 // This is a helper method that can be used by any installer that needs to copy files
 // with specific permissions during installation.
 func (b *baseInstaller) installFile(src, dst string, perm os.FileMode) error {
+
+	// Create destination directory if it doesn't exist
+	destDir := path.Dir(dst)
+	err := b.fileManager.CreateDirectory(destDir, true)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to create directory %s", destDir)
+	}
+
 	// Copy file
-	err := b.fileManager.CopyFile(src, dst, true)
+	err = b.fileManager.CopyFile(src, dst, true)
 	if err != nil {
 		return errorx.IllegalState.Wrap(err, "failed to copy %s to %s", src, dst)
 	}
@@ -1118,4 +1126,9 @@ func (b *baseInstaller) installFile(src, dst string, perm os.FileMode) error {
 	}
 
 	return nil
+}
+
+// getLatestPath returns the path to the .latest file in the sandbox
+func getLatestPath(originalPath string) string {
+	return originalPath + ".latest"
 }

--- a/pkg/software/crio_installer.go
+++ b/pkg/software/crio_installer.go
@@ -1,6 +1,7 @@
 package software
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
@@ -11,11 +12,37 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/joomcode/errorx"
 	"golang.hedera.com/solo-provisioner/internal/core"
+	"golang.hedera.com/solo-provisioner/internal/tomlx"
 	"golang.hedera.com/solo-provisioner/pkg/hardware"
 )
 
 const (
 	CrioServiceName = "crio"
+
+	// File names - extracted as constants to avoid duplication
+	CrioConfFile          = "10-crio.conf"
+	CrioServiceFile       = "crio.service"
+	PolicyJsonFile        = "policy.json"
+	CrictlYamlFile        = "crictl.yaml"
+	CrioUmountConfFile    = "crio-umount.conf"
+	CrioConfDisabledFile  = "10-crio-bridge.conflist.disabled"
+	CrioConf5File         = "crio.conf.5"
+	CrioConfd5File        = "crio.conf.d.5"
+	Crio8File             = "crio.8"
+	CrioFishFile          = "crio.fish"
+	RegistriesConfFile    = "registries.conf"
+	CrioInstallFile       = ".crio-install"
+	CrioDefaultConfigFile = "crio"
+
+	// Directory names
+	ContribDir = "contrib/"
+
+	// Expected counts
+	// ExpectedCniPluginCount represents the expected number of CNI plugin binaries
+	// that should be present after successful CRI-O installation. This includes
+	// standard plugins like bridge, host-local, loopback, portmap, etc.
+	// The count is based on the CNI plugins bundled with the CRI-O distribution.
+	ExpectedCniPluginCount = 20
 )
 
 var (
@@ -52,6 +79,7 @@ var (
 
 type crioInstaller struct {
 	*baseInstaller
+	tomlManager *tomlx.TomlConfigManager
 }
 
 func NewCrioInstaller(opts ...InstallerOption) (Software, error) {
@@ -62,6 +90,7 @@ func NewCrioInstaller(opts ...InstallerOption) (Software, error) {
 
 	return &crioInstaller{
 		baseInstaller: bi,
+		tomlManager:   tomlx.NewTomlConfigManager(),
 	}, nil
 }
 
@@ -71,9 +100,6 @@ func (ci *crioInstaller) Install() error {
 	// Variables matching the shell script structure
 	srcDir := path.Join(ci.downloadFolder(), core.DefaultUnpackFolderName, "cri-o")
 	destDir := core.Paths().SandboxDir
-
-	// Get SYSCONFIGDIR based on OS
-	sysconfigDir := getSysconfigDir()
 
 	// Ensure directories exist
 	dirs := []string{
@@ -117,7 +143,7 @@ func (ci *crioInstaller) Install() error {
 		ociDir,
 
 		//install $SELINUX -D -m 644 -t "$DESTDIR$SYSCONFIGDIR" etc/crio
-		sysconfigDir,
+		getSysconfigDir(),
 
 		//install $SELINUX -D -m 644 -t "$DESTDIR$ETC_CRIO_DIR" contrib/policy.json
 		//install $SELINUX -D -m 644 -t "$DESTDIR$ETC_CRIO_DIR/crio.conf.d" etc/10-crio.conf
@@ -136,14 +162,14 @@ func (ci *crioInstaller) Install() error {
 	for _, d := range dirs {
 		err := ci.fileManager.CreateDirectory(filepath.Join(destDir, d), true)
 		if err != nil {
-			return err
+			return NewInstallationError(err, ci.software.Name, ci.versionToBeInstalled)
 		}
 	}
 
 	// Copy CNI plugins
 	err := ci.copyCNIPlugins(srcDir, filepath.Join(destDir, optCniBinDir))
 	if err != nil {
-		return err
+		return NewInstallationError(err, ci.software.Name, ci.versionToBeInstalled)
 	}
 
 	// Copy binary files
@@ -166,7 +192,7 @@ func (ci *crioInstaller) Install() error {
 	for src, dst := range binaries {
 		err := ci.installFile(filepath.Join(srcDir, "bin", src), dst, core.DefaultDirOrExecPerm)
 		if err != nil {
-			return err
+			return NewInstallationError(err, ci.software.Name, ci.versionToBeInstalled)
 		}
 	}
 
@@ -186,38 +212,25 @@ func (ci *crioInstaller) Install() error {
 	//install $SELINUX -D -m 644 -t "$DESTDIR$SYSTEMDDIR" contrib/crio.service
 	//install $SELINUX -D -m 644 -t "$DESTDIR$CONTAINERS_REGISTRIES_CONFD_DIR" contrib/registries.conf
 	configs := map[string]string{
-		"contrib/10-crio-bridge.conflist.disabled": filepath.Join(destDir, cniDir, "10-crio-bridge.conflist.disabled"),
-		"etc/crictl.yaml":                          filepath.Join(destDir, etcDir, "crictl.yaml"),
-		"etc/crio-umount.conf":                     filepath.Join(destDir, ociDir, "crio-umount.conf"),
-		"etc/crio":                                 filepath.Join(destDir, sysconfigDir, "crio"),
-		"contrib/policy.json":                      filepath.Join(destDir, etcCrioDir, "policy.json"),
-		"etc/10-crio.conf":                         filepath.Join(destDir, crioConfdDir, "10-crio.conf"),
-		"man/crio.conf.5":                          filepath.Join(destDir, man5Dir, "crio.conf.5"),
-		"man/crio.conf.d.5":                        filepath.Join(destDir, man5Dir, "crio.conf.d.5"),
-		"man/crio.8":                               filepath.Join(destDir, man8Dir, "crio.8"),
-		"completions/bash/crio":                    filepath.Join(destDir, bashInstallDir, "crio"),
-		"completions/fish/crio.fish":               filepath.Join(destDir, fishInstallDir, "crio.fish"),
-		"completions/zsh/_crio":                    filepath.Join(destDir, zshInstallDir, "_crio"),
-		"contrib/crio.service":                     filepath.Join(destDir, userSystemdDir, "crio.service"),
-		"contrib/registries.conf":                  filepath.Join(destDir, containersRegistriesConfdDir, "registries.conf"),
+		ContribDir + CrioConfDisabledFile:  filepath.Join(destDir, cniDir, CrioConfDisabledFile),
+		"etc/" + CrictlYamlFile:            filepath.Join(destDir, etcDir, CrictlYamlFile),
+		"etc/" + CrioUmountConfFile:        filepath.Join(destDir, ociDir, CrioUmountConfFile),
+		"etc/" + CrioDefaultConfigFile:     filepath.Join(destDir, getSysconfigDir(), CrioDefaultConfigFile),
+		ContribDir + PolicyJsonFile:        filepath.Join(destDir, etcCrioDir, PolicyJsonFile),
+		"etc/" + CrioConfFile:              filepath.Join(destDir, crioConfdDir, CrioConfFile),
+		"man/" + CrioConf5File:             filepath.Join(destDir, man5Dir, CrioConf5File),
+		"man/" + CrioConfd5File:            filepath.Join(destDir, man5Dir, CrioConfd5File),
+		"man/" + Crio8File:                 filepath.Join(destDir, man8Dir, Crio8File),
+		"completions/bash/crio":            filepath.Join(destDir, bashInstallDir, "crio"),
+		"completions/fish/" + CrioFishFile: filepath.Join(destDir, fishInstallDir, CrioFishFile),
+		"completions/zsh/_crio":            filepath.Join(destDir, zshInstallDir, "_crio"),
+		ContribDir + CrioServiceFile:       filepath.Join(destDir, userSystemdDir, CrioServiceFile),
+		ContribDir + RegistriesConfFile:    filepath.Join(destDir, containersRegistriesConfdDir, RegistriesConfFile),
 	}
 	for src, dst := range configs {
 		if err := ci.installFile(filepath.Join(srcDir, src), dst, core.DefaultFilePerm); err != nil {
-			return err
+			return NewInstallationError(err, ci.software.Name, ci.versionToBeInstalled)
 		}
-	}
-
-	// Patch crio.conf.d/10-crio.conf with adjusted paths
-	confPath := filepath.Join(destDir, crioConfdDir, "10-crio.conf")
-	err = patchConfig(confPath, destDir, binDir, libexecDir, etcCrioDir)
-	if err != nil {
-		return err
-	}
-
-	// Generate crio-install list using template
-	err = ci.generateCrioInstallList(destDir, sysconfigDir)
-	if err != nil {
-		return err
 	}
 
 	return nil
@@ -229,9 +242,16 @@ func (ci *crioInstaller) Install() error {
 func (ci *crioInstaller) copyCNIPlugins(srcDir, destDir string) error {
 	cniPluginsDir := filepath.Join(srcDir, "cni-plugins")
 
+	// Make sure the cni-plugins directory exists
+	if _, exists, err := ci.fileManager.PathExists(cniPluginsDir); err != nil {
+		return NewInstallationError(errorx.IllegalState.Wrap(err, "failed to check cni-plugins directory"), ci.software.Name, ci.versionToBeInstalled)
+	} else if !exists {
+		return NewInstallationError(errorx.IllegalState.New("cni-plugins directory not found in extracted archive"), ci.software.Name, ci.versionToBeInstalled)
+	}
+
 	entries, err := os.ReadDir(cniPluginsDir)
 	if err != nil {
-		return fmt.Errorf("failed to read cni-plugins directory: %w", err)
+		return NewInstallationError(errorx.IllegalState.Wrap(err, "failed to read cni-plugins directory"), ci.software.Name, ci.versionToBeInstalled)
 	}
 
 	for _, entry := range entries {
@@ -241,29 +261,11 @@ func (ci *crioInstaller) copyCNIPlugins(srcDir, destDir string) error {
 		src := filepath.Join(cniPluginsDir, entry.Name())
 		dst := filepath.Join(destDir, entry.Name())
 		if err := ci.installFile(src, dst, core.DefaultDirOrExecPerm); err != nil {
-			return err
+			return NewInstallationError(err, ci.software.Name, ci.versionToBeInstalled)
 		}
 	}
 
 	return nil
-}
-
-// patchConfig updates the CRI-O configuration file with the correct paths
-// Matching the shell script logic:
-// sed -i 's;/usr/bin;'"$DESTDIR$BINDIR"';g' "$DESTDIR$ETC_CRIO_DIR/crio.conf.d/10-crio.conf"
-// sed -i 's;/usr/libexec;'"$DESTDIR$LIBEXECDIR"';g' "$DESTDIR$ETC_CRIO_DIR/crio.conf.d/10-crio.conf"
-// sed -i 's;/etc/crio;'"$DESTDIR$ETC_CRIO_DIR"';g' "$DESTDIR$ETC_CRIO_DIR/crio.conf.d/10-crio.conf"
-func patchConfig(path, destdir, bindir, libexecdir, etcdir string) error {
-	b, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	content := string(b)
-	// Update the DESTDIR in the CRI-O configuration, matching shell script sed commands
-	content = strings.ReplaceAll(content, usrBinDir, filepath.Join(destdir, bindir))
-	content = strings.ReplaceAll(content, libexecDir, filepath.Join(destdir, libexecdir))
-	content = strings.ReplaceAll(content, etcCrioDir, filepath.Join(destdir, etcdir))
-	return os.WriteFile(path, []byte(content), core.DefaultFilePerm)
 }
 
 // getSysconfigDir returns the sysconfig directory for the current OS
@@ -286,7 +288,20 @@ func getSysconfigDir() string {
 func (ci *crioInstaller) Configure() error {
 	sandboxDir := core.Paths().SandboxDir
 
-	err := ci.patchServiceFile()
+	// Patch crio.conf.d/10-crio.conf with adjusted paths
+	err := ci.patchCrioConf(sandboxDir, binDir, libexecDir, etcCrioDir)
+	if err != nil {
+		return err
+	}
+
+	// Generate crio-install list using template
+	err = ci.generateCrioInstallList(sandboxDir)
+	if err != nil {
+		return err
+	}
+
+	// Patch CRI-O systemd service file
+	err = ci.patchServiceFile()
 	if err != nil {
 		return err
 	}
@@ -305,16 +320,16 @@ func (ci *crioInstaller) Configure() error {
 	}
 
 	// Update CRI-O TOML configuration
-	crioConfPath := filepath.Join(sandboxDir, crioConfdDir, "10-crio.conf")
-	err = ci.updateCrioTomlConfig(crioConfPath)
+	latestCrioConfPath := getLatestPath(getCrioConfPath())
+	err = ci.updateCrioTomlConfig(latestCrioConfPath)
 	if err != nil {
 		return errorx.IllegalState.Wrap(err, "failed to update CRI-O TOML configuration")
 	}
 
 	// Setup CRI-O Service SymLink
 	systemdServicePath := filepath.Join(userSystemdDir, "crio.service")
-	sandboxServicePath := filepath.Join(sandboxDir, userSystemdDir, "crio.service")
-	err = ci.fileManager.CreateSymbolicLink(sandboxServicePath, systemdServicePath, true)
+	latestSandboxServicePath := getLatestPath(getCrioServicePath())
+	err = ci.fileManager.CreateSymbolicLink(latestSandboxServicePath, systemdServicePath, true)
 	if err != nil {
 		return errorx.IllegalState.Wrap(err, "failed to create CRI-O service symlink")
 	}
@@ -322,11 +337,583 @@ func (ci *crioInstaller) Configure() error {
 	return nil
 }
 
+// patchCrioConf updates the CRI-O configuration file with the correct paths
+// Matching the shell script logic:
+// sed -i 's;/usr/bin;'"$DESTDIR$BINDIR"';g' "$DESTDIR$ETC_CRIO_DIR/crio.conf.d/10-crio.conf"
+// sed -i 's;/usr/libexec;'"$DESTDIR$LIBEXECDIR"';g' "$DESTDIR$ETC_CRIO_DIR/crio.conf.d/10-crio.conf"
+// sed -i 's;/etc/crio;'"$DESTDIR$ETC_CRIO_DIR"';g' "$DESTDIR$ETC_CRIO_DIR/crio.conf.d/10-crio.conf"
+func (ci *crioInstaller) patchCrioConf(destdir, bindir, libexecdir, etcdir string) error {
+	originalConfPath := getCrioConfPath()
+	latestConfPath := getLatestPath(originalConfPath)
+
+	// Create latest file which will have some strings replaced
+	err := ci.fileManager.CopyFile(originalConfPath, latestConfPath, true)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to create .latest crio.conf file")
+	}
+
+	// Replace binary paths with sandbox path
+	// Update the DESTDIR in the CRI-O configuration, matching shell script sed commands
+	err = ci.replaceAllInFile(latestConfPath, usrBinDir, filepath.Join(destdir, bindir))
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to replace /usr/bin in crio.conf")
+	}
+	err = ci.replaceAllInFile(latestConfPath, libexecDir, filepath.Join(destdir, libexecdir))
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to replace /usr/libexec in crio.conf")
+	}
+	err = ci.replaceAllInFile(latestConfPath, etcCrioDir, filepath.Join(destdir, etcdir))
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to replace /etc/crio in crio.conf")
+	}
+
+	return nil
+}
+
+// getCrioConfPath returns the path to the 10-crio.conf file in the sandbox
+func getCrioConfPath() string {
+	return path.Join(core.Paths().SandboxDir, crioConfdDir, CrioConfFile)
+}
+
 // generateEtcDefaultCrioConfigurationFile generates the /etc/default/crio file in the sandbox
 func (ci *crioInstaller) generateEtcDefaultCrioConfigurationFile() error {
 	sandboxDir := core.Paths().SandboxDir
 
-	crioConfigContent := fmt.Sprintf(`# /etc/default/crio
+	// Generate the content using the shared logic
+	crioConfigContent := ci.generateExpectedEtcDefaultCrioContent()
+
+	err := os.WriteFile(filepath.Join(sandboxDir, "etc", "default", CrioDefaultConfigFile), []byte(crioConfigContent), core.DefaultFilePerm)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to create CRI-O default file")
+	}
+
+	return nil
+}
+
+// patchServiceFile patches the CRI-O systemd service file with sandbox paths
+func (ci *crioInstaller) patchServiceFile() error {
+	originalServiceFilePath := getCrioServicePath()
+	latestServiceFilePath := getLatestPath(originalServiceFilePath)
+
+	// Create latest file which will have some strings replaced
+	err := ci.fileManager.CopyFile(originalServiceFilePath, latestServiceFilePath, true)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to create .latest crio.service file")
+	}
+
+	// Patch the service file
+	err = ci.replaceAllInFile(latestServiceFilePath, "/usr/local/bin/crio", filepath.Join(core.Paths().SandboxLocalBinDir, "crio"))
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to patch crio.service file")
+	}
+
+	err = ci.replaceAllInFile(latestServiceFilePath, "/etc/sysconfig/crio", filepath.Join(core.Paths().SandboxDir, "etc", "default", CrioDefaultConfigFile))
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to patch crio.service sysconfig path")
+	}
+
+	return nil
+}
+
+// getCrioServicePath returns the path to the crio.service file in the sandbox
+func getCrioServicePath() string {
+	return path.Join(core.Paths().SandboxDir, "usr", "lib", "systemd", "system", CrioServiceFile)
+}
+
+// updateCrioTomlConfig updates the CRI-O TOML configuration file with sandbox paths
+func (ci *crioInstaller) updateCrioTomlConfig(confPath string) error {
+	// Get expected configuration using shared logic
+	expectedConfig := ci.generateExpectedCrioConfig()
+
+	// Use TomlConfigManager to update the file
+	return ci.tomlManager.UpdateTomlFile(confPath, expectedConfig)
+}
+
+// Generate crio-install list generates the crio-install list file
+// This matches the shell command:
+// touch ~/.crio-install
+// cat <<EOF | tee ~/.crio-install
+// $DESTDIR$OPT_CNI_BIN_DIR/*
+// ...
+// EOF
+func (ci *crioInstaller) generateCrioInstallList(destDir string) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to get user home directory")
+	}
+	installListPath := filepath.Join(homeDir, CrioInstallFile)
+
+	// Generate the content using the shared logic
+	content, err := ci.generateExpectedCrioInstallContent(destDir)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(installListPath, []byte(content), core.DefaultFilePerm); err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to write crio-install list file")
+	}
+
+	return nil
+}
+
+// Uninstall removes the CRI-O software from the sandbox and cleans up related files
+// This reverses the operations performed by Install()
+func (ci *crioInstaller) Uninstall() error {
+	sandboxDir := core.Paths().SandboxDir
+
+	// Remove all installed binaries
+	binaries := []string{
+		filepath.Join(sandboxDir, libexecCrioDir, "conmon"),
+		filepath.Join(sandboxDir, libexecCrioDir, "conmonrs"),
+		filepath.Join(sandboxDir, libexecCrioDir, "crun"),
+		filepath.Join(sandboxDir, libexecCrioDir, "runc"),
+		filepath.Join(sandboxDir, binDir, "crio"),
+		filepath.Join(sandboxDir, binDir, "pinns"),
+		filepath.Join(sandboxDir, binDir, "crictl"),
+	}
+
+	for _, binary := range binaries {
+		err := ci.fileManager.RemoveAll(binary)
+		if err != nil {
+			return errorx.IllegalState.Wrap(err, "failed to remove CRI-O binary %s", binary)
+		}
+	}
+
+	// Remove CNI plugins directory
+	cniPluginsDir := filepath.Join(sandboxDir, optCniBinDir)
+	err := ci.fileManager.RemoveAll(cniPluginsDir)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to remove CNI plugins directory %s", cniPluginsDir)
+	}
+
+	// Remove configuration files
+	configFiles := []string{
+		filepath.Join(sandboxDir, cniDir, CrioConfDisabledFile),
+		filepath.Join(sandboxDir, etcDir, CrictlYamlFile),
+		filepath.Join(sandboxDir, ociDir, CrioUmountConfFile),
+		filepath.Join(sandboxDir, getSysconfigDir(), CrioDefaultConfigFile),
+		filepath.Join(sandboxDir, etcCrioDir, PolicyJsonFile),
+		filepath.Join(sandboxDir, crioConfdDir, CrioConfFile),
+		filepath.Join(sandboxDir, man5Dir, CrioConf5File),
+		filepath.Join(sandboxDir, man5Dir, CrioConfd5File),
+		filepath.Join(sandboxDir, man8Dir, Crio8File),
+		filepath.Join(sandboxDir, bashInstallDir, "crio"),
+		filepath.Join(sandboxDir, fishInstallDir, CrioFishFile),
+		filepath.Join(sandboxDir, zshInstallDir, "_crio"),
+		filepath.Join(sandboxDir, userSystemdDir, CrioServiceFile),
+		filepath.Join(sandboxDir, containersRegistriesConfdDir, RegistriesConfFile),
+	}
+
+	for _, config := range configFiles {
+		err := ci.fileManager.RemoveAll(config)
+		if err != nil {
+			return errorx.IllegalState.Wrap(err, "failed to remove CRI-O config file %s", config)
+		}
+	}
+
+	// Remove directories created during installation (only if empty)
+	installDirs := []string{
+		filepath.Join(sandboxDir, libexecCrioDir),
+		filepath.Join(sandboxDir, bashInstallDir),
+		filepath.Join(sandboxDir, fishInstallDir),
+		filepath.Join(sandboxDir, zshInstallDir),
+		filepath.Join(sandboxDir, containersRegistriesConfdDir),
+		filepath.Join(sandboxDir, ociDir),
+		filepath.Join(sandboxDir, crioConfdDir),
+		filepath.Join(sandboxDir, man5Dir),
+		filepath.Join(sandboxDir, man8Dir),
+		filepath.Join(sandboxDir, userSystemdDir),
+		filepath.Join(sandboxDir, cniDir),
+	}
+
+	for _, dir := range installDirs {
+		err := ci.fileManager.RemoveAll(dir)
+		if err != nil {
+			return errorx.IllegalState.Wrap(err, "failed to remove CRI-O install directory %s", dir)
+		}
+	}
+
+	// Remove .crio-install file
+	homeDir, err := os.UserHomeDir()
+	if err == nil {
+		installListPath := filepath.Join(homeDir, CrioInstallFile)
+		err := ci.fileManager.RemoveAll(installListPath)
+		if err != nil {
+			return errorx.IllegalState.Wrap(err, "failed to remove CRI-O install list file %s", installListPath)
+		}
+	}
+
+	return nil
+}
+
+// RemoveConfiguration removes symlinks and restores the configuration files
+// This reverses the operations performed by Configure()
+func (ci *crioInstaller) RemoveConfiguration() error {
+	// Remove CRI-O service symlink
+	systemdServicePath := filepath.Join(userSystemdDir, "crio.service")
+	err := ci.fileManager.RemoveAll(systemdServicePath)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to remove CRI-O service symlink")
+	}
+
+	// Remove /etc/containers/registries.conf.d symlink
+	err = ci.fileManager.RemoveAll(etcContainersFolder)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to remove CRI-O /etc/containers/registries.conf.d symlink")
+	}
+
+	// Remove .latest configuration files
+	latestConfPath := getLatestPath(getCrioConfPath())
+	err = ci.fileManager.RemoveAll(latestConfPath)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to remove latest CRI-O configuration file")
+	}
+
+	latestServicePath := getLatestPath(getCrioServicePath())
+	err = ci.fileManager.RemoveAll(latestServicePath)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to remove latest CRI-O service file")
+	}
+
+	// Remove /etc/default/crio configuration file from sandbox
+	sandboxDir := core.Paths().SandboxDir
+	etcDefaultCrioPath := filepath.Join(sandboxDir, "etc", "default", CrioDefaultConfigFile)
+	err = ci.fileManager.RemoveAll(etcDefaultCrioPath)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to remove /etc/default/crio configuration file")
+	}
+
+	return nil
+}
+
+// IsInstalled checks if CRI-O has been fully installed
+// This includes checking binaries are installed, core directories exist, and configuration files are present
+func (ci *crioInstaller) IsInstalled() (bool, error) {
+	sandboxDir := core.Paths().SandboxDir
+
+	cniPluginsInstalled, err := ci.areCniPluginsInstalled(sandboxDir)
+	if err != nil {
+		return false, err
+	}
+	if !cniPluginsInstalled {
+		return false, nil
+	}
+
+	areBinaryInstalled, err := ci.areBinariesInstalled(sandboxDir)
+	if err != nil {
+		return false, err
+	}
+	if !areBinaryInstalled {
+		return false, nil
+	}
+
+	areConfigFilesInstalled, err := ci.areConfigFilesInstalled(sandboxDir)
+	if err != nil {
+		return false, err
+	}
+	if !areConfigFilesInstalled {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// areCniPluginsInstalled checks CNI plugins files are present by making sure the number of files
+// under the CNI bin directory matches the expected count
+func (ci *crioInstaller) areCniPluginsInstalled(sandboxDir string) (bool, error) {
+	targetPath := filepath.Join(sandboxDir, optCniBinDir)
+	if _, exists, err := ci.fileManager.PathExists(targetPath); err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to check CNI plugins directory existence")
+	} else if !exists {
+		return false, nil
+	}
+
+	entries, err := os.ReadDir(targetPath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to read CNI plugins directory")
+	}
+	if len(entries) != ExpectedCniPluginCount {
+		return false, nil
+	}
+	return true, nil
+}
+
+// areBinariesInstalled checks if all CRI-O binaries are installed
+// by verifying their existence and checksums
+func (ci *crioInstaller) areBinariesInstalled(sandboxDir string) (bool, error) {
+	// Map of binary source paths to their expected destination sandbox paths
+	binaryFilesMapping := map[string]string{
+		"cri-o/bin/crio":     filepath.Join(sandboxDir, binDir, "crio"),
+		"cri-o/bin/crictl":   filepath.Join(sandboxDir, binDir, "crictl"),
+		"cri-o/bin/pinns":    filepath.Join(sandboxDir, binDir, "pinns"),
+		"cri-o/bin/conmon":   filepath.Join(sandboxDir, libexecCrioDir, "conmon"),
+		"cri-o/bin/conmonrs": filepath.Join(sandboxDir, libexecCrioDir, "conmonrs"),
+		"cri-o/bin/runc":     filepath.Join(sandboxDir, libexecCrioDir, "runc"),
+		"cri-o/bin/crun":     filepath.Join(sandboxDir, libexecCrioDir, "crun"),
+	}
+
+	versionInfo, exists := ci.software.Versions[Version(ci.versionToBeInstalled)]
+	platform := ci.software.getPlatform()
+
+	if !exists {
+		return false, NewVersionNotFoundError(ci.software.Name, ci.versionToBeInstalled)
+	}
+	for _, binary := range versionInfo.Binaries {
+
+		// Check if binary exists in the sandbox
+		pathInSandbox := binaryFilesMapping[binary.Name]
+		if _, exists, err := ci.fileManager.PathExists(pathInSandbox); err != nil {
+			return false, errorx.IllegalState.Wrap(err, "failed to check binary existence: %s", binary)
+		} else if !exists || pathInSandbox == "" {
+			return false, nil
+		}
+
+		// Get expected checksum for this binary
+		osInfo, exists := binary.PlatformChecksum[platform.os]
+		if !exists {
+			return false, NewPlatformNotFoundError(ci.software.Name, ci.versionToBeInstalled, platform.os, "")
+		}
+		checksum, exists := osInfo[platform.arch]
+		if !exists {
+			return false, NewPlatformNotFoundError(ci.software.Name, ci.versionToBeInstalled, platform.os, platform.arch)
+		}
+
+		err := VerifyChecksum(pathInSandbox, checksum.Value, checksum.Algorithm)
+		if err != nil {
+			return false, errorx.IllegalState.Wrap(err, "checksum verification failed for binary: %s", binary)
+		}
+	}
+
+	return true, nil
+}
+
+// areConfigFilesInstalled checks if all essential CRI-O configuration files are installed
+func (ci *crioInstaller) areConfigFilesInstalled(sandboxDir string) (bool, error) {
+	// Check essential configuration files
+	configFiles := []string{
+		filepath.Join(sandboxDir, cniDir, CrioConfDisabledFile),
+		filepath.Join(sandboxDir, etcDir, CrictlYamlFile),
+		filepath.Join(sandboxDir, ociDir, CrioUmountConfFile),
+		filepath.Join(sandboxDir, getSysconfigDir(), CrioDefaultConfigFile),
+		filepath.Join(sandboxDir, etcCrioDir, PolicyJsonFile),
+		filepath.Join(sandboxDir, crioConfdDir, CrioConfFile),
+		filepath.Join(sandboxDir, man5Dir, CrioConf5File),
+		filepath.Join(sandboxDir, man5Dir, CrioConfd5File),
+		filepath.Join(sandboxDir, man8Dir, Crio8File),
+		filepath.Join(sandboxDir, bashInstallDir, "crio"),
+		filepath.Join(sandboxDir, fishInstallDir, CrioFishFile),
+		filepath.Join(sandboxDir, zshInstallDir, "_crio"),
+		filepath.Join(sandboxDir, userSystemdDir, CrioServiceFile),
+		filepath.Join(sandboxDir, containersRegistriesConfdDir, RegistriesConfFile),
+	}
+
+	for _, config := range configFiles {
+		if _, exists, err := ci.fileManager.PathExists(config); err != nil {
+			return false, err
+		} else if !exists {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// IsConfigured checks if CRI-O has been fully configured
+// This includes checking configuration files and symlinks
+// to ensure they are correctly set up
+func (ci *crioInstaller) IsConfigured() (bool, error) {
+	// Check .crio-install is valid
+	crioInstallValid, err := ci.isCrioInstallListValid()
+	if err != nil {
+		return false, err
+	}
+	if !crioInstallValid {
+		return false, nil
+	}
+
+	// Check if /etc/containers/registries.conf.d symlink
+	if !ci.fileManager.IsSymbolicLink(etcContainersFolder) {
+		return false, nil
+	}
+
+	// Check /etc/default/crio is valid
+	etcDefaultCrioValid, err := ci.isEtcDefaultCrioValid()
+	if err != nil {
+		return false, err
+	}
+	if !etcDefaultCrioValid {
+		return false, nil
+	}
+
+	// Check if 10-crio.conf.latest is valid
+	latestConfValid, err := ci.isLatestCrioConfValid()
+	if err != nil {
+		return false, err
+	}
+	if !latestConfValid {
+		return false, nil
+	}
+
+	// Check if crio.service.latest is valid
+	latestCrioServiceValid, err := ci.isLatestCrioServiceValid()
+	if err != nil {
+		return false, err
+	}
+	if !latestCrioServiceValid {
+		return false, nil
+	}
+
+	// Check symlink for crio.service is valid
+	crioServiceSymlinkValid, err := ci.isCrioServiceSymlinkValid()
+	if err != nil {
+		return false, err
+	}
+	if !crioServiceSymlinkValid {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// isLatestCrioConfValid checks if the latest 10-crio.conf file is valid
+// by comparing its content with the expected content
+func (ci *crioInstaller) isLatestCrioConfValid() (bool, error) {
+	latestConfPath := getLatestPath(getCrioConfPath())
+
+	// Check if the .latest file exists
+	fi, exists, err := ci.fileManager.PathExists(latestConfPath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to check if latest 10-crio.conf exists at %s", latestConfPath)
+	}
+	if !exists || !ci.fileManager.IsRegularFileByFileInfo(fi) {
+		return false, nil
+	}
+
+	// Read and parse TOML configuration file
+	contents, err := os.ReadFile(latestConfPath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to read file at %s", latestConfPath)
+	}
+
+	var tomlEntries map[string]any
+	if _, err = toml.NewDecoder(bytes.NewBufferString(string(contents))).Decode(&tomlEntries); err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to parse toml file at %s", latestConfPath)
+	}
+
+	// Get expected configuration using shared logic
+	expectedConfig := ci.generateExpectedCrioConfig()
+
+	// Validate each configuration value by iterating through the expected config
+	return ci.tomlManager.ValidateConfigValues(tomlEntries, expectedConfig), nil
+}
+
+// isCrioInstallListValid checks if the .crio-install file exists and contains the correct content
+// by comparing it with the expected paths that would be generated by generateCrioInstallList()
+func (ci *crioInstaller) isCrioInstallListValid() (bool, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to get user home directory")
+	}
+	installListPath := filepath.Join(homeDir, CrioInstallFile)
+
+	// Check if the .crio-install file exists
+	fi, exists, err := ci.fileManager.PathExists(installListPath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to check if .crio-install exists at %s", installListPath)
+	}
+	if !exists || !ci.fileManager.IsRegularFileByFileInfo(fi) {
+		return false, nil
+	}
+
+	// Read the current content
+	currentContent, err := os.ReadFile(installListPath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to read .crio-install file")
+	}
+
+	// Generate expected content using the same logic as generateCrioInstallList()
+	sandboxDir := core.Paths().SandboxDir
+	expectedContent, err := ci.generateExpectedCrioInstallContent(sandboxDir)
+	if err != nil {
+		return false, err
+	}
+
+	// Compare the content
+	return string(currentContent) == expectedContent, nil
+}
+
+// generateExpectedCrioInstallContent generates the expected content for .crio-install file
+// This mirrors the logic in generateCrioInstallList() without writing to file
+func (ci *crioInstaller) generateExpectedCrioInstallContent(destDir string) (string, error) {
+	// Define relativePaths relative to destDir (same as in generateCrioInstallList())
+	relativePaths := []string{
+		filepath.Join(optCniBinDir, "*"),
+		filepath.Join(cniDir, CrioConfDisabledFile),
+		filepath.Join(libexecCrioDir, "conmon"),
+		filepath.Join(libexecCrioDir, "conmonrs"),
+		filepath.Join(libexecCrioDir, "crun"),
+		filepath.Join(libexecCrioDir, "runc"),
+		filepath.Join(binDir, "crio"),
+		filepath.Join(binDir, "pinns"),
+		filepath.Join(binDir, "crictl"),
+		filepath.Join(etcDir, CrictlYamlFile),
+		filepath.Join(ociDir, CrioUmountConfFile),
+		filepath.Join(getSysconfigDir(), CrioDefaultConfigFile),
+		filepath.Join(etcCrioDir, PolicyJsonFile),
+		filepath.Join(crioConfdDir, CrioConfFile),
+		filepath.Join(man5Dir, CrioConf5File),
+		filepath.Join(man5Dir, CrioConfd5File),
+		filepath.Join(man8Dir, Crio8File),
+		filepath.Join(bashInstallDir, "crio"),
+		filepath.Join(fishInstallDir, CrioFishFile),
+		filepath.Join(zshInstallDir, "_crio"),
+		filepath.Join(userSystemdDir, CrioServiceFile),
+		filepath.Join(containersRegistriesConfdDir, RegistriesConfFile),
+	}
+
+	// Prepend destDir to each
+	var fullPaths []string
+	for _, p := range relativePaths {
+		fullPaths = append(fullPaths, filepath.Join(destDir, p))
+	}
+
+	return strings.Join(fullPaths, "\n") + "\n", nil
+}
+
+// isEtcDefaultCrioValid checks if the /etc/default/crio file exists and contains the correct content
+// by comparing it with the expected content that would be generated by generateEtcDefaultCrioConfigurationFile()
+func (ci *crioInstaller) isEtcDefaultCrioValid() (bool, error) {
+	sandboxDir := core.Paths().SandboxDir
+	etcDefaultCrioPath := filepath.Join(sandboxDir, "etc", "default", CrioDefaultConfigFile)
+
+	// Check if the /etc/default/crio file exists
+	fi, exists, err := ci.fileManager.PathExists(etcDefaultCrioPath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to check if /etc/default/crio exists at %s", etcDefaultCrioPath)
+	}
+	if !exists || !ci.fileManager.IsRegularFileByFileInfo(fi) {
+		return false, nil
+	}
+
+	// Read the current content
+	currentContent, err := os.ReadFile(etcDefaultCrioPath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to read /etc/default/crio file")
+	}
+
+	// Generate expected content using the same logic as generateEtcDefaultCrioConfigurationFile()
+	expectedContent := ci.generateExpectedEtcDefaultCrioContent()
+
+	// Compare the content
+	return string(currentContent) == expectedContent, nil
+}
+
+// generateExpectedEtcDefaultCrioContent generates the expected content for /etc/default/crio file
+// This mirrors the logic in generateEtcDefaultCrioConfigurationFile() without writing to file
+func (ci *crioInstaller) generateExpectedEtcDefaultCrioContent() string {
+	sandboxDir := core.Paths().SandboxDir
+
+	return fmt.Sprintf(`# /etc/default/crio
 
 # use "--enable-metrics" and "--metrics-port value"
 #CRIO_METRICS_OPTIONS="--enable-metrics"
@@ -337,185 +924,108 @@ func (ci *crioInstaller) generateEtcDefaultCrioConfigurationFile() error {
 # CRI-O configuration directory
 CRIO_CONFIG_OPTIONS="--config-dir=%s/etc/crio/crio.conf.d"
 `, sandboxDir)
-
-	err := os.WriteFile(filepath.Join(sandboxDir, "etc", "default", "crio"), []byte(crioConfigContent), core.DefaultFilePerm)
-	if err != nil {
-		return errorx.IllegalState.Wrap(err, "failed to create CRI-O default file")
-	}
-
-	return nil
 }
 
-// patchServiceFile patches the CRI-O systemd service file with sandbox paths
-func (ci *crioInstaller) patchServiceFile() error {
+// isLatestCrioServiceValid checks if the crio.service.latest file exists and contains valid content
+// by comparing it with the expected content that would be generated by patchServiceFile()
+func (ci *crioInstaller) isLatestCrioServiceValid() (bool, error) {
+	latestServicePath := getLatestPath(getCrioServicePath())
+
+	// Check if the .latest file exists
+	fi, exists, err := ci.fileManager.PathExists(latestServicePath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to check if crio.service.latest exists at %s", latestServicePath)
+	}
+	if !exists || !ci.fileManager.IsRegularFileByFileInfo(fi) {
+		return false, nil
+	}
+
+	// Read the current content, and validate the content contains the expected sandbox paths
+	currentContent, err := os.ReadFile(latestServicePath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to read crio.service.latest file")
+	}
+
+	contentStr := string(currentContent)
+	expectedSandboxBinPath := filepath.Join(core.Paths().SandboxLocalBinDir, "crio")
+	expectedSandboxConfigPath := filepath.Join(core.Paths().SandboxDir, "etc", "default", CrioDefaultConfigFile)
+
+	// Check if the service file has been properly patched with sandbox paths
+	if !strings.Contains(contentStr, expectedSandboxBinPath) {
+		return false, nil
+	}
+	if !strings.Contains(contentStr, expectedSandboxConfigPath) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// isCrioServiceSymlinkValid checks if the crio.service symlink exists and points to the correct .latest file
+func (ci *crioInstaller) isCrioServiceSymlinkValid() (bool, error) {
+	systemServicePath := filepath.Join(userSystemdDir, CrioServiceFile)
+	expectedTarget := getLatestPath(getCrioServicePath())
+
+	// Check if the symlink exists
+	if !ci.fileManager.IsSymbolicLink(systemServicePath) {
+		return false, nil
+	}
+
+	// Check if symlink points to the correct target
+	actualTarget, err := os.Readlink(systemServicePath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to read symlink target for %s", systemServicePath)
+	}
+
+	return actualTarget == expectedTarget, nil
+}
+
+// generateExpectedCrioConfig returns the expected CRI-O TOML configuration
+// with sandbox-specific paths. This method centralizes the configuration definition
+// for both setting during Configure() and validation during IsConfigured().
+//
+// The configuration includes:
+// - Runtime configuration: default runtime, container paths, runtime roots
+// - API configuration: socket paths for CRI-O API communication
+// - Storage configuration: container storage paths and version files
+// - Network configuration: CNI network directories and plugin paths
+// - NRI configuration: Node Resource Interface plugin paths and sockets
+//
+// All paths are adjusted to use the sandbox directory structure rather than
+// system-wide paths, enabling isolated testing and development environments.
+func (ci *crioInstaller) generateExpectedCrioConfig() map[string]interface{} {
 	sandboxDir := core.Paths().SandboxDir
 	sandboxLocalBin := core.Paths().SandboxLocalBinDir
 
-	crioServicePath := filepath.Join(sandboxDir, "usr", "lib", "systemd", "system", "crio.service")
-
-	// Patch the service file
-	err := ci.replaceAllInFile(crioServicePath, "/usr/local/bin/crio", filepath.Join(sandboxLocalBin, "crio"))
-	if err != nil {
-		return errorx.IllegalState.Wrap(err, "failed to patch crio.service file")
-	}
-
-	err = ci.replaceAllInFile(crioServicePath, "/etc/sysconfig/crio", filepath.Join(sandboxDir, "etc", "default", "crio"))
-	if err != nil {
-		return errorx.IllegalState.Wrap(err, "failed to patch crio.service sysconfig path")
-	}
-
-	return nil
-}
-
-// updateCrioTomlConfig updates the CRI-O TOML configuration file with sandbox paths
-func (ci *crioInstaller) updateCrioTomlConfig(confPath string) error {
-	// Read the existing TOML file
-	data, err := os.ReadFile(confPath)
-	if err != nil {
-		return err
-	}
-
-	// Parse the TOML content into a generic map to preserve all existing configuration
-	var config map[string]interface{}
-	err = toml.Unmarshal(data, &config)
-	if err != nil {
-		return err
-	}
-
-	// Update all the configuration values with sandbox paths
-	ci.setCrioConfigPaths(config)
-
-	// Marshal back to TOML
-	file, err := os.Create(confPath)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-	}()
-
-	encoder := toml.NewEncoder(file)
-	err = encoder.Encode(config)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// setCrioConfigPaths updates all CRI-O configuration paths in the config map
-func (ci *crioInstaller) setCrioConfigPaths(config map[string]interface{}) {
-	sandboxDir := core.Paths().SandboxDir
-	sandboxLocalBin := core.Paths().SandboxLocalBinDir
+	config := make(map[string]interface{})
 
 	// Runtime configuration
-	setNestedValue(config, "crio.runtime.default_runtime", "runc")
-	setNestedValue(config, "crio.runtime.decryption_keys_path", filepath.Join(sandboxDir, "etc/crio/keys"))
-	setNestedValue(config, "crio.runtime.container_exits_dir", filepath.Join(sandboxDir, "var/run/crio/exits"))
-	setNestedValue(config, "crio.runtime.container_attach_socket_dir", filepath.Join(sandboxDir, "var/run/crio"))
-	setNestedValue(config, "crio.runtime.namespaces_dir", filepath.Join(sandboxDir, "var/run"))
-	setNestedValue(config, "crio.runtime.pinns_path", filepath.Join(sandboxLocalBin, "pinns"))
-	setNestedValue(config, "crio.runtime.runtimes.runc.runtime_root", filepath.Join(sandboxDir, "run/runc"))
+	ci.tomlManager.SetNestedValue(config, "crio.runtime.default_runtime", "runc")
+	ci.tomlManager.SetNestedValue(config, "crio.runtime.decryption_keys_path", filepath.Join(sandboxDir, "etc/crio/keys"))
+	ci.tomlManager.SetNestedValue(config, "crio.runtime.container_exits_dir", filepath.Join(sandboxDir, "var/run/crio/exits"))
+	ci.tomlManager.SetNestedValue(config, "crio.runtime.container_attach_socket_dir", filepath.Join(sandboxDir, "var/run/crio"))
+	ci.tomlManager.SetNestedValue(config, "crio.runtime.namespaces_dir", filepath.Join(sandboxDir, "var/run"))
+	ci.tomlManager.SetNestedValue(config, "crio.runtime.pinns_path", filepath.Join(sandboxLocalBin, "pinns"))
+	ci.tomlManager.SetNestedValue(config, "crio.runtime.runtimes.runc.runtime_root", filepath.Join(sandboxDir, "run/runc"))
 
 	// API configuration
-	setNestedValue(config, "crio.api.listen", filepath.Join(sandboxDir, "var/run/crio/crio.sock"))
+	ci.tomlManager.SetNestedValue(config, "crio.api.listen", filepath.Join(sandboxDir, "var/run/crio/crio.sock"))
 
 	// Storage configuration
-	setNestedValue(config, "crio.root", filepath.Join(sandboxDir, "var/lib/containers/storage"))
-	setNestedValue(config, "crio.runroot", filepath.Join(sandboxDir, "var/run/containers/storage"))
-	setNestedValue(config, "crio.version_file", filepath.Join(sandboxDir, "var/run/crio/version"))
-	setNestedValue(config, "crio.log_dir", filepath.Join(sandboxDir, "var/logs/crio/pods"))
-	setNestedValue(config, "crio.clean_shutdown_file", filepath.Join(sandboxDir, "var/lib/crio/clean.shutdown"))
+	ci.tomlManager.SetNestedValue(config, "crio.root", filepath.Join(sandboxDir, "var/lib/containers/storage"))
+	ci.tomlManager.SetNestedValue(config, "crio.runroot", filepath.Join(sandboxDir, "var/run/containers/storage"))
+	ci.tomlManager.SetNestedValue(config, "crio.version_file", filepath.Join(sandboxDir, "var/run/crio/version"))
+	ci.tomlManager.SetNestedValue(config, "crio.log_dir", filepath.Join(sandboxDir, "var/logs/crio/pods"))
+	ci.tomlManager.SetNestedValue(config, "crio.clean_shutdown_file", filepath.Join(sandboxDir, "var/lib/crio/clean.shutdown"))
 
 	// Network configuration
-	setNestedValue(config, "crio.network.network_dir", filepath.Join(sandboxDir, "etc/cni/net.d/"))
-	setNestedValue(config, "crio.network.plugin_dirs", []string{filepath.Join(sandboxDir, "opt/cni/bin")})
+	ci.tomlManager.SetNestedValue(config, "crio.network.network_dir", filepath.Join(sandboxDir, "etc/cni/net.d"))
+	ci.tomlManager.SetNestedValue(config, "crio.network.plugin_dirs", []interface{}{filepath.Join(sandboxDir, "opt/cni/bin")})
 
 	// NRI configuration
-	setNestedValue(config, "crio.nri.nri_plugin_dir", filepath.Join(sandboxDir, "opt/nri/plugins"))
-	setNestedValue(config, "crio.nri.nri_plugin_config_dir", filepath.Join(sandboxDir, "etc/nri/conf.d"))
-	setNestedValue(config, "crio.nri.nri_listen", filepath.Join(sandboxDir, "var/run/nri/nri.sock"))
-}
+	ci.tomlManager.SetNestedValue(config, "crio.nri.nri_plugin_dir", filepath.Join(sandboxDir, "opt/nri/plugins"))
+	ci.tomlManager.SetNestedValue(config, "crio.nri.nri_plugin_config_dir", filepath.Join(sandboxDir, "etc/nri/conf.d"))
+	ci.tomlManager.SetNestedValue(config, "crio.nri.nri_listen", filepath.Join(sandboxDir, "var/run/nri/nri.sock"))
 
-// setNestedValue safely sets nested values in a map, creating intermediate maps as needed
-// The value can be a string, slice, or any other type
-func setNestedValue(config map[string]interface{}, path string, value interface{}) {
-	keys := strings.Split(path, ".")
-	m := config
-
-	// Navigate/create the nested structure
-	for i := 0; i < len(keys)-1; i++ {
-		key := keys[i]
-		if _, exists := m[key]; !exists {
-			m[key] = make(map[string]interface{})
-		}
-		// Type assertion to continue navigating
-		if nextMap, ok := m[key].(map[string]interface{}); ok {
-			m = nextMap
-		} else {
-			// If the existing value isn't a map, replace it
-			newMap := make(map[string]interface{})
-			m[key] = newMap
-			m = newMap
-		}
-	}
-	// Set the final value
-	m[keys[len(keys)-1]] = value
-}
-
-// Generate crio-install list generates the crio-install list file
-// This matches the shell command:
-// touch ~/.crio-install
-// cat <<EOF | tee ~/.crio-install
-// $DESTDIR$OPT_CNI_BIN_DIR/*
-// ...
-// EOF
-func (ci *crioInstaller) generateCrioInstallList(destDir, sysconfigDir string) error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return errorx.IllegalState.Wrap(err, "failed to get user home directory")
-	}
-	installListPath := filepath.Join(homeDir, ".crio-install")
-
-	// Define relativePaths relative to destDir
-	relativePaths := []string{
-		filepath.Join(optCniBinDir, "*"),
-		filepath.Join(cniDir, "10-crio-bridge.conflist.disabled"),
-		filepath.Join(libexecCrioDir, "conmon"),
-		filepath.Join(libexecCrioDir, "conmonrs"),
-		filepath.Join(libexecCrioDir, "crun"),
-		filepath.Join(libexecCrioDir, "runc"),
-		filepath.Join(binDir, "crio"),
-		filepath.Join(binDir, "pinns"),
-		filepath.Join(binDir, "crictl"),
-		filepath.Join(etcDir, "crictl.yaml"),
-		filepath.Join(ociDir, "crio-umount.conf"),
-		filepath.Join(sysconfigDir, "crio"),
-		filepath.Join(etcCrioDir, "policy.json"),
-		filepath.Join(crioConfdDir, "10-crio.conf"),
-		filepath.Join(man5Dir, "crio.conf.5"),
-		filepath.Join(man5Dir, "crio.conf.d.5"),
-		filepath.Join(man8Dir, "crio.8"),
-		filepath.Join(bashInstallDir, "crio"),
-		filepath.Join(fishInstallDir, "crio.fish"),
-		filepath.Join(zshInstallDir, "_crio"),
-		filepath.Join(userSystemdDir, "crio.service"),
-		filepath.Join(containersRegistriesConfdDir, "registries.conf"),
-	}
-
-	// Prepend destDir to each
-	var fullPaths []string
-	for _, p := range relativePaths {
-		fullPaths = append(fullPaths, filepath.Join(destDir, p))
-	}
-
-	content := strings.Join(fullPaths, "\n") + "\n"
-
-	if err := os.WriteFile(installListPath, []byte(content), core.DefaultFilePerm); err != nil {
-		return errorx.IllegalState.Wrap(err, "failed to write crio-install list file")
-	}
-
-	return nil
+	return config
 }

--- a/pkg/software/kubelet_installer.go
+++ b/pkg/software/kubelet_installer.go
@@ -77,7 +77,7 @@ func (ki *kubeletInstaller) Configure() error {
 	}
 
 	// Create the latest service file with updated paths
-	err = ki.createLatestServiceFile()
+	err = ki.patchServiceFile()
 	if err != nil {
 		return err
 	}
@@ -201,8 +201,8 @@ func (ki *kubeletInstaller) validateCriticalPaths() error {
 	return nil
 }
 
-// createLatestServiceFile creates a copy of kubelet.service with updated paths
-func (ki *kubeletInstaller) createLatestServiceFile() error {
+// patchServiceFile creates a copy of kubelet.service with updated paths
+func (ki *kubeletInstaller) patchServiceFile() error {
 	kubeletServicePath := ki.getKubeletServicePath()
 	latestServicePath := ki.getLatestKubeletServicePath()
 


### PR DESCRIPTION
## Description

This pull request introduces significant improvements to the TOML configuration utilities and enhances the robustness and reporting of the CRI-O setup workflow, as well as test environment management for Kubernetes-related integration tests. The main themes are:  (1) enhanced step metadata and rollback handling for CRI-O installation and configuration, (2) a new TOML configuration management package, and (3) improved test environment setup and teardown.

**Key changes:**


**1. CRI-O Step Improvements**
- Enhanced the `SetupCrio` workflow and its steps (`installCrio`, `configureCrio`) to provide more granular status notifications, improved error and completion reporting, and detailed metadata on step execution (such as whether CRI-O was already installed/configured, and which actions were performed by the step). [[1]](diffhunk://#diff-d7a6a5a9ff86380c583666a3358a57395b7974910659c4dcb050e9aee451e496L13-R40) [[2]](diffhunk://#diff-d7a6a5a9ff86380c583666a3358a57395b7974910659c4dcb050e9aee451e496R49-L61) [[3]](diffhunk://#diff-d7a6a5a9ff86380c583666a3358a57395b7974910659c4dcb050e9aee451e496R129-R163)
- Improved rollback logic for both installation and configuration steps, ensuring that uninstall or configuration removal only occurs if the step actually performed the action, and that all rollbacks are reported with appropriate metadata. [[1]](diffhunk://#diff-d7a6a5a9ff86380c583666a3358a57395b7974910659c4dcb050e9aee451e496R49-L61) [[2]](diffhunk://#diff-d7a6a5a9ff86380c583666a3358a57395b7974910659c4dcb050e9aee451e496R129-R163)
- 
**2. TOML Configuration Management**
- Added a new `tomlx` package (`internal/tomlx/tomlx.go`) that provides a `TomlConfigManager` for reading, updating, merging, setting, and validating TOML configuration files, with support for nested structures and dot notation paths. This is designed to help software installers patch configuration files while preserving their structure.

**3. Test Environment Setup and Cleanup**
- Introduced a `reset` helper in `helpers_test.go` to fully clean up and reset the Kubernetes environment between integration tests. All relevant integration tests now use `reset` instead of the previous `cleanUpTempDir`, ensuring a more thorough and reliable test environment reset. [[1]](diffhunk://#diff-49b3aeb2cc95d190f3db44530d977d58889c2f12d62fcf9be81a79b272bf494bR57-R242) [[2]](diffhunk://#diff-afb25c993e01f7ddf200e180f1666d7040a65d76a33edd7c7b86b64ca9439723L23-R23) [[3]](diffhunk://#diff-afb25c993e01f7ddf200e180f1666d7040a65d76a33edd7c7b86b64ca9439723L51-R51) [[4]](diffhunk://#diff-afb25c993e01f7ddf200e180f1666d7040a65d76a33edd7c7b86b64ca9439723L89-R89) [[5]](diffhunk://#diff-afb25c993e01f7ddf200e180f1666d7040a65d76a33edd7c7b86b64ca9439723L130-R130) [[6]](diffhunk://#diff-afb25c993e01f7ddf200e180f1666d7040a65d76a33edd7c7b86b64ca9439723L172-R172) [[7]](diffhunk://#diff-afb25c993e01f7ddf200e180f1666d7040a65d76a33edd7c7b86b64ca9439723L227-R227) [[8]](diffhunk://#diff-afb25c993e01f7ddf200e180f1666d7040a65d76a33edd7c7b86b64ca9439723L289-R289) [[9]](diffhunk://#diff-afb25c993e01f7ddf200e180f1666d7040a65d76a33edd7c7b86b64ca9439723L351-R351) [[10]](diffhunk://#diff-afb25c993e01f7ddf200e180f1666d7040a65d76a33edd7c7b86b64ca9439723L421-R421) [[11]](diffhunk://#diff-afb25c993e01f7ddf200e180f1666d7040a65d76a33edd7c7b86b64ca9439723L471-R471) [[12]](diffhunk://#diff-afb25c993e01f7ddf200e180f1666d7040a65d76a33edd7c7b86b64ca9439723L517-R517)
- Added `setupPrerequisitesToLevel` to help tests set up system prerequisites incrementally, improving test clarity and reliability.

**Other minor changes**
- Updated imports in test helpers to support new functionality.

These changes increase the maintainability, reliability, and observability of both the configuration management utilities and the Kubernetes/CRI-O provisioning workflows.

### Test Results

#### Running Weaver

<img width="1276" height="1851" alt="image" src="https://github.com/user-attachments/assets/b2d36694-712f-428e-ab35-bbd5cf5cb2cf" />


#### Integration Test Results



### Related Issues

* Closes #183 
