### PR TITLE
feat(security): validate and sanitize module name

### DIFF
--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -64,15 +64,26 @@ func filterValidIdentifierChars(s string) (string, int) {
 	return string(sb[:j]), j
 }
 
-// Filename sanitize the input string to be safe filename
-// It only allows alphanumeric characters (a-z, A-Z, 0-9), underscores, and hyphens
-// It returns error if the filename is empty string after the sanitization
-func Filename(s string) (string, error) {
+// Identifier validates and sanitizes a string to be a safe identifier.
+// It only allows alphanumeric characters (a-z, A-Z, 0-9), underscores, and hyphens.
+// This is useful for validating module names, filenames, usernames, and other identifiers.
+// Returns an error if the identifier is empty or contains no valid characters after sanitization.
+func Identifier(s string) (string, error) {
 	sanitized, count := filterValidIdentifierChars(s)
 	if count == 0 {
 		return "", ErrInvalidFilename
 	}
 	return sanitized, nil
+}
+
+// Filename is an alias for Identifier
+func Filename(s string) (string, error) {
+	return Identifier(s)
+}
+
+// ModuleName is an alias for Identifier
+func ModuleName(s string) (string, error) {
+	return Identifier(s)
 }
 
 // Username validates and sanitizes a username string to prevent security vulnerabilities.


### PR DESCRIPTION
## Description

This pull request strengthens security in the kernel module loading logic by validating module names to prevent command injection attacks. It introduces strict checks to ensure only safe, valid module names are accepted and adds comprehensive tests to verify this behavior.

**Security improvements for module name validation:**

* Added validation in `NewModule`, `defaultOperations.load`, and `defaultOperations.unload` to ensure module names only contain allowed characters (alphanumeric, underscore, hyphen), rejecting names with shell metacharacters or other dangerous input. This prevents command injection vulnerabilities when interacting with system utilities like `modprobe`. [[1]](diffhunk://#diff-868618094ae58253c172f0d4b2551d4c4c9f0bb604f9056c8be9a52119295142R36-R49) [[2]](diffhunk://#diff-868618094ae58253c172f0d4b2551d4c4c9f0bb604f9056c8be9a52119295142R121-R142)
* Introduced new error messages and used the `sanity.Filename` utility and `errorx` for more informative error handling related to invalid module names.

**Testing enhancements:**

* Added extensive tests in `module_test.go` to confirm that only valid module names are accepted and that various forms of invalid or dangerous names are correctly rejected in both module creation and load/unload operations.

### Related Issues

* Closes #251 
