### PR TITLE
docs: update instructions and clarify asset file ID during install

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ Below is a quickstart guide to get you up and running with Solo Weaver.
 
 ## Prerequisites
 
-- A Unix-like operating system (Linux)
+- Unix operating system (Tested on: Debian 13.1.0, Ubuntu 22.04)
 - `curl` installed
 
 ## Install
@@ -23,16 +23,16 @@ weaver --help
 
 ## Configuration
 
-Solo Weaver accepts a configuration file. _See the documentation or comments in `test/config/config.yaml` for
-all options._
+Solo Weaver accepts a configuration file. See the documentation or comments in sample [config.yaml](../test/config/config.yaml) for
+all options.
 
 ## Setup Block Node
 
 Solo Weaver deploys a Kubernetes cluster and deploys a Hedera Block Node on it using a Helm chart. It comes with
-pre-configured profiles for local development, mainnet, and testnet.
+pre-configured profiles for local, mainnet, and testnet deployment mode.
 
 ```
-$ ./weaver block node -h
+$ weaver block node -h
 Manage lifecycle of a Hedera Block Node
 
 Usage:
@@ -60,7 +60,7 @@ Also, if you would like to use custom BlockNode configurations, you can create a
 chart and pass using `--values` flag
 
 ```
-$ ./weaver-linux-arm64 block node install -h
+$ weaver block node install -h
 Run safety checks, setup a K8s cluster and install a Hedera Block Node
 
 Usage:
@@ -83,7 +83,10 @@ Global Flags:
 To set up a block node, run (use appropriate profile and values file as required):
 
 ``` 
-weaver block node install --profile <local | mainnet | testnet> --values <custom-values-file>
+sudo weaver block node install --profile <local | mainnet | testnet> --values <custom-values-file>
+
+# For example to deploy with a 'local' profile (local dev testing), run the below command:
+# sudo solo weaver block node install --profile=local 
 ```
 
-_This command will take a while to complete as it sets up the entire environment._
+This command will take a while (~5mins) to complete as it sets up the entire environment. Keep an eye on the console logs.

--- a/install.sh
+++ b/install.sh
@@ -170,8 +170,8 @@ TARGET_CHECKSUM="$TARGET_BINARY.sha256"
 BINARY_ID=$(extract_asset_id "$TMP_JSON" "$TARGET_BINARY" || true)
 CHECKSUM_ID=$(extract_asset_id "$TMP_JSON" "$TARGET_CHECKSUM" || true)
 
-echo "Binary ID: $BINARY_ID"
-echo "Checksum ID: $CHECKSUM_ID"
+echo "Binary File ID: $BINARY_ID"
+echo "Checksum File ID: $CHECKSUM_ID"
 
 if [[ -z "$BINARY_ID" ]]; then
     echo "❌ Could not find asset: $TARGET_BINARY"


### PR DESCRIPTION
## Description

This pull request updates documentation and installation scripts to improve clarity and usability for users deploying a Hedera Block Node with Weaver. The main changes are focused on simplifying command usage examples and clarifying script output.

Documentation improvements:

* Updated usage examples in `docs/quickstart.md` to remove unnecessary prefixes (`./` and platform-specific binaries) from Weaver CLI commands, making instructions simpler and more consistent. [[1]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL35-R35) [[2]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL63-R63)
* Added `sudo` to the block node install command in `docs/quickstart.md` to clarify that elevated privileges may be required for installation.

Script output clarification:

* Changed echo statements in `install.sh` to use more descriptive labels (`Binary File ID` and `Checksum File ID`), improving clarity in script output.

### Related Issues

* Closes #
