### PR TITLE
chore: fix dry-mode for deploy release workflow

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -91,6 +91,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: |
+          set -euo pipefail
+          
           FLAGS=""
           if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
             FLAGS="--dry-run"
@@ -100,9 +102,9 @@ jobs:
           
           # Extract the next version from semantic-release output for dry-run
           if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
-            NEXT_VERSION=$(grep -oP "The next release version is \K[0-9]+\.[0-9]+\.[0-9]+" semantic-release-output.txt || echo "")
+            NEXT_VERSION=$(sed -n 's/.*The next release version is \([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\).*/\1/p' semantic-release-output.txt || echo "")
             if [[ -n "$NEXT_VERSION" ]]; then
-              echo "next-version=v${NEXT_VERSION}" >> "${GITHUB_OUTPUT}"
+              echo "next-version=${NEXT_VERSION}" >> "${GITHUB_OUTPUT}"
               echo "::notice::Dry-run: Next release would be v${NEXT_VERSION}"
             else
               echo "::notice::Dry-run: No new release would be created"
@@ -112,6 +114,8 @@ jobs:
       - name: Retrieve Release Version
         id: version
         run: |
+          set -euo pipefail
+          
           if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
             VERSION="${{ steps.semantic-release.outputs.next-version }}"
             if [[ -n "$VERSION" ]]; then


### PR DESCRIPTION
## Description

This pull request enhances the release workflow to improve support for dry-run mode and provide better visibility into what would happen during a semantic release without actually publishing a new version. The main changes focus on capturing and exposing the predicted next version in dry-run scenarios, and improving error handling and output messaging.

Release workflow improvements:

* Added an `id: semantic-release` step to allow capturing outputs from the semantic release process in the workflow (`.github/workflows/flow-deploy-release-artifact.yaml`).
* Modified the semantic release execution to pipe output to a file, extract the predicted next version during dry-run mode, and expose it as a workflow output and GitHub Actions notice (`.github/workflows/flow-deploy-release-artifact.yaml`).

Version retrieval and error handling enhancements:

* Updated the version retrieval step to use the predicted version from dry-run mode if available, or fall back to reading from the `VERSION` file in normal runs. Improved output and error messages for both scenarios (`.github/workflows/flow-deploy-release-artifact.yaml`).

### Related Issues

* Closes #351 
