### PR TITLE
feat(security): sanitize input file name

### DIFF
--- a/cmd/weaver/commands/block/node/install.go
+++ b/cmd/weaver/commands/block/node/install.go
@@ -8,6 +8,7 @@ import (
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/weaver/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/workflows"
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
 	"github.com/joomcode/errorx"
 	"github.com/spf13/cobra"
 )
@@ -23,14 +24,24 @@ var installCmd = &cobra.Command{
 			return errorx.IllegalArgument.Wrap(err, "failed to get profile flag")
 		}
 
+		// Validate the values file path if provided
+		// This is the primary security validation point for user-supplied file paths.
+		var validatedValuesFile string
+		if flagValuesFile != "" {
+			validatedValuesFile, err = sanity.ValidateInputFile(flagValuesFile)
+			if err != nil {
+				return err
+			}
+		}
+
 		logx.As().Debug().
 			Strs("args", args).
 			Str("nodeType", nodeType).
 			Str("profile", flagProfile).
-			Str("valuesFile", flagValuesFile).
+			Str("valuesFile", validatedValuesFile).
 			Msg("Installing Hedera Block Node")
 
-		common.RunWorkflow(cmd.Context(), workflows.NewBlockNodeInstallWorkflow(flagProfile, flagValuesFile))
+		common.RunWorkflow(cmd.Context(), workflows.NewBlockNodeInstallWorkflow(flagProfile, validatedValuesFile))
 
 		logx.As().Info().Msg("Successfully installed Hedera Block Node")
 		return nil


### PR DESCRIPTION
## Description

This pull request introduces comprehensive input file path validation to improve security and prevent path traversal and shell injection attacks when reading user-supplied files. The main focus is on validating file paths at both the CLI entry point and internal API layers, using a new utility function. The changes also include extensive unit tests to ensure the correctness and robustness of the validation logic.

**Security and input validation improvements:**

* Added a new function `ValidateInputFile` in `pkg/sanity/sanity.go` that performs thorough validation on user-supplied file paths, including checks for path traversal, shell metacharacters, file existence, and ensuring the path points to a regular file.
* Updated the CLI command in `cmd/weaver/commands/block/node/install.go` to validate the `--values-file` argument using `ValidateInputFile` before proceeding with installation, ensuring user input is always sanitized at the entry point. [[1]](diffhunk://#diff-835fa6ddca4435596fff9b76f8176c9a0771490edf70cac6d4044dbe623c8f9aR11) [[2]](diffhunk://#diff-835fa6ddca4435596fff9b76f8176c9a0771490edf70cac6d4044dbe623c8f9aR27-R44)
* Modified the internal `Manager.ComputeValuesFile` method in `internal/blocknode/manager.go` to apply defense-in-depth by re-validating the provided file path, protecting against future misuse or bypasses. [[1]](diffhunk://#diff-f9b42562d7351d8ddceb146839027037ca045b06d0c7b90d09acbe036e500c97R18) [[2]](diffhunk://#diff-f9b42562d7351d8ddceb146839027037ca045b06d0c7b90d09acbe036e500c97L289-R331)

**Testing and reliability:**

* Added comprehensive unit tests in `pkg/sanity/sanity_test.go` to cover a wide range of scenarios for `ValidateInputFile`, including valid files, path traversal attempts, shell metacharacters, non-existent files, directories, device files, and symlinks. [[1]](diffhunk://#diff-01ba1f5014346e7ad996755d51805ca47113127de91c7b873665e2157bcd61deR6-R7) [[2]](diffhunk://#diff-01ba1f5014346e7ad996755d51805ca47113127de91c7b873665e2157bcd61deR1403-R1588)

### Related Issues

* Closes #250 
