### PR TITLE
chore: improve squid caching

### DIFF
--- a/test/cache-proxy/Dockerfile
+++ b/test/cache-proxy/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && \
         squid-openssl \
         ssl-cert \
         openssl \
-        ca-certificates && \
+        ca-certificates \
+        perl && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /var/cache/squid \
         /var/log/squid \
@@ -22,6 +23,10 @@ RUN apt-get update && \
 
 # Copy Squid configuration
 COPY squid.conf /etc/squid/squid.conf
+
+# Copy store-id helper for URL normalization
+COPY store-id-helper.pl /usr/local/bin/store-id-helper.pl
+RUN chmod +x /usr/local/bin/store-id-helper.pl
 
 # Copy entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/test/cache-proxy/squid.conf
+++ b/test/cache-proxy/squid.conf
@@ -8,11 +8,17 @@ http_port 3128 ssl-bump cert=/etc/squid/certs/ca-cert.pem key=/etc/squid/certs/c
 sslcrtd_program /usr/lib/squid/security_file_certgen -s /var/lib/squid/ssl_db -M 16MB
 sslcrtd_children 5 startup=1 idle=1
 
-# SSL Bump - peek and bump everything
+# SSL Bump - intercept all HTTPS traffic to cache content
 acl step1 at_step SslBump1
+acl step2 at_step SslBump2
+acl step3 at_step SslBump3
+
+# Bump all traffic: peek at step1 (inspect TLS Client Hello without terminating),
+# stare at step2 (examine server certificate and decide policy),
+# bump at step3 (perform full SSL interception/decryption).
 ssl_bump peek step1
-ssl_bump bump all
-sslproxy_cert_error allow all
+ssl_bump stare step2
+ssl_bump bump step3
 
 # Basic ACLs
 acl localnet src 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 127.0.0.1/32 ::1/128
@@ -30,9 +36,9 @@ acl go_proxy dstdomain proxy.golang.org sum.golang.org
 cache deny container_registries
 cache deny go_proxy
 
-# Access control
+# Access control - MUST allow CONNECT for SSL bump to work
 http_access deny !Safe_ports
-http_access deny CONNECT !SSL_ports
+http_access allow CONNECT SSL_ports localnet
 http_access allow localnet
 http_access deny all
 
@@ -42,21 +48,65 @@ cache_mem 256 MB
 maximum_object_size 500 MB
 minimum_object_size 1 KB
 
+# Force caching even when origin sends restrictive headers
+refresh_all_ims on
+ignore_expect_100 on
+collapsed_forwarding on
+
+# Ignore Vary headers that might prevent cache reuse
+# Even if store_id normalizes the URL, Vary can cause separate cache entries
+vary_ignore_expire on
+
+# Normalize URLs by stripping query parameters for caching
+# This allows GitHub release assets and container registry blobs with different
+# authentication tokens to be served from the same cached copy
+store_id_program /usr/local/bin/store-id-helper.pl
+store_id_children 5 startup=1 idle=1
+
 ########################
 # Refresh patterns
 ########################
 
-# CRI-O and container runtime binaries - cache aggressively for 30 days
-refresh_pattern -i (storage\.googleapis\.com/cri-o|github\.com/.*/releases/download) \
+# GitHub release assets - MUST be first to catch these URLs
+# These have signed Azure blob URLs with expiring tokens that we strip via store_id
+refresh_pattern -i release-assets\.githubusercontent\.com \
     43200 100% 525600 ignore-no-cache ignore-private ignore-no-store ignore-must-revalidate \
-    ignore-reload ignore-auth override-expire override-lastmod
+    ignore-reload ignore-auth override-expire override-lastmod reload-into-ims
 
-# Kubernetes binaries and related artifacts - cache aggressively for 30 days
-refresh_pattern -i (dl\.k8s\.io|cdn\.dl\.k8s\.io|storage\.googleapis\.com) \
+# GitHub container registry blobs - immutable content by SHA256
+refresh_pattern -i pkg-containers\.githubusercontent\.com/ghcr1/blobs \
     43200 100% 525600 ignore-no-cache ignore-private ignore-no-store ignore-must-revalidate \
-    ignore-reload ignore-auth override-expire override-lastmod
+    ignore-reload ignore-auth override-expire override-lastmod reload-into-ims
 
-# Helm charts and other package downloads (tar.gz, tgz, zip, deb, rpm) - cache for 7 days
+# Specific: Kubernetes binaries on cdn.dl.k8s.io - versioned, immutable, cache forever
+refresh_pattern -i cdn\.dl\.k8s\.io/release/v[0-9.]+/bin \
+    525600 100% 525600 ignore-no-cache ignore-private ignore-no-store ignore-must-revalidate \
+    ignore-reload ignore-auth override-expire override-lastmod reload-into-ims
+
+# Specific: Kubernetes binaries on dl.k8s.io - just redirects, short cache
+refresh_pattern -i dl\.k8s\.io/release \
+    1440 50% 10080 ignore-no-cache ignore-private
+
+# Specific: Helm releases - versioned, immutable
+refresh_pattern -i get\.helm\.sh/helm-v[0-9.]+ \
+    525600 100% 525600 ignore-no-cache ignore-private ignore-no-store ignore-must-revalidate \
+    ignore-reload ignore-auth override-expire override-lastmod reload-into-ims
+
+# Specific: CRI-O versioned archives - immutable
+refresh_pattern -i storage\.googleapis\.com/cri-o/artifacts/.*\.v[0-9.]+\.tar\.gz \
+    525600 100% 525600 ignore-no-cache ignore-private ignore-no-store ignore-must-revalidate \
+    ignore-reload ignore-auth override-expire override-lastmod reload-into-ims
+
+# Specific: Helm chart repositories (index.yaml files) - cache for 1 hour, revalidate
+refresh_pattern -i (metallb\.github\.io|kubernetes-sigs\.github\.io)/.*/index\.yaml \
+    60 50% 1440 ignore-no-cache ignore-private ignore-reload reload-into-ims
+
+# Generic: Any .tar.gz, .tgz with version numbers - likely immutable
+refresh_pattern -i /v[0-9.]+/.*\.(tar\.gz|tgz)$ \
+    525600 100% 525600 ignore-no-cache ignore-private ignore-no-store ignore-must-revalidate \
+    ignore-reload ignore-auth override-expire override-lastmod reload-into-ims
+
+# Fallback: Other package downloads (tar.gz, tgz, zip, deb, rpm) - cache for 7 days
 refresh_pattern -i \.(tar\.gz|tgz|zip|deb|rpm)$ \
     10080 100% 525600 ignore-no-cache ignore-private ignore-no-store ignore-must-revalidate \
     ignore-reload ignore-auth override-expire override-lastmod
@@ -74,7 +124,7 @@ refresh_pattern -i . \
 # Logging
 access_log stdio:/var/log/squid/access.log squid
 cache_log /var/log/squid/cache.log
-cache_store_log none
+cache_store_log stdio:/var/log/squid/store.log
 
 # Basic settings
 visible_hostname solo-weaver-squid-proxy

--- a/test/cache-proxy/store-id-helper.pl
+++ b/test/cache-proxy/store-id-helper.pl
@@ -1,0 +1,68 @@
+#!/usr/bin/perl
+# SPDX-License-Identifier: Apache-2.0
+# Store ID helper for Squid - normalizes URLs by stripping query parameters
+# This allows caching of GitHub release assets and container registry blobs
+# that have authentication tokens or signatures in the URL
+
+use strict;
+use warnings;
+
+$|=1;  # Unbuffered output
+
+# Debug log file
+open(my $log, '>>', '/var/log/squid/store-id-debug.log') or die "Cannot open log: $!";
+$log->autoflush(1);
+print $log "=== Store ID Helper Started at " . localtime() . " ===\n";
+
+while (<>) {
+    chomp;
+    print $log "INPUT: $_\n";
+
+    # Squid's store_id protocol sends just: URL [kv-pairs]
+    # The first field IS the URL (not a channel ID)
+    my @fields = split(/\s+/);
+
+    # Need at least the URL
+    if (@fields < 1) {
+        print $log "ERROR: No URL in input\n";
+        print "$_\n";
+        next;
+    }
+
+    # First field is the URL itself
+    my $url = $fields[0];
+
+    print $log "URL: $url\n";
+
+    my $new_url = $url;
+
+    # Strip query params from GitHub release assets
+    if ($url =~ m{^(https?://release-assets\.githubusercontent\.com/[^?]+)}) {
+        $new_url = $1;
+        print $log "MATCHED release-assets, normalized to: $new_url\n";
+    }
+    # Strip query params from pkg-containers (GitHub Container Registry)
+    elsif ($url =~ m{^(https?://pkg-containers\.githubusercontent\.com/[^?]+)}) {
+        $new_url = $1;
+        print $log "MATCHED pkg-containers, normalized to: $new_url\n";
+    }
+    else {
+        print $log "NO MATCH for URL\n";
+    }
+
+    # Output format: just the result
+    # Either: OK store-id=URL (rewritten) or OK (pass-through)
+    my $output;
+    if ($new_url ne $url) {
+        # URL was rewritten - return normalized version
+        $output = "OK store-id=$new_url\n";
+        print $log "OUTPUT (rewritten): $output";
+    } else {
+        # No rewrite needed - return OK without store-id
+        $output = "OK\n";
+        print $log "OUTPUT (passthrough): $output";
+    }
+    print $output;
+}
+
+close $log;


### PR DESCRIPTION
## Description

This pull request makes significant improvements to the Squid cache proxy configuration to enhance caching effectiveness for GitHub release assets, container registry blobs, and other common artifacts. The changes introduce a custom URL normalization helper, refine SSL bumping and access controls, and optimize refresh patterns for better cache hit rates and efficiency.

**Caching and URL normalization improvements:**

* Added a custom `store-id-helper.pl` script to normalize URLs by stripping query parameters from GitHub release assets and container registry blobs, enabling better cache reuse for resources with expiring tokens or signatures. (`test/cache-proxy/store-id-helper.pl`, `test/cache-proxy/Dockerfile`, `test/cache-proxy/squid.conf`) [[1]](diffhunk://#diff-64252760dfc680343e07b039e244ef91308272d311f9d39fc6e8a9c44e164daaR1-R72) [[2]](diffhunk://#diff-c7588ab4649b48ac2159a808028d8bf1064683e36257ca200879b2b317f75deaR27-R30) [[3]](diffhunk://#diff-4e0c6356aa273abcddb2460a81f38d0d5670281accb4349236b4b2d4a67ff142R51-R109)
* Configured Squid to use the `store_id_program` directive with the new helper, and increased the number of helper processes for concurrency. (`test/cache-proxy/squid.conf`)

**SSL bumping and access control enhancements:**

* Improved SSL bump configuration to peek, stare, and bump at the appropriate steps, and allowed CONNECT for SSL ports from local networks to ensure HTTPS caching works as intended. (`test/cache-proxy/squid.conf`) [[1]](diffhunk://#diff-4e0c6356aa273abcddb2460a81f38d0d5670281accb4349236b4b2d4a67ff142L11-R21) [[2]](diffhunk://#diff-4e0c6356aa273abcddb2460a81f38d0d5670281accb4349236b4b2d4a67ff142L33-R41)

**Refresh patterns and cache control:**

* Refined and expanded `refresh_pattern` rules for aggressive and targeted caching of GitHub, Kubernetes, Helm, and CRI-O assets, with specific rules for immutable content and fallback patterns for generic artifacts. (`test/cache-proxy/squid.conf`)
* Enabled Squid options to force caching and ignore restrictive headers, and added settings to ignore Vary headers that could prevent cache reuse. (`test/cache-proxy/squid.conf`)

**Logging improvements:**

* Enabled store log output and added debug logging for the URL normalization helper to aid in troubleshooting and cache analysis. (`test/cache-proxy/squid.conf`, `test/cache-proxy/store-id-helper.pl`) [[1]](diffhunk://#diff-4e0c6356aa273abcddb2460a81f38d0d5670281accb4349236b4b2d4a67ff142L77-R127) [[2]](diffhunk://#diff-64252760dfc680343e07b039e244ef91308272d311f9d39fc6e8a9c44e164daaR1-R72)

**Dependency updates:**

* Added `perl` as a dependency in the Dockerfile to support the new store-id helper script. (`test/cache-proxy/Dockerfile`)

### Improvements

From:
<img width="417" height="154" alt="image" src="https://github.com/user-attachments/assets/66bf5466-3228-45cc-bef4-42897fe47e03" />

To:
<img width="398" height="157" alt="image" src="https://github.com/user-attachments/assets/ef963792-f158-4471-a860-227562a08872" />


### Related Issues

* Closes #311 
