### PR TITLE
chore: change kube registry mirror port from 5000 to 5050

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -929,22 +929,22 @@ tasks:
               -o ServerAliveCountMax=3 \
               -R 3128:localhost:3128 \
               -R 8081:localhost:8081 \
-              -R 5000:localhost:5000 \
+              -R 5050:localhost:5050 \
               {{.VM_USER}}@$VM_IP "
             source /etc/profile.d/go.sh 2>/dev/null || true
             cd /mnt/solo-weaver &&
             echo 'Using cache infrastructure via SSH tunnels:' &&
             echo '  - HTTP/HTTPS proxy at localhost:3128 (Squid with SSL MITM - binaries, packages)' &&
             echo '  - Go module proxy at localhost:8081 (Go dependencies)' &&
-            echo '  - Registry mirror at localhost:5000 (container images)' &&
+            echo '  - Registry mirror at localhost:5050 (container images)' &&
             echo '' &&
             echo 'Verifying SSH tunnels are active...' &&
-            netstat -tln | grep -E ':(3128|8081|5000)' || echo 'WARNING: Some tunnels may not be active yet' &&
+            netstat -tln | grep -E ':(3128|8081|5050)' || echo 'WARNING: Some tunnels may not be active yet' &&
             echo '' &&
             echo 'Testing proxy connectivity...' &&
             timeout 5 nc -zv localhost 3128 2>&1 | grep -q succeeded && echo '✓ Squid proxy (3128) is reachable' || echo '✗ Squid proxy (3128) is NOT reachable' &&
             timeout 5 nc -zv localhost 8081 2>&1 | grep -q succeeded && echo '✓ Go proxy (8081) is reachable' || echo '✗ Go proxy (8081) is NOT reachable' &&
-            timeout 5 nc -zv localhost 5000 2>&1 | grep -q succeeded && echo '✓ Registry mirror (5000) is reachable' || echo '✗ Registry mirror (5000) is NOT reachable' &&
+            timeout 5 nc -zv localhost 5050 2>&1 | grep -q succeeded && echo '✓ Registry mirror (5050) is reachable' || echo '✗ Registry mirror (5050) is NOT reachable' &&
             echo '' &&
             export HTTP_PROXY=http://localhost:3128
             export HTTPS_PROXY=http://localhost:3128
@@ -1035,7 +1035,7 @@ tasks:
           echo ""
           echo "Services running:"
           echo "  • HTTP/HTTPS Proxy:    http://localhost:3128 (Squid with SSL MITM)"
-          echo "  • Container Registry:  http://localhost:5000 (mirrors registry.k8s.io)"
+          echo "  • Container Registry:  http://localhost:5050 (mirrors registry.k8s.io)"
           echo "  • Go Module Proxy:     http://localhost:8081"
           echo ""
           echo "To use the proxies, set these environment variables:"

--- a/internal/templates/files/crio/registries.conf
+++ b/internal/templates/files/crio/registries.conf
@@ -14,6 +14,6 @@ blocked = false
 
 # Use local registry mirror as primary source (via SSH tunnel in VM)
 [[registry.mirror]]
-location = "localhost:5000"
+location = "localhost:5050"
 insecure = true
 

--- a/test/cache-proxy/docker-compose.yml
+++ b/test/cache-proxy/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile
     container_name: solo-weaver-cache-proxy
     ports:
-      - "127.0.0.1:3128:3128"
+      - "0.0.0.0:3128:3128"
     volumes:
       - cache-data:/var/cache/squid
       - ca-certs:/etc/squid/certs
@@ -16,7 +16,7 @@ services:
     image: registry:2
     container_name: solo-weaver-registry-mirror
     ports:
-      - "127.0.0.1:5000:5000"
+      - "0.0.0.0:5050:5000"
     volumes:
       - registry-data:/var/lib/registry
       - ./registry-config.yml:/etc/docker/registry/config.yml:ro
@@ -31,7 +31,7 @@ services:
     container_name: solo-weaver-goproxy
     command: server --address :8081 --cacher-dir /go/cache
     ports:
-      - "127.0.0.1:8081:8081"
+      - "0.0.0.0:8081:8081"
     volumes:
       - goproxy-cache:/go
     restart: unless-stopped


### PR DESCRIPTION
## Description

This pull request updates the local container registry mirror port from 5000 to 5050 across the development and test environments, and broadens the network binding for cache proxy services to allow connections from any interface. These changes help standardize port usage and improve accessibility for local development and testing.

**Port changes for container registry mirror:**

* Changed all references to the container registry mirror port from `5000` to `5050` in `Taskfile.yaml`, `crio/registries.conf`, and Docker Compose configuration. This ensures consistency and avoids potential port conflicts. [[1]](diffhunk://#diff-1552e0a6f970b2191f0e8ef34ac62e41815fc6cdbc213921e915a042e500f03aL932-R947) [[2]](diffhunk://#diff-1552e0a6f970b2191f0e8ef34ac62e41815fc6cdbc213921e915a042e500f03aL1038-R1038) [[3]](diffhunk://#diff-0c905742322a2f0ddf67255f0fbcb24e2caf940c3d5c87ce6993e15bd7cfa774L17-R17) [[4]](diffhunk://#diff-94511c535792e233088d332c08c9ce924812894333b7d0ea4bcab4dd0e8a73baL19-R19)

**Network binding updates for cache proxy services:**

* Updated Docker Compose service definitions for Squid proxy, registry mirror, and Go proxy to bind to `0.0.0.0` instead of `127.0.0.1`, allowing these services to accept connections from any network interface rather than just localhost. [[1]](diffhunk://#diff-94511c535792e233088d332c08c9ce924812894333b7d0ea4bcab4dd0e8a73baL9-R9) [[2]](diffhunk://#diff-94511c535792e233088d332c08c9ce924812894333b7d0ea4bcab4dd0e8a73baL19-R19) [[3]](diffhunk://#diff-94511c535792e233088d332c08c9ce924812894333b7d0ea4bcab4dd0e8a73baL34-R34)

### Related Issues

* Closes #299 
