### PR TITLE
feat: do not remove deleted file

### DIFF
--- a/internal/core/const.go
+++ b/internal/core/const.go
@@ -69,6 +69,7 @@ type WeaverPaths struct {
 	ConfigDir      string
 	BackupDir      string
 	TempDir        string
+	DownloadsDir   string
 	DiagnosticsDir string
 	StateDir       string
 
@@ -91,6 +92,7 @@ func NewWeaverPaths(home string) *WeaverPaths {
 		UtilsDir:       path.Join(home, "utils"),
 		BackupDir:      path.Join(home, "backup"),
 		TempDir:        path.Join(home, "tmp"),
+		DownloadsDir:   path.Join(home, "downloads"),
 		DiagnosticsDir: path.Join(home, "tmp", "diagnostics"),
 		StateDir:       path.Join(home, "state"),
 	}
@@ -141,6 +143,7 @@ func NewWeaverPaths(home string) *WeaverPaths {
 		pp.ConfigDir,
 		pp.BackupDir,
 		pp.TempDir,
+		pp.DownloadsDir,
 		pp.DiagnosticsDir,
 		pp.StateDir,
 	}

--- a/internal/workflows/steps/step_cilium_it_test.go
+++ b/internal/workflows/steps/step_cilium_it_test.go
@@ -136,16 +136,16 @@ func Test_StepCilium_Rollback_Setup_DownloadFailed(t *testing.T) {
 	//
 	testutil.Reset(t)
 
-	// Make the download directory read-only
-	err := os.MkdirAll(core.Paths().TempDir, core.DefaultDirOrExecPerm)
-	require.NoError(t, err, "Failed to create download directory")
-	cmd := exec.Command("chattr", "+i", core.Paths().TempDir)
+	// Make the downloads directory read-only
+	err := os.MkdirAll(core.Paths().DownloadsDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create downloads directory")
+	cmd := exec.Command("chattr", "+i", core.Paths().DownloadsDir)
 	err = cmd.Run()
-	require.NoError(t, err, "Failed to make download directory read-only")
+	require.NoError(t, err, "Failed to make downloads directory read-only")
 
 	// Restore permissions after test
 	t.Cleanup(func() {
-		_ = exec.Command("chattr", "-i", core.Paths().TempDir).Run()
+		_ = exec.Command("chattr", "-i", core.Paths().DownloadsDir).Run()
 	})
 
 	//

--- a/internal/workflows/steps/step_crio_it_test.go
+++ b/internal/workflows/steps/step_crio_it_test.go
@@ -184,16 +184,16 @@ func Test_StepCrio_Rollback_Setup_DownloadFailed(t *testing.T) {
 	//
 	testutil.Reset(t)
 
-	// Make the download directory read-only
-	err := os.MkdirAll(core.Paths().TempDir, core.DefaultDirOrExecPerm)
-	require.NoError(t, err, "Failed to create download directory")
-	cmd := exec.Command("chattr", "+i", core.Paths().TempDir)
+	// Make the downloads directory read-only
+	err := os.MkdirAll(core.Paths().DownloadsDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create downloads directory")
+	cmd := exec.Command("chattr", "+i", core.Paths().DownloadsDir)
 	err = cmd.Run()
-	require.NoError(t, err, "Failed to make download directory read-only")
+	require.NoError(t, err, "Failed to make downloads directory read-only")
 
 	// Restore permissions after test
 	t.Cleanup(func() {
-		_ = exec.Command("chattr", "-i", core.Paths().TempDir).Run()
+		_ = exec.Command("chattr", "-i", core.Paths().DownloadsDir).Run()
 	})
 
 	//

--- a/internal/workflows/steps/step_helm_it_test.go
+++ b/internal/workflows/steps/step_helm_it_test.go
@@ -136,16 +136,16 @@ func Test_StepHelm_Rollback_Setup_DownloadFailed(t *testing.T) {
 	//
 	testutil.CleanUpTempDir(t)
 
-	// Make the download directory read-only
-	err := os.MkdirAll(core.Paths().TempDir, core.DefaultDirOrExecPerm)
-	require.NoError(t, err, "Failed to create download directory")
-	cmd := exec.Command("chattr", "+i", core.Paths().TempDir)
+	// Make the downloads directory read-only
+	err := os.MkdirAll(core.Paths().DownloadsDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create downloads directory")
+	cmd := exec.Command("chattr", "+i", core.Paths().DownloadsDir)
 	err = cmd.Run()
-	require.NoError(t, err, "Failed to make download directory read-only")
+	require.NoError(t, err, "Failed to make downloads directory read-only")
 
 	// Restore permissions after test
 	t.Cleanup(func() {
-		_ = exec.Command("chattr", "-i", core.Paths().TempDir).Run()
+		_ = exec.Command("chattr", "-i", core.Paths().DownloadsDir).Run()
 	})
 
 	//

--- a/internal/workflows/steps/step_k9s_it_test.go
+++ b/internal/workflows/steps/step_k9s_it_test.go
@@ -137,16 +137,16 @@ func Test_StepK9s_Rollback_Setup_DownloadFailed(t *testing.T) {
 	//
 	testutil.CleanUpTempDir(t)
 
-	// Make the download directory read-only
-	err := os.MkdirAll(core.Paths().TempDir, core.DefaultDirOrExecPerm)
-	require.NoError(t, err, "Failed to create download directory")
-	cmd := exec.Command("chattr", "+i", core.Paths().TempDir)
+	// Make the downloads directory read-only
+	err := os.MkdirAll(core.Paths().DownloadsDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create downloads directory")
+	cmd := exec.Command("chattr", "+i", core.Paths().DownloadsDir)
 	err = cmd.Run()
-	require.NoError(t, err, "Failed to make download directory read-only")
+	require.NoError(t, err, "Failed to make downloads directory read-only")
 
 	// Restore permissions after test
 	t.Cleanup(func() {
-		_ = exec.Command("chattr", "-i", core.Paths().TempDir).Run()
+		_ = exec.Command("chattr", "-i", core.Paths().DownloadsDir).Run()
 	})
 
 	//

--- a/internal/workflows/steps/step_kubeadm_it_test.go
+++ b/internal/workflows/steps/step_kubeadm_it_test.go
@@ -133,16 +133,16 @@ func Test_StepKubeadm_Rollback_Setup_DownloadFailed(t *testing.T) {
 	//
 	testutil.Reset(t)
 
-	// Make the download directory read-only
-	err := os.MkdirAll(core.Paths().TempDir, core.DefaultDirOrExecPerm)
-	require.NoError(t, err, "Failed to create download directory")
-	cmd := exec.Command("chattr", "+i", core.Paths().TempDir)
+	// Make the downloads directory read-only
+	err := os.MkdirAll(core.Paths().DownloadsDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create downloads directory")
+	cmd := exec.Command("chattr", "+i", core.Paths().DownloadsDir)
 	err = cmd.Run()
-	require.NoError(t, err, "Failed to make download directory read-only")
+	require.NoError(t, err, "Failed to make downloads directory read-only")
 
 	// Restore permissions after test
 	t.Cleanup(func() {
-		_ = exec.Command("chattr", "-i", core.Paths().TempDir).Run()
+		_ = exec.Command("chattr", "-i", core.Paths().DownloadsDir).Run()
 	})
 
 	//

--- a/internal/workflows/steps/step_kubectl_it_test.go
+++ b/internal/workflows/steps/step_kubectl_it_test.go
@@ -134,16 +134,16 @@ func Test_StepKubectl_Rollback_Setup_DownloadFailed(t *testing.T) {
 	//
 	testutil.CleanUpTempDir(t)
 
-	// Make the download directory read-only
-	err := os.MkdirAll(core.Paths().TempDir, core.DefaultDirOrExecPerm)
-	require.NoError(t, err, "Failed to create download directory")
-	cmd := exec.Command("chattr", "+i", core.Paths().TempDir)
+	// Make the downloads directory read-only
+	err := os.MkdirAll(core.Paths().DownloadsDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create downloads directory")
+	cmd := exec.Command("chattr", "+i", core.Paths().DownloadsDir)
 	err = cmd.Run()
-	require.NoError(t, err, "Failed to make download directory read-only")
+	require.NoError(t, err, "Failed to make downloads directory read-only")
 
 	// Restore permissions after test
 	t.Cleanup(func() {
-		_ = exec.Command("chattr", "-i", core.Paths().TempDir).Run()
+		_ = exec.Command("chattr", "-i", core.Paths().DownloadsDir).Run()
 	})
 
 	//

--- a/internal/workflows/steps/step_kubelet_it_test.go
+++ b/internal/workflows/steps/step_kubelet_it_test.go
@@ -134,16 +134,16 @@ func Test_StepKubelet_Rollback_Setup_DownloadFailed(t *testing.T) {
 	//
 	testutil.CleanUpTempDir(t)
 
-	// Make the download directory read-only
-	err := os.MkdirAll(core.Paths().TempDir, core.DefaultDirOrExecPerm)
-	require.NoError(t, err, "Failed to create download directory")
-	cmd := exec.Command("chattr", "+i", core.Paths().TempDir)
+	// Make the downloads directory read-only
+	err := os.MkdirAll(core.Paths().DownloadsDir, core.DefaultDirOrExecPerm)
+	require.NoError(t, err, "Failed to create downloads directory")
+	cmd := exec.Command("chattr", "+i", core.Paths().DownloadsDir)
 	err = cmd.Run()
-	require.NoError(t, err, "Failed to make download directory read-only")
+	require.NoError(t, err, "Failed to make downloads directory read-only")
 
 	// Restore permissions after test
 	t.Cleanup(func() {
-		_ = exec.Command("chattr", "-i", core.Paths().TempDir).Run()
+		_ = exec.Command("chattr", "-i", core.Paths().DownloadsDir).Run()
 	})
 
 	//

--- a/pkg/software/cilium_installer_it_test.go
+++ b/pkg/software/cilium_installer_it_test.go
@@ -32,17 +32,20 @@ func Test_CiliumInstaller_FullWorkflow_Success(t *testing.T) {
 	err = installer.Download()
 	require.NoError(t, err, "Failed to download cilium and/or its configuration")
 
-	// Verify downloaded files exist
-	files, err := os.ReadDir("/opt/solo/weaver/tmp/cilium")
+	// Verify downloaded files exist in the shared downloads folder
+	files, err := os.ReadDir("/opt/solo/weaver/downloads")
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(files), "There should be exactly one file in the download directory")
-	// Check that the downloaded file has the expected name format by regex
-	require.Regexp(t,
-		regexp.MustCompile(`^cilium-[^-]+-[^-]+\.tar\.gz$`),
-		files[0].Name(),
-		"Downloaded file name should match expected pattern",
-	)
+	require.GreaterOrEqual(t, len(files), 1, "There should be at least one file in the download directory")
+	// Check that the downloaded cilium file exists with expected name format by regex
+	var foundCilium bool
+	for _, file := range files {
+		if regexp.MustCompile(`^cilium-[^-]+-[^-]+\.tar\.gz$`).MatchString(file.Name()) {
+			foundCilium = true
+			break
+		}
+	}
+	require.True(t, foundCilium, "Downloaded cilium file should exist with expected pattern")
 
 	//
 	// When - Extract

--- a/pkg/software/crio_installer.go
+++ b/pkg/software/crio_installer.go
@@ -97,7 +97,7 @@ func NewCrioInstaller(opts ...InstallerOption) (Software, error) {
 // DESTDIR="${SANDBOX_DIR}" SYSTEMDDIR="/usr/lib/systemd/system" sudo -E "$(command -v bash)" ./install
 func (ci *crioInstaller) Install() error {
 	// Variables matching the shell script structure
-	srcDir := path.Join(ci.downloadFolder(), core.DefaultUnpackFolderName, "cri-o")
+	srcDir := path.Join(ci.extractFolder(), "cri-o")
 	destDir := core.Paths().SandboxDir
 
 	// Ensure directories exist

--- a/pkg/software/crio_installer_it_test.go
+++ b/pkg/software/crio_installer_it_test.go
@@ -35,17 +35,20 @@ func Test_CrioInstaller_FullWorkflow_Success(t *testing.T) {
 	err = installer.Download()
 	require.NoError(t, err, "Failed to download cri-o and/or its configuration")
 
-	// Verify downloaded files exist
-	files, err := os.ReadDir("/opt/solo/weaver/tmp/cri-o")
+	// Verify downloaded files exist in the shared downloads folder
+	files, err := os.ReadDir("/opt/solo/weaver/downloads")
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(files), "There should be exactly one file in the download directory")
-	// Check that the downloaded file has the expected name format by regex
-	require.Regexp(t,
-		regexp.MustCompile(`^cri-o\.[^-]+\.v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz$`),
-		files[0].Name(),
-		"Downloaded file name should match expected pattern",
-	)
+	require.GreaterOrEqual(t, len(files), 1, "There should be at least one file in the download directory")
+	// Check that the downloaded cri-o file exists with expected name format by regex
+	var foundCrio bool
+	for _, file := range files {
+		if regexp.MustCompile(`^cri-o\.[^-]+\.v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz$`).MatchString(file.Name()) {
+			foundCrio = true
+			break
+		}
+	}
+	require.True(t, foundCrio, "Downloaded cri-o file should exist with expected pattern")
 
 	//
 	// When - Extract

--- a/pkg/software/downloader.go
+++ b/pkg/software/downloader.go
@@ -78,9 +78,10 @@ func (fd *Downloader) validateRedirect(req *http.Request, via []*http.Request) e
 // NewDownloader creates a new Downloader with default settings and optional configurations
 func NewDownloader(opts ...DownloaderOption) *Downloader {
 	// Set defaults
+	// Use HomeDir as basePath since downloads and extractions span multiple folders under home
 	downloader := &Downloader{
 		timeout:        30 * time.Minute,
-		basePath:       core.Paths().TempDir,
+		basePath:       core.Paths().HomeDir,
 		allowedDomains: sanity.AllowedDomains(),
 	}
 

--- a/pkg/software/helm_installer_it_test.go
+++ b/pkg/software/helm_installer_it_test.go
@@ -31,17 +31,20 @@ func Test_HelmInstaller_FullWorkflow_Success(t *testing.T) {
 	err = installer.Download()
 	require.NoError(t, err, "Failed to download helm and/or its configuration")
 
-	// Verify downloaded files exist
-	files, err := os.ReadDir("/opt/solo/weaver/tmp/helm")
+	// Verify downloaded files exist in the shared downloads folder
+	files, err := os.ReadDir("/opt/solo/weaver/downloads")
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(files), "There should be exactly one file in the download directory")
-	// Check that the downloaded file has the expected name format by regex
-	require.Regexp(t,
-		regexp.MustCompile(`^helm-v[0-9]+\.[0-9]+\.[0-9]+-[^-]+-[^-]+\.tar\.gz$`),
-		files[0].Name(),
-		"Downloaded file name should match expected pattern",
-	)
+	require.GreaterOrEqual(t, len(files), 1, "There should be at least one file in the download directory")
+	// Check that the downloaded helm file exists with expected name format by regex
+	var foundHelm bool
+	for _, file := range files {
+		if regexp.MustCompile(`^helm-v[0-9]+\.[0-9]+\.[0-9]+-[^-]+-[^-]+\.tar\.gz$`).MatchString(file.Name()) {
+			foundHelm = true
+			break
+		}
+	}
+	require.True(t, foundHelm, "Downloaded helm file should exist with expected pattern")
 
 	//
 	// When - Extract

--- a/pkg/software/k9s_installer_it_test.go
+++ b/pkg/software/k9s_installer_it_test.go
@@ -33,16 +33,19 @@ func Test_K9sInstaller_FullWorkflow_Success(t *testing.T) {
 	require.NoError(t, err, "Failed to download k9s and/or its configuration")
 
 	// Verify downloaded files exist
-	files, err := os.ReadDir("/opt/solo/weaver/tmp/k9s")
+	files, err := os.ReadDir("/opt/solo/weaver/downloads")
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(files), "There should be exactly one file in the download directory")
-	// Check that the downloaded file has the expected name format by regex
-	require.Regexp(t,
-		regexp.MustCompile(`^k9s_[^-]+_[^-]+\.tar\.gz$`),
-		files[0].Name(),
-		"Downloaded file name should match expected pattern",
-	)
+	require.GreaterOrEqual(t, len(files), 1, "There should be at least one file in the download directory")
+	// Check that the downloaded k9s file exists with expected name format by regex
+	var foundK9s bool
+	for _, file := range files {
+		if regexp.MustCompile(`^k9s_[^-]+_[^-]+\.tar\.gz$`).MatchString(file.Name()) {
+			foundK9s = true
+			break
+		}
+	}
+	require.True(t, foundK9s, "Downloaded k9s file should exist with expected pattern")
 
 	//
 	// When - Extract

--- a/pkg/software/kubeadm_installer_it_test.go
+++ b/pkg/software/kubeadm_installer_it_test.go
@@ -32,13 +32,13 @@ func Test_KubeadmInstaller_FullWorkflow_Success(t *testing.T) {
 	err = installer.Download()
 	require.NoError(t, err, "Failed to download kubeadm and/or its configuration")
 
-	// Verify downloaded files exist
-	_, exists, err := fileManager.PathExists("/opt/solo/weaver/tmp/kubeadm/kubeadm")
+	// Verify downloaded files exist in the shared downloads folder
+	_, exists, err := fileManager.PathExists("/opt/solo/weaver/downloads/kubeadm")
 	require.NoError(t, err)
 	require.True(t, exists, "kubeadm binary should exist in download folder")
 
 	// Check config file exists (10-kubeadm.conf)
-	_, exists, err = fileManager.PathExists("/opt/solo/weaver/tmp/kubeadm/10-kubeadm.conf")
+	_, exists, err = fileManager.PathExists("/opt/solo/weaver/downloads/10-kubeadm.conf")
 	require.NoError(t, err)
 	require.True(t, exists, "10-kubeadm.conf should exist in download folder")
 

--- a/pkg/software/kubectl_installer_it_test.go
+++ b/pkg/software/kubectl_installer_it_test.go
@@ -31,8 +31,8 @@ func Test_KubectlInstaller_FullWorkflow_Success(t *testing.T) {
 	err = installer.Download()
 	require.NoError(t, err, "Failed to download kubectl and/or its configuration")
 
-	// Verify downloaded files exist
-	_, exists, err := fileManager.PathExists("/opt/solo/weaver/tmp/kubectl/kubectl")
+	// Verify downloaded files exist in the shared downloads folder
+	_, exists, err := fileManager.PathExists("/opt/solo/weaver/downloads/kubectl")
 	require.NoError(t, err)
 	require.True(t, exists, "kubectl binary should exist in download folder")
 

--- a/pkg/software/kubelet_installer_it_test.go
+++ b/pkg/software/kubelet_installer_it_test.go
@@ -32,12 +32,12 @@ func Test_KubeletInstaller_FullWorkflow_Success(t *testing.T) {
 	err = installer.Download()
 	require.NoError(t, err, "Failed to download kubelet")
 
-	// Verify downloaded files exist
-	_, exists, err := fileManager.PathExists("/opt/solo/weaver/tmp/kubelet/kubelet")
+	// Verify downloaded files exist in the shared downloads folder
+	_, exists, err := fileManager.PathExists("/opt/solo/weaver/downloads/kubelet")
 	require.NoError(t, err)
 	require.True(t, exists, "kubelet binary should exist in download folder")
 
-	_, exists, err = fileManager.PathExists("/opt/solo/weaver/tmp/kubelet/kubelet.service")
+	_, exists, err = fileManager.PathExists("/opt/solo/weaver/downloads/kubelet.service")
 	require.NoError(t, err)
 	require.True(t, exists, "kubelet.service should exist in download folder")
 


### PR DESCRIPTION
## Description

This pull request refactors how downloaded files are managed and stored during software installation. It introduces a shared `downloads` directory for all downloads, updates the cleanup logic to preserve this directory for caching, and ensures extraction and cleanup happen in software-specific temporary folders. Tests and related code have been updated to reflect these changes.

**Directory management and download location changes:**
- Added a new `DownloadsDir` field to the `WeaverPaths` struct and initialized it in `NewWeaverPaths`, ensuring a dedicated shared location for all downloaded files (`internal/core/const.go`). [[1]](diffhunk://#diff-32178321452c9c41821cea61bcf173d93d40a6b0b2277f634fbc3f32fd1ba945R72) [[2]](diffhunk://#diff-32178321452c9c41821cea61bcf173d93d40a6b0b2277f634fbc3f32fd1ba945R95) [[3]](diffhunk://#diff-32178321452c9c41821cea61bcf173d93d40a6b0b2277f634fbc3f32fd1ba945R146)
- Updated the base installer logic to always use the shared `DownloadsDir` for downloads, instead of creating software-specific download folders. Extraction now occurs in software-specific subfolders under `TempDir` (`pkg/software/base_installer.go`). [[1]](diffhunk://#diff-3538fd418a343de45551e23dec55c9ba0580cf946d6e43231d752fc99bf182aaL86-R86) [[2]](diffhunk://#diff-3538fd418a343de45551e23dec55c9ba0580cf946d6e43231d752fc99bf182aaL152-R152) [[3]](diffhunk://#diff-3538fd418a343de45551e23dec55c9ba0580cf946d6e43231d752fc99bf182aaL236-R236) [[4]](diffhunk://#diff-3538fd418a343de45551e23dec55c9ba0580cf946d6e43231d752fc99bf182aaL290-R290) [[5]](diffhunk://#diff-3538fd418a343de45551e23dec55c9ba0580cf946d6e43231d752fc99bf182aaL331-R331) [[6]](diffhunk://#diff-3538fd418a343de45551e23dec55c9ba0580cf946d6e43231d752fc99bf182aaL396-R395) [[7]](diffhunk://#diff-3538fd418a343de45551e23dec55c9ba0580cf946d6e43231d752fc99bf182aaL436-R435) [[8]](diffhunk://#diff-3538fd418a343de45551e23dec55c9ba0580cf946d6e43231d752fc99bf182aaL492-R490) [[9]](diffhunk://#diff-3538fd418a343de45551e23dec55c9ba0580cf946d6e43231d752fc99bf182aaL558-R556) [[10]](diffhunk://#diff-3538fd418a343de45551e23dec55c9ba0580cf946d6e43231d752fc99bf182aaL622-R620) [[11]](diffhunk://#diff-3538fd418a343de45551e23dec55c9ba0580cf946d6e43231d752fc99bf182aaL779-R778) [[12]](diffhunk://#diff-3538fd418a343de45551e23dec55c9ba0580cf946d6e43231d752fc99bf182aaR892-R900)

**Cleanup and caching improvements:**
- Modified the cleanup process to only remove the extraction folder for the specific software, preserving the shared downloads folder for future reuse and checksum-based caching (`pkg/software/base_installer.go`).

**Test updates:**
- Updated integration and unit tests to use the new `DownloadsDir` and to verify the correct creation, usage, and cleanup of download and extraction folders (`internal/workflows/steps/step_cilium_it_test.go`, `internal/workflows/steps/step_crio_it_test.go`, `internal/workflows/steps/step_helm_it_test.go`, `internal/workflows/steps/step_k9s_it_test.go`, `internal/workflows/steps/step_kubeadm_it_test.go`, `internal/workflows/steps/step_kubectl_it_test.go`, `internal/workflows/steps/step_kubelet_it_test.go`, `pkg/software/base_installer_test.go`). [[1]](diffhunk://#diff-bc81a1fec35ea52dda02474c8e6dbb84ab5c785f3a5e20d656b8384299d70ec5L139-R148) [[2]](diffhunk://#diff-9545d936d1d5668ffaa581a720dd8943127876349f52bf6a7104cc41567cbb32L187-R196) [[3]](diffhunk://#diff-ef909f88ac04583642ab9df0c4e90b0d4de099026200093a09d0a32958fa273fL139-R148) [[4]](diffhunk://#diff-bfabfc8ed687dfa1f9e26a23770aa9846b02a3aaabf7e4395e6391de2f9578e3L140-R149) [[5]](diffhunk://#diff-afb25c993e01f7ddf200e180f1666d7040a65d76a33edd7c7b86b64ca9439723L136-R145) [[6]](diffhunk://#diff-61ccb77078afa34f2c1120f85ac0cb0db0aff8901b6b97ef3d0ae0029b5c8006L137-R146) [[7]](diffhunk://#diff-0e3899b797f78668b1abe47832471e77ea885db726202f9fe7eefa0b9dacd942L137-R146) [[8]](diffhunk://#diff-91fb63f07bed0ffa9ac21d62775ce36ef34ac1db90d008c1049925c1ed591bd8L332-R332) [[9]](diffhunk://#diff-91fb63f07bed0ffa9ac21d62775ce36ef34ac1db90d008c1049925c1ed591bd8L375-R375) [[10]](diffhunk://#diff-91fb63f07bed0ffa9ac21d62775ce36ef34ac1db90d008c1049925c1ed591bd8L487-R495) [[11]](diffhunk://#diff-91fb63f07bed0ffa9ac21d62775ce36ef34ac1db90d008c1049925c1ed591bd8L600-L633)

**Other changes:**
- Removed a test that checked for permission errors in the old download folder structure, as it is no longer relevant with the new shared downloads directory (`pkg/software/base_installer_test.go`).

### Related Issues

* Closes #259
