### PR TITLE
fix: improve crio binary installation verification and error handling

### DIFF
--- a/internal/doctor/diagnose.go
+++ b/internal/doctor/diagnose.go
@@ -242,7 +242,7 @@ func CheckErr(ctx context.Context, err error, instructions ...string) {
 	fmt.Printf("%s*%s\t%sError Code:%s %d\n", Red, Reset, Bold+White, Reset, resp.Code)
 	fmt.Printf("%s*%s\t%sCommit:%s %s\n", Red, Reset, Gray, Reset, resp.Commit)
 	fmt.Printf("%s*%s\t%sPid:%s %d\n", Red, Reset, Gray, Reset, resp.Pid)
-	fmt.Printf("%s*%s\t%sTraceId: %s\n", Red, Reset, Gray, Reset, resp.TraceId)
+	fmt.Printf("%s*%s\t%sTraceId:%s %s\n", Red, Reset, Gray, Reset, resp.TraceId)
 	fmt.Printf("%s*%s\t%sVersion:%s %s\n", Red, Reset, Gray, Reset, resp.Version)
 	if resp.Logfile != "" {
 		fmt.Printf("%s*%s\t%sLogfile:%s %s\n", Red, Reset, Cyan, Reset, resp.Logfile)

--- a/internal/workflows/steps/step_crio_it_test.go
+++ b/internal/workflows/steps/step_crio_it_test.go
@@ -50,23 +50,18 @@ func Test_StepCrio_AlreadyInstalled_Integration(t *testing.T) {
 	//
 	reset(t)
 
-	step, err := SetupCrio().Build()
-	require.NoError(t, err)
-	report := step.Execute(context.Background())
-	require.NotNil(t, report)
-	require.NoError(t, report.Error)
-	require.Equal(t, automa.StatusSuccess, report.Status)
+	setupPrerequisitesToLevel(t, SetupMetalLBLevel)
 
 	//
 	// When
 	//
-	step, err = SetupCrio().Build()
+	step, err := SetupCrio().Build()
 
 	//
 	// Then
 	//
 	require.NoError(t, err)
-	report = step.Execute(context.Background())
+	report := step.Execute(context.Background())
 	require.NotNil(t, report)
 	require.NoError(t, report.Error)
 	require.Equal(t, automa.StatusSuccess, report.Status)


### PR DESCRIPTION
## Description

This pull request focuses on improving the robustness and clarity of the CRI-O installer logic and its related tests. The main changes ensure better error handling, update expected plugin counts, and clarify output formatting.

**CRI-O Installer Improvements:**

* Added a check to ensure that every binary in `versionInfo.Binaries` has a valid mapping in `binaryFilesMapping` before proceeding. If a mapping is missing, the installer now returns a clear error, helping catch configuration issues early. Error messages have been improved to include both the binary name and its path for easier debugging. [[1]](diffhunk://#diff-12eb6d2dd664cfc78803ee6b46bcf564e348b461766d3b46a8c188d2b5a34ac2R662-R671) [[2]](diffhunk://#diff-12eb6d2dd664cfc78803ee6b46bcf564e348b461766d3b46a8c188d2b5a34ac2L683-R687)
* Increased the `ExpectedCniPluginCount` constant from 20 to 21 to reflect the updated number of CNI plugins expected after installation.

**Testing Improvements:**

* Updated the CRI-O integration test (`Test_StepCrio_AlreadyInstalled_Integration`) to set up prerequisites explicitly using `setupPrerequisitesToLevel`, making the test setup clearer and more reliable.

**Output Formatting:**

* Fixed the formatting of the TraceId output in the `CheckErr` function to be consistent with other output lines, ensuring better readability.

### Related Issues

* Closes #191 
