### PR TITLE
feat: implement cluster uninstall workflow

### DIFF
--- a/.github/workflows/zxc-integration-test.yaml
+++ b/.github/workflows/zxc-integration-test.yaml
@@ -186,7 +186,6 @@ jobs:
             - openssh-server
             - sudo
             - ca-certificates
-            - curl
             - rsync
             - git
             - build-essential

--- a/cmd/weaver/commands/kube/cluster/cluster.go
+++ b/cmd/weaver/commands/kube/cluster/cluster.go
@@ -23,8 +23,7 @@ var (
 
 func init() {
 	clusterCmd.AddCommand(installCmd)
-	// NOTE: uninstallCmd is implemented but intentionally disabled until uninstall has been fully validated and approved for release.
-	// clusterCmd.AddCommand(uninstallCmd)
+	clusterCmd.AddCommand(uninstallCmd)
 }
 
 func GetCmd() *cobra.Command {

--- a/cmd/weaver/commands/kube/cluster/uninstall.go
+++ b/cmd/weaver/commands/kube/cluster/uninstall.go
@@ -13,7 +13,7 @@ import (
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Uninstall a Kubernetes Cluster",
-	Long:  "Uninstall a Kubernetes Cluster",
+	Long:  "Teardown the K8s cluster, stop services, remove bind mounts, and cleanup configuration files while preserving downloads cache",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		execMode, err := common.GetExecutionMode(flagContinueOnError, flagStopOnError, flagRollbackOnError)
 		if err != nil {

--- a/internal/mount/mount_unix.go
+++ b/internal/mount/mount_unix.go
@@ -194,7 +194,7 @@ func unmountBindMount(mount BindMount) error {
 	}
 
 	// Perform the unmount
-	err = unix.Unmount(mount.Target, 0)
+	err = unix.Unmount(mount.Target, unix.MNT_DETACH)
 	if err != nil {
 		return errorx.ExternalError.Wrap(err, "failed to unmount %s", mount.Target)
 	}

--- a/internal/testutil/helper.go
+++ b/internal/testutil/helper.go
@@ -138,3 +138,22 @@ func FileWithPrefixExists(t *testing.T, directory string, prefix string) bool {
 	}
 	return found
 }
+
+// AssertBashCommand executes a bash command and asserts that it produces the expected output
+func AssertBashCommand(t *testing.T, command string, expectedOutput string) {
+	t.Helper()
+
+	cmd := exec.Command("bash", "-c", command)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "Command failed: %s\nOutput: %s", command, string(output))
+	require.Equal(t, expectedOutput, string(output), "Command output mismatch for: %s", command)
+}
+
+// AssertBashCommandFails executes a bash command and asserts that it fails (non-zero exit code)
+func AssertBashCommandFails(t *testing.T, command string) {
+	t.Helper()
+
+	cmd := exec.Command("bash", "-c", command)
+	err := cmd.Run()
+	require.Error(t, err, "Expected command to fail but it succeeded: %s", command)
+}

--- a/internal/workflows/cluster_it_test.go
+++ b/internal/workflows/cluster_it_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package workflows
+
+import (
+	"context"
+	"testing"
+
+	"github.com/automa-saga/automa"
+	"github.com/hashgraph/solo-weaver/internal/core"
+	"github.com/hashgraph/solo-weaver/internal/testutil"
+	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ClusterWorkflow_Integration(t *testing.T) {
+	testutil.Reset(t)
+
+	installWf, err := InstallClusterWorkflow(core.NodeTypeBlock, core.ProfileLocal).
+		WithExecutionMode(automa.StopOnError).
+		Build()
+	require.NoError(t, err)
+
+	report := installWf.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+
+	steps.PrintWorkflowReport(report, "")
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	uninstallWf, err := UninstallClusterWorkflow().
+		WithExecutionMode(automa.ContinueOnError).
+		Build()
+	require.NoError(t, err)
+
+	report = uninstallWf.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error)
+
+	steps.PrintWorkflowReport(report, "")
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	// Verify system is clean after uninstall
+	t.Run("verify_cleanup", func(t *testing.T) {
+		// Verify crio service is stopped
+		testutil.AssertBashCommand(t, "systemctl is-active crio || true", "inactive\n")
+
+		// Verify kubernetes directories are not mounted
+		testutil.AssertBashCommandFails(t, "mountpoint -q /etc/kubernetes")
+		testutil.AssertBashCommandFails(t, "mountpoint -q /var/lib/kubelet")
+		testutil.AssertBashCommandFails(t, "mountpoint -q /var/run/cilium")
+
+		// Verify systemd service files are removed
+		testutil.AssertBashCommand(t, "[ ! -f /usr/lib/systemd/system/crio.service ] && echo 'removed' || echo 'exists'", "removed\n")
+		testutil.AssertBashCommand(t, "[ ! -d /usr/lib/systemd/system/kubelet.service.d ] && echo 'removed' || echo 'exists'", "removed\n")
+		testutil.AssertBashCommand(t, "[ ! -f /usr/lib/systemd/system/kubelet.service ] && echo 'removed' || echo 'exists'", "removed\n")
+
+		// Verify configuration directories are removed
+		testutil.AssertBashCommand(t, "[ ! -d /etc/containers ] && echo 'removed' || echo 'exists'", "removed\n")
+		testutil.AssertBashCommand(t, "[ ! -d /etc/crio ] && echo 'removed' || echo 'exists'", "removed\n")
+
+		// Verify .kube directories are removed
+		testutil.AssertBashCommand(t, "[ ! -d /root/.kube ] && echo 'removed' || echo 'exists'", "removed\n")
+		testutil.AssertBashCommand(t, "[ ! -d /home/weaver/.kube ] && echo 'removed' || echo 'exists'", "removed\n")
+
+		// Verify weaver directory cleanup (downloads, bin, and logs should be preserved)
+		testutil.AssertBashCommand(t, "[ -d /opt/solo/weaver/downloads ] && echo 'preserved' || echo 'missing'", "preserved\n")
+		testutil.AssertBashCommand(t, "[ -d /opt/solo/weaver/bin ] && echo 'preserved' || echo 'missing'", "preserved\n")
+		testutil.AssertBashCommand(t, "[ -d /opt/solo/weaver/logs ] && echo 'preserved' || echo 'missing'", "preserved\n")
+
+		// Verify that only the downloads, bin, and logs folders exist under /opt/solo/weaver
+		testutil.AssertBashCommand(t, "ls -1 /opt/solo/weaver | wc -l | tr -d ' '", "3\n")
+		testutil.AssertBashCommand(t, "ls -1 /opt/solo/weaver | sort", "bin\ndownloads\nlogs\n")
+	})
+}

--- a/internal/workflows/steps/step_bind_mounts.go
+++ b/internal/workflows/steps/step_bind_mounts.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/core"
 	"github.com/hashgraph/solo-weaver/internal/mount"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
@@ -121,6 +122,54 @@ func setupBindMount(name string, target string) automa.Builder {
 					return automa.FailureReport(stp,
 						automa.WithError(err))
 				}
+			}
+
+			return automa.SuccessReport(stp)
+		})
+}
+
+// TeardownBindMounts removes bind mounts and their fstab entries
+func TeardownBindMounts() *automa.WorkflowBuilder {
+	return automa.NewWorkflowBuilder().WithId("teardown-bind-mounts").
+		Steps(
+			teardownBindMount("kubernetes", "/etc/kubernetes"),
+			teardownBindMount("kubelet", "/var/lib/kubelet"),
+			teardownBindMount("cilium", "/var/run/cilium"),
+		).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Removing bind mounts")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to remove bind mounts")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Bind mounts removed successfully")
+		})
+}
+
+func teardownBindMount(name string, target string) automa.Builder {
+	return automa.NewStepBuilder().WithId(fmt.Sprintf("teardown-bind-mount-for-%s", name)).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, fmt.Sprintf("Removing bind mount - %s", target))
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, fmt.Sprintf("Failed to remove bind mount - %s", target))
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, fmt.Sprintf("Bind mount removed successfully - %s", target))
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			bindMount := mount.BindMount{
+				Source: path.Join(core.Paths().SandboxDir, target),
+				Target: target,
+			}
+
+			err := mount.RemoveBindMountsWithFstab(bindMount)
+			if err != nil {
+				logx.As().Warn().Err(err).Msgf("Failed to remove bind mount %s, continuing with teardown", target)
+				// Don't fail if unmount fails - mount might not exist
 			}
 
 			return automa.SuccessReport(stp)

--- a/internal/workflows/steps/step_cluster_uninstall.go
+++ b/internal/workflows/steps/step_cluster_uninstall.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/core"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/fsx"
+	osutil "github.com/hashgraph/solo-weaver/pkg/os"
+)
+
+// RemoveSystemdServiceFiles removes systemd service files created during cluster setup
+func RemoveSystemdServiceFiles() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId("remove-systemd-service-files").
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Removing systemd service files")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to remove systemd service files")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Systemd service files removed successfully")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			fsManager, err := fsx.NewManager()
+			if err != nil {
+				logx.As().Warn().Err(err).Msg("Failed to create filesystem manager, continuing with teardown")
+				return automa.SuccessReport(stp)
+			}
+
+			// Remove systemd service files
+			filesToRemove := []string{
+				"/usr/lib/systemd/system/crio.service",
+				"/usr/lib/systemd/system/kubelet.service.d",
+				"/usr/lib/systemd/system/kubelet.service",
+			}
+
+			for _, file := range filesToRemove {
+				if err := fsManager.RemoveAll(file); err != nil {
+					logx.As().Warn().Err(err).Msgf("Failed to remove %s, continuing with teardown", file)
+				}
+			}
+
+			// Reload systemd daemon
+			if err := osutil.DaemonReload(ctx); err != nil {
+				logx.As().Warn().Err(err).Msg("Failed to reload systemd daemon, continuing with teardown")
+			}
+
+			return automa.SuccessReport(stp)
+		})
+}
+
+// RemoveConfigDirectories removes configuration directories created during cluster setup
+func RemoveConfigDirectories() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId("remove-config-directories").
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Removing configuration directories")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to remove configuration directories")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Configuration directories removed successfully")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			fsManager, err := fsx.NewManager()
+			if err != nil {
+				logx.As().Warn().Err(err).Msg("Failed to create filesystem manager, continuing with teardown")
+				return automa.SuccessReport(stp)
+			}
+
+			directoriesToRemove := []string{
+				"/etc/containers",
+				"/etc/crio",
+				"/root/.kube",
+				"/home/weaver/.kube",
+			}
+
+			for _, dir := range directoriesToRemove {
+				if err := fsManager.RemoveAll(dir); err != nil {
+					logx.As().Warn().Err(err).Msgf("Failed to remove %s, continuing with teardown", dir)
+				}
+			}
+
+			return automa.SuccessReport(stp)
+		})
+}
+
+// CleanupWeaverFiles removes weaver installation files while preserving downloads, bin, and logs folders
+func CleanupWeaverFiles() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId("cleanup-weaver-files").
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Cleaning up weaver files")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to cleanup weaver files")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Weaver files cleaned up successfully")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			fsManager, err := fsx.NewManager()
+			if err != nil {
+				logx.As().Warn().Err(err).Msg("Failed to create filesystem manager, continuing with teardown")
+				return automa.SuccessReport(stp)
+			}
+
+			weaverHome := "/opt/solo/weaver"
+
+			// Read the weaver home directory
+			entries, err := os.ReadDir(weaverHome)
+			if err != nil {
+				// Directory doesn't exist, nothing to clean
+				logx.As().Debug().Err(err).Msg("Weaver home directory doesn't exist, nothing to clean")
+				return automa.SuccessReport(stp)
+			}
+
+			// Remove each top-level directory/file except downloads
+			for _, entry := range entries {
+				entryPath := filepath.Join(weaverHome, entry.Name())
+
+				// Skip the downloads, bin, and logs folders
+				if entryPath == core.Paths().DownloadsDir ||
+					entryPath == core.Paths().BinDir ||
+					entryPath == core.Paths().LogsDir {
+					continue
+				}
+
+				// Remove all other directories/files
+				if err := fsManager.RemoveAll(entryPath); err != nil {
+					logx.As().Warn().Err(err).Msgf("Failed to remove %s, continuing with teardown", entryPath)
+				}
+			}
+
+			return automa.SuccessReport(stp)
+		})
+}


### PR DESCRIPTION
## Description

This pull request implements a complete and robust uninstall (teardown) workflow for Kubernetes clusters, ensuring that all cluster artifacts are properly cleaned up while preserving necessary caches. It introduces new teardown steps, enables the uninstall command, and adds comprehensive integration tests to verify the cleanup. The changes also improve the reliability and safety of unmount operations and add new test utilities.

**Cluster Uninstall Workflow Enhancements:**

* Implemented a full uninstall workflow in `UninstallClusterWorkflow`, adding teardown steps to reset the cluster, stop services, remove bind mounts, clean up systemd service files, remove configuration directories, and clean up weaver files while preserving the downloads cache (`internal/workflows/cluster.go`, `internal/workflows/steps/step_kubeadm.go`, `internal/workflows/steps/step_systemd_service.go`, `internal/workflows/steps/step_bind_mounts.go`, `internal/workflows/steps/step_cluster_uninstall.go`, [[1]](diffhunk://#diff-0cbd5d0d3e1884e017374a994ce18b0ab71220ae089c0b21deca20d2064a6503L81-R104) [[2]](diffhunk://#diff-f9cecc271251854f62017fc5d1ff34d070b8b633d6816b59854f1275bc55e0f6R248-R275) [[3]](diffhunk://#diff-23573cb3acee50e24587ce0f99ec25ada0284c7e9ebc96fbfefe935dfc9c22c8R110-R141) [[4]](diffhunk://#diff-bc6b24594909b595a422f67491d2891aeed6ae237a4616f9ddb3a1f172acd8c9R130-R177) [[5]](diffhunk://#diff-146c2413af8ccbfc6b1b30c72f5223c42ab563b6a01c9167cb8577c685393c2bR1-R146).
* Enabled the `uninstall` subcommand for the cluster CLI, allowing users to trigger the uninstall workflow (`cmd/weaver/commands/kube/cluster/cluster.go`, [cmd/weaver/commands/kube/cluster/cluster.goL26-R26](diffhunk://#diff-1a129b378f7dbce7e2cd31b21061feb6c4e7528a5027d4bb96196f32d16bb261L26-R26)).
* Improved the uninstall command description for clarity (`cmd/weaver/commands/kube/cluster/uninstall.go`, [cmd/weaver/commands/kube/cluster/uninstall.goL16-R16](diffhunk://#diff-d363374de77a5c161416143a1856194a27bf412a773a92ebf064e6459dbbbe7eL16-R16)).

**Testing Improvements:**

* Added an end-to-end integration test that runs the install and uninstall cluster workflows, then asserts that all services, mounts, and files are properly cleaned up, and only the downloads folder remains (`internal/workflows/cluster_it_test.go`, [internal/workflows/cluster_it_test.goR1-R75](diffhunk://#diff-1f44f7f2674bcde5bf54ee8cebb10a6911b7b91e8dcd9d5a2ed4c7d13968c32dR1-R75)).
* Introduced new test utilities to assert bash command output and failure, improving test reliability (`internal/testutil/helper.go`, [internal/testutil/helper.goR141-R159](diffhunk://#diff-93cfdecc91ced60842e07ff8533b79a81568a9fa4af3333c23b96b815d3d4bd2R141-R159)).

**Reliability and Safety Improvements:**

* Changed bind mount unmounting to use the `MNT_DETACH` flag for safer unmount operations, preventing failures if mount points are busy (`internal/mount/mount_unix.go`, [internal/mount/mount_unix.goL197-R197](diffhunk://#diff-81088ec31456395b9993029a4b569f379c9047e85d443979ef88b3208204254dL197-R197)).

**Minor/Other:**

* Removed an unnecessary package dependency (`curl`) from the integration test workflow setup (`.github/workflows/zxc-integration-test.yaml`, [.github/workflows/zxc-integration-test.yamlL189](diffhunk://#diff-68122e070f3aff4b7ec9fcb448483b386d6e4218697f020183c14e30257df2cdL189)).
* Added missing imports for logging in step files (`internal/workflows/steps/step_systemd_service.go`, `internal/workflows/steps/step_bind_mounts.go`, [[1]](diffhunk://#diff-23573cb3acee50e24587ce0f99ec25ada0284c7e9ebc96fbfefe935dfc9c22c8R11) [[2]](diffhunk://#diff-bc6b24594909b595a422f67491d2891aeed6ae237a4616f9ddb3a1f172acd8c9R11).

These changes collectively provide a safe, thorough, and tested mechanism for uninstalling Kubernetes clusters managed by this project.

### Related Issues

* Closes #177 
