### PR TITLE
chore: add Apache 2.0 SPDX license headers to all source files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Bug Report
 description: File a bug report
 labels: ["Bug", "Pending Triage"]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
 blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/feature_enhancement.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Feature Enhancement
 description: Enhance an existing feature
 labels: ["Feature Enhancement", "Pending Triage"]

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: New Feature
 description: Request a new feature
 labels: ["New Feature", "Pending Triage"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: "Deploy Release Artifact"
 on:
   workflow_dispatch:

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: "PR Checks"
 on:
   workflow_dispatch:

--- a/.github/workflows/zxc-code-compiles.yaml
+++ b/.github/workflows/zxc-code-compiles.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: "ZXC: Code Compiles"
 on:
   workflow_call:

--- a/.github/workflows/zxc-unit-test.yaml
+++ b/.github/workflows/zxc-unit-test.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: "ZXC: Unit Test"
 on:
   workflow_call:

--- a/.gitignore
+++ b/.gitignore
@@ -259,7 +259,8 @@ fabric.properties
 ### IDE Configuration Files ###
 !.idea/sshConfigs.xml
 !.idea/remote-targets.xml
-
+!.idea/copyright/profiles_settings.xml
+!.idea/copyright/Hashgraph_Apache_2_0.xml
 
 ### Linux template
 *~
@@ -371,3 +372,4 @@ docs/playbooks/production/dir-structure.txt
 .ssh/
 integration-test-report.md
 integration-test.json
+

--- a/.idea/copyright/Hashgraph_Apache_2_0.xml
+++ b/.idea/copyright/Hashgraph_Apache_2_0.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="keyword" value="SPDX-License-Identifier" />
+    <option name="notice" value="SPDX-License-Identifier: Apache-2.0" />
+    <option name="myName" value="Hashgraph Apache 2.0" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,10 @@
+<component name="CopyrightManager">
+  <settings>
+    <module2copyright>
+      <element module="All" copyright="Hashgraph Apache 2.0" />
+    </module2copyright>
+    <LanguageOptions name="__TEMPLATE__">
+      <option name="block" value="false" />
+    </LanguageOptions>
+  </settings>
+</component>

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # (mandatory) 
 # Path to coverage profile file (output of `go test -coverprofile` command).
 #

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 version: 3
 silent: false
 output: prefixed
@@ -45,6 +47,23 @@ tasks:
     cmds:
       - "R=$(go fmt ./...) && if [[ -n \"$R\" ]]; then echo \"The following files require formatting:\"; echo \"$R\"; exit 1; fi"
   
+  license:check:
+    desc: "Check if all source files have SPDX license headers"
+    dir: scripts
+    cmds:
+      - "./license-header.sh check"
+
+  license:add:
+    desc: "Add SPDX license headers to source files that are missing them"
+    dir: scripts
+    cmds:
+      - "./license-header.sh add"
+
+  license:
+    desc: "Alias for license:add - Add SPDX license headers to source files"
+    cmds:
+      - task: license:add
+
   build:
     deps:
       - "vendor"

--- a/build/container-entrypoint.sh
+++ b/build/container-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 set -x
 mkdir -p /var/run/dbus
 

--- a/build/debug-run.sh
+++ b/build/debug-run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 
 # Unified debug script for solo-weaver
 # Usage: ./debug.sh app [args...]        - Debug application

--- a/build/debug-setup.sh
+++ b/build/debug-setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 
 # This script sets up remote debugging for the Ubuntu container
 set -e

--- a/build/launch-ci.sh
+++ b/build/launch-ci.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 SCRIPT_PATH="$(cd "$(dirname "${0}")" && pwd)"
 docker build -t local/solo-weaver-ci:latest -f "${SCRIPT_PATH}/Dockerfile.ci" "${SCRIPT_PATH}"
 docker stop solo-weaver-ci || true

--- a/build/launch-local.sh
+++ b/build/launch-local.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 SCRIPT_PATH="$(cd "$(dirname "${0}")" && pwd)"
 docker build -t local/solo-weaver-local:latest -f "${SCRIPT_PATH}/Dockerfile.local" "${SCRIPT_PATH}"
 docker stop solo-weaver-local || true

--- a/cmd/weaver-shim/main.go
+++ b/cmd/weaver-shim/main.go
@@ -1,1 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package main

--- a/cmd/weaver/commands/block/block.go
+++ b/cmd/weaver/commands/block/block.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package block
 
 import (

--- a/cmd/weaver/commands/block/node/check.go
+++ b/cmd/weaver/commands/block/node/check.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package node
 
 import (

--- a/cmd/weaver/commands/block/node/check_it_test.go
+++ b/cmd/weaver/commands/block/node/check_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package node

--- a/cmd/weaver/commands/block/node/install.go
+++ b/cmd/weaver/commands/block/node/install.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package node
 
 import (

--- a/cmd/weaver/commands/block/node/install_it_test.go
+++ b/cmd/weaver/commands/block/node/install_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package node

--- a/cmd/weaver/commands/block/node/node.go
+++ b/cmd/weaver/commands/block/node/node.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package node
 
 import (

--- a/cmd/weaver/commands/common/flags.go
+++ b/cmd/weaver/commands/common/flags.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 // define common flag names used across multiple commands

--- a/cmd/weaver/commands/common/run.go
+++ b/cmd/weaver/commands/common/run.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 import (

--- a/cmd/weaver/commands/root.go
+++ b/cmd/weaver/commands/root.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package commands
 
 import (

--- a/cmd/weaver/commands/version/version.go
+++ b/cmd/weaver/commands/version/version.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 import (

--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/docs/playbooks/mainnet-simulation/rhel-8-9-steps.sh
+++ b/docs/playbooks/mainnet-simulation/rhel-8-9-steps.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 set -x
 
 OS="$(uname -s)"

--- a/docs/playbooks/mainnet-simulation/ubuntu-focal-jammy-steps.sh
+++ b/docs/playbooks/mainnet-simulation/ubuntu-focal-jammy-steps.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 set -x
 
 OS="$(uname -s)"

--- a/docs/playbooks/production/ubuntu-production.sh
+++ b/docs/playbooks/production/ubuntu-production.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 set -ex
 
 OS="$(uname -s)"

--- a/internal/blocknode/manager.go
+++ b/internal/blocknode/manager.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package blocknode
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import "github.com/joomcode/errorx"

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import "github.com/automa-saga/logx"

--- a/internal/core/const.go
+++ b/internal/core/const.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package core
 
 import (

--- a/internal/doctor/diagnose.go
+++ b/internal/doctor/diagnose.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package doctor
 
 import (

--- a/internal/doctor/style.go
+++ b/internal/doctor/style.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package doctor
 
 // ANSI color codes for terminal output

--- a/internal/kube/admin.go
+++ b/internal/kube/admin.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package kube
 
 import (

--- a/internal/kube/admin_test.go
+++ b/internal/kube/admin_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package kube
 
 import (

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package kube
 
 import (

--- a/internal/kube/client_it_test.go
+++ b/internal/kube/client_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build kubeclient || require_cluster
 
 package kube

--- a/internal/kube/client_test.go
+++ b/internal/kube/client_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package kube
 
 import (

--- a/internal/mount/mount_unix.go
+++ b/internal/mount/mount_unix.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build linux
 
 package mount

--- a/internal/mount/mount_unix_it_test.go
+++ b/internal/mount/mount_unix_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package mount

--- a/internal/mount/mount_unix_test.go
+++ b/internal/mount/mount_unix_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build linux
 
 package mount

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/internal/nio/std.go
+++ b/internal/nio/std.go
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016-2022 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package nio
 

--- a/internal/nio/std_test.go
+++ b/internal/nio/std_test.go
@@ -1,25 +1,12 @@
-/*
- * Copyright 2016-2022 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package nio
 
 import (
-	"github.com/stretchr/testify/require"
 	"io"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewTestIOStreams(t *testing.T) {

--- a/internal/state/manager.go
+++ b/internal/state/manager.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/internal/state/manager_test.go
+++ b/internal/state/manager_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/internal/sysctl/sysctl.go
+++ b/internal/sysctl/sysctl.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package sysctl
 
 import (

--- a/internal/sysctl/sysctl_it_test.go
+++ b/internal/sysctl/sysctl_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package sysctl

--- a/internal/templates/copy.go
+++ b/internal/templates/copy.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package templates
 
 import (

--- a/internal/templates/copy_test.go
+++ b/internal/templates/copy_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package templates
 
 import (

--- a/internal/templates/embed.go
+++ b/internal/templates/embed.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package templates
 
 import (

--- a/internal/templates/files/block-node/full-values.yaml
+++ b/internal/templates/files/block-node/full-values.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 blockNode:
   config:
     BLOCK_NODE_EARLIEST_MANAGED_BLOCK: "100000000"

--- a/internal/templates/files/block-node/namespace.yaml
+++ b/internal/templates/files/block-node/namespace.yaml
@@ -1,4 +1,5 @@
 ---
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/internal/templates/files/block-node/nano-values.yaml
+++ b/internal/templates/files/block-node/nano-values.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 resources:
   requests:
     cpu: "500m"

--- a/internal/templates/files/health/health.sh
+++ b/internal/templates/files/health/health.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 # Updated health check with icons and robust parsing
 # File: 'internal/templates/files/health/health.sh'
 

--- a/internal/templates/files/kubeadm/kubeadm-init.yaml
+++ b/internal/templates/files/kubeadm/kubeadm-init.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 bootstrapTokens:

--- a/internal/templates/files/metallb/metallb.yaml
+++ b/internal/templates/files/metallb/metallb.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:

--- a/internal/templates/read.go
+++ b/internal/templates/read.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package templates
 
 import (

--- a/internal/templates/read_test.go
+++ b/internal/templates/read_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package templates
 
 import (

--- a/internal/testutil/cmd.go
+++ b/internal/testutil/cmd.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package testutil
 
 import "github.com/spf13/cobra"

--- a/internal/tomlx/tomlx.go
+++ b/internal/tomlx/tomlx.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package tomlx provides utilities for managing TOML configuration files.
 //
 // This package offers a TomlConfigManager that can:

--- a/internal/tomlx/tomlx_test.go
+++ b/internal/tomlx/tomlx_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package tomlx
 
 import (

--- a/internal/version/generate_unix.go
+++ b/internal/version/generate_unix.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 //go:generate chmod +x generate_version_unix.sh

--- a/internal/version/generate_version_unix.sh
+++ b/internal/version/generate_version_unix.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 
 if [[ ! -f VERSION ]]; then
   echo -n "0.0.0" >VERSION

--- a/internal/version/generate_windows.go
+++ b/internal/version/generate_windows.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 //go:generate ./generate_version_windows.ps1

--- a/internal/version/info.go
+++ b/internal/version/info.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 import (

--- a/internal/version/releases.go
+++ b/internal/version/releases.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 import _ "embed"

--- a/internal/workflows/blocknode.go
+++ b/internal/workflows/blocknode.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package workflows
 
 import (

--- a/internal/workflows/cluster.go
+++ b/internal/workflows/cluster.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package workflows
 
 import (

--- a/internal/workflows/cluster_it_test.go
+++ b/internal/workflows/cluster_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build e2e
 
 package workflows

--- a/internal/workflows/notify/handler.go
+++ b/internal/workflows/notify/handler.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package notify
 
 import (

--- a/internal/workflows/notify/handler_test.go
+++ b/internal/workflows/notify/handler_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package notify
 
 import (

--- a/internal/workflows/preflight.go
+++ b/internal/workflows/preflight.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package workflows
 
 import (

--- a/internal/workflows/setup.go
+++ b/internal/workflows/setup.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package workflows
 
 import (

--- a/internal/workflows/steps/const.go
+++ b/internal/workflows/steps/const.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import "github.com/automa-saga/automa"

--- a/internal/workflows/steps/helpers.go
+++ b/internal/workflows/steps/helpers.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/helpers_test.go
+++ b/internal/workflows/steps/helpers_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/report.go
+++ b/internal/workflows/steps/report.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/report_test.go
+++ b/internal/workflows/steps/report_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_bind_mounts.go
+++ b/internal/workflows/steps/step_bind_mounts.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_bind_mounts_it_test.go
+++ b/internal/workflows/steps/step_bind_mounts_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/internal/workflows/steps/step_block_node.go
+++ b/internal/workflows/steps/step_block_node.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_block_node_test.go
+++ b/internal/workflows/steps/step_block_node_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/internal/workflows/steps/step_cilium.go
+++ b/internal/workflows/steps/step_cilium.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_cilium_it_test.go
+++ b/internal/workflows/steps/step_cilium_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/internal/workflows/steps/step_cluster_configmaps.go
+++ b/internal/workflows/steps/step_cluster_configmaps.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_cluster_crds.go
+++ b/internal/workflows/steps/step_cluster_crds.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_cluster_namespace.go
+++ b/internal/workflows/steps/step_cluster_namespace.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_cluster_node_ready.go
+++ b/internal/workflows/steps/step_cluster_node_ready.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_cluster_pod_ready.go
+++ b/internal/workflows/steps/step_cluster_pod_ready.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_cluster_services.go
+++ b/internal/workflows/steps/step_cluster_services.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_crio.go
+++ b/internal/workflows/steps/step_crio.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_crio_it_test.go
+++ b/internal/workflows/steps/step_crio_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/internal/workflows/steps/step_disable_swap.go
+++ b/internal/workflows/steps/step_disable_swap.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_disable_swap_it_test.go
+++ b/internal/workflows/steps/step_disable_swap_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/internal/workflows/steps/step_health.go
+++ b/internal/workflows/steps/step_health.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_health_it_test.go
+++ b/internal/workflows/steps/step_health_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build require_cluster
 
 package steps

--- a/internal/workflows/steps/step_helm.go
+++ b/internal/workflows/steps/step_helm.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_helm_it_test.go
+++ b/internal/workflows/steps/step_helm_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/internal/workflows/steps/step_k9s.go
+++ b/internal/workflows/steps/step_k9s.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_k9s_it_test.go
+++ b/internal/workflows/steps/step_k9s_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/internal/workflows/steps/step_kubeadm.go
+++ b/internal/workflows/steps/step_kubeadm.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_kubeadm_it_test.go
+++ b/internal/workflows/steps/step_kubeadm_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/internal/workflows/steps/step_kubeconfig.go
+++ b/internal/workflows/steps/step_kubeconfig.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_kubectl.go
+++ b/internal/workflows/steps/step_kubectl.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_kubectl_it_test.go
+++ b/internal/workflows/steps/step_kubectl_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/internal/workflows/steps/step_kubelet.go
+++ b/internal/workflows/steps/step_kubelet.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_kubelet_it_test.go
+++ b/internal/workflows/steps/step_kubelet_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/internal/workflows/steps/step_metallb.go
+++ b/internal/workflows/steps/step_metallb.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_setup_directories.go
+++ b/internal/workflows/steps/step_setup_directories.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_setup_directories_test.go
+++ b/internal/workflows/steps/step_setup_directories_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_sysctl.go
+++ b/internal/workflows/steps/step_sysctl.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_sysctl_it_test.go
+++ b/internal/workflows/steps/step_sysctl_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/internal/workflows/steps/step_system_module.go
+++ b/internal/workflows/steps/step_system_module.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_system_package.go
+++ b/internal/workflows/steps/step_system_package.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_system_package_it_test.go
+++ b/internal/workflows/steps/step_system_package_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/internal/workflows/steps/step_systemd_service.go
+++ b/internal/workflows/steps/step_systemd_service.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package steps
 
 import (

--- a/internal/workflows/steps/step_systemd_service_it_test.go
+++ b/internal/workflows/steps/step_systemd_service_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package steps

--- a/pkg/collections/pair.go
+++ b/pkg/collections/pair.go
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016-2022 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package collections
 

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package deps
 
 const (

--- a/pkg/exit/exit.go
+++ b/pkg/exit/exit.go
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016-2022 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package exit
 

--- a/pkg/exit/exit_test.go
+++ b/pkg/exit/exit_test.go
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016-2022 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package exit
 

--- a/pkg/fsx/errors.go
+++ b/pkg/fsx/errors.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package fsx
 
 import (

--- a/pkg/fsx/errors_test.go
+++ b/pkg/fsx/errors_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package fsx
 
 import (

--- a/pkg/fsx/interface.go
+++ b/pkg/fsx/interface.go
@@ -1,18 +1,4 @@
-/*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package fsx
 

--- a/pkg/fsx/manager_unix.go
+++ b/pkg/fsx/manager_unix.go
@@ -1,20 +1,6 @@
-//go:build !windows
+// SPDX-License-Identifier: Apache-2.0
 
-/*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+//go:build !windows
 
 package fsx
 

--- a/pkg/fsx/manager_unix_test.go
+++ b/pkg/fsx/manager_unix_test.go
@@ -1,18 +1,4 @@
-/*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package fsx
 

--- a/pkg/fsx/wrappers.go
+++ b/pkg/fsx/wrappers.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package fsx
 
 import (

--- a/pkg/fsx/wrappers_test.go
+++ b/pkg/fsx/wrappers_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package fsx
 
 import (

--- a/pkg/hardware/base_node.go
+++ b/pkg/hardware/base_node.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package hardware
 
 import (

--- a/pkg/hardware/block_node.go
+++ b/pkg/hardware/block_node.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package hardware
 
 // blockNode represents a block node with its specific requirements and validation logic

--- a/pkg/hardware/consensus_node.go
+++ b/pkg/hardware/consensus_node.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package hardware
 
 // consensusNode represents a consensus node with its specific requirements and validation logic

--- a/pkg/hardware/factory.go
+++ b/pkg/hardware/factory.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package hardware
 
 import (

--- a/pkg/hardware/hardware_test.go
+++ b/pkg/hardware/hardware_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package hardware
 
 import (

--- a/pkg/hardware/host_profile.go
+++ b/pkg/hardware/host_profile.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package hardware
 
 import (

--- a/pkg/hardware/local_node.go
+++ b/pkg/hardware/local_node.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package hardware
 
 // localNode represents a local node with its specific requirements and validation logic

--- a/pkg/hardware/spec.go
+++ b/pkg/hardware/spec.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package hardware
 
 import (

--- a/pkg/hardware/validation.go
+++ b/pkg/hardware/validation.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package hardware
 
 import (

--- a/pkg/helm/errors.go
+++ b/pkg/helm/errors.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package helm
 
 import "github.com/joomcode/errorx"

--- a/pkg/helm/helpers.go
+++ b/pkg/helm/helpers.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package helm
 
 import (

--- a/pkg/helm/interface.go
+++ b/pkg/helm/interface.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package helm
 
 import (

--- a/pkg/helm/manager.go
+++ b/pkg/helm/manager.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package helm
 
 import (

--- a/pkg/helm/manager_it_test.go
+++ b/pkg/helm/manager_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build helm_integration || require_cluster
 
 package helm

--- a/pkg/helm/options.go
+++ b/pkg/helm/options.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package helm
 
 import (

--- a/pkg/kernel/interface.go
+++ b/pkg/kernel/interface.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package kernel
 
 // Module defines the interface for kernel module management operations

--- a/pkg/kernel/module.go
+++ b/pkg/kernel/module.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package kernel
 
 import (

--- a/pkg/kernel/module_it_test.go
+++ b/pkg/kernel/module_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package kernel

--- a/pkg/kernel/module_test.go
+++ b/pkg/kernel/module_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package kernel
 
 import (

--- a/pkg/os/dump.go
+++ b/pkg/os/dump.go
@@ -1,21 +1,4 @@
-/*
- * Copyright 2016-2023 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- *
- *
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package os
 

--- a/pkg/os/errors.go
+++ b/pkg/os/errors.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package os
 
 import "github.com/joomcode/errorx"

--- a/pkg/os/signal.go
+++ b/pkg/os/signal.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package os
 
 import (

--- a/pkg/os/signal_test.go
+++ b/pkg/os/signal_test.go
@@ -1,33 +1,17 @@
-/*
- * Copyright 2016-2023 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- *
- *
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package os
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 	"os"
 	"sync"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 type SignalHandlerTestSuite struct {

--- a/pkg/os/swap_unix.go
+++ b/pkg/os/swap_unix.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build linux
 
 package os

--- a/pkg/os/swap_unix_it_test.go
+++ b/pkg/os/swap_unix_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build linux && integration
 
 package os

--- a/pkg/os/swap_unix_test.go
+++ b/pkg/os/swap_unix_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build linux
 
 package os

--- a/pkg/os/systemd.go
+++ b/pkg/os/systemd.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package os
 
 import (

--- a/pkg/os/systemd_it_test.go
+++ b/pkg/os/systemd_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package os

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016-2022 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package sanity
 

--- a/pkg/sanity/sanity_test.go
+++ b/pkg/sanity/sanity_test.go
@@ -1,24 +1,11 @@
-/*
- * Copyright 2016-2022 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package sanity
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSanity_Alphanumeric(t *testing.T) {

--- a/pkg/security/principal/errors.go
+++ b/pkg/security/principal/errors.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package principal
 
 import (

--- a/pkg/security/principal/errors_test.go
+++ b/pkg/security/principal/errors_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package principal
 
 import (

--- a/pkg/security/principal/interface.go
+++ b/pkg/security/principal/interface.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package principal provides routines to set and check security for users, groups, files, and folders.
 //
 // Use NewManager() to get an operating system specific implementation.

--- a/pkg/security/principal/manager.go
+++ b/pkg/security/principal/manager.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package principal
 
 import (

--- a/pkg/security/principal/manager_test.go
+++ b/pkg/security/principal/manager_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package principal
 
 import (

--- a/pkg/security/principal/manager_unix.go
+++ b/pkg/security/principal/manager_unix.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package principal
 
 func (m *defaultManager) processGroupMembership() {

--- a/pkg/security/principal/manager_unix_test.go
+++ b/pkg/security/principal/manager_unix_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package principal
 
 import (

--- a/pkg/security/principal/principal_test.go
+++ b/pkg/security/principal/principal_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package principal
 
 import (

--- a/pkg/security/principal/principal_unix.go
+++ b/pkg/security/principal/principal_unix.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package principal
 
 import (

--- a/pkg/security/principal/principal_unix_test.go
+++ b/pkg/security/principal/principal_unix_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package principal
 
 import (

--- a/pkg/security/principal/provider_darwin.go
+++ b/pkg/security/principal/provider_darwin.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package principal
 
 type darwinProvider struct{}

--- a/pkg/security/principal/provider_unix.go
+++ b/pkg/security/principal/provider_unix.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build !darwin && !windows
 
 package principal

--- a/pkg/security/principal/provider_unix_test.go
+++ b/pkg/security/principal/provider_unix_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build !darwin && !windows && !plan9
 
 package principal

--- a/pkg/security/principal/provider_utils_darwin.go
+++ b/pkg/security/principal/provider_utils_darwin.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package principal
 
 import (

--- a/pkg/security/principal/provider_utils_unix.go
+++ b/pkg/security/principal/provider_utils_unix.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build !darwin && !windows
 
 package principal

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package security
 
 import "os"

--- a/pkg/security/security_test.go
+++ b/pkg/security/security_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package security
 
 import (

--- a/pkg/semver/const.go
+++ b/pkg/semver/const.go
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016-2022 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package semver
 

--- a/pkg/semver/semver.go
+++ b/pkg/semver/semver.go
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016-2022 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Semver 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package semver
 

--- a/pkg/semver/semver_test.go
+++ b/pkg/semver/semver_test.go
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016-2022 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Semver 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package semver
 

--- a/pkg/software/artifact.yaml
+++ b/pkg/software/artifact.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # This file contains the list of software artifacts with their download URLs,
 # versions, and checksums for verification.
 artifact:

--- a/pkg/software/base_installer.go
+++ b/pkg/software/base_installer.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/base_installer_test.go
+++ b/pkg/software/base_installer_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/cilium_installer.go
+++ b/pkg/software/cilium_installer.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/cilium_installer_it_test.go
+++ b/pkg/software/cilium_installer_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package software

--- a/pkg/software/config.go
+++ b/pkg/software/config.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/config_it_test.go
+++ b/pkg/software/config_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/config_test.go
+++ b/pkg/software/config_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/crio_installer.go
+++ b/pkg/software/crio_installer.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/crio_installer_it_test.go
+++ b/pkg/software/crio_installer_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package software

--- a/pkg/software/downloader.go
+++ b/pkg/software/downloader.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/downloader_test.go
+++ b/pkg/software/downloader_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/errors.go
+++ b/pkg/software/errors.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/helm_installer.go
+++ b/pkg/software/helm_installer.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 func NewHelmInstaller(opts ...InstallerOption) (Software, error) {

--- a/pkg/software/helm_installer_it_test.go
+++ b/pkg/software/helm_installer_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package software

--- a/pkg/software/helpers_test.go
+++ b/pkg/software/helpers_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/integrity_checker.go
+++ b/pkg/software/integrity_checker.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/integrity_checker_test.go
+++ b/pkg/software/integrity_checker_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/interface.go
+++ b/pkg/software/interface.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/k9s_installer.go
+++ b/pkg/software/k9s_installer.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 func NewK9sInstaller(opts ...InstallerOption) (Software, error) {

--- a/pkg/software/k9s_installer_it_test.go
+++ b/pkg/software/k9s_installer_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package software

--- a/pkg/software/kubeadm_installer.go
+++ b/pkg/software/kubeadm_installer.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/kubeadm_installer_it_test.go
+++ b/pkg/software/kubeadm_installer_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package software

--- a/pkg/software/kubeadm_installer_test.go
+++ b/pkg/software/kubeadm_installer_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/kubectl_installer.go
+++ b/pkg/software/kubectl_installer.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 func NewKubectlInstaller(opts ...InstallerOption) (Software, error) {

--- a/pkg/software/kubectl_installer_it_test.go
+++ b/pkg/software/kubectl_installer_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package software

--- a/pkg/software/kubelet_installer.go
+++ b/pkg/software/kubelet_installer.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/kubelet_installer_it_test.go
+++ b/pkg/software/kubelet_installer_it_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 
 package software

--- a/pkg/software/package_installer.go
+++ b/pkg/software/package_installer.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/pkg/software/system_packages.go
+++ b/pkg/software/system_packages.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import "github.com/bluet/syspkg/manager"

--- a/pkg/software/system_packages_test.go
+++ b/pkg/software/system_packages_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package software
 
 import (

--- a/scripts/debug-vm-run.sh
+++ b/scripts/debug-vm-run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 
 # This script runs a remote debug session on a VM
 set -e

--- a/scripts/license-header.sh
+++ b/scripts/license-header.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# Get the project root directory (parent of scripts directory)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Change to project root
+cd "$PROJECT_ROOT"
+
+# License header for different file types
+GO_HEADER="// SPDX-License-Identifier: Apache-2.0"
+SHELL_HEADER="# SPDX-License-Identifier: Apache-2.0"
+YAML_HEADER="# SPDX-License-Identifier: Apache-2.0"
+
+# Function to check if file has license header
+has_license_header() {
+    local file="$1"
+    head -n 5 "$file" | grep -q "SPDX-License-Identifier: Apache-2.0"
+}
+
+# Function to add license header to Go files
+add_go_header() {
+    local file="$1"
+    if ! has_license_header "$file"; then
+        echo "Adding license header to: $file"
+        # Create a temporary file with the header
+        echo "$GO_HEADER" > "$file.tmp"
+        echo "" >> "$file.tmp"
+        cat "$file" >> "$file.tmp"
+        mv "$file.tmp" "$file"
+        return 0
+    fi
+    return 1
+}
+
+# Function to add license header to shell scripts
+add_shell_header() {
+    local file="$1"
+    if ! has_license_header "$file"; then
+        echo "Adding license header to: $file"
+        # Check if file starts with shebang
+        if head -n 1 "$file" | grep -q '^#!'; then
+            # If shebang exists, insert license header after it
+            {
+                head -n 1 "$file"
+                echo "$SHELL_HEADER"
+                tail -n +2 "$file"
+            } > "$file.tmp"
+        else
+            # Otherwise, add license header at the top
+            {
+                echo "$SHELL_HEADER"
+                echo ""
+                cat "$file"
+            } > "$file.tmp"
+        fi
+        mv "$file.tmp" "$file"
+        return 0
+    fi
+    return 1
+}
+
+# Function to add license header to YAML files
+add_yaml_header() {
+    local file="$1"
+    if ! has_license_header "$file"; then
+        echo "Adding license header to: $file"
+        # Check if file starts with yaml directives (---)
+        if head -n 1 "$file" | grep -q '^---'; then
+            # If YAML directive exists, insert license header after it
+            {
+                head -n 1 "$file"
+                echo "$YAML_HEADER"
+                tail -n +2 "$file"
+            } > "$file.tmp"
+        else
+            # Otherwise, add license header at the top
+            {
+                echo "$YAML_HEADER"
+                echo ""
+                cat "$file"
+            } > "$file.tmp"
+        fi
+        mv "$file.tmp" "$file"
+        return 0
+    fi
+    return 1
+}
+
+# Main function
+main() {
+    local action="${1:-check}"
+    local count=0
+    local total=0
+
+    case "$action" in
+        check)
+            echo "Checking for missing SPDX license headers..."
+
+            # Check Go files
+            while IFS= read -r -d '' file; do
+                total=$((total + 1))
+                if ! has_license_header "$file"; then
+                    echo "Missing license header: $file"
+                    count=$((count + 1))
+                fi
+            done < <(find . -type f -name "*.go" \
+                -not -path "./vendor/*" \
+                -not -path "./bin/*" \
+                -not -path "./.git/*" \
+                -not -name "*_generated.go" \
+                -not -name "mocks_generated.go" \
+                -print0)
+
+            # Check shell scripts
+            while IFS= read -r -d '' file; do
+                total=$((total + 1))
+                if ! has_license_header "$file"; then
+                    echo "Missing license header: $file"
+                    count=$((count + 1))
+                fi
+            done < <(find . -type f -name "*.sh" \
+                -not -path "./vendor/*" \
+                -not -path "./bin/*" \
+                -not -path "./.git/*" \
+                -print0)
+
+            # Check YAML files (excluding vendor and specific files)
+            while IFS= read -r -d '' file; do
+                # Skip config.yaml, integration-test.json, and other non-source files
+                if [[ "$file" =~ (config\.yaml|integration-test\.json)$ ]]; then
+                    continue
+                fi
+                total=$((total + 1))
+                if ! has_license_header "$file"; then
+                    echo "Missing license header: $file"
+                    count=$((count + 1))
+                fi
+            done < <(find . -type f \( -name "*.yaml" -o -name "*.yml" \) \
+                -not -path "./vendor/*" \
+                -not -path "./bin/*" \
+                -not -path "./.git/*" \
+                -print0)
+
+            echo ""
+            echo "Summary: $count of $total files are missing license headers"
+
+            if [ $count -gt 0 ]; then
+                exit 1
+            fi
+            ;;
+
+        add)
+            echo "Adding SPDX license headers to source files..."
+
+            # Add headers to Go files
+            while IFS= read -r -d '' file; do
+                if add_go_header "$file"; then
+                    count=$((count + 1))
+                fi
+            done < <(find . -type f -name "*.go" \
+                -not -path "./vendor/*" \
+                -not -path "./bin/*" \
+                -not -path "./.git/*" \
+                -not -name "*_generated.go" \
+                -not -name "mocks_generated.go" \
+                -print0)
+
+            # Add headers to shell scripts
+            while IFS= read -r -d '' file; do
+                if add_shell_header "$file"; then
+                    count=$((count + 1))
+                fi
+            done < <(find . -type f -name "*.sh" \
+                -not -path "./vendor/*" \
+                -not -path "./bin/*" \
+                -not -path "./.git/*" \
+                -print0)
+
+            # Add headers to YAML files
+            while IFS= read -r -d '' file; do
+                # Skip config.yaml and other non-source files
+                if [[ "$file" =~ (config\.yaml|integration-test\.json)$ ]]; then
+                    continue
+                fi
+                if add_yaml_header "$file"; then
+                    count=$((count + 1))
+                fi
+            done < <(find . -type f \( -name "*.yaml" -o -name "*.yml" \) \
+                -not -path "./vendor/*" \
+                -not -path "./bin/*" \
+                -not -path "./.git/*" \
+                -print0)
+
+            echo ""
+            echo "Summary: Added license headers to $count files"
+            ;;
+
+        *)
+            echo "Usage: $0 {check|add}"
+            echo "  check  - Check for missing license headers (exits 1 if any are missing)"
+            echo "  add    - Add license headers to files that are missing them"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"
+

--- a/test/config/blocknode_values.yaml
+++ b/test/config/blocknode_values.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 resources:
   requests:
     cpu: "500m"

--- a/test/scripts/health.sh
+++ b/test/scripts/health.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 # File: `test/scripts/health.sh`
 # Modular cluster health checks (non-destructive). Returns non-zero on failure.
 

--- a/test/scripts/reset.sh
+++ b/test/scripts/reset.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 helm uninstall metallb -n metallb-system || true
 kubectl delete namespace metallb-system || true
 cilium uninstall || true


### PR DESCRIPTION
## Description

This pull request introduces SPDX license headers to various files throughout the repository to ensure compliance with the Apache 2.0 license. The changes cover configuration files, GitHub workflow and issue templates, build scripts, and source code files. Additionally, new Taskfile commands are added to help automate checking and adding license headers.

**License Compliance and Automation**

* Added SPDX license headers to all relevant configuration files, GitHub workflow files, issue templates, and build scripts [[1]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efR1-R2) [[2]](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2R1-R2) [[3]](diffhunk://#diff-4c31585a100a6c7c4850d6e6f3745ef9116b31fed3b38b8ba8cce02f66b43a7bR1-R2) [[4]](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdR1-R2) [[5]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R2) [[6]](diffhunk://#diff-f1bcd1ef387efde297c1469d5f2c6ed7ba81f38b14e3d54d270914d1125bb2ccR1-R2) [[7]](diffhunk://#diff-8cfd4c6cf56c23e15480733e0f568aaf4df7bf57834054f786f0740c351276baR1-R2) [[8]](diffhunk://#diff-27967245a97a8a29128fb6b78effef1a93934d79b3f4b838394993f006ce858cR1-R2) [[9]](diffhunk://#diff-16519657be7a7de47f7810334df1f22e9ab4ab0fe4f3f3bbe13bb61e73eea922R1-R2) [[10]](diffhunk://#diff-6d09ae139b77769862a6695df9e82e6f27d74fa6ace5b4ee56bfc51272458b7aR1-R2) [[11]](diffhunk://#diff-1552e0a6f970b2191f0e8ef34ac62e41815fc6cdbc213921e915a042e500f03aR1-R2) [[12]](diffhunk://#diff-37df0a550e9f23c4c5b4f4ea1d12d27b3f7cdf579dc175b908c330492084ca29R2) [[13]](diffhunk://#diff-e482acf5d6c668dcdf5f8ef1ba216e7b4c15af03ad308a9488cecd13a4db929bR2) [[14]](diffhunk://#diff-94159af1246cf76d26319f2ecee86909595e798ac86ea5e39a463019d1f14da8R2) [[15]](diffhunk://#diff-38006aacc16df74cfcb2b75e2af5fd53de00ff4249c04c8367590b53ecadbd07R2) [[16]](diffhunk://#diff-56f5f685a77337f9753291f8854b0d536864e19302f327a8f945273c840f2d92R2).
* Added SPDX license headers to source code files such as `cmd/weaver-shim/main.go` and `cmd/weaver/commands/block/block.go` [[1]](diffhunk://#diff-91bbd877e63c70b16fa007327d81c581792d02e63bc911eab6b044a051ee693dR1-R2) [[2]](diffhunk://#diff-4e015bb73f9846f175af76d353d65e102baa269290a4fbd567167e65fdf5ff9fR1-R2).

**Taskfile Enhancements**

* Introduced new `Taskfile.yaml` tasks to check for and add SPDX license headers (`license:check`, `license:add`, and `license` alias) to automate license compliance.

**IDE Copyright Profiles**

* Added and configured copyright profiles for Apache 2.0 license in `.idea/copyright/Hashgraph_Apache_2_0.xml` and `.idea/copyright/profiles_settings.xml` for IDE integration [[1]](diffhunk://#diff-48ca1c8bdd3a44cb1642ece654212cfb8d103e1d609c5828950fd408f466cc87R1-R7) [[2]](diffhunk://#diff-ea076abf469f423616a549869b1f6e9bb7ac61b53728d855f0b6ec439bb67ff1R1-R10).

These updates help standardize license management across the project and streamline future compliance checks.

### Related Issues

* Closes #229 
