### PR TITLE
feat: add --skip-hardware-checks hidden option

### DIFF
--- a/cmd/weaver/commands/block/node/install.go
+++ b/cmd/weaver/commands/block/node/install.go
@@ -72,8 +72,12 @@ var installCmd = &cobra.Command{
 			Any("opts", opts).
 			Msg("Installing Hedera Block Node")
 
+		skipHardwareChecks, err := cmd.Flags().GetBool(common.FlagSkipHardwareChecks.Name)
+		if err != nil {
+			return errorx.IllegalArgument.Wrap(err, "failed to get %s flag", common.FlagSkipHardwareChecks.Name)
+		}
 		wb := workflows.WithWorkflowExecutionMode(
-			workflows.NewBlockNodeInstallWorkflow(flagProfile, validatedValuesFile), opts)
+			workflows.NewBlockNodeInstallWorkflow(flagProfile, validatedValuesFile, skipHardwareChecks), opts)
 
 		common.RunWorkflow(cmd.Context(), wb)
 

--- a/cmd/weaver/commands/common/flags.go
+++ b/cmd/weaver/commands/common/flags.go
@@ -65,6 +65,22 @@ var (
 		Description: "Install Metrics Server",
 		Default:     true,
 	}
+
+	// FlagSkipHardwareChecks is a hidden persistent flag registered on the root command.
+	// When set, it skips CPU, memory, and storage validation in NewNodeSafetyCheckWorkflow
+	// (see internal/workflows/preflight.go). Privilege, user, and host profile checks
+	// still run. This flag is intentionally not supported by the "check" command since its
+	// purpose is to validate hardware requirements.
+	//
+	// Used by: block node install, kube cluster install.
+	// Registered in: cmd/weaver/commands/root.go (hidden).
+	// See docs/dev/hidden-flags.md for full documentation.
+	FlagSkipHardwareChecks = FlagDefinition[bool]{
+		Name:        "skip-hardware-checks",
+		ShortName:   "",
+		Description: "DANGEROUS: Skip hardware validation checks. May cause node instability or data loss.",
+		Default:     false,
+	}
 )
 
 // FlagDefinition defines a command-line flag typed by T.

--- a/cmd/weaver/commands/kube/cluster/install.go
+++ b/cmd/weaver/commands/kube/cluster/install.go
@@ -53,7 +53,11 @@ var installCmd = &cobra.Command{
 			Any("opts", opts).
 			Msg("Installing Kubernetes Cluster")
 
-		wb := workflows.WithWorkflowExecutionMode(workflows.InstallClusterWorkflow(flagNodeType, flagProfile), opts)
+		skipHardwareChecks, err := cmd.Flags().GetBool(common.FlagSkipHardwareChecks.Name)
+		if err != nil {
+			return errorx.IllegalArgument.Wrap(err, "failed to get %s flag", common.FlagSkipHardwareChecks.Name)
+		}
+		wb := workflows.WithWorkflowExecutionMode(workflows.InstallClusterWorkflow(flagNodeType, flagProfile, skipHardwareChecks), opts)
 		common.RunWorkflow(cmd.Context(), wb)
 
 		logx.As().Info().Msg("Successfully installed Kubernetes Cluster")

--- a/cmd/weaver/commands/root.go
+++ b/cmd/weaver/commands/root.go
@@ -30,9 +30,10 @@ import (
 // rootCmd represents the base command when called without any subcommands
 var (
 	// Used for flags.
-	flagConfig       string
-	flagVersion      bool
-	flagOutputFormat string
+	flagConfig             string
+	flagVersion            bool
+	flagOutputFormat       string
+	flagSkipHardwareChecks bool
 
 	rootCmd = &cobra.Command{
 		Use:   "solo-provisioner",
@@ -59,6 +60,11 @@ func init() {
 	// support '--version', '-v' to show version information
 	rootCmd.PersistentFlags().BoolVarP(&flagVersion, "version", "v", false, "Show version")
 	rootCmd.PersistentFlags().StringVarP(&flagOutputFormat, "output", "o", "yaml", "Output format (yaml|json)")
+
+	// Hardware check override flag - hidden to discourage casual use
+	rootCmd.PersistentFlags().BoolVar(&flagSkipHardwareChecks, common.FlagSkipHardwareChecks.Name, false,
+		"DANGEROUS: Skip hardware validation checks. May cause node instability or data loss.")
+	_ = rootCmd.PersistentFlags().MarkHidden(common.FlagSkipHardwareChecks.Name)
 
 	// disable command sorting to keep the order of commands as added
 	cobra.EnableCommandSorting = false

--- a/docs/dev/hidden-flags.md
+++ b/docs/dev/hidden-flags.md
@@ -1,0 +1,33 @@
+# Hidden Flags
+
+This document describes hidden CLI flags that are not shown in `--help` output. These flags exist for
+support and debugging purposes and should not be used in normal operations.
+
+## `--skip-hardware-checks`
+
+**Scope:** `block node install`, `kube cluster install`
+
+Skips OS, CPU, memory, and storage validation during installation workflows. The following preflight checks
+still run even when this flag is set:
+
+- Privilege validation (root user)
+- Weaver user/group validation
+- Host profile validation
+
+**When to use:**
+
+- Working around a false-positive hardware check failure.
+- Development or testing on machines that don't meet production hardware requirements.
+
+**Not supported by:** `block node check` — that command always runs all checks since its purpose
+is to validate system requirements.
+
+**Implementation:**
+
+- Flag defined in `cmd/weaver/commands/common/flags.go` (`FlagSkipHardwareChecks`).
+- Registered as a hidden persistent flag on the root command in `cmd/weaver/commands/root.go`.
+- Read via `cmd.Flags().GetBool(common.FlagSkipHardwareChecks.Name)` in install commands.
+- Passed as `skipHardwareChecks bool` through the workflow chain to `NewNodeSafetyCheckWorkflow`
+  in `internal/workflows/preflight.go`, which conditionally excludes hardware steps.
+
+

--- a/internal/workflows/blocknode.go
+++ b/internal/workflows/blocknode.go
@@ -8,15 +8,15 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
 )
 
-// NewBlockNodePreflightCheckWorkflow creates a safety check workflow for block node
+// NewBlockNodePreflightCheckWorkflow creates a safety check workflow for block node.
 func NewBlockNodePreflightCheckWorkflow(profile string) *automa.WorkflowBuilder {
-	return NewNodeSafetyCheckWorkflow(core.NodeTypeBlock, profile)
+	return NewNodeSafetyCheckWorkflow(core.NodeTypeBlock, profile, false)
 }
 
-// NewBlockNodeInstallWorkflow creates a comprehensive install workflow for block node
-func NewBlockNodeInstallWorkflow(profile string, valuesFile string) *automa.WorkflowBuilder {
+// NewBlockNodeInstallWorkflow creates a comprehensive install workflow for block node.
+func NewBlockNodeInstallWorkflow(profile string, valuesFile string, skipHardwareChecks bool) *automa.WorkflowBuilder {
 	return automa.NewWorkflowBuilder().WithId("block-node-install").Steps(
-		InstallClusterWorkflow(core.NodeTypeBlock, profile),
+		InstallClusterWorkflow(core.NodeTypeBlock, profile, skipHardwareChecks),
 		steps.SetupBlockNode(profile, valuesFile),
 	)
 }

--- a/internal/workflows/cluster.go
+++ b/internal/workflows/cluster.go
@@ -22,11 +22,11 @@ func DefaultWorkflowExecutionOptions() *WorkflowExecutionOptions {
 	}
 }
 
-// InstallClusterWorkflow creates a workflow to set up a kubernetes cluster
-func InstallClusterWorkflow(nodeType string, profile string) *automa.WorkflowBuilder {
+// InstallClusterWorkflow creates a workflow to set up a kubernetes cluster.
+func InstallClusterWorkflow(nodeType string, profile string, skipHardwareChecks bool) *automa.WorkflowBuilder {
 	// Build the base steps that are common to all node types
 	baseSteps := []automa.Builder{
-		NodeSetupWorkflow(nodeType, profile),
+		NodeSetupWorkflow(nodeType, profile, skipHardwareChecks),
 
 		// setup env for k8s
 		steps.DisableSwap(),

--- a/internal/workflows/cluster_it_test.go
+++ b/internal/workflows/cluster_it_test.go
@@ -46,7 +46,7 @@ import (
 func Test_ClusterSetup(t *testing.T) {
 	testutil.Reset(t)
 
-	installWf, err := InstallClusterWorkflow(core.NodeTypeBlock, core.ProfileLocal).
+	installWf, err := InstallClusterWorkflow(core.NodeTypeBlock, core.ProfileLocal, false).
 		WithExecutionMode(automa.StopOnError).
 		Build()
 	require.NoError(t, err)

--- a/internal/workflows/setup.go
+++ b/internal/workflows/setup.go
@@ -10,13 +10,13 @@ import (
 )
 
 // NodeSetupWorkflow creates a comprehensive setup workflow for any node type
-// It runs preflight checks first, then performs the actual setup
-func NodeSetupWorkflow(nodeType string, profile string) *automa.WorkflowBuilder {
+// It runs preflight checks first, then performs the actual setup.
+func NodeSetupWorkflow(nodeType string, profile string, skipHardwareChecks bool) *automa.WorkflowBuilder {
 	return automa.NewWorkflowBuilder().
 		WithId(nodeType+"-node-setup").
 		Steps(
 			// First run preflight checks to ensure system readiness
-			NewNodeSafetyCheckWorkflow(nodeType, profile),
+			NewNodeSafetyCheckWorkflow(nodeType, profile, skipHardwareChecks),
 			// Then perform the actual setup
 			steps.SetupHomeDirectoryStructure(core.Paths()),
 			steps.RefreshSystemPackageIndex(),


### PR DESCRIPTION
## Description

This pull request introduces a hidden CLI flag, `--unsafe-skip-hardware-checks`, which allows users to bypass hardware validation checks (CPU, memory, storage) during installation workflows for block nodes and Kubernetes clusters. The flag is intended for advanced use cases such as development, testing, or working around false-positive hardware check failures. The implementation ensures that other critical checks (privilege, user, host profile, OS) still run, and the flag is not available for the `check` command to maintain system safety. Documentation has also been added to clarify the flag's purpose and usage.

The most important changes are:

**Feature: Add hidden flag to skip hardware checks**
- Introduced the `--unsafe-skip-hardware-checks` flag as a hidden persistent flag on the root command, with clear warnings about its risks and intended use. The flag is documented and registered in `flags.go` and `root.go`. [[1]](diffhunk://#diff-f3293288804e27c687b2019ae8154de27c6ab211c5982d30938a34bfa7985bc1R68-R83) [[2]](diffhunk://#diff-45410074f2fd3857e628ffaa910cde1e59b5323af44d8ddb2516799b4916d62bR36) [[3]](diffhunk://#diff-45410074f2fd3857e628ffaa910cde1e59b5323af44d8ddb2516799b4916d62bR64-R68) [[4]](diffhunk://#diff-7323d089d9cdccdfbb46bef96574968133c5dbd686f840706aec175c97c6b251R1-R33)

**Workflow updates to support the new flag**
- Updated workflow constructors (`InstallClusterWorkflow`, `NewBlockNodeInstallWorkflow`, `NodeSetupWorkflow`, `NewNodeSafetyCheckWorkflow`) to accept and propagate the `skipHardwareChecks` boolean, ensuring hardware validation steps are conditionally included or excluded. [[1]](diffhunk://#diff-0cbd5d0d3e1884e017374a994ce18b0ab71220ae089c0b21deca20d2064a6503L25-R29) [[2]](diffhunk://#diff-4e5b3641f10e9215607e3012fa0ef44b593a8b1e28cc3e265c4258386cd838f8L11-R19) [[3]](diffhunk://#diff-aa45b470797caef6d43646860798d8337654c9bc2cd4649b64378b12a2b0d53eL13-R19) [[4]](diffhunk://#diff-47269ac315e048bf447692be25309b3126eb2b45e62c3af39420999d96539fb9L372-R395)

**Command changes to wire the flag into install workflows**
- Modified the `block node install` and `kube cluster install` commands to read the new flag and pass its value into the workflow chain, enabling hardware check skipping when requested. [[1]](diffhunk://#diff-835fa6ddca4435596fff9b76f8176c9a0771490edf70cac6d4044dbe623c8f9aR75-R77) [[2]](diffhunk://#diff-01d1e86936af2723319004052ecb01c19b3924895cadd1fc18ffc5b108e56c35L56-R57)

**Testing and documentation**
- Updated integration tests and added developer documentation (`hidden-flags.md`) detailing the flag’s scope, use cases, and implementation. [[1]](diffhunk://#diff-1f44f7f2674bcde5bf54ee8cebb10a6911b7b91e8dcd9d5a2ed4c7d13968c32dL49-R49) [[2]](diffhunk://#diff-7323d089d9cdccdfbb46bef96574968133c5dbd686f840706aec175c97c6b251R1-R33)

**Logging and messaging**
- Added logging to warn users when hardware checks are skipped, increasing visibility of potentially unsafe operations.

These changes collectively provide a controlled, well-documented mechanism to bypass hardware checks for advanced scenarios while preserving safety for standard operations.

<img width="1442" height="308" alt="image" src="https://github.com/user-attachments/assets/8e531d5f-710c-4ca9-81b6-efacf3392c3a" />

### Related Issues

* Closes #372 
