### PR TITLE
feat: add block node installation support

### DIFF
--- a/cmd/provisioner/commands/root.go
+++ b/cmd/provisioner/commands/root.go
@@ -7,18 +7,17 @@ import (
 	"github.com/joomcode/errorx"
 	"github.com/spf13/cobra"
 	"golang.hedera.com/solo-provisioner/internal/config"
+	"golang.hedera.com/solo-provisioner/internal/core"
 	"golang.hedera.com/solo-provisioner/internal/doctor"
 )
 
 // examples:
 // ./provisioner block node check
-// ./provisioner consensus node check
-// ./provisioner local node check
-
-// Future commands (not yet implemented):
 // ./provisioner block node setup --config ./config.yaml
-// ./provisioner consensus node setup --manifest ./manifests/consensus-node.yaml
-// ./provisioner local node setup
+// ./provisioner consensus node check
+// ./provisioner consensus node setup --config ./config.yaml
+// ./provisioner local node check
+// ./provisioner local node setup --config ./config.yaml
 
 // NodeTypeConfig defines the configuration for a node type
 type NodeTypeConfig struct {
@@ -58,9 +57,9 @@ var (
 
 // nodeTypeConfigs defines all supported node types and their configuration
 var nodeTypeConfigs = []NodeTypeConfig{
-	{Name: "block", ParentCmd: blockCmd},
-	{Name: "consensus", ParentCmd: consensusCmd},
-	{Name: "local", ParentCmd: localCmd},
+	{Name: core.NodeTypeBlock, ParentCmd: blockCmd},
+	{Name: core.NodeTypeConsensus, ParentCmd: consensusCmd},
+	{Name: core.NodeTypeLocal, ParentCmd: localCmd},
 }
 
 // Execute executes the root command.

--- a/internal/blocknode/manager.go
+++ b/internal/blocknode/manager.go
@@ -1,0 +1,311 @@
+package blocknode
+
+import (
+	"context"
+	"os"
+	"path"
+	"time"
+
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+	"github.com/rs/zerolog"
+	"golang.hedera.com/solo-provisioner/internal/core"
+	"golang.hedera.com/solo-provisioner/internal/kube"
+	"golang.hedera.com/solo-provisioner/internal/templates"
+	"golang.hedera.com/solo-provisioner/pkg/fsx"
+	"golang.hedera.com/solo-provisioner/pkg/helm"
+	"helm.sh/helm/v3/pkg/cli/values"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	// Kubernetes resources
+	Namespace         = "block-node"
+	Release           = "block-node"
+	Chart             = "oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server"
+	Version           = "0.22.1"
+	ServiceName       = "block-node-block-node-server"
+	PodLabelSelector  = "app.kubernetes.io/name=block-node-server"
+	MetalLBAnnotation = "metallb.io/address-pool=public-address-pool"
+
+	// Storage paths
+	StorageBasePath    = "/opt/provisioner/block-node-storage"
+	ArchiveStoragePath = StorageBasePath + "/archive"
+	LiveStoragePath    = StorageBasePath + "/live"
+	LogsStoragePath    = StorageBasePath + "/logs"
+
+	// Template paths
+	NamespacePath     = "files/block-node/namespace.yaml"
+	StorageConfigPath = "files/block-node/storage-config.yaml"
+	ValuesPath        = "files/block-node/full-values.yaml"
+	NanoValuesPath    = "files/block-node/nano-values.yaml"
+
+	// Timeouts
+	PodReadyTimeoutSeconds = 300
+)
+
+// Manager handles block node setup and management operations
+type Manager struct {
+	fsManager   fsx.Manager
+	helmManager helm.Manager
+	kubeClient  *kube.Client
+	clientset   *kubernetes.Clientset // Still needed for pod listing and service updates
+	logger      *zerolog.Logger
+}
+
+// NewManager creates a new block node manager
+func NewManager() (*Manager, error) {
+	l := logx.As()
+
+	// File system manager
+	fsManager, err := fsx.NewManager()
+	if err != nil {
+		return nil, errorx.IllegalState.Wrap(err, "failed to create file system manager")
+	}
+
+	// Helm manager
+	helmManager, err := helm.NewManager(helm.WithLogger(*l))
+	if err != nil {
+		return nil, errorx.IllegalState.Wrap(err, "failed to create helm manager")
+	}
+
+	// Kubernetes client
+	kubeClient, err := kube.NewClient()
+	if err != nil {
+		return nil, errorx.IllegalState.Wrap(err, "failed to create kubernetes client")
+	}
+
+	// Kubernetes clientset for namespace operations
+	config, err := getKubeConfig()
+	if err != nil {
+		return nil, errorx.IllegalState.Wrap(err, "failed to get kubeconfig")
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, errorx.IllegalState.Wrap(err, "failed to create kubernetes clientset")
+	}
+
+	return &Manager{
+		fsManager:   fsManager,
+		helmManager: helmManager,
+		kubeClient:  kubeClient,
+		clientset:   clientset,
+		logger:      l,
+	}, nil
+}
+
+// getKubeConfig returns the kubernetes rest config
+func getKubeConfig() (*rest.Config, error) {
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		return rest.InClusterConfig()
+	}
+
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = os.Getenv("HOME") + "/.kube/config"
+	}
+	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+}
+
+// SetupStorage creates the required directories for block node storage
+func (m *Manager) SetupStorage(ctx context.Context) error {
+	storagePaths := []string{
+		StorageBasePath,
+		ArchiveStoragePath,
+		LiveStoragePath,
+		LogsStoragePath,
+	}
+
+	for _, dirPath := range storagePaths {
+		_, exists, err := m.fsManager.PathExists(dirPath)
+		if err != nil {
+			return errorx.IllegalState.Wrap(err, "failed to check path existence: %s", dirPath)
+		}
+
+		if exists {
+			m.logger.Info().Str("path", dirPath).Msg("Directory already exists, skipping")
+			continue
+		}
+
+		if err := m.fsManager.CreateDirectory(dirPath, true); err != nil {
+			return errorx.IllegalState.Wrap(err, "failed to create directory: %s", dirPath)
+		}
+
+		if err := m.fsManager.WritePermissions(dirPath, core.DefaultDirOrExecPerm, true); err != nil {
+			return errorx.IllegalState.Wrap(err, "failed to set permissions on: %s", dirPath)
+		}
+	}
+
+	return nil
+}
+
+// CreateNamespace creates the block-node namespace if it doesn't exist
+func (m *Manager) CreateNamespace(ctx context.Context, tempDir string) error {
+	// Read the namespace template
+	namespaceManifest, err := templates.Read(NamespacePath)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to read namespace template")
+	}
+
+	// Write to temp file
+	manifestFilePath := path.Join(tempDir, "block-node-namespace.yaml")
+	if err := os.WriteFile(manifestFilePath, []byte(namespaceManifest), core.DefaultFilePerm); err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to write namespace manifest to temp file")
+	}
+
+	// Apply the manifest - ApplyManifest is idempotent, so it will create or update
+	if err := m.kubeClient.ApplyManifest(ctx, manifestFilePath); err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to apply namespace manifest")
+	}
+
+	m.logger.Info().Msgf("Applied namespace manifest for: %s", Namespace)
+	return nil
+}
+
+// DeleteNamespace deletes the block-node namespace
+func (m *Manager) DeleteNamespace(ctx context.Context, tempDir string) error {
+	manifestFilePath := path.Join(tempDir, "block-node-namespace.yaml")
+	return m.kubeClient.DeleteManifest(ctx, manifestFilePath)
+}
+
+// CreatePersistentVolumes creates PVs and PVCs from the storage config
+func (m *Manager) CreatePersistentVolumes(ctx context.Context, tempDir string) error {
+	// Read the storage config template
+	storageConfig, err := templates.Read(StorageConfigPath)
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to read storage config template")
+	}
+
+	// Write to temp file
+	configFilePath := path.Join(tempDir, "block-node-storage-config.yaml")
+	if err := os.WriteFile(configFilePath, []byte(storageConfig), core.DefaultFilePerm); err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to write storage config to temp file")
+	}
+
+	// Apply the configuration
+	if err := m.kubeClient.ApplyManifest(ctx, configFilePath); err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to apply storage configuration")
+	}
+
+	// Wait for all PVCs to be bound
+	pvcNames := []string{"live-storage-pvc", "archive-storage-pvc", "logging-storage-pvc"}
+	timeout := 2 * time.Minute
+
+	for _, pvcName := range pvcNames {
+		m.logger.Info().Str("pvc", pvcName).Msg("Waiting for PVC to be bound...")
+		if err := m.kubeClient.WaitForResource(ctx, kube.KindPVC, Namespace, pvcName, kube.IsPVCBound, timeout); err != nil {
+			return errorx.IllegalState.Wrap(err, "PVC %s did not become bound in time", pvcName)
+		}
+		m.logger.Info().Str("pvc", pvcName).Msg("PVC is bound")
+	}
+
+	return nil
+}
+
+// DeletePersistentVolumes deletes PVs and PVCs
+func (m *Manager) DeletePersistentVolumes(ctx context.Context, tempDir string) error {
+	configFilePath := path.Join(tempDir, "block-node-storage-config.yaml")
+	return m.kubeClient.DeleteManifest(ctx, configFilePath)
+}
+
+// InstallChart installs the block node helm chart
+func (m *Manager) InstallChart(ctx context.Context, tempDir string, nodeType string) (bool, error) {
+	// Check if already installed
+	isInstalled, err := m.helmManager.IsInstalled(Release, Namespace)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to check if block node is installed")
+	}
+
+	if isInstalled {
+		m.logger.Info().Msg("Block Node is already installed, skipping installation")
+		return false, nil
+	}
+
+	// Choose the appropriate values file based on node type
+	valuesTemplatePath := ValuesPath
+	if nodeType == core.NodeTypeLocal {
+		valuesTemplatePath = NanoValuesPath
+		m.logger.Info().Msg("Using nano values configuration for local node type")
+	}
+
+	// Read the values file template
+	valuesContent, err := templates.Read(valuesTemplatePath)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to read values template")
+	}
+
+	// Write to temp file
+	valuesFilePath := path.Join(tempDir, "block-node-values.yaml")
+	if err := os.WriteFile(valuesFilePath, []byte(valuesContent), core.DefaultFilePerm); err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to write values to temp file")
+	}
+
+	// Install the chart
+	_, err = m.helmManager.InstallChart(
+		ctx,
+		Release,
+		Chart,
+		Version,
+		Namespace,
+		helm.InstallChartOptions{
+			ValueOpts: &values.Options{
+				ValueFiles: []string{valuesFilePath},
+			},
+			CreateNamespace: false, // namespace already created
+			Atomic:          true,
+			Wait:            true,
+			Timeout:         helm.DefaultTimeout,
+		},
+	)
+	if err != nil {
+		return false, errorx.IllegalState.Wrap(err, "failed to install block node chart")
+	}
+
+	return true, nil
+}
+
+// UninstallChart uninstalls the block node helm chart
+func (m *Manager) UninstallChart(ctx context.Context) error {
+	return m.helmManager.UninstallChart(Release, Namespace)
+}
+
+// AnnotateService annotates the block node service with MetalLB address pool
+func (m *Manager) AnnotateService(ctx context.Context) error {
+	svc, err := m.clientset.CoreV1().Services(Namespace).Get(ctx, ServiceName, metav1.GetOptions{})
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to get service: %s", ServiceName)
+	}
+
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+
+	svc.Annotations["metallb.io/address-pool"] = "public-address-pool"
+
+	_, err = m.clientset.CoreV1().Services(Namespace).Update(ctx, svc, metav1.UpdateOptions{})
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to annotate service: %s", ServiceName)
+	}
+
+	return nil
+}
+
+// WaitForPodReady waits for the block node pod to be ready
+func (m *Manager) WaitForPodReady(ctx context.Context) error {
+	m.logger.Info().Msg("Waiting for Block Node pod to be ready...")
+
+	timeout := time.Duration(PodReadyTimeoutSeconds) * time.Second
+	opts := kube.WaitOptions{
+		LabelSelector: PodLabelSelector,
+	}
+
+	if err := m.kubeClient.WaitForResources(ctx, kube.KindPod, Namespace, kube.IsPodReady, timeout, opts); err != nil {
+		return errorx.IllegalState.Wrap(err, "pod did not become ready in time")
+	}
+
+	return nil
+}

--- a/internal/core/const.go
+++ b/internal/core/const.go
@@ -7,13 +7,20 @@ import (
 )
 
 const (
+	// File and directory permissions
 	DefaultDirOrExecPerm = 0755 // for directories and executable files
 	DefaultFilePerm      = 0644 // for regular data/config files
 
+	// Provisioner paths
 	DefaultProvisionerHome  = "/opt/provisioner"
 	DefaultUnpackFolderName = "unpack"
 	SystemBinDir            = "/usr/local/bin"
 	SystemdUnitFilesDir     = "/usr/lib/systemd/system"
+
+	// Node types
+	NodeTypeLocal     = "local"
+	NodeTypeBlock     = "block"
+	NodeTypeConsensus = "consensus"
 )
 
 var (

--- a/internal/templates/files/block-node/full-values.yaml
+++ b/internal/templates/files/block-node/full-values.yaml
@@ -1,0 +1,47 @@
+blockNode:
+  config:
+    BLOCK_NODE_EARLIEST_MANAGED_BLOCK: "100000000"
+    MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "512"
+  logs:
+    level: "INFO"
+    loggingProperties:
+      org.hiero.block.level: "FINEST"
+      java.util.logging.ConsoleHandler.level: "FINEST"
+      java.util.logging.FileHandler.level: "FINEST"
+  initContainers:
+    - name: init-storage-dirs
+      image: docker.io/library/busybox:latest
+      command:
+        - sh
+        - -c
+        - |
+          chown 2000:2000 /live-pvc && \
+          chmod 700 /live-pvc && \
+          chown 2000:2000 /archive-pvc && \
+          chmod 700 /archive-pvc && \
+          chown 2000:2000 /logging-pvc && \
+          chmod 700 /logging-pvc
+      volumeMounts:
+        - name: live-storage
+          mountPath: /live-pvc
+        - name: archive-storage
+          mountPath: /archive-pvc
+        - name: logging-storage
+          mountPath: /logging-pvc
+  persistence:
+    live:
+      create: false
+      existingClaim: live-storage-pvc
+      subPath: ""
+    archive:
+      create: false
+      existingClaim: archive-storage-pvc
+      subPath: ""
+    logging:
+      create: false
+      existingClaim: logging-storage-pvc
+      subPath: ""
+
+service:
+  type: LoadBalancer
+  port: 40840

--- a/internal/templates/files/block-node/namespace.yaml
+++ b/internal/templates/files/block-node/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: block-node

--- a/internal/templates/files/block-node/nano-values.yaml
+++ b/internal/templates/files/block-node/nano-values.yaml
@@ -1,0 +1,66 @@
+resources:
+  requests:
+    cpu: "500m"
+    memory: "1Gi"
+  limits:
+    cpu: "1"
+    memory: "1.5Gi"
+
+blockNode:
+  config:
+    JAVA_OPTS: '-Xms1G -Xmx1G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
+    MESSAGING_BLOCK_ITEM_QUEUE_SIZE: "128"
+    MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "16"
+    BACKFILL_FETCH_BATCH_SIZE: "5"
+  logs:
+    level: "INFO"
+    loggingProperties:
+      org.hiero.block.level: "FINEST"
+      java.util.logging.ConsoleHandler.level: "FINEST"
+      java.util.logging.FileHandler.level: "FINEST"
+  initContainers:
+    - name: init-storage-dirs
+      image: docker.io/library/busybox:latest
+      command:
+        - sh
+        - -c
+        - |
+          chown 2000:2000 /live-pvc && \
+          chmod 700 /live-pvc && \
+          chown 2000:2000 /archive-pvc && \
+          chmod 700 /archive-pvc && \
+          chown 2000:2000 /logging-pvc && \
+          chmod 700 /logging-pvc
+      volumeMounts:
+        - name: live-storage
+          mountPath: /live-pvc
+        - name: archive-storage
+          mountPath: /archive-pvc
+        - name: logging-storage
+          mountPath: /logging-pvc
+  persistence:
+    live:
+      create: false
+      existingClaim: live-storage-pvc
+      subPath: ""
+    archive:
+      create: false
+      existingClaim: archive-storage-pvc
+      subPath: ""
+    logging:
+      create: false
+      existingClaim: logging-storage-pvc
+      subPath: ""
+
+kubepromstack:
+  enabled: false
+
+loki:
+  enabled: false
+
+promtail:
+  enabled: false
+
+service:
+  type: LoadBalancer
+  port: 40840

--- a/internal/templates/files/block-node/storage-config.yaml
+++ b/internal/templates/files/block-node/storage-config.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: live-storage-pv
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 5Gi
+  hostPath:
+    path: /opt/provisioner/block-node-storage/live
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: live-storage-pvc
+  namespace: block-node
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  volumeName: live-storage-pv
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: archive-storage-pv
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 5Gi
+  hostPath:
+    path: /opt/provisioner/block-node-storage/archive
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: archive-storage-pvc
+  namespace: block-node
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  volumeName: archive-storage-pv
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: logging-storage-pv
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 5Gi
+  hostPath:
+    path: /opt/provisioner/block-node-storage/logs
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: logging-storage-pvc
+  namespace: block-node
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  volumeName: logging-storage-pv

--- a/internal/workflows/steps/helpers_test.go
+++ b/internal/workflows/steps/helpers_test.go
@@ -101,6 +101,8 @@ const (
 	SetupKubeletLevel
 	SetupCrioLevel
 	SetupKubeadmLevel
+	SetupCiliumLevel
+	SetupMetalLBLevel
 )
 
 // setupPrerequisitesToLevel sets up all the required components before cluster initialization
@@ -241,6 +243,32 @@ func setupPrerequisitesToLevel(t *testing.T, level SetupLevel) {
 	require.NoError(t, report.Error, "Failed to initialize cluster")
 
 	if level == SetupKubeadmLevel {
+		return
+	}
+
+	// Setup Cilium
+	step, err = SetupCilium().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to setup Cilium")
+
+	// Start Cilium
+	step, err = StartCilium().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to start Cilium")
+
+	if level == SetupCiliumLevel {
+		return
+	}
+
+	// Setup MetalLB
+	step, err = SetupMetalLB().Build()
+	require.NoError(t, err)
+	report = step.Execute(context.Background())
+	require.NoError(t, report.Error, "Failed to setup MetalLB")
+
+	if level == SetupMetalLBLevel {
 		return
 	}
 }

--- a/internal/workflows/steps/step_block_node.go
+++ b/internal/workflows/steps/step_block_node.go
@@ -1,0 +1,286 @@
+package steps
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"golang.hedera.com/solo-provisioner/internal/blocknode"
+	"golang.hedera.com/solo-provisioner/internal/core"
+	"golang.hedera.com/solo-provisioner/internal/workflows/notify"
+)
+
+const (
+	SetupBlockNodeStepId           = "setup-block-node"
+	SetupBlockNodeStorageStepId    = "setup-block-node-storage"
+	CreateBlockNodeNamespaceStepId = "create-block-node-namespace"
+	CreateBlockNodePVsStepId       = "create-block-node-pvs"
+	InstallBlockNodeStepId         = "install-block-node"
+	AnnotateBlockNodeServiceStepId = "annotate-block-node-service"
+	WaitForBlockNodeStepId         = "wait-for-block-node"
+)
+
+// SetupBlockNode sets up the block node on the cluster
+func SetupBlockNode(nodeType string) automa.Builder {
+	return automa.NewWorkflowBuilder().WithId(SetupBlockNodeStepId).Steps(
+		setupBlockNodeStorage(),
+		createBlockNodeNamespace(),
+		createBlockNodePVs(),
+		installBlockNode(nodeType),
+		annotateBlockNodeService(),
+		waitForBlockNode(),
+	).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Setting up Block Node")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to setup Block Node")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Block Node setup successfully")
+		})
+}
+
+// setupBlockNodeStorage creates the required directories for block node storage
+func setupBlockNodeStorage() automa.Builder {
+	return automa.NewStepBuilder().WithId(SetupBlockNodeStorageStepId).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			meta := map[string]string{}
+
+			manager, err := blocknode.NewManager()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			if err := manager.SetupStorage(ctx); err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			meta[ConfiguredByThisStep] = "true"
+			stp.State().Set(ConfiguredByThisStep, true)
+
+			return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Setting up Block Node storage directories")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to setup Block Node storage directories")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Block Node storage directories setup successfully")
+		})
+}
+
+// createBlockNodeNamespace creates the block-node namespace in the cluster
+func createBlockNodeNamespace() automa.Builder {
+	return automa.NewStepBuilder().WithId(CreateBlockNodeNamespaceStepId).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			meta := map[string]string{}
+
+			manager, err := blocknode.NewManager()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			err = manager.CreateNamespace(ctx, core.Paths().TempDir)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			meta[ConfiguredByThisStep] = "true"
+			stp.State().Set(ConfiguredByThisStep, true)
+
+			return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if !stp.State().Bool(ConfiguredByThisStep) {
+				return automa.StepSkippedReport(stp.Id())
+			}
+
+			manager, err := blocknode.NewManager()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			if err := manager.DeleteNamespace(ctx, core.Paths().TempDir); err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			return automa.StepSuccessReport(stp.Id())
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Creating Block Node namespace")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to create Block Node namespace")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Block Node namespace created successfully")
+		})
+}
+
+// createBlockNodePVs creates the PersistentVolumes and PersistentVolumeClaims for block node
+func createBlockNodePVs() automa.Builder {
+	return automa.NewStepBuilder().WithId(CreateBlockNodePVsStepId).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			meta := map[string]string{}
+
+			manager, err := blocknode.NewManager()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			if err := manager.CreatePersistentVolumes(ctx, core.Paths().TempDir); err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			meta[ConfiguredByThisStep] = "true"
+			stp.State().Set(ConfiguredByThisStep, true)
+
+			return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if stp.State().Bool(ConfiguredByThisStep) == false {
+				return automa.StepSkippedReport(stp.Id())
+			}
+
+			manager, err := blocknode.NewManager()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			if err := manager.DeletePersistentVolumes(ctx, core.Paths().TempDir); err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			return automa.StepSuccessReport(stp.Id())
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Creating Block Node PVs and PVCs")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to create Block Node PVs and PVCs")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Block Node PVs and PVCs created successfully")
+		})
+}
+
+// installBlockNode installs the block node helm chart
+func installBlockNode(nodeType string) automa.Builder {
+	return automa.NewStepBuilder().WithId(InstallBlockNodeStepId).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			meta := map[string]string{}
+
+			manager, err := blocknode.NewManager()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			installed, err := manager.InstallChart(ctx, core.Paths().TempDir, nodeType)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			if !installed {
+				meta[AlreadyInstalled] = "true"
+			} else {
+				meta[InstalledByThisStep] = "true"
+				stp.State().Set(InstalledByThisStep, true)
+			}
+
+			return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if stp.State().Bool(InstalledByThisStep) == false {
+				return automa.StepSkippedReport(stp.Id())
+			}
+
+			manager, err := blocknode.NewManager()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			if err := manager.UninstallChart(ctx); err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			return automa.StepSuccessReport(stp.Id())
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Installing Block Node")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to install Block Node")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Block Node installed successfully")
+		})
+}
+
+// annotateBlockNodeService annotates the block node service with MetalLB address pool
+func annotateBlockNodeService() automa.Builder {
+	return automa.NewStepBuilder().WithId(AnnotateBlockNodeServiceStepId).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			meta := map[string]string{}
+
+			manager, err := blocknode.NewManager()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			if err := manager.AnnotateService(ctx); err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			meta[ConfiguredByThisStep] = "true"
+			stp.State().Set(ConfiguredByThisStep, true)
+
+			return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Annotating Block Node service")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to annotate Block Node service")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Block Node service annotated successfully")
+		})
+}
+
+// waitForBlockNode waits for the block node pod to be ready
+func waitForBlockNode() automa.Builder {
+	return automa.NewStepBuilder().WithId(WaitForBlockNodeStepId).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			meta := map[string]string{}
+
+			manager, err := blocknode.NewManager()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			if err := manager.WaitForPodReady(ctx); err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			meta[ConfiguredByThisStep] = "true"
+			return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Waiting for Block Node to be ready")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Block Node failed to become ready")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Block Node is ready")
+		})
+}

--- a/internal/workflows/steps/step_block_node_test.go
+++ b/internal/workflows/steps/step_block_node_test.go
@@ -1,0 +1,208 @@
+package steps
+
+import (
+	"context"
+	"testing"
+
+	"github.com/automa-saga/automa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.hedera.com/solo-provisioner/internal/blocknode"
+	"golang.hedera.com/solo-provisioner/internal/core"
+	"golang.hedera.com/solo-provisioner/pkg/hardware"
+)
+
+func TestBlockNodeConstants(t *testing.T) {
+	// Verify block node constants are properly defined
+	assert.Equal(t, "block-node", blocknode.Namespace)
+	assert.Equal(t, "block-node", blocknode.Release)
+	assert.Equal(t, "oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server", blocknode.Chart)
+	assert.Equal(t, "0.22.1", blocknode.Version)
+	assert.Equal(t, "/opt/provisioner/block-node-storage", blocknode.StorageBasePath)
+	assert.Equal(t, "block-node-block-node-server", blocknode.ServiceName)
+	assert.Equal(t, "metallb.io/address-pool=public-address-pool", blocknode.MetalLBAnnotation)
+	assert.Equal(t, "block", core.NodeTypeBlock)
+}
+
+func TestSetupBlockNode_FreshInstall(t *testing.T) {
+	// Check if system has at least 16GB memory for block node
+	hostProfile := hardware.GetHostProfile()
+	totalMemoryGB := hostProfile.GetTotalMemoryGB()
+	if totalMemoryGB < 16 {
+		t.Skipf("Skipping test: Block node requires at least 16GB memory, but system has only %dGB", totalMemoryGB)
+	}
+
+	//
+	// Given
+	//
+
+	reset(t)
+	setupPrerequisitesToLevel(t, SetupMetalLBLevel)
+
+	wb := SetupBlockNode(core.NodeTypeBlock)
+	require.NotNil(t, wb)
+
+	workflow, err := wb.Build()
+	require.NoError(t, err)
+	require.NotNil(t, workflow)
+
+	//
+	// When
+	//
+
+	report := workflow.Execute(context.Background())
+
+	//
+	// Then
+	//
+
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+	assert.Equal(t, SetupBlockNodeStepId, workflow.Id())
+
+	// Verify all substeps were executed successfully
+	require.Len(t, report.StepReports, 6, "Expected 6 substeps: storage, namespace, PVs, install, annotate, wait")
+
+	// Verify storage setup step
+	storageReport := report.StepReports[0]
+	require.Equal(t, SetupBlockNodeStorageStepId, storageReport.Id)
+	require.Equal(t, automa.StatusSuccess, storageReport.Status)
+	require.Equal(t, "true", storageReport.Metadata[ConfiguredByThisStep])
+
+	// Verify namespace creation step
+	namespaceReport := report.StepReports[1]
+	require.Equal(t, CreateBlockNodeNamespaceStepId, namespaceReport.Id)
+	require.Equal(t, automa.StatusSuccess, namespaceReport.Status)
+	require.Equal(t, "true", namespaceReport.Metadata[ConfiguredByThisStep])
+
+	// Verify PVs creation step
+	pvsReport := report.StepReports[2]
+	require.Equal(t, CreateBlockNodePVsStepId, pvsReport.Id)
+	require.Equal(t, automa.StatusSuccess, pvsReport.Status)
+	require.Equal(t, "true", pvsReport.Metadata[ConfiguredByThisStep])
+
+	// Verify helm chart installation step
+	installReport := report.StepReports[3]
+	require.Equal(t, InstallBlockNodeStepId, installReport.Id)
+	require.Equal(t, automa.StatusSuccess, installReport.Status)
+	require.Equal(t, "true", installReport.Metadata[InstalledByThisStep])
+
+	// Verify service annotation step
+	annotateReport := report.StepReports[4]
+	require.Equal(t, AnnotateBlockNodeServiceStepId, annotateReport.Id)
+	require.Equal(t, automa.StatusSuccess, annotateReport.Status)
+	require.Equal(t, "true", annotateReport.Metadata[ConfiguredByThisStep])
+
+	// Verify wait step
+	waitReport := report.StepReports[5]
+	require.Equal(t, WaitForBlockNodeStepId, waitReport.Id)
+	require.Equal(t, automa.StatusSuccess, waitReport.Status)
+}
+
+func TestSetupBlockNodeLocal_FreshInstall(t *testing.T) {
+	//
+	// Given
+	//
+
+	reset(t)
+	setupPrerequisitesToLevel(t, SetupMetalLBLevel)
+
+	wb := SetupBlockNode(core.NodeTypeLocal)
+	require.NotNil(t, wb)
+
+	workflow, err := wb.Build()
+	require.NoError(t, err)
+	require.NotNil(t, workflow)
+
+	//
+	// When
+	//
+
+	report := workflow.Execute(context.Background())
+
+	//
+	// Then
+	//
+
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+	assert.Equal(t, SetupBlockNodeStepId, workflow.Id())
+
+	// Verify all substeps were executed successfully
+	require.Len(t, report.StepReports, 6, "Expected 6 substeps: storage, namespace, PVs, install, annotate, wait")
+
+	// Verify storage setup step
+	storageReport := report.StepReports[0]
+	require.Equal(t, SetupBlockNodeStorageStepId, storageReport.Id)
+	require.Equal(t, automa.StatusSuccess, storageReport.Status)
+	require.Equal(t, "true", storageReport.Metadata[ConfiguredByThisStep])
+
+	// Verify namespace creation step
+	namespaceReport := report.StepReports[1]
+	require.Equal(t, CreateBlockNodeNamespaceStepId, namespaceReport.Id)
+	require.Equal(t, automa.StatusSuccess, namespaceReport.Status)
+	require.Equal(t, "true", namespaceReport.Metadata[ConfiguredByThisStep])
+
+	// Verify PVs creation step
+	pvsReport := report.StepReports[2]
+	require.Equal(t, CreateBlockNodePVsStepId, pvsReport.Id)
+	require.Equal(t, automa.StatusSuccess, pvsReport.Status)
+	require.Equal(t, "true", pvsReport.Metadata[ConfiguredByThisStep])
+
+	// Verify helm chart installation step
+	installReport := report.StepReports[3]
+	require.Equal(t, InstallBlockNodeStepId, installReport.Id)
+	require.Equal(t, automa.StatusSuccess, installReport.Status)
+	require.Equal(t, "true", installReport.Metadata[InstalledByThisStep])
+
+	// Verify service annotation step
+	annotateReport := report.StepReports[4]
+	require.Equal(t, AnnotateBlockNodeServiceStepId, annotateReport.Id)
+	require.Equal(t, automa.StatusSuccess, annotateReport.Status)
+	require.Equal(t, "true", annotateReport.Metadata[ConfiguredByThisStep])
+
+	// Verify wait step
+	waitReport := report.StepReports[5]
+	require.Equal(t, WaitForBlockNodeStepId, waitReport.Id)
+	require.Equal(t, automa.StatusSuccess, waitReport.Status)
+}
+
+func TestSetupBlockNodeLocal_Idempotency(t *testing.T) {
+	//
+	// Given - already installed from fresh install test
+	//
+
+	wb := SetupBlockNode(core.NodeTypeLocal)
+	require.NotNil(t, wb)
+
+	workflow, err := wb.Build()
+	require.NoError(t, err)
+	require.NotNil(t, workflow)
+
+	//
+	// When - run the workflow again on already installed system
+	//
+
+	report := workflow.Execute(context.Background())
+
+	//
+	// Then - should succeed without errors (idempotent)
+	//
+
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+	assert.Equal(t, SetupBlockNodeStepId, workflow.Id())
+
+	// Verify all substeps still complete successfully
+	require.Len(t, report.StepReports, 6, "Expected 6 substeps: storage, namespace, PVs, install, annotate, wait")
+
+	// All steps should succeed (idempotent)
+	for _, stepReport := range report.StepReports {
+		require.Equal(t, automa.StatusSuccess, stepReport.Status, "Step %s should succeed", stepReport.Id)
+	}
+
+	// Verify helm chart installation step reports already installed
+	installReport := report.StepReports[3]
+	require.Equal(t, InstallBlockNodeStepId, installReport.Id)
+	require.Equal(t, "true", installReport.Metadata[AlreadyInstalled], "Block node should already be installed")
+}

--- a/pkg/hardware/factory.go
+++ b/pkg/hardware/factory.go
@@ -4,16 +4,17 @@ import (
 	"strings"
 
 	"github.com/joomcode/errorx"
+	"golang.hedera.com/solo-provisioner/internal/core"
 )
 
 // SupportedNodeTypes returns all supported node types
-func SupportedNodeTypes() []NodeType {
-	return []NodeType{NodeTypeLocal, NodeTypeBlock, NodeTypeConsensus}
+func SupportedNodeTypes() []string {
+	return []string{core.NodeTypeLocal, core.NodeTypeBlock, core.NodeTypeConsensus}
 }
 
 // IsValidNodeType checks if the given node type is supported
 func IsValidNodeType(nodeType string) bool {
-	normalized := NodeType(strings.ToLower(nodeType))
+	normalized := strings.ToLower(nodeType)
 	for _, supported := range SupportedNodeTypes() {
 		if normalized == supported {
 			return true
@@ -24,14 +25,14 @@ func IsValidNodeType(nodeType string) bool {
 
 // CreateNodeSpec creates the appropriate node spec based on node type and host profile
 func CreateNodeSpec(nodeType string, hostProfile HostProfile) (Spec, error) {
-	normalized := NodeType(strings.ToLower(nodeType))
+	normalized := strings.ToLower(nodeType)
 
 	switch normalized {
-	case NodeTypeLocal:
+	case core.NodeTypeLocal:
 		return NewLocalNodeSpec(hostProfile), nil
-	case NodeTypeBlock:
+	case core.NodeTypeBlock:
 		return NewBlockNodeSpec(hostProfile), nil
-	case NodeTypeConsensus:
+	case core.NodeTypeConsensus:
 		return NewConsensusNodeSpec(hostProfile), nil
 	default:
 		supportedTypes := make([]string, len(SupportedNodeTypes()))

--- a/pkg/hardware/spec.go
+++ b/pkg/hardware/spec.go
@@ -4,15 +4,6 @@ import (
 	"fmt"
 )
 
-// NodeType represents a supported node type
-type NodeType string
-
-const (
-	NodeTypeLocal     NodeType = "local"
-	NodeTypeBlock     NodeType = "block"
-	NodeTypeConsensus NodeType = "consensus"
-)
-
 type Spec interface {
 	ValidateOS() error
 	ValidateCPU() error


### PR DESCRIPTION
## Description

This pull request introduces the initial implementation for automated provisioning and management of "block node" infrastructure in Kubernetes, including storage, namespace, Helm chart deployment, and configuration. It adds a new `blocknode.Manager` with all necessary methods and templates, and refactors code to standardize node type constants.

The most important changes are:

**Block Node Provisioning Implementation:**

* Added a new `blocknode.Manager` in `internal/blocknode/manager.go`, which encapsulates logic for setting up storage, namespaces, persistent volumes/claims, Helm chart installation, service annotation, and pod readiness checks for block nodes. This manager centralizes all block node lifecycle operations.
* Introduced Kubernetes manifest and Helm values templates for block node setup: `namespace.yaml`, `storage-config.yaml`, `full-values.yaml`, and `nano-values.yaml` in `internal/templates/files/block-node/`. These templates are used by the manager for resource creation and configuration. [[1]](diffhunk://#diff-efe24b4c7a837d27d6c05e0a12972b4fb7547c8f69ed0a2f4b7e8698a5954815R1-R6) [[2]](diffhunk://#diff-89cf26d5771eef362210e5c5f8958c264c3ea8e2eda5c071378979e2242035ecR1-R81) [[3]](diffhunk://#diff-ded027ae2b47a1e483c75dc4dc836bc612c6df368c3cbd75e2a40b914a125123R1-R47) [[4]](diffhunk://#diff-c45affff1b04028f74dfc35936db54a4f8add8f83d108c14b98831e9da41175eR1-R66)

**Node Type Standardization:**

* Defined constants for node types (`NodeTypeBlock`, `NodeTypeConsensus`, `NodeTypeLocal`) in `internal/core/const.go` and refactored usage in `cmd/provisioner/commands/root.go` to use these constants, ensuring consistency across the codebase. [[1]](diffhunk://#diff-32178321452c9c41821cea61bcf173d93d40a6b0b2277f634fbc3f32fd1ba945R10-R23) [[2]](diffhunk://#diff-f6acd45e6c9503f665db528dbaefee357fdd001befcd855c611ad3fadfbdb9b8L61-R62)

**Workflow Integration:**

* Updated the cluster setup workflow in `internal/workflows/cluster.go` to include block node setup steps when the node type is block or local, integrating the new provisioning logic into the automated workflow. [[1]](diffhunk://#diff-0cbd5d0d3e1884e017374a994ce18b0ab71220ae089c0b21deca20d2064a6503R5-R12) [[2]](diffhunk://#diff-0cbd5d0d3e1884e017374a994ce18b0ab71220ae089c0b21deca20d2064a6503L47-R56)

**Command Documentation:**

* Updated CLI command documentation in `cmd/provisioner/commands/root.go` to reflect the new `setup` commands for block, consensus, and local nodes.

### Weaver output on fresh install

<img width="1267" height="2044" alt="image" src="https://github.com/user-attachments/assets/af8902ac-dcd1-4ba9-b820-5d0cedb0a083" />

### Related Issues

* Closes #92 
