### PR TITLE
feat(security): validate URLs to prevent SSRF

### DIFF
--- a/pkg/sanity/domains.go
+++ b/pkg/sanity/domains.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package sanity
+
+// AllowedDomains is an allowlist of trusted domains for software downloads.
+// This list is used by ValidateURL to prevent downloads from untrusted sources
+// and protect against SSRF (Server-Side Request Forgery) attacks.
+//
+// SECURITY GUIDELINES - WHAT TO ADD:
+// Only HTTPS URLs from these domains (and their subdomains) will be allowed.
+// When adding new domains, ensure they are:
+//  1. Trusted and reputable sources (e.g., official software registries)
+//  2. Use HTTPS with valid certificates
+//  3. Have a legitimate business need for software downloads
+//  4. Documented with a comment explaining their purpose
+//
+// SECURITY GUIDELINES - WHAT NOT TO ADD:
+// DO NOT add any of the following, as they pose security risks:
+//   - Cloud metadata IP addresses:
+//   - 169.254.169.254 (AWS, Azure, OpenStack metadata)
+//   - fd00:ec2::254 (AWS IMDSv2 IPv6)
+//   - 169.254.169.123 (DigitalOcean metadata)
+//   - 169.254.169.250 (Oracle Cloud metadata)
+//   - metadata.google.internal (GCP metadata)
+//   - Loopback addresses:
+//   - 127.0.0.0/8 (IPv4 loopback range)
+//   - ::1 (IPv6 loopback)
+//   - localhost
+//   - Private IP ranges (RFC 1918):
+//   - 10.0.0.0/8
+//   - 172.16.0.0/12
+//   - 192.168.0.0/16
+//   - Link-local addresses:
+//   - 169.254.0.0/16 (IPv4 link-local)
+//   - fe80::/10 (IPv6 link-local)
+//   - Unspecified addresses:
+//   - 0.0.0.0 (IPv4)
+//   - :: (IPv6)
+//   - Any IP addresses instead of domain names
+//   - Internal or development domains (e.g., .local, .internal, .test)
+//   - Domains that redirect to untrusted sources
+//
+// The domain allowlist is the primary security control. Adding inappropriate
+// domains can bypass SSRF protections and expose the system to attacks.
+var allowedDomains = []string{
+	// Google Cloud Storage - used for various Kubernetes components
+	"storage.googleapis.com",
+	"dl.google.com",
+
+	// GitHub releases and content
+	"github.com",
+	"githubusercontent.com",
+
+	// Kubernetes official
+	"dl.k8s.io",
+	"packages.cloud.google.com",
+
+	// Container registries
+	"gcr.io",
+	"registry.k8s.io",
+	"quay.io",
+
+	// Helm charts and releases
+	"charts.helm.sh",
+	"get.helm.sh",
+
+	// HashiCorp releases
+	"releases.hashicorp.com",
+}
+
+// AllowedDomains returns the allowlist of trusted domains for software downloads.
+func AllowedDomains() []string {
+	return append([]string(nil), allowedDomains...)
+}

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -162,14 +162,14 @@ func SanitizePath(path string) (string, error) {
 
 // ValidateURL validates a URL to ensure it's safe to use for downloads.
 //
-// This function checks that:
-//  1. The URL is not empty
-//  2. The URL can be parsed
-//  3. The scheme is either "http" or "https"
-//  4. The host is not empty
+// This function provides SSRF (Server-Side Request Forgery) protection by checking that:
+//  1. The URL is not empty and can be parsed
+//  2. The scheme is HTTPS only (HTTP is rejected for security)
+//  3. The host is not empty
+//  4. The host is in the allowed domain list for trusted registries
 //
 // Returns an error if the URL is invalid or unsafe.
-func ValidateURL(rawURL string) error {
+func ValidateURL(rawURL string, allowedDomains []string) error {
 	if rawURL == "" {
 		return errorx.IllegalArgument.New("URL cannot be empty")
 	}
@@ -179,9 +179,9 @@ func ValidateURL(rawURL string) error {
 		return errorx.IllegalArgument.New("invalid URL: %s", err.Error())
 	}
 
-	// Only allow http and https schemes
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return errorx.IllegalArgument.New("URL scheme must be http or https, got: %s", parsedURL.Scheme)
+	// Only allow HTTPS scheme for security (reject HTTP)
+	if parsedURL.Scheme != "https" {
+		return errorx.IllegalArgument.New("URL scheme must be https for security, got: %s", parsedURL.Scheme)
 	}
 
 	// Ensure host is not empty
@@ -189,7 +189,66 @@ func ValidateURL(rawURL string) error {
 		return errorx.IllegalArgument.New("URL must have a valid host")
 	}
 
+	// Extract hostname without port
+	hostname := parsedURL.Hostname()
+	if hostname == "" {
+		return errorx.IllegalArgument.New("URL must have a valid hostname")
+	}
+
+	// Validate against allowed domains - this is our primary security control
+	if !isAllowedDomain(hostname, allowedDomains) {
+		return errorx.IllegalArgument.New("URL host %s is not in the allowed domain list", hostname)
+	}
+
 	return nil
+}
+
+// isASCII checks if a string contains only ASCII characters.
+// This prevents Unicode homograph attacks where visually similar characters
+// from different scripts could be used to spoof trusted domains.
+// For example: "githսb.com" using Armenian 'ս' instead of Latin 'u'.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] > 127 {
+			return false
+		}
+	}
+	return true
+}
+
+// isAllowedDomain checks if a hostname is in the allowlist of trusted domains.
+// This implements a domain allowlist strategy to prevent downloads from untrusted sources.
+//
+// SECURITY: This function protects against:
+//  1. Untrusted domain access - only allowlisted domains are permitted
+//  2. Unicode homograph attacks - non-ASCII characters are rejected
+//  3. Case variations - domains are normalized to lowercase
+func isAllowedDomain(hostname string, allowedDomains []string) bool {
+	// Reject non-ASCII hostnames to prevent Unicode homograph attacks
+	// This prevents attacks like using "githսb.com" (Armenian 'ս') instead of "github.com"
+	if !isASCII(hostname) {
+		return false
+	}
+
+	// Normalize hostname to lowercase
+	hostname = strings.ToLower(hostname)
+
+	// Check exact match
+	for _, allowed := range allowedDomains {
+		// Normalize allowed domain to lowercase for robust comparison
+		// This prevents future bugs if uppercase domains are added to the allowlist
+		allowedLower := strings.ToLower(allowed)
+
+		if hostname == allowedLower {
+			return true
+		}
+		// Also check if it's a subdomain of an allowed domain
+		if strings.HasSuffix(hostname, "."+allowedLower) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ValidatePathWithinBase validates that a path is within a specific base directory.

--- a/pkg/sanity/sanity_test.go
+++ b/pkg/sanity/sanity_test.go
@@ -8,6 +8,369 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSanity_isAllowedDomain(t *testing.T) {
+	testCases := []struct {
+		name     string
+		hostname string
+		allowed  bool
+	}{
+		// Exact matches - should be allowed
+		{
+			name:     "exact match: github.com",
+			hostname: "github.com",
+			allowed:  true,
+		},
+		{
+			name:     "exact match: storage.googleapis.com",
+			hostname: "storage.googleapis.com",
+			allowed:  true,
+		},
+		{
+			name:     "exact match: dl.k8s.io",
+			hostname: "dl.k8s.io",
+			allowed:  true,
+		},
+
+		// Valid subdomains - should be allowed
+		{
+			name:     "valid subdomain: api.github.com",
+			hostname: "api.github.com",
+			allowed:  true,
+		},
+		{
+			name:     "valid subdomain: raw.githubusercontent.com",
+			hostname: "raw.githubusercontent.com",
+			allowed:  true,
+		},
+		{
+			name:     "valid nested subdomain: test.api.github.com",
+			hostname: "test.api.github.com",
+			allowed:  true,
+		},
+		{
+			name:     "exact match: charts.helm.sh",
+			hostname: "charts.helm.sh",
+			allowed:  true,
+		},
+
+		// Edge case: domains that end with allowed domain but are not subdomains
+		// These should be REJECTED to prevent "evilgithub.com" bypassing "github.com"
+		{
+			name:     "malicious domain: evilgithub.com (NOT a subdomain of github.com)",
+			hostname: "evilgithub.com",
+			allowed:  false,
+		},
+		{
+			name:     "malicious domain: notgithub.com (NOT a subdomain of github.com)",
+			hostname: "notgithub.com",
+			allowed:  false,
+		},
+		{
+			name:     "rejected domain: fakestorage.googleapis.com (subdomain of googleapis.com, but only storage.googleapis.com is allowlisted)",
+			hostname: "fakestorage.googleapis.com",
+			allowed:  false,
+		},
+		{
+			name:     "malicious domain: evil-github.com (NOT a subdomain of github.com)",
+			hostname: "evil-github.com",
+			allowed:  false,
+		},
+		{
+			name:     "malicious domain: github.com.evil.com (NOT a subdomain of github.com)",
+			hostname: "github.com.evil.com",
+			allowed:  false,
+		},
+
+		// Completely unrelated domains - should be rejected
+		{
+			name:     "untrusted domain: evil.com",
+			hostname: "evil.com",
+			allowed:  false,
+		},
+		{
+			name:     "untrusted domain: attacker.net",
+			hostname: "attacker.net",
+			allowed:  false,
+		},
+		{
+			name:     "untrusted domain: malware.org",
+			hostname: "malware.org",
+			allowed:  false,
+		},
+
+		// Case sensitivity - should be case-insensitive
+		{
+			name:     "case insensitive: GitHub.com",
+			hostname: "GitHub.com",
+			allowed:  true,
+		},
+		{
+			name:     "case insensitive: GITHUB.COM",
+			hostname: "GITHUB.COM",
+			allowed:  true,
+		},
+		{
+			name:     "case insensitive: Api.GitHub.Com",
+			hostname: "Api.GitHub.Com",
+			allowed:  true,
+		},
+
+		// Empty and invalid inputs
+		{
+			name:     "empty hostname",
+			hostname: "",
+			allowed:  false,
+		},
+
+		// IP addresses - should be rejected (not in domain allowlist)
+		{
+			name:     "IPv4 address",
+			hostname: "192.168.1.1",
+			allowed:  false,
+		},
+		{
+			name:     "IPv6 address",
+			hostname: "::1",
+			allowed:  false,
+		},
+		{
+			name:     "cloud metadata endpoint",
+			hostname: "169.254.169.254",
+			allowed:  false,
+		},
+
+		// Unicode homograph attacks - should be rejected
+		{
+			name:     "Cyrillic 'а' instead of Latin 'a' in github",
+			hostname: "githаb.com", // Using Cyrillic 'а' (U+0430)
+			allowed:  false,
+		},
+		{
+			name:     "Armenian 'ս' instead of Latin 'u' in github",
+			hostname: "githսb.com", // Using Armenian 'ս' (U+057D)
+			allowed:  false,
+		},
+		{
+			name:     "Greek 'ο' instead of Latin 'o' in google",
+			hostname: "gοοgle.com", // Using Greek 'ο' (U+03BF)
+			allowed:  false,
+		},
+		{
+			name:     "Cyrillic 'е' instead of Latin 'e' in helm",
+			hostname: "hеlm.sh", // Using Cyrillic 'е' (U+0435)
+			allowed:  false,
+		},
+		{
+			name:     "Mixed Latin and Cyrillic characters",
+			hostname: "storаge.googleаpis.com", // Using Cyrillic 'а' in multiple places
+			allowed:  false,
+		},
+		{
+			name:     "Full-width Latin characters",
+			hostname: "ｇｉｔｈｕｂ．ｃｏｍ", // Using full-width characters
+			allowed:  false,
+		},
+		{
+			name:     "Chinese characters in domain",
+			hostname: "github.中国",
+			allowed:  false,
+		},
+		{
+			name:     "Arabic characters in domain",
+			hostname: "github.العربية",
+			allowed:  false,
+		},
+		{
+			name:     "Emoji in domain",
+			hostname: "github😀.com",
+			allowed:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := require.New(t)
+			result := isAllowedDomain(tc.hostname, AllowedDomains())
+			req.Equal(tc.allowed, result, "hostname: %s", tc.hostname)
+		})
+	}
+}
+
+func TestSanity_isASCII(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		// Valid ASCII strings
+		{
+			name:     "simple ASCII domain",
+			input:    "github.com",
+			expected: true,
+		},
+		{
+			name:     "ASCII with numbers",
+			input:    "test123.example.com",
+			expected: true,
+		},
+		{
+			name:     "ASCII with hyphens",
+			input:    "my-domain.example.com",
+			expected: true,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: true, // Empty string is technically all ASCII
+		},
+		{
+			name:     "ASCII printable characters",
+			input:    "test-domain_123.example.com",
+			expected: true,
+		},
+
+		// Invalid non-ASCII strings
+		{
+			name:     "Cyrillic character",
+			input:    "githаb.com", // Cyrillic 'а'
+			expected: false,
+		},
+		{
+			name:     "Armenian character",
+			input:    "githսb.com", // Armenian 'ս'
+			expected: false,
+		},
+		{
+			name:     "Greek character",
+			input:    "gοοgle.com", // Greek 'ο'
+			expected: false,
+		},
+		{
+			name:     "Chinese characters",
+			input:    "example.中国",
+			expected: false,
+		},
+		{
+			name:     "Arabic characters",
+			input:    "example.العربية",
+			expected: false,
+		},
+		{
+			name:     "Emoji",
+			input:    "github😀.com",
+			expected: false,
+		},
+		{
+			name:     "Full-width characters",
+			input:    "ｇｉｔｈｕｂ.com",
+			expected: false,
+		},
+		{
+			name:     "Mixed ASCII and non-ASCII",
+			input:    "github.cоm", // Latin 'o' replaced with Cyrillic 'о'
+			expected: false,
+		},
+		{
+			name:     "Unicode normalization attack",
+			input:    "github.com\u0301", // Combining acute accent
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := require.New(t)
+			result := isASCII(tc.input)
+			req.Equal(tc.expected, result, "input: %s", tc.input)
+		})
+	}
+}
+
+func TestSanity_isAllowedDomain_WithUppercaseInAllowlist(t *testing.T) {
+	// This test verifies that the function correctly normalizes both sides of the comparison
+	// by temporarily adding uppercase domains to the allowlist
+	req := require.New(t)
+
+	// Set allowlist with mixed case domains (simulating future maintainability scenario)
+	testAllowedDomains := []string{
+		"GitHub.COM",             // Uppercase
+		"Storage.GoogleAPIs.com", // Mixed case
+		"dl.k8s.io",              // Lowercase (normal)
+	}
+
+	testCases := []struct {
+		name     string
+		hostname string
+		allowed  bool
+	}{
+		// Should match despite case differences in allowlist
+		{
+			name:     "lowercase hostname matches uppercase allowlist entry",
+			hostname: "github.com",
+			allowed:  true,
+		},
+		{
+			name:     "uppercase hostname matches uppercase allowlist entry",
+			hostname: "GITHUB.COM",
+			allowed:  true,
+		},
+		{
+			name:     "mixed case hostname matches uppercase allowlist entry",
+			hostname: "GitHub.Com",
+			allowed:  true,
+		},
+		{
+			name:     "subdomain of uppercase allowlist entry",
+			hostname: "api.github.com",
+			allowed:  true,
+		},
+		{
+			name:     "lowercase hostname matches mixed case allowlist entry",
+			hostname: "storage.googleapis.com",
+			allowed:  true,
+		},
+		{
+			name:     "uppercase hostname matches mixed case allowlist entry",
+			hostname: "STORAGE.GOOGLEAPIS.COM",
+			allowed:  true,
+		},
+		{
+			name:     "subdomain of mixed case allowlist entry",
+			hostname: "test.storage.googleapis.com",
+			allowed:  true,
+		},
+		{
+			name:     "lowercase hostname matches lowercase allowlist entry",
+			hostname: "dl.k8s.io",
+			allowed:  true,
+		},
+		{
+			name:     "uppercase hostname matches lowercase allowlist entry",
+			hostname: "DL.K8S.IO",
+			allowed:  true,
+		},
+
+		// Should NOT match
+		{
+			name:     "domain not in allowlist",
+			hostname: "evil.com",
+			allowed:  false,
+		},
+		{
+			name:     "fake subdomain",
+			hostname: "github.com.evil.com",
+			allowed:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isAllowedDomain(tc.hostname, testAllowedDomains)
+			req.Equal(tc.allowed, result, "hostname: %s", tc.hostname)
+		})
+	}
+}
+
 func TestSanity_Alphanumeric(t *testing.T) {
 	req := require.New(t)
 	testCases := []struct {
@@ -680,31 +1043,39 @@ func TestSanity_ValidateURL(t *testing.T) {
 		shouldErr bool
 		errMsg    string
 	}{
-		// Valid URLs
+		// Valid URLs - trusted domains with HTTPS
 		{
-			name:      "valid http URL",
-			url:       "http://example.com/file.tar.gz",
+			name:      "valid https URL from storage.googleapis.com",
+			url:       "https://storage.googleapis.com/cri-o/artifacts/file.tar.gz",
 			shouldErr: false,
 		},
 		{
-			name:      "valid https URL",
-			url:       "https://example.com/file.tar.gz",
+			name:      "valid https URL from github.com",
+			url:       "https://github.com/kubernetes/kubernetes/releases/file.tar.gz",
+			shouldErr: false,
+		},
+		{
+			name:      "valid https URL from dl.k8s.io",
+			url:       "https://dl.k8s.io/release/v1.28.0/bin/linux/amd64/kubectl",
 			shouldErr: false,
 		},
 		{
 			name:      "valid https URL with port",
-			url:       "https://example.com:8443/file.tar.gz",
+			url:       "https://storage.googleapis.com:443/file.tar.gz",
 			shouldErr: false,
 		},
 		{
 			name:      "valid https URL with query params",
-			url:       "https://example.com/file.tar.gz?version=1.0",
+			url:       "https://github.com/kubernetes/kubernetes/releases/download/v1.28.0/file.tar.gz?version=1.0",
 			shouldErr: false,
 		},
+
+		// Invalid URLs - HTTP not allowed (must be HTTPS)
 		{
-			name:      "valid https URL with path",
-			url:       "https://example.com/path/to/file.tar.gz",
-			shouldErr: false,
+			name:      "http URL rejected",
+			url:       "http://storage.googleapis.com/file.tar.gz",
+			shouldErr: true,
+			errMsg:    "URL scheme must be https",
 		},
 
 		// Invalid URLs - empty or malformed
@@ -716,7 +1087,7 @@ func TestSanity_ValidateURL(t *testing.T) {
 		},
 		{
 			name:      "malformed URL",
-			url:       "ht!tp://example.com",
+			url:       "ht!tps://example.com",
 			shouldErr: true,
 			errMsg:    "invalid URL",
 		},
@@ -724,27 +1095,21 @@ func TestSanity_ValidateURL(t *testing.T) {
 		// Invalid URLs - wrong scheme
 		{
 			name:      "ftp scheme",
-			url:       "ftp://example.com/file.tar.gz",
+			url:       "ftp://storage.googleapis.com/file.tar.gz",
 			shouldErr: true,
-			errMsg:    "URL scheme must be http or https",
+			errMsg:    "URL scheme must be https",
 		},
 		{
 			name:      "file scheme",
 			url:       "file:///etc/passwd",
 			shouldErr: true,
-			errMsg:    "URL scheme must be http or https",
+			errMsg:    "URL scheme must be https",
 		},
 		{
 			name:      "javascript scheme",
 			url:       "javascript:alert(1)",
 			shouldErr: true,
-			errMsg:    "URL scheme must be http or https",
-		},
-		{
-			name:      "data scheme",
-			url:       "data:text/html,<script>alert(1)</script>",
-			shouldErr: true,
-			errMsg:    "URL scheme must be http or https",
+			errMsg:    "URL scheme must be https",
 		},
 
 		// Invalid URLs - missing host
@@ -758,14 +1123,93 @@ func TestSanity_ValidateURL(t *testing.T) {
 			name:      "relative URL",
 			url:       "/path/to/file.tar.gz",
 			shouldErr: true,
-			errMsg:    "URL scheme must be http or https",
+			errMsg:    "URL scheme must be https",
+		},
+
+		// Invalid URLs - untrusted domains
+		{
+			name:      "untrusted domain",
+			url:       "https://evil.com/malware.tar.gz",
+			shouldErr: true,
+			errMsg:    "not in the allowed domain list",
+		},
+		{
+			name:      "untrusted subdomain",
+			url:       "https://attacker.example.com/file.tar.gz",
+			shouldErr: true,
+			errMsg:    "not in the allowed domain list",
+		},
+
+		// Edge cases - domains ending with allowed domain but not actual subdomains
+		// These test the subdomain matching logic to prevent bypass attacks
+		{
+			name:      "malicious domain: evilgithub.com (not a subdomain of github.com)",
+			url:       "https://evilgithub.com/malware.tar.gz",
+			shouldErr: true,
+			errMsg:    "not in the allowed domain list",
+		},
+		{
+			name:      "malicious domain: notgithub.com (not a subdomain of github.com)",
+			url:       "https://notgithub.com/malware.tar.gz",
+			shouldErr: true,
+			errMsg:    "not in the allowed domain list",
+		},
+		{
+			name:      "rejected domain: fakestorage.googleapis.com (subdomain of googleapis.com, but only storage.googleapis.com is allowlisted)",
+			url:       "https://fakestorage.googleapis.com/malware.tar.gz",
+			shouldErr: true,
+			errMsg:    "not in the allowed domain list",
+		},
+		{
+			name:      "malicious domain: evil-github.com (not a subdomain of github.com)",
+			url:       "https://evil-github.com/malware.tar.gz",
+			shouldErr: true,
+			errMsg:    "not in the allowed domain list",
+		},
+		{
+			name:      "malicious domain: github.com.evil.com (not a subdomain of github.com)",
+			url:       "https://github.com.evil.com/malware.tar.gz",
+			shouldErr: true,
+			errMsg:    "not in the allowed domain list",
+		},
+		{
+			name:      "malicious domain: attackerdl.k8s.io (not valid)",
+			url:       "https://attackerdl.k8s.io/malware.tar.gz",
+			shouldErr: true,
+			errMsg:    "not in the allowed domain list",
+		},
+
+		// Invalid URLs - IP addresses (direct IP access blocked)
+		{
+			name:      "IPv4 address",
+			url:       "https://192.168.1.1/file.tar.gz",
+			shouldErr: true,
+			errMsg:    "is not in the allowed domain list",
+		},
+		{
+			name:      "IPv6 address",
+			url:       "https://[::1]/file.tar.gz",
+			shouldErr: true,
+			errMsg:    "is not in the allowed domain list",
+		},
+		{
+			name:      "cloud metadata endpoint IPv4",
+			url:       "https://169.254.169.254/latest/meta-data/",
+			shouldErr: true,
+			errMsg:    "is not in the allowed domain list",
+		},
+		{
+			name:      "loopback address",
+			url:       "https://127.0.0.1/file.tar.gz",
+			shouldErr: true,
+			errMsg:    "is not in the allowed domain list",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			req := require.New(t)
-			err := ValidateURL(tc.url)
+			err := ValidateURL(tc.url, AllowedDomains())
 			if tc.shouldErr {
 				req.Error(err, "expected error for URL: %s", tc.url)
 				if tc.errMsg != "" {

--- a/pkg/software/downloader.go
+++ b/pkg/software/downloader.go
@@ -17,51 +17,102 @@ import (
 	"github.com/hashgraph/solo-weaver/pkg/sanity"
 )
 
-// Downloader is responsible for downloading a software package and check its integrity.
+// Downloader is responsible for downloading a software package and checking its integrity.
 type Downloader struct {
-	client   *http.Client
-	timeout  time.Duration
-	basePath string // Base directory for validating download/extraction paths
+	client         *http.Client
+	timeout        time.Duration
+	basePath       string   // Base directory for validating download/extraction paths
+	allowedDomains []string // List of allowed domains for SSRF protection
 }
 
-// NewDownloader creates a new Downloader with default settings
-func NewDownloader() *Downloader {
-	transport := &http.Transport{
-		// Use ProxyFromEnvironment to respect HTTP_PROXY, HTTPS_PROXY, and NO_PROXY
-		Proxy: http.ProxyFromEnvironment,
-	}
+// DownloaderOption is a function that configures a Downloader
+type DownloaderOption func(*Downloader)
 
-	return &Downloader{
-		client: &http.Client{
-			Timeout:   30 * time.Minute, // Default timeout for large downloads
-			Transport: transport,
-		},
-		timeout:  30 * time.Minute,
-		basePath: core.Paths().TempDir,
+// WithTimeout sets a custom timeout for the downloader
+func WithTimeout(timeout time.Duration) DownloaderOption {
+	return func(d *Downloader) {
+		d.timeout = timeout
+		if d.client != nil {
+			d.client.Timeout = timeout
+		}
 	}
 }
 
-// NewDownloaderWithTimeout creates a new Downloader with custom timeout
-func NewDownloaderWithTimeout(timeout time.Duration) *Downloader {
-	transport := &http.Transport{
-		// Use ProxyFromEnvironment to respect HTTP_PROXY, HTTPS_PROXY, and NO_PROXY
-		Proxy: http.ProxyFromEnvironment,
+// WithBasePath sets a custom base path for the downloader
+func WithBasePath(basePath string) DownloaderOption {
+	return func(d *Downloader) {
+		d.basePath = basePath
+	}
+}
+
+// WithAllowedDomains sets custom allowed domains for the downloader
+func WithAllowedDomains(domains []string) DownloaderOption {
+	return func(d *Downloader) {
+		d.allowedDomains = domains
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client for the downloader (useful for testing)
+func WithHTTPClient(client *http.Client) DownloaderOption {
+	return func(d *Downloader) {
+		d.client = client
+	}
+}
+
+// validateRedirect validates redirect URLs to prevent redirect-based SSRF attacks
+// where an attacker redirects from a trusted domain to an internal service.
+func (fd *Downloader) validateRedirect(req *http.Request, via []*http.Request) error {
+	// Limit the number of redirects to prevent redirect loops
+	if len(via) >= 10 {
+		return fmt.Errorf("stopped after 10 redirects")
 	}
 
-	return &Downloader{
-		client: &http.Client{
-			Timeout:   timeout,
-			Transport: transport,
-		},
-		timeout:  timeout,
-		basePath: core.Paths().TempDir,
+	// Validate the redirect URL against the allowlist
+	if err := sanity.ValidateURL(req.URL.String(), fd.allowedDomains); err != nil {
+		return fmt.Errorf("redirect to untrusted domain: %w", err)
 	}
+
+	return nil
+}
+
+// NewDownloader creates a new Downloader with default settings and optional configurations
+func NewDownloader(opts ...DownloaderOption) *Downloader {
+	// Set defaults
+	downloader := &Downloader{
+		timeout:        30 * time.Minute,
+		basePath:       core.Paths().TempDir,
+		allowedDomains: sanity.AllowedDomains(),
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(downloader)
+	}
+
+	// Create HTTP client if not provided via options
+	if downloader.client == nil {
+		transport := &http.Transport{
+			// Use ProxyFromEnvironment to respect HTTP_PROXY, HTTPS_PROXY, and NO_PROXY
+			Proxy: http.ProxyFromEnvironment,
+		}
+
+		downloader.client = &http.Client{
+			Timeout:   downloader.timeout,
+			Transport: transport,
+		}
+	}
+
+	// Always set the redirect validation, even if a custom client was provided
+	// This ensures SSRF protection is enforced regardless of how the client was configured
+	downloader.client.CheckRedirect = downloader.validateRedirect
+
+	return downloader
 }
 
 // Download downloads a file from the given URL to the specified destination
 func (fd *Downloader) Download(url, destination string) error {
 	// Validate URL before attempting download
-	if err := sanity.ValidateURL(url); err != nil {
+	if err := sanity.ValidateURL(url, fd.allowedDomains); err != nil {
 		return NewInvalidURLError(err, url)
 	}
 

--- a/pkg/software/downloader_test.go
+++ b/pkg/software/downloader_test.go
@@ -17,9 +17,9 @@ import (
 )
 
 func Test_Downloader_Download(t *testing.T) {
-	// Create a test server
+	// Create a TLS test server (uses HTTPS)
 	testContent := "This is test content for download"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(testContent))
 	}))
@@ -31,10 +31,14 @@ func Test_Downloader_Download(t *testing.T) {
 	_ = tmpFile.Close()
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
-	// Test download
-	downloader := NewDownloader()
-	// Set basePath to allow test temp directory
-	downloader.basePath = filepath.Dir(tmpFile.Name())
+	// Test download with a custom downloader that accepts the test server's certificate
+	testClient := server.Client()
+	downloader := NewDownloader(
+		WithHTTPClient(testClient),
+		WithBasePath(filepath.Dir(tmpFile.Name())),
+		WithAllowedDomains([]string{"localhost", "127.0.0.1"}),
+	)
+
 	err = downloader.Download(server.URL, tmpFile.Name())
 	require.NoError(t, err, "Download failed")
 
@@ -47,7 +51,7 @@ func Test_Downloader_Download(t *testing.T) {
 
 func Test_Downloader_Download_HTTPError(t *testing.T) {
 	// Create a test server that returns 404
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
@@ -57,7 +61,14 @@ func Test_Downloader_Download_HTTPError(t *testing.T) {
 	_ = tmpFile.Close()
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
-	downloader := NewDownloader()
+	testClient := server.Client()
+	testClient.Timeout = 30 * time.Minute
+	downloader := NewDownloader(
+		WithHTTPClient(testClient),
+		WithBasePath(filepath.Dir(tmpFile.Name())),
+		WithAllowedDomains([]string{"localhost", "127.0.0.1"}),
+	)
+
 	err = downloader.Download(server.URL, tmpFile.Name())
 	require.Error(t, err, "Download should fail with HTTP 404")
 
@@ -66,7 +77,7 @@ func Test_Downloader_Download_HTTPError(t *testing.T) {
 
 func Test_Downloader_Timeout(t *testing.T) {
 	// Create a test server that sleeps longer than the timeout
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(3 * time.Second)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("This should timeout"))
@@ -78,9 +89,14 @@ func Test_Downloader_Timeout(t *testing.T) {
 	_ = tmpFile.Close()
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
-	downloader := NewDownloaderWithTimeout(1 * time.Second)
-	// Set basePath to allow test temp directory
-	downloader.basePath = filepath.Dir(tmpFile.Name())
+	testClient := server.Client()
+	downloader := NewDownloader(
+		WithHTTPClient(testClient),
+		WithTimeout(1*time.Second),
+		WithBasePath(filepath.Dir(tmpFile.Name())),
+		WithAllowedDomains([]string{"localhost", "127.0.0.1"}),
+	)
+
 	err = downloader.Download(server.URL, tmpFile.Name())
 	require.Error(t, err, "Download should fail with timeout")
 
@@ -109,9 +125,9 @@ func Test_Downloader_Extract(t *testing.T) {
 	require.NoError(t, err, "Failed to create extraction directory")
 
 	// Test extraction
-	downloader := NewDownloader()
-	// Set basePath to allow test temp directory
-	downloader.basePath = filepath.Dir(tempDir)
+	downloader := NewDownloader(
+		WithBasePath(filepath.Dir(tempDir)),
+	)
 	err = downloader.Extract(tarGzPath, extractDir)
 	require.NoError(t, err, "Extract failed")
 
@@ -129,9 +145,9 @@ func Test_Downloader_Extract_FileNotFound(t *testing.T) {
 	require.NoError(t, err, "Failed to create temp dir")
 	defer func() { _ = os.RemoveAll(tempDir) }()
 
-	downloader := NewDownloader()
-	// Set basePath to allow test temp directory
-	downloader.basePath = filepath.Dir(tempDir)
+	downloader := NewDownloader(
+		WithBasePath(filepath.Dir(tempDir)),
+	)
 	err = downloader.Extract(filepath.Join(tempDir, "nonexistent.tar.gz"), tempDir)
 	require.Error(t, err, "Extract should fail with file not found")
 	require.True(t, errorx.IsOfType(err, FileNotFoundError), "Error should be of type FileNotFoundError")
@@ -154,11 +170,265 @@ func Test_Downloader_Extract_Timeout(t *testing.T) {
 	require.NoError(t, err, "Failed to create test tar.gz")
 
 	extractDir := filepath.Join(tempDir, "extracted")
-	downloader := NewDownloaderWithTimeout(1 * time.Millisecond) // Very short timeout
-	// Set basePath to allow test temp directory
-	downloader.basePath = filepath.Dir(tempDir)
+	downloader := NewDownloader(
+		WithTimeout(1*time.Millisecond),
+		WithBasePath(filepath.Dir(tempDir)),
+	)
 
 	err = downloader.Extract(tarGzPath, extractDir)
 	require.Error(t, err, "Extract should fail with timeout")
 	require.True(t, errorx.IsOfType(err, ExtractionError), "Error should be of type ExtractionError")
+}
+
+func Test_Downloader_Redirect_ToAllowedDomain(t *testing.T) {
+	testContent := "Redirect successful"
+
+	// Create the redirect target server
+	targetServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(testContent))
+	}))
+	defer targetServer.Close()
+
+	// Create the initial server that redirects to the target
+	redirectServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, targetServer.URL, http.StatusFound)
+	}))
+	defer redirectServer.Close()
+
+	// Create temporary file for destination
+	tmpFile, err := os.CreateTemp("", "test_redirect_*.txt")
+	require.NoError(t, err, "Failed to create temp file")
+	_ = tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	testClient := redirectServer.Client()
+	testClient.Timeout = 30 * time.Minute
+	downloader := NewDownloader(
+		WithHTTPClient(testClient),
+		WithBasePath(filepath.Dir(tmpFile.Name())),
+		WithAllowedDomains([]string{"localhost", "127.0.0.1"}),
+	)
+
+	err = downloader.Download(redirectServer.URL, tmpFile.Name())
+	require.NoError(t, err, "Download with redirect to allowed domain should succeed")
+
+	// Verify content
+	content, err := os.ReadFile(tmpFile.Name())
+	require.NoError(t, err, "Failed to read downloaded file")
+	require.Equal(t, testContent, string(content), "Downloaded content mismatch")
+}
+
+func Test_Downloader_Redirect_ToUntrustedDomain(t *testing.T) {
+	// Create a target server that would be blocked
+	targetServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Should not reach here"))
+	}))
+	defer targetServer.Close()
+
+	// Create the initial server that tries to redirect to untrusted domain
+	// We'll redirect to "https://untrusted.example.com" which is not in the allowlist
+	redirectServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://untrusted.example.com/malicious", http.StatusFound)
+	}))
+	defer redirectServer.Close()
+
+	tmpFile, err := os.CreateTemp("", "test_redirect_blocked_*.txt")
+	require.NoError(t, err, "Failed to create temp file")
+	_ = tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	testClient := redirectServer.Client()
+	testClient.Timeout = 30 * time.Minute
+	downloader := NewDownloader(
+		WithHTTPClient(testClient),
+		WithBasePath(filepath.Dir(tmpFile.Name())),
+		WithAllowedDomains([]string{"localhost", "127.0.0.1"}),
+	)
+
+	err = downloader.Download(redirectServer.URL, tmpFile.Name())
+	require.Error(t, err, "Download with redirect to untrusted domain should fail")
+	require.Contains(t, err.Error(), "redirect to untrusted domain", "Error should mention redirect to untrusted domain")
+}
+
+func Test_Downloader_Redirect_TooManyRedirects(t *testing.T) {
+	redirectCount := 0
+	maxRedirects := 10
+
+	// Create a server that keeps redirecting to itself
+	var redirectServer *httptest.Server
+	redirectServer = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectCount++
+		if redirectCount > maxRedirects+5 { // Safety limit
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Too many redirects"))
+			return
+		}
+		// Keep redirecting to self with a different path to avoid browser caching
+		http.Redirect(w, r, fmt.Sprintf("%s/redirect%d", redirectServer.URL, redirectCount), http.StatusFound)
+	}))
+	defer redirectServer.Close()
+
+	tmpFile, err := os.CreateTemp("", "test_redirect_limit_*.txt")
+	require.NoError(t, err, "Failed to create temp file")
+	_ = tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	testClient := redirectServer.Client()
+	testClient.Timeout = 30 * time.Minute
+	downloader := NewDownloader(
+		WithHTTPClient(testClient),
+		WithBasePath(filepath.Dir(tmpFile.Name())),
+		WithAllowedDomains([]string{"localhost", "127.0.0.1"}),
+	)
+
+	err = downloader.Download(redirectServer.URL, tmpFile.Name())
+	require.Error(t, err, "Download with too many redirects should fail")
+	require.Contains(t, err.Error(), "stopped after 10 redirects", "Error should mention redirect limit")
+}
+
+func Test_Downloader_Redirect_ErrorMessage(t *testing.T) {
+	// Create server that redirects to an untrusted domain
+	redirectServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://malicious.example.com/exploit", http.StatusFound)
+	}))
+	defer redirectServer.Close()
+
+	tmpFile, err := os.CreateTemp("", "test_redirect_error_*.txt")
+	require.NoError(t, err, "Failed to create temp file")
+	_ = tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	testClient := redirectServer.Client()
+	testClient.Timeout = 30 * time.Minute
+	downloader := NewDownloader(
+		WithHTTPClient(testClient),
+		WithBasePath(filepath.Dir(tmpFile.Name())),
+		WithAllowedDomains([]string{"localhost", "127.0.0.1"}),
+	)
+
+	err = downloader.Download(redirectServer.URL, tmpFile.Name())
+	require.Error(t, err, "Download should fail")
+
+	// Verify the error message is clear and informative
+	errMsg := err.Error()
+	require.Contains(t, errMsg, "redirect to untrusted domain", "Error should mention redirect blocking")
+	require.Contains(t, errMsg, "not in the allowed domain list", "Error should mention allowlist")
+}
+
+func Test_Downloader_Redirect_ChainOfRedirects(t *testing.T) {
+	testContent := "Multiple redirects successful"
+
+	// Create the final target server
+	targetServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(testContent))
+	}))
+	defer targetServer.Close()
+
+	// Create intermediate redirect server
+	redirect2 := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, targetServer.URL, http.StatusFound)
+	}))
+	defer redirect2.Close()
+
+	// Create first redirect server
+	redirect1 := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirect2.URL, http.StatusFound)
+	}))
+	defer redirect1.Close()
+
+	tmpFile, err := os.CreateTemp("", "test_redirect_chain_*.txt")
+	require.NoError(t, err, "Failed to create temp file")
+	_ = tmpFile.Close()
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	testClient := redirect1.Client()
+	testClient.Timeout = 30 * time.Minute
+	downloader := NewDownloader(
+		WithHTTPClient(testClient),
+		WithBasePath(filepath.Dir(tmpFile.Name())),
+		WithAllowedDomains([]string{"localhost", "127.0.0.1"}),
+	)
+
+	err = downloader.Download(redirect1.URL, tmpFile.Name())
+	require.NoError(t, err, "Download with multiple allowed redirects should succeed")
+
+	// Verify content
+	content, err := os.ReadFile(tmpFile.Name())
+	require.NoError(t, err, "Failed to read downloaded file")
+	require.Equal(t, testContent, string(content), "Downloaded content mismatch")
+}
+
+func Test_validateRedirect_DirectCall(t *testing.T) {
+	tests := []struct {
+		name           string
+		allowedDomains []string
+		redirectURL    string
+		redirectCount  int
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name:           "Valid redirect to allowed domain",
+			allowedDomains: []string{"github.com"},
+			redirectURL:    "https://github.com/releases",
+			redirectCount:  5,
+			expectError:    false,
+		},
+		{
+			name:           "Redirect to untrusted domain",
+			allowedDomains: []string{"github.com"},
+			redirectURL:    "https://malicious.com/exploit",
+			redirectCount:  2,
+			expectError:    true,
+			errorContains:  "redirect to untrusted domain",
+		},
+		{
+			name:           "Redirect limit exceeded",
+			allowedDomains: []string{"github.com"},
+			redirectURL:    "https://github.com/releases",
+			redirectCount:  10,
+			expectError:    true,
+			errorContains:  "stopped after 10 redirects",
+		},
+		{
+			name:           "Redirect to subdomain of allowed domain",
+			allowedDomains: []string{"github.com"},
+			redirectURL:    "https://api.github.com/releases",
+			redirectCount:  3,
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			downloader := NewDownloader(WithAllowedDomains(tt.allowedDomains))
+
+			// Create dummy previous requests to simulate redirect chain
+			via := make([]*http.Request, tt.redirectCount)
+			for i := 0; i < tt.redirectCount; i++ {
+				req, err := http.NewRequest("GET", "https://example.com", nil)
+				require.NoError(t, err)
+				via[i] = req
+			}
+
+			// Create the redirect request
+			req, err := http.NewRequest("GET", tt.redirectURL, nil)
+			require.NoError(t, err)
+
+			// Test the validateRedirect function
+			err = downloader.validateRedirect(req, via)
+
+			if tt.expectError {
+				require.Error(t, err, "validateRedirect should return error")
+				if tt.errorContains != "" {
+					require.Contains(t, err.Error(), tt.errorContains, "Error message should contain expected text")
+				}
+			} else {
+				require.NoError(t, err, "validateRedirect should not return error")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

This pull request introduces significant improvements to the security and configurability of software downloads, focusing on SSRF (Server-Side Request Forgery) protection and domain allowlisting. The changes enforce HTTPS-only downloads, introduce a strict allowlist of trusted domains, and provide mechanisms to prevent Unicode homograph attacks. The downloader and its tests are refactored to support customizable options and better SSRF protection.

**Security enhancements:**

* Added a strict allowlist of trusted domains for software downloads in `pkg/sanity/domains.go`, including documentation and security guidelines for managing the list.
* Updated `ValidateURL` in `pkg/sanity/sanity.go` to enforce HTTPS-only downloads, require the host to be in the allowlist, and reject non-ASCII hostnames to prevent Unicode homograph attacks. Also introduced the `isAllowedDomain` helper. [[1]](diffhunk://#diff-5f474d5e942deddc05691e4ab8b76024db286eb95fd6a4f1939a049a893d92d1L165-R172) [[2]](diffhunk://#diff-5f474d5e942deddc05691e4ab8b76024db286eb95fd6a4f1939a049a893d92d1L182-R253)

**Downloader refactoring and configurability:**

* Refactored `Downloader` in `pkg/software/downloader.go` to accept configuration options (timeout, base path, allowed domains, custom HTTP client) via functional options, and to validate redirects against the allowlist for SSRF protection.
* Updated tests in `pkg/software/base_installer_test.go` and `pkg/software/downloader_test.go` to use HTTPS test servers and configure the downloader with custom allowed domains and HTTP clients, ensuring tests work with the new SSRF protections. [[1]](diffhunk://#diff-91fb63f07bed0ffa9ac21d62775ce36ef34ac1db90d008c1049925c1ed591bd8L50-R52) [[2]](diffhunk://#diff-91fb63f07bed0ffa9ac21d62775ce36ef34ac1db90d008c1049925c1ed591bd8R168-R175) [[3]](diffhunk://#diff-91fb63f07bed0ffa9ac21d62775ce36ef34ac1db90d008c1049925c1ed591bd8L506-R514) [[4]](diffhunk://#diff-91fb63f07bed0ffa9ac21d62775ce36ef34ac1db90d008c1049925c1ed591bd8R566-R573) [[5]](diffhunk://#diff-2099b3c4c6999e3f85a39759801e3710e0d2ceb03e88700236b42551f0b9f6b6L20-R22) [[6]](diffhunk://#diff-2099b3c4c6999e3f85a39759801e3710e0d2ceb03e88700236b42551f0b9f6b6L34-R42) [[7]](diffhunk://#diff-2099b3c4c6999e3f85a39759801e3710e0d2ceb03e88700236b42551f0b9f6b6L50-R55) [[8]](diffhunk://#diff-2099b3c4c6999e3f85a39759801e3710e0d2ceb03e88700236b42551f0b9f6b6L60-R72) [[9]](diffhunk://#diff-2099b3c4c6999e3f85a39759801e3710e0d2ceb03e88700236b42551f0b9f6b6L69-R81) [[10]](diffhunk://#diff-2099b3c4c6999e3f85a39759801e3710e0d2ceb03e88700236b42551f0b9f6b6L81-R100) [[11]](diffhunk://#diff-2099b3c4c6999e3f85a39759801e3710e0d2ceb03e88700236b42551f0b9f6b6L112-R131) [[12]](diffhunk://#diff-2099b3c4c6999e3f85a39759801e3710e0d2ceb03e88700236b42551f0b9f6b6L132-R151)

### Related Issues

* Closes #252 
