### PR TITLE
refactor: simplify alloy installation by only requiring k8s secrets

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1375,19 +1375,35 @@ tasks:
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
   alloy:start:
-    desc: "Start Alloy stack (used by VM, CI/CD, and Kind/k3d)"
+    desc: "Start Alloy stack (Prometheus, Loki, Grafana) for local development"
     dir: test/alloy
-    deps: [vault:start]
     cmds:
       - docker compose up -d prometheus loki grafana
       - |
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
         echo "✅ Alloy stack started!"
         echo ""
-        echo "📦 This task is used by:"
-        echo "   • VM development (via task vm:alloy:start)"
-        echo "   • CI/CD workflows (GitHub Actions, GitLab CI)"
-        echo "   • Local Kind/k3d clusters"
+        echo "🌐 Services:"
+        echo "   • Prometheus: http://localhost:9090"
+        echo "   • Loki:       http://localhost:3100"
+        echo "   • Grafana:    http://localhost:3000"
+        echo ""
+        echo "📝 Next step: Create K8s secret for Alloy passwords"
+        echo "   task alloy:create-secret"
+        echo ""
+        echo "💡 Optionally start Vault for ESO-based secret sync:"
+        echo "   task vault:start"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+  alloy:start-with-vault:
+    desc: "Start full Alloy stack with Vault (Prometheus, Loki, Grafana, Vault)"
+    dir: test/alloy
+    deps: [vault:start]
+    cmds:
+      - docker compose up -d prometheus loki grafana
+      - |
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "✅ Alloy stack started with Vault!"
         echo ""
         echo "🌐 Services:"
         echo "   • Vault:      http://localhost:8200 (token: devtoken)"
@@ -1397,8 +1413,8 @@ tasks:
         echo ""
         echo "🔐 Vault has been initialized with development secrets"
         echo ""
-        echo "📝 Next step: Apply ClusterSecretStore to connect ESO to Vault"
-        echo "   kubectl apply -f test/alloy/cluster-secret-store-local.yaml"
+        echo "📝 Next step: Configure ESO ClusterSecretStore"
+        echo "   task vault:setup-secret-store"
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
   alloy:stop:
@@ -1440,6 +1456,51 @@ tasks:
           echo ""
           echo "💡 For VM-based development, use: task vm:alloy:start"
         fi
+
+  alloy:create-secret:
+    desc: "Create K8s secret 'grafana-alloy-secrets' with dev passwords for local testing"
+    vars:
+      CLUSTER_NAME: '{{.CLUSTER_NAME | default "vm-cluster"}}'
+    cmds:
+      - |
+        echo "🔐 Creating K8s secret for Alloy (local dev)..."
+        
+        # Create the namespace if it doesn't exist
+        kubectl create namespace grafana-alloy --dry-run=client -o yaml | kubectl apply -f -
+
+        # Create/update the secret with dev passwords
+        # Key naming convention: PROMETHEUS_PASSWORD_<REMOTE_NAME>, LOKI_PASSWORD_<REMOTE_NAME>
+        # The remote name must match the name= value in --add-prometheus-remote / --add-loki-remote
+        kubectl create secret generic grafana-alloy-secrets \
+          --namespace=grafana-alloy \
+          --from-literal=PROMETHEUS_PASSWORD_LOCAL=dev-password \
+          --from-literal=LOKI_PASSWORD_LOCAL=dev-password \
+          --dry-run=client -o yaml | kubectl apply -f -
+
+        echo ""
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "✅ Secret 'grafana-alloy-secrets' created in namespace 'grafana-alloy'"
+        echo ""
+        echo "📦 Keys (convention: {PROMETHEUS|LOKI}_PASSWORD_{REMOTE_NAME}):"
+        echo "   • PROMETHEUS_PASSWORD_LOCAL"
+        echo "   • LOKI_PASSWORD_LOCAL"
+        echo ""
+        echo "📋 Next step: install Alloy with remotes:"
+        echo "   NODE_IP=\$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type==\"InternalIP\")].address}')"
+        echo "   sudo solo-provisioner alloy cluster install \\"
+        echo "     --cluster-name={{.CLUSTER_NAME}} \\"
+        echo "     --add-prometheus-remote=name=local,url=http://\$NODE_IP:9090/api/v1/write,username=admin \\"
+        echo "     --add-loki-remote=name=local,url=http://\$NODE_IP:3100/loki/api/v1/push,username=admin \\"
+        echo "     --monitor-block-node"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+  alloy:delete-secret:
+    desc: "Delete K8s secret 'grafana-alloy-secrets'"
+    cmds:
+      - |
+        echo "🧹 Deleting K8s secret..."
+        kubectl delete secret grafana-alloy-secrets -n grafana-alloy --ignore-not-found
+        echo "✅ Secret deleted"
 
   # ===========================
   # VM Docker & Alloy Setup
@@ -1535,12 +1596,10 @@ tasks:
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
         echo "✅ Alloy stack setup complete!"
         echo ""
-        echo "🔐 Vault has been initialized with development secrets"
-        echo ""
         echo "📋 Next steps:"
         echo "   1. SSH into VM: task vm:ssh"
-        echo "   2. Apply ClusterSecretStore: task vault:setup-secret-store"
-        echo "   3. Deploy with Alloy: sudo weaver kube cluster install --alloy-enabled ..."
+        echo "   2. Create K8s secret: task alloy:create-secret"
+        echo "   3. Install Alloy with remotes (see test/alloy/README.md)"
         echo ""
         echo "💡 To access from your Mac, use SSH port forwarding:"
         echo "   task vm:alloy-forward"

--- a/cmd/weaver/commands/alloy/cluster/cluster.go
+++ b/cmd/weaver/commands/alloy/cluster/cluster.go
@@ -35,13 +35,18 @@ func init() {
 	// Core configuration flags
 	clusterCmd.PersistentFlags().StringVar(&flagClusterName, "cluster-name", "", "Cluster name for Alloy metrics/logs labels")
 	clusterCmd.PersistentFlags().BoolVar(&flagMonitorBlockNode, "monitor-block-node", false, "Enable Block Node monitoring in Alloy")
-	clusterCmd.PersistentFlags().StringVar(&flagClusterSecretStore, "cluster-secret-store", "vault-secret-store", "Name of the ClusterSecretStore resource for External Secrets Operator")
+
+	// Deprecated: kept for backward compatibility but hidden
+	clusterCmd.PersistentFlags().StringVar(&flagClusterSecretStore, "cluster-secret-store", "vault-secret-store", "Name of the ClusterSecretStore resource")
+	_ = clusterCmd.PersistentFlags().MarkHidden("cluster-secret-store")
 
 	// Multi-remote flags (repeatable)
 	clusterCmd.PersistentFlags().StringArrayVar(&flagPrometheusRemotes, "add-prometheus-remote", nil,
-		"Add a Prometheus remote (format: name=<name>,url=<url>,username=<username>). Can be specified multiple times")
+		"Add a Prometheus remote (format: name=<name>,url=<url>,username=<username>). Can be specified multiple times. "+
+			"Password is expected in K8s Secret 'grafana-alloy-secrets' under key 'PROMETHEUS_PASSWORD_<NAME>'")
 	clusterCmd.PersistentFlags().StringArrayVar(&flagLokiRemotes, "add-loki-remote", nil,
-		"Add a Loki remote (format: name=<name>,url=<url>,username=<username>). Can be specified multiple times")
+		"Add a Loki remote (format: name=<name>,url=<url>,username=<username>). Can be specified multiple times. "+
+			"Password is expected in K8s Secret 'grafana-alloy-secrets' under key 'LOKI_PASSWORD_<NAME>'")
 
 	// Legacy single-remote flags (kept for backward compatibility)
 	clusterCmd.PersistentFlags().StringVar(&flagPrometheusURL, "prometheus-url", "", "Prometheus remote write URL (deprecated: use --add-prometheus-remote)")

--- a/cmd/weaver/commands/alloy/cluster/install.go
+++ b/cmd/weaver/commands/alloy/cluster/install.go
@@ -19,8 +19,21 @@ var installCmd = &cobra.Command{
 	Long: `Install the Grafana Alloy observability stack including Prometheus CRDs, 
 Node Exporter, and Alloy for metrics and logs collection.
 
+Passwords for remote endpoints must exist in K8s Secret "grafana-alloy-secrets" 
+in the "grafana-alloy" namespace before running this command. Use 
+"solo-provisioner eso secret create" to create the secret from an external store,
+or create it manually.
+
 Examples:
-  # Multiple remotes (recommended)
+  # Step 1: Create the K8s secret with passwords (via ESO)
+  solo-provisioner eso secret create \
+    --store=vault-store \
+    --name=grafana-alloy-secrets \
+    --namespace=grafana-alloy \
+    --set PROMETHEUS_PASSWORD_PRIMARY=secret/data/grafana/alloy/prod/prometheus/primary#password \
+    --set LOKI_PASSWORD_PRIMARY=secret/data/grafana/alloy/prod/loki/primary#password
+
+  # Step 2: Install Alloy with remotes
   solo-provisioner alloy cluster install \
     --cluster-name=my-cluster \
     --add-prometheus-remote=name=primary,url=https://prom1.example.com/api/v1/write,username=user1 \
@@ -28,13 +41,9 @@ Examples:
     --add-loki-remote=name=primary,url=https://loki1.example.com/loki/api/v1/push,username=user1 \
     --monitor-block-node
 
-  # Single remote (legacy mode - deprecated)
+  # Install Alloy without remotes (no secret needed)
   solo-provisioner alloy cluster install \
-    --cluster-name=my-cluster \
-    --prometheus-url=https://prometheus.example.com/api/v1/write \
-    --prometheus-username=user \
-    --loki-url=https://loki.example.com/loki/api/v1/push \
-    --loki-username=user`,
+    --cluster-name=my-cluster`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Parse multi-remote flags
 		prometheusRemotes, err := parseRemoteFlags(flagPrometheusRemotes)

--- a/cmd/weaver/commands/block/node/install_upgrade_it_test.go
+++ b/cmd/weaver/commands/block/node/install_upgrade_it_test.go
@@ -472,6 +472,8 @@ func resetFlags(cmd *cobra.Command) {
 		cmd.ResetFlags()
 		// Add the profile flag since it's required by the parent block command
 		cmd.PersistentFlags().String(common.FlagProfile.Name, "", "profile to use for block commands")
+		// Re-add skip-hardware-checks since it's registered on the root command
+		cmd.PersistentFlags().Bool(common.FlagSkipHardwareChecks.Name, false, "Skip hardware validation checks")
 	}
 }
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -230,7 +230,6 @@ Sets up a complete single-node Kubernetes environment with all required componen
 - **Helm**: Kubernetes package manager
 - **kubectl**: Kubernetes CLI
 - **k9s**: Terminal-based Kubernetes UI
-- **External Secrets Operator**: Secret management integration
 - **Metrics Server**: Resource metrics for pods and nodes
 
 ```bash
@@ -336,33 +335,32 @@ When installing Alloy with remote endpoints (`--add-prometheus-remote` or `--add
 | Prerequisite | Description |
 |--------------|-------------|
 | **Running Kubernetes Cluster** | A cluster must be set up via `solo-provisioner block node install` or `solo-provisioner kube cluster install` |
-| **ClusterSecretStore** | A `ClusterSecretStore` named `vault-secret-store` (or custom name via `--cluster-secret-store`) must exist and be configured to connect to Vault |
-| **Reachable Vault** | The Vault server referenced in the ClusterSecretStore must be reachable |
+| **K8s Secret** | A Kubernetes Secret named `grafana-alloy-secrets` must exist in the `grafana-alloy` namespace with password keys for each configured remote (e.g., `PROMETHEUS_PASSWORD_PRIMARY`, `LOKI_PASSWORD_PRIMARY`) |
 | **Reachable Remote Endpoints** | Prometheus/Loki URLs must be reachable from the cluster |
-| **Vault Secrets** | Secrets must exist at `grafana/alloy/{clusterName}/{prometheus\|loki}/{remoteName}` with a `password` key |
 | **Block Node (optional)** | If using `--monitor-block-node`, the block node must be installed first |
 
-> **Note**: Without `--add-prometheus-remote` or `--add-loki-remote` flags, Alloy installs in "local-only" mode and does not require Vault secrets or a ClusterSecretStore.
+> **Note**: Without `--add-prometheus-remote` or `--add-loki-remote` flags, Alloy installs without remotes and does not require the K8s secret.
 
 #### Install Alloy Stack
 
 ```bash
-# Basic installation with single remote (legacy mode)
-sudo solo-provisioner alloy cluster install \
-  --cluster-name=mainnet-block-01 \
-  --prometheus-url=https://prometheus.example.com/api/v1/write \
-  --prometheus-username=metrics-user \
-  --loki-url=https://loki.example.com/loki/api/v1/push \
-  --loki-username=logs-user
+# Step 1: Create the K8s secret with passwords for remote endpoints
+kubectl create namespace grafana-alloy
+kubectl create secret generic grafana-alloy-secrets \
+  --namespace=grafana-alloy \
+  --from-literal=PROMETHEUS_PASSWORD_PRIMARY=<password> \
+  --from-literal=LOKI_PASSWORD_PRIMARY=<password>
 
-# Multiple remotes using repeatable flags (recommended)
+# Step 2: Install Alloy with remotes
 sudo solo-provisioner alloy cluster install \
   --cluster-name=mainnet-block-01 \
   --add-prometheus-remote=name=primary,url=https://prom1.example.com/api/v1/write,username=user1 \
-  --add-prometheus-remote=name=backup,url=https://prom2.example.com/api/v1/write,username=user2 \
   --add-loki-remote=name=primary,url=https://loki1.example.com/loki/api/v1/push,username=user1 \
-  --add-loki-remote=name=backup,url=https://loki2.example.com/loki/api/v1/push,username=user2 \
   --monitor-block-node
+
+# Install Alloy without remotes (no secret needed)
+sudo solo-provisioner alloy cluster install \
+  --cluster-name=mainnet-block-01
 ```
 
 **Available Flags**:
@@ -371,7 +369,6 @@ sudo solo-provisioner alloy cluster install \
 |------|-------------|
 | `--cluster-name` | Cluster name for metrics/logs labels |
 | `--monitor-block-node` | Enable Block Node specific monitoring |
-| `--cluster-secret-store` | Name of the ClusterSecretStore for Vault access (default: `vault-secret-store`) |
 | `--add-prometheus-remote` | Add a Prometheus remote (format: `name=<name>,url=<url>,username=<username>`). Repeatable |
 | `--add-loki-remote` | Add a Loki remote (format: `name=<name>,url=<url>,username=<username>`). Repeatable |
 | `--prometheus-url` | Prometheus remote write URL *(deprecated: use `--add-prometheus-remote`)* |
@@ -379,25 +376,30 @@ sudo solo-provisioner alloy cluster install \
 | `--loki-url` | Loki remote write URL *(deprecated: use `--add-loki-remote`)* |
 | `--loki-username` | Loki authentication username *(deprecated)* |
 
-> **Note**: Passwords are managed via Vault and External Secrets Operator, not via CLI flags.
+> **Note**: Passwords must be pre-created in a K8s Secret named `grafana-alloy-secrets` in the `grafana-alloy` namespace. The secret can be created manually, via ESO, Terraform, or any other mechanism.
 
 #### Multiple Remote Endpoints
 
 The `--add-prometheus-remote` and `--add-loki-remote` flags use the format `name=<name>,url=<url>,username=<username>`:
 - **name**: Unique identifier for the remote (e.g., `primary`, `backup`, `grafana-cloud`)
 - **url**: The remote write endpoint URL
-- **username**: Authentication username (password is fetched from Vault)
+- **username**: Authentication username (password is read from the K8s Secret)
 
-**Vault Secret Paths** (for multiple remotes):
-- Prometheus: `grafana/alloy/{clusterName}/prometheus/{remoteName}` → property: `password`
-- Loki: `grafana/alloy/{clusterName}/loki/{remoteName}` → property: `password`
+**K8s Secret Keys** (for multiple remotes):
 
-Example for `mainnet-block-01` cluster with `primary` and `backup` remotes:
-```
-grafana/alloy/mainnet-block-01/prometheus/primary
-grafana/alloy/mainnet-block-01/prometheus/backup
-grafana/alloy/mainnet-block-01/loki/primary
-grafana/alloy/mainnet-block-01/loki/backup
+Each remote requires a corresponding password key in the `grafana-alloy-secrets` K8s Secret. The key name is derived from the remote type and name:
+- Prometheus: `PROMETHEUS_PASSWORD_<REMOTE_NAME>`
+- Loki: `LOKI_PASSWORD_<REMOTE_NAME>`
+
+Example for a cluster with `primary` and `backup` remotes, create the secret with:
+```bash
+kubectl create namespace grafana-alloy
+kubectl create secret generic grafana-alloy-secrets \
+  --namespace=grafana-alloy \
+  --from-literal=PROMETHEUS_PASSWORD_PRIMARY=<password> \
+  --from-literal=PROMETHEUS_PASSWORD_BACKUP=<password> \
+  --from-literal=LOKI_PASSWORD_PRIMARY=<password> \
+  --from-literal=LOKI_PASSWORD_BACKUP=<password>
 ```
 
 #### Managing Remote Endpoints
@@ -432,7 +434,7 @@ sudo solo-provisioner alloy cluster install \
   --add-loki-remote=name=primary,url=https://loki1.example.com/loki/api/v1/push,username=user1
 ```
 
-**Remove all remotes (local-only mode):**
+**Remove all remotes (install without remotes):**
 ```bash
 sudo solo-provisioner alloy cluster install \
   --cluster-name=mainnet-block-01
@@ -496,10 +498,14 @@ blockNode:
 alloy:
   monitorBlockNode: true
   clusterName: "mainnet-block-01"
-  prometheusUrl: "https://prometheus.example.com/api/v1/write"
-  prometheusUsername: "metrics"
-  lokiUrl: "https://loki.example.com/loki/api/v1/push"
-  lokiUsername: "logs"
+  prometheusRemotes:
+    - name: "primary"
+      url: "https://prometheus.example.com/api/v1/write"
+      username: "metrics"
+  lokiRemotes:
+    - name: "primary"
+      url: "https://loki.example.com/loki/api/v1/push"
+      username: "logs"
 
 teleport:
   version: "16.0.0"
@@ -560,8 +566,8 @@ sudo solo-provisioner teleport cluster install \
 sudo solo-provisioner alloy cluster install \
   --monitor-block-node \
   --cluster-name=mainnet-block-01 \
-  --prometheus-url=https://metrics.hedera.internal/write \
-  --prometheus-username=block-metrics
+  --add-prometheus-remote=name=primary,url=https://metrics.hedera.internal/write,username=block-metrics \
+  --add-loki-remote=name=primary,url=https://loki.hedera.internal/loki/api/v1/push,username=block-logs
 ```
 
 ### Development Environment Setup

--- a/internal/alloy/manifest.go
+++ b/internal/alloy/manifest.go
@@ -5,7 +5,6 @@ package alloy
 import (
 	"sort"
 
-	"github.com/hashgraph/solo-weaver/internal/config"
 	"github.com/hashgraph/solo-weaver/internal/templates"
 )
 
@@ -50,39 +49,6 @@ func ConfigMapManifest(modules []ModuleConfig) (string, error) {
 	}
 
 	return templates.Render("files/alloy/configmap.yaml", data)
-}
-
-// ExternalSecretTemplateData holds data for the ExternalSecret template.
-type ExternalSecretTemplateData struct {
-	ExternalSecretName     string
-	Namespace              string
-	ClusterSecretStoreName string
-	SecretsName            string
-	ClusterName            string
-	SecretDataEntries      string
-}
-
-// ExternalSecretManifest generates the Alloy ExternalSecret manifest.
-// Uses the external-secret.yaml template file.
-func ExternalSecretManifest(cfg config.AlloyConfig, clusterName string) (string, error) {
-	secretDataEntries := BuildExternalSecretDataEntries(cfg, clusterName)
-
-	// Use configurable ClusterSecretStoreName, fallback to default constant
-	clusterSecretStoreName := cfg.ClusterSecretStoreName
-	if clusterSecretStoreName == "" {
-		clusterSecretStoreName = ClusterSecretStoreName
-	}
-
-	data := ExternalSecretTemplateData{
-		ExternalSecretName:     ExternalSecretName,
-		Namespace:              Namespace,
-		ClusterSecretStoreName: clusterSecretStoreName,
-		SecretsName:            SecretsName,
-		ClusterName:            clusterName,
-		SecretDataEntries:      secretDataEntries,
-	}
-
-	return templates.Render("files/alloy/external-secret.yaml", data)
 }
 
 // BaseHelmValues returns the base Helm values for Alloy installation.
@@ -160,21 +126,4 @@ func NamespaceManifest() (string, error) {
 	}
 
 	return templates.Render("files/alloy/namespace.yaml", data)
-}
-
-// EmptySecretTemplateData holds data for the empty secret template.
-type EmptySecretTemplateData struct {
-	SecretsName string
-	Namespace   string
-}
-
-// EmptySecretManifest generates an empty secret manifest.
-// Used when no remotes are configured so the pod doesn't fail looking for the secret.
-func EmptySecretManifest() (string, error) {
-	data := EmptySecretTemplateData{
-		SecretsName: SecretsName,
-		Namespace:   Namespace,
-	}
-
-	return templates.Render("files/alloy/empty-secret.yaml", data)
 }

--- a/internal/alloy/render_test.go
+++ b/internal/alloy/render_test.go
@@ -20,7 +20,7 @@ func TestRenderModularConfigs(t *testing.T) {
 		expectedModuleCount int
 	}{
 		{
-			name: "local-only mode - no remotes, no block node",
+			name: "no remotes, no block node",
 			cfg: config.AlloyConfig{
 				ClusterName: "test-cluster",
 			},
@@ -29,7 +29,7 @@ func TestRenderModularConfigs(t *testing.T) {
 			expectedModuleCount: 1,
 		},
 		{
-			name: "local-only mode with block node monitoring - still skipped without remotes",
+			name: "block node monitoring without remotes - still skipped",
 			cfg: config.AlloyConfig{
 				ClusterName:      "test-cluster",
 				MonitorBlockNode: true,
@@ -217,15 +217,101 @@ func TestNamespaceManifest(t *testing.T) {
 	assert.Contains(t, manifest, "name: "+Namespace)
 }
 
-func TestEmptySecretManifest(t *testing.T) {
-	manifest, err := EmptySecretManifest()
+func TestBuildHelmEnvVars_DefaultSecret(t *testing.T) {
+	cfg := config.AlloyConfig{
+		PrometheusRemotes: []config.AlloyRemoteConfig{
+			{Name: "primary", URL: "http://prom:9090/api/v1/write", Username: "user1"},
+		},
+		LokiRemotes: []config.AlloyRemoteConfig{
+			{Name: "primary", URL: "http://loki:3100/loki/api/v1/push", Username: "user1"},
+		},
+	}
+
+	envVars := BuildHelmEnvVars(cfg)
+
+	// All env vars should reference the convention-based grafana-alloy-secrets
+	assert.Contains(t, envVars, "alloy.extraEnv[0].name=PROMETHEUS_PASSWORD_PRIMARY")
+	assert.Contains(t, envVars, "alloy.extraEnv[0].valueFrom.secretKeyRef.name="+SecretsName)
+	assert.Contains(t, envVars, "alloy.extraEnv[0].valueFrom.secretKeyRef.key=PROMETHEUS_PASSWORD_PRIMARY")
+	assert.Contains(t, envVars, "alloy.extraEnv[1].name=LOKI_PASSWORD_PRIMARY")
+	assert.Contains(t, envVars, "alloy.extraEnv[1].valueFrom.secretKeyRef.name="+SecretsName)
+	assert.Contains(t, envVars, "alloy.extraEnv[1].valueFrom.secretKeyRef.key=LOKI_PASSWORD_PRIMARY")
+}
+
+func TestBuildHelmEnvVars_MultipleRemotes(t *testing.T) {
+	cfg := config.AlloyConfig{
+		PrometheusRemotes: []config.AlloyRemoteConfig{
+			{Name: "primary", URL: "http://prom1:9090/api/v1/write", Username: "user1"},
+			{Name: "backup", URL: "http://prom2:9090/api/v1/write", Username: "user2"},
+		},
+	}
+
+	envVars := BuildHelmEnvVars(cfg)
+
+	// Both remotes reference the same conventional secret with derived keys
+	assert.Contains(t, envVars, "alloy.extraEnv[0].name=PROMETHEUS_PASSWORD_PRIMARY")
+	assert.Contains(t, envVars, "alloy.extraEnv[0].valueFrom.secretKeyRef.name="+SecretsName)
+	assert.Contains(t, envVars, "alloy.extraEnv[0].valueFrom.secretKeyRef.key=PROMETHEUS_PASSWORD_PRIMARY")
+	assert.Contains(t, envVars, "alloy.extraEnv[1].name=PROMETHEUS_PASSWORD_BACKUP")
+	assert.Contains(t, envVars, "alloy.extraEnv[1].valueFrom.secretKeyRef.name="+SecretsName)
+	assert.Contains(t, envVars, "alloy.extraEnv[1].valueFrom.secretKeyRef.key=PROMETHEUS_PASSWORD_BACKUP")
+}
+
+func TestRequiredSecrets(t *testing.T) {
+	cfg := config.AlloyConfig{
+		ClusterName: "test-cluster",
+		PrometheusRemotes: []config.AlloyRemoteConfig{
+			{Name: "primary", URL: "http://prom:9090/api/v1/write", Username: "user1"},
+		},
+		LokiRemotes: []config.AlloyRemoteConfig{
+			{Name: "primary", URL: "http://loki:3100/loki/api/v1/push", Username: "user1"},
+		},
+	}
+
+	cb, err := NewConfigBuilder(cfg)
 	require.NoError(t, err)
 
-	// Verify it's a valid secret manifest
-	assert.Contains(t, manifest, "apiVersion: v1")
-	assert.Contains(t, manifest, "kind: Secret")
-	assert.Contains(t, manifest, "name: "+SecretsName)
-	assert.Contains(t, manifest, "namespace: "+Namespace)
-	assert.Contains(t, manifest, "type: Opaque")
-	assert.Contains(t, manifest, "data: {}")
+	secrets := cb.RequiredSecrets()
+
+	// All keys should be under the single conventional secret
+	require.Contains(t, secrets, SecretsName)
+	assert.Contains(t, secrets[SecretsName], "PROMETHEUS_PASSWORD_PRIMARY")
+	assert.Contains(t, secrets[SecretsName], "LOKI_PASSWORD_PRIMARY")
+	assert.Len(t, secrets, 1, "should only reference one secret")
+}
+
+func TestRequiredSecrets_NoRemotes(t *testing.T) {
+	cfg := config.AlloyConfig{
+		ClusterName: "test-cluster",
+	}
+
+	cb, err := NewConfigBuilder(cfg)
+	require.NoError(t, err)
+
+	secrets := cb.RequiredSecrets()
+	assert.Nil(t, secrets, "should return nil when no remotes configured")
+}
+
+func TestRequiredSecrets_MultipleRemotes(t *testing.T) {
+	cfg := config.AlloyConfig{
+		ClusterName: "test-cluster",
+		PrometheusRemotes: []config.AlloyRemoteConfig{
+			{Name: "primary", URL: "http://prom1:9090/api/v1/write", Username: "user1"},
+			{Name: "backup", URL: "http://prom2:9090/api/v1/write", Username: "user2"},
+		},
+		LokiRemotes: []config.AlloyRemoteConfig{
+			{Name: "primary", URL: "http://loki:3100/loki/api/v1/push", Username: "user1"},
+		},
+	}
+
+	cb, err := NewConfigBuilder(cfg)
+	require.NoError(t, err)
+
+	secrets := cb.RequiredSecrets()
+
+	require.Contains(t, secrets, SecretsName)
+	assert.Len(t, secrets[SecretsName], 3)
+	assert.Contains(t, secrets[SecretsName], "PROMETHEUS_PASSWORD_PRIMARY")
+	assert.Contains(t, secrets[SecretsName], "PROMETHEUS_PASSWORD_BACKUP")
+	assert.Contains(t, secrets[SecretsName], "LOKI_PASSWORD_PRIMARY")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,6 +126,9 @@ type BlockNodeConfig struct {
 }
 
 // AlloyRemoteConfig represents a single remote endpoint for metrics or logs.
+// Passwords are expected in K8s Secret "grafana-alloy-secrets" under conventional keys:
+//   - Prometheus: PROMETHEUS_PASSWORD_<NAME>
+//   - Loki: LOKI_PASSWORD_<NAME>
 type AlloyRemoteConfig struct {
 	Name     string `yaml:"name" json:"name"`         // Unique identifier for this remote
 	URL      string `yaml:"url" json:"url"`           // Remote write URL

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -463,6 +463,31 @@ func (c *Client) GetResourceNestedString(ctx context.Context, apiVersion, kind, 
 	return value, nil
 }
 
+// GetSecretKeys returns the keys present in a Kubernetes Secret's data field.
+// Returns nil and no error if the secret does not exist.
+func (c *Client) GetSecretKeys(ctx context.Context, namespace, name string) ([]string, error) {
+	dr := c.Dyn.Resource(schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "secrets",
+	}).Namespace(namespace)
+
+	obj, err := dr.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, errorx.InternalError.Wrap(err, "failed to get Secret %s/%s", namespace, name)
+	}
+
+	data, _, _ := unstructured.NestedMap(obj.Object, "data")
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
 // =====================
 // Generic WaitFor
 // =====================

--- a/internal/testutil/helper.go
+++ b/internal/testutil/helper.go
@@ -23,9 +23,12 @@ var bindMountTargets = []string{
 }
 
 // PrepareSubCmdForTest creates a root command with the given subcommand added.
+// It registers persistent flags that the real root command provides (e.g. skip-hardware-checks)
+// so that subcommands can read them during tests.
 // Use this from tests in other packages to avoid duplicating the helper.
 func PrepareSubCmdForTest(sub *cobra.Command) *cobra.Command {
 	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().Bool("skip-hardware-checks", false, "Skip hardware validation checks")
 	root.AddCommand(sub)
 	return root
 }

--- a/internal/workflows/steps/step_alloy.go
+++ b/internal/workflows/steps/step_alloy.go
@@ -24,23 +24,24 @@ import (
 )
 
 const (
-	SetupAlloyStepId           = "setup-alloy"
-	PreCheckAlloyStepId        = "precheck-alloy"
-	InstallAlloyStepId         = "install-alloy"
-	InstallNodeExporterStepId  = "install-node-exporter"
-	DeployAlloyConfigStepId    = "deploy-alloy-config"
-	CreateAlloyNamespaceStepId = "create-alloy-namespace"
-	CreateAlloySecretsStepId   = "create-alloy-secrets"
-	IsAlloyReadyStepId         = "is-alloy-ready"
-	IsNodeExporterReadyStepId  = "is-node-exporter-ready"
+	SetupAlloyStepId                = "setup-alloy"
+	PreCheckAlloyStepId             = "precheck-alloy"
+	InstallAlloyStepId              = "install-alloy"
+	InstallNodeExporterStepId       = "install-node-exporter"
+	DeployAlloyConfigStepId         = "deploy-alloy-config"
+	DeployBlockNodeMonitoringStepId = "deploy-block-node-monitoring"
+	CreateAlloyNamespaceStepId      = "create-alloy-namespace"
+	IsAlloyReadyStepId              = "is-alloy-ready"
+	IsNodeExporterReadyStepId       = "is-node-exporter-ready"
 )
 
 // SetupAlloyStack returns a workflow builder that sets up the complete Alloy observability stack.
 // This includes Prometheus Operator CRDs and Grafana Alloy.
+// K8s secrets containing passwords for remote endpoints must be pre-created before running this.
+// Secrets can be created manually, via ESO/Vault, Terraform, or any other mechanism.
 func SetupAlloyStack() *automa.WorkflowBuilder {
 	return automa.NewWorkflowBuilder().WithId("setup-alloy-stack").Steps(
-		preCheckAlloy(),               // Verify prerequisites (ClusterSecretStore, remote endpoints)
-		SetupExternalSecrets(),        // External Secrets Operator (general-purpose secret management for the cluster)
+		preCheckAlloy(),               // Verify prerequisites (K8s secrets, remote endpoints)
 		SetupPrometheusOperatorCRDs(), // Install CRDs for ServiceMonitor/PodMonitor
 		SetupAlloy(),                  // Install Alloy with Node Exporter
 	).
@@ -77,8 +78,7 @@ func TeardownAlloyStack() *automa.WorkflowBuilder {
 }
 
 // preCheckAlloy verifies that all prerequisites are in place before installing Alloy.
-// This includes checking for ClusterSecretStore existence and verifying
-// remote endpoint reachability.
+// This includes verifying that required K8s secrets exist and that remote endpoints are reachable.
 func preCheckAlloy() automa.Builder {
 	return automa.NewStepBuilder().WithId(PreCheckAlloyStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
@@ -87,48 +87,57 @@ func preCheckAlloy() automa.Builder {
 
 			meta := map[string]string{}
 
-			// Get the ClusterSecretStore name (from config or default)
-			clusterSecretStoreName := cfg.ClusterSecretStoreName
-			if clusterSecretStoreName == "" {
-				clusterSecretStoreName = alloy.ClusterSecretStoreName
-			}
-
-			// Check if any remotes are configured (require ClusterSecretStore only if remotes exist)
+			// Check if any remotes are configured
 			hasRemotes := len(cfg.PrometheusRemotes) > 0 || len(cfg.LokiRemotes) > 0 ||
 				cfg.PrometheusURL != "" || cfg.LokiURL != ""
 
-			k, err := kube.NewClient()
-			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(
-					fmt.Errorf("failed to create kubernetes client: %w", err)))
-			}
-
 			if hasRemotes {
-				// Verify ClusterSecretStore exists which is required to fetch credentials for remotes
-				exists, err := k.ResourceExists(ctx, "external-secrets.io/v1beta1", "ClusterSecretStore", "", clusterSecretStoreName)
+				k, err := kube.NewClient()
 				if err != nil {
 					return automa.StepFailureReport(stp.Id(), automa.WithError(
-						fmt.Errorf("failed to check ClusterSecretStore existence: %w", err)))
-				} else if !exists {
-					return automa.StepFailureReport(stp.Id(), automa.WithError(
-						fmt.Errorf("ClusterSecretStore %q not found; please create it first (e.g., run 'task vault:setup-secret-store') or specify a different name with --cluster-secret-store", clusterSecretStoreName)))
-				} else {
-					l.Info().Str("name", clusterSecretStoreName).Msg("ClusterSecretStore found")
-					meta["clusterSecretStore"] = clusterSecretStoreName
+						fmt.Errorf("failed to create kubernetes client: %w", err)))
+				}
 
-					// Check if Vault URL from ClusterSecretStore is reachable
-					vaultURL, err := k.GetResourceNestedString(ctx, "external-secrets.io/v1beta1", "ClusterSecretStore", "", clusterSecretStoreName,
-						"spec", "provider", "vault", "server")
+				// Build config to determine required secrets
+				cb, err := alloy.NewConfigBuilder(cfg)
+				if err != nil {
+					return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+				}
+
+				// Verify that required K8s secrets exist with expected keys
+				requiredSecrets := cb.RequiredSecrets()
+				for secretName, expectedKeys := range requiredSecrets {
+					actualKeys, err := k.GetSecretKeys(ctx, alloy.Namespace, secretName)
 					if err != nil {
-						l.Warn().Err(err).Msg("Failed to get Vault URL from ClusterSecretStore")
-					} else if vaultURL != "" {
-						if err := network.CheckEndpointReachable(ctx, vaultURL, 10*time.Second); err != nil {
-							return automa.StepFailureReport(stp.Id(), automa.WithError(
-								fmt.Errorf("Vault at %s is not reachable: %w", vaultURL, err)))
-						}
-						l.Info().Str("url", vaultURL).Msg("Vault endpoint is reachable")
-						meta["vaultURL"] = vaultURL
+						return automa.StepFailureReport(stp.Id(), automa.WithError(
+							fmt.Errorf("failed to read K8s Secret %q in namespace %q: %w", secretName, alloy.Namespace, err)))
 					}
+					if actualKeys == nil {
+						return automa.StepFailureReport(stp.Id(), automa.WithError(
+							fmt.Errorf("K8s Secret %q not found in namespace %q; expected keys: %v. "+
+								"Create the secret before installing Alloy, e.g.: "+
+								"kubectl create secret generic %s --namespace=%s --from-literal=<KEY>=<password>",
+								secretName, alloy.Namespace, expectedKeys, secretName, alloy.Namespace)))
+					}
+
+					// Check that all expected keys are present in the secret
+					actualKeySet := make(map[string]struct{}, len(actualKeys))
+					for _, k := range actualKeys {
+						actualKeySet[k] = struct{}{}
+					}
+					var missingKeys []string
+					for _, key := range expectedKeys {
+						if _, ok := actualKeySet[key]; !ok {
+							missingKeys = append(missingKeys, key)
+						}
+					}
+					if len(missingKeys) > 0 {
+						return automa.StepFailureReport(stp.Id(), automa.WithError(
+							fmt.Errorf("K8s Secret %q in namespace %q is missing required keys: %v; found keys: %v",
+								secretName, alloy.Namespace, missingKeys, actualKeys)))
+					}
+
+					l.Info().Str("name", secretName).Str("namespace", alloy.Namespace).Strs("expectedKeys", expectedKeys).Msg("Required K8s Secret found")
 				}
 
 				// Check Prometheus remote endpoints reachability
@@ -165,7 +174,7 @@ func preCheckAlloy() automa.Builder {
 					l.Info().Str("url", cfg.LokiURL).Msg("Loki remote is reachable")
 				}
 			} else {
-				l.Info().Msg("No remotes configured; skipping ClusterSecretStore and endpoint checks")
+				l.Info().Msg("No remotes configured; skipping secret and endpoint checks")
 			}
 
 			// Log summary of what will be installed
@@ -195,9 +204,9 @@ func SetupAlloy() *automa.WorkflowBuilder {
 		createAlloyNamespace(),
 		installNodeExporter(),
 		isNodeExporterPodsReady(),
-		createAlloyExternalSecret(),
 		deployAlloyConfig(),
 		installAlloy(),
+		deployBlockNodeMonitoring(),
 		isAlloyPodsReady(),
 	).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
@@ -373,97 +382,6 @@ func createAlloyNamespace() automa.Builder {
 		})
 }
 
-func createAlloyExternalSecret() automa.Builder {
-	return automa.NewStepBuilder().WithId(CreateAlloySecretsStepId).
-		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
-			cfg := config.Get().Alloy
-
-			k, err := kube.NewClient()
-			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-			}
-
-			// Check if remotes are configured
-			hasRemotes := len(cfg.PrometheusRemotes) > 0 || len(cfg.LokiRemotes) > 0 ||
-				cfg.PrometheusURL != "" || cfg.LokiURL != ""
-
-			meta := map[string]string{}
-			var manifestPath string
-			var manifest string
-
-			if hasRemotes {
-				// Create ExternalSecret to fetch passwords from Vault
-				manifestPath = path.Join(core.Paths().TempDir, "alloy-external-secret.yaml")
-
-				// Build config to get cluster name
-				cb, err := alloy.NewConfigBuilder(cfg)
-				if err != nil {
-					return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-				}
-				clusterName := cb.ClusterName()
-
-				// Generate the ExternalSecret manifest using the alloy package
-				manifest, err = alloy.ExternalSecretManifest(cfg, clusterName)
-				if err != nil {
-					return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-				}
-			} else {
-				// Create an empty secret so the pod doesn't fail looking for it
-				manifestPath = path.Join(core.Paths().TempDir, "alloy-empty-secret.yaml")
-				manifest, err = alloy.EmptySecretManifest()
-				if err != nil {
-					return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-				}
-			}
-
-			err = os.WriteFile(manifestPath, []byte(manifest), 0600)
-			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-			}
-
-			err = k.ApplyManifest(ctx, manifestPath)
-			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-			}
-
-			meta[InstalledByThisStep] = "true"
-			stp.State().Set(InstalledByThisStep, true)
-			stp.State().Set("secretManifestPath", manifestPath)
-
-			return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
-		}).
-		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
-			if stp.State().Bool(InstalledByThisStep) == false {
-				return automa.StepSkippedReport(stp.Id())
-			}
-
-			k, err := kube.NewClient()
-			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-			}
-
-			manifestPath := stp.State().String("secretManifestPath")
-			if manifestPath != "" {
-				err = k.DeleteManifest(ctx, manifestPath)
-				if err != nil {
-					return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-				}
-			}
-
-			return automa.StepSuccessReport(stp.Id())
-		}).
-		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
-			notify.As().StepStart(ctx, stp, "Creating Alloy secrets")
-			return ctx, nil
-		}).
-		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepFailure(ctx, stp, rpt, "Failed to create Alloy secrets")
-		}).
-		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepCompletion(ctx, stp, rpt, "Alloy secrets created successfully")
-		})
-}
-
 func installAlloy() automa.Builder {
 	return automa.NewStepBuilder().WithId(InstallAlloyStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
@@ -631,54 +549,6 @@ func deployAlloyConfig() automa.Builder {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			// If monitoring block-node, deploy the ServiceMonitor and PodLogs for discovery
-			if cb.MonitorBlockNode() {
-				// Discover block node namespace from Helm
-				blockNodeNamespace, err := state.GetBlockNodeNamespace()
-				if err != nil {
-					return automa.StepFailureReport(stp.Id(), automa.WithError(fmt.Errorf("failed to discover block node namespace: %w", err)))
-				}
-				if blockNodeNamespace == "" {
-					l.Warn().Msg("Block node monitoring enabled but block node not found; skipping ServiceMonitor and PodLogs deployment")
-				} else {
-					// Deploy ServiceMonitor for metrics discovery
-					serviceMonitorManifest, err := alloy.BlockNodeServiceMonitorManifest(blockNodeNamespace)
-					if err != nil {
-						return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-					}
-					serviceMonitorPath := path.Join(core.Paths().TempDir, "block-node-servicemonitor.yaml")
-					err = os.WriteFile(serviceMonitorPath, []byte(serviceMonitorManifest), core.DefaultFilePerm)
-					if err != nil {
-						return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-					}
-
-					err = k.ApplyManifest(ctx, serviceMonitorPath)
-					if err != nil {
-						return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-					}
-					stp.State().Set("serviceMonitorPath", serviceMonitorPath)
-
-					// Deploy PodLogs for logs discovery
-					podLogsManifest, err := alloy.BlockNodePodLogsManifest(blockNodeNamespace)
-					if err != nil {
-						return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-					}
-					podLogsPath := path.Join(core.Paths().TempDir, "block-node-podlogs.yaml")
-					err = os.WriteFile(podLogsPath, []byte(podLogsManifest), core.DefaultFilePerm)
-					if err != nil {
-						return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-					}
-
-					err = k.ApplyManifest(ctx, podLogsPath)
-					if err != nil {
-						return automa.StepFailureReport(stp.Id(), automa.WithError(err))
-					}
-					stp.State().Set("podLogsPath", podLogsPath)
-
-					l.Info().Str("namespace", blockNodeNamespace).Msg("Block Node ServiceMonitor and PodLogs deployed for metrics/logs discovery")
-				}
-			}
-
 			meta[InstalledByThisStep] = "true"
 			meta["modules"] = strings.Join(moduleNames, ",")
 			stp.State().Set(InstalledByThisStep, true)
@@ -704,6 +574,106 @@ func deployAlloyConfig() automa.Builder {
 				}
 			}
 
+			return automa.StepSuccessReport(stp.Id())
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Deploying Alloy configuration")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to deploy Alloy configuration")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Alloy configuration deployed successfully")
+		})
+}
+
+// deployBlockNodeMonitoring deploys the ServiceMonitor and PodLogs resources for block-node monitoring.
+// This step must run AFTER installAlloy() because the PodLogs CRD (monitoring.grafana.com/v1alpha2)
+// is registered by the Alloy Helm chart. If it ran before, the PodLogs resource would fail to apply
+// because the CRD would not exist yet.
+func deployBlockNodeMonitoring() automa.Builder {
+	return automa.NewStepBuilder().WithId(DeployBlockNodeMonitoringStepId).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			cfg := config.Get().Alloy
+			l := logx.As()
+			meta := map[string]string{}
+
+			cb, err := alloy.NewConfigBuilder(cfg)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			if !cb.MonitorBlockNode() {
+				l.Info().Msg("Block node monitoring not enabled; skipping ServiceMonitor and PodLogs deployment")
+				return automa.StepSkippedReport(stp.Id())
+			}
+
+			k, err := kube.NewClient()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			// Discover block node namespace from Helm
+			blockNodeNamespace, err := state.GetBlockNodeNamespace()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(fmt.Errorf("failed to discover block node namespace: %w", err)))
+			}
+			if blockNodeNamespace == "" {
+				l.Warn().Msg("Block node monitoring enabled but block node not found; skipping ServiceMonitor and PodLogs deployment")
+				return automa.StepSkippedReport(stp.Id())
+			}
+
+			// Deploy ServiceMonitor for metrics discovery
+			serviceMonitorManifest, err := alloy.BlockNodeServiceMonitorManifest(blockNodeNamespace)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+			serviceMonitorPath := path.Join(core.Paths().TempDir, "block-node-servicemonitor.yaml")
+			err = os.WriteFile(serviceMonitorPath, []byte(serviceMonitorManifest), core.DefaultFilePerm)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			err = k.ApplyManifest(ctx, serviceMonitorPath)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+			stp.State().Set("serviceMonitorPath", serviceMonitorPath)
+
+			// Deploy PodLogs for logs discovery
+			podLogsManifest, err := alloy.BlockNodePodLogsManifest(blockNodeNamespace)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+			podLogsPath := path.Join(core.Paths().TempDir, "block-node-podlogs.yaml")
+			err = os.WriteFile(podLogsPath, []byte(podLogsManifest), core.DefaultFilePerm)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			err = k.ApplyManifest(ctx, podLogsPath)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+			stp.State().Set("podLogsPath", podLogsPath)
+
+			l.Info().Str("namespace", blockNodeNamespace).Msg("Block Node ServiceMonitor and PodLogs deployed for metrics/logs discovery")
+
+			meta[InstalledByThisStep] = "true"
+			stp.State().Set(InstalledByThisStep, true)
+			return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if stp.State().Bool(InstalledByThisStep) == false {
+				return automa.StepSkippedReport(stp.Id())
+			}
+
+			k, err := kube.NewClient()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
 			// Clean up ServiceMonitor if it was deployed
 			serviceMonitorPath := stp.State().String("serviceMonitorPath")
 			if serviceMonitorPath != "" {
@@ -719,14 +689,14 @@ func deployAlloyConfig() automa.Builder {
 			return automa.StepSuccessReport(stp.Id())
 		}).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
-			notify.As().StepStart(ctx, stp, "Deploying Alloy configuration")
+			notify.As().StepStart(ctx, stp, "Deploying Block Node monitoring resources")
 			return ctx, nil
 		}).
 		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepFailure(ctx, stp, rpt, "Failed to deploy Alloy configuration")
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to deploy Block Node monitoring resources")
 		}).
 		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepCompletion(ctx, stp, rpt, "Alloy configuration deployed successfully")
+			notify.As().StepCompletion(ctx, stp, rpt, "Block Node monitoring resources deployed successfully")
 		})
 }
 

--- a/test/alloy/README.md
+++ b/test/alloy/README.md
@@ -1,29 +1,37 @@
-# Alloy Stack - Grafana Alloy with Vault
+# Alloy Stack - Grafana Alloy Observability
 
-Complete Alloy observability stack for Solo Provisioner with Vault-managed secrets.
+Complete Alloy observability stack for Solo Provisioner.
 
 **Components:**
 - Grafana Alloy - Metrics and log collection
-- HashiCorp Vault - Secret management
-- External Secrets Operator - Secret synchronization
 - Prometheus - Metrics storage
 - Loki - Log aggregation
 - Grafana - Visualization
 
+**Optional (for production secret management):**
+- HashiCorp Vault - Secret management
+- External Secrets Operator - Secret synchronization from Vault/AWS/GCP
+
 ## 🎯 Architecture Overview
 
-**All secrets are managed by Vault via External Secrets Operator** - no plain Kubernetes secrets!
+Alloy expects passwords in a K8s Secret named `grafana-alloy-secrets` in the `grafana-alloy` namespace.
+How that secret gets created is up to you — manually, via ESO/Vault, Terraform, or any other mechanism.
 
 ```
-Local Dev:                          Production:
-Docker Vault (dev mode)             Enterprise Vault cluster
+Manual (local dev):                 ESO + Vault (production):
+kubectl create secret               Vault/AWS/GCP
      ↓                                   ↓
-External Secrets Operator  ←→  External Secrets Operator
-     ↓                                   ↓
-K8s Secret (auto-synced)       K8s Secret (auto-synced)
-     ↓                                   ↓
-Alloy Pod (metrics/logs)       Alloy Pod (metrics/logs)
+K8s Secret                     External Secrets Operator
+  "grafana-alloy-secrets"              ↓
+     ↓                         K8s Secret (auto-synced)
+Alloy Pod (metrics/logs)          "grafana-alloy-secrets"
+                                       ↓
+                                Alloy Pod (metrics/logs)
 ```
+
+**Key naming convention:**
+- `PROMETHEUS_PASSWORD_<REMOTE_NAME>` — password for each `--add-prometheus-remote name=<remote_name>`
+- `LOKI_PASSWORD_<REMOTE_NAME>` — password for each `--add-loki-remote name=<remote_name>`
 
 ---
 
@@ -36,14 +44,14 @@ From your Mac, ensure you have the latest build:
 task build
 ```
 
-### Step 1: Start Alloy Stack
+### Step 1: Start Observability Stack
 
 Start and SSH into a fresh VM:
 ```bash
 task vm:ssh
 ```
 
-Then, from within the VM, start the Alloy stack:
+Then, from within the VM, start the observability stack (Prometheus, Loki, Grafana):
 ```bash
 task alloy:start
 ```
@@ -64,32 +72,35 @@ sudo solo-provisioner block node install \
   --config=/mnt/solo-weaver/test/config/config.yaml
 ```
 
-### Step 3: Install Alloy (Minimal)
+### Step 3: Create K8s Secret
 
-Install Alloy without remote endpoints. This installs External Secrets Operator and the basic Alloy stack without requiring secrets from Vault:
+Create the K8s secret containing passwords for the remote endpoints.
 
+**Option A: Using the task (recommended for local dev):**
 ```bash
-sudo solo-provisioner alloy cluster install \
-  --cluster-name=vm-cluster
+task alloy:create-secret
 ```
 
-> **Note:** Without `--add-prometheus-remote` or `--add-loki-remote` flags, Alloy installs in "local-only" mode. No secrets are required.
+This creates secret `grafana-alloy-secrets` in namespace `grafana-alloy` with keys
+`PROMETHEUS_PASSWORD_LOCAL` and `LOKI_PASSWORD_LOCAL` set to `dev-password`.
 
-### Step 4: Configure Vault Connection
-
-Now that ESO is installed, configure the ClusterSecretStore to connect to Vault:
-
+**Option B: Using kubectl directly:**
 ```bash
-task vault:setup-secret-store
+kubectl create namespace grafana-alloy --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic grafana-alloy-secrets \
+  --namespace=grafana-alloy \
+  --from-literal=PROMETHEUS_PASSWORD_LOCAL=dev-password \
+  --from-literal=LOKI_PASSWORD_LOCAL=dev-password \
+  --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-This will auto-detect the node IP and configure the ClusterSecretStore.
+> **Convention:** The key names follow the pattern `{PROMETHEUS|LOKI}_PASSWORD_{REMOTE_NAME}`,
+> where `REMOTE_NAME` matches the `name=` value in the `--add-*-remote` flags (uppercased, dashes replaced with underscores).
 
-### Step 5: Upgrade Alloy with Remotes
+### Step 4: Install Alloy with Remotes
 
-Now that secrets can sync, upgrade Alloy with remote endpoints:
 ```bash
-# Get the node IP for remote endpoints
 NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
 echo "Node IP: $NODE_IP"
 
@@ -100,7 +111,7 @@ sudo solo-provisioner alloy cluster install \
   --monitor-block-node
 ```
 
-> **Note:** The `--add-*-remote` flags use the format `name=<name>,url=<url>,username=<username>`. The password is fetched from Vault at path `grafana/alloy/{clusterName}/{prometheus|loki}/{remoteName}`.
+> **Note:** The remote name `local` maps to secret keys `PROMETHEUS_PASSWORD_LOCAL` and `LOKI_PASSWORD_LOCAL`.
 
 Wait for pods to be ready:
 ```bash
@@ -108,7 +119,12 @@ kubectl get pods -n grafana-alloy
 # Should show Running
 ```
 
-### Step 6: Access Grafana and Vault UI
+> **Tip:** To install Alloy without remote endpoints (no secrets needed):
+> ```bash
+> sudo solo-provisioner alloy cluster install --cluster-name=vm-cluster
+> ```
+
+### Step 5: Access Grafana
 
 From your Mac, forward the ports:
 ```bash
@@ -117,9 +133,10 @@ task vm:alloy-forward
 
 This forwards:
 - **Grafana:** http://localhost:3000 (anonymous auth enabled - no login required)
-- **Vault UI:** http://localhost:8200 (token: `devtoken`)
+- **Prometheus:** http://localhost:9090
+- **Loki:** http://localhost:3100
 
-### Step 7: Verify in Grafana
+### Step 6: Verify in Grafana
 
 Navigate to **Explore** and test these queries organized by module:
 
@@ -282,9 +299,25 @@ sudo solo-provisioner alloy cluster install \
   --monitor-block-node
 ```
 
-Each remote requires a corresponding Vault secret at:
-- `grafana/alloy/{clusterName}/prometheus/{remoteName}` → property: `password`
-- `grafana/alloy/{clusterName}/loki/{remoteName}` → property: `password`
+Each remote requires a corresponding key in K8s Secret `grafana-alloy-secrets`:
+
+| Remote flag | Expected secret key |
+|---|---|
+| `--add-prometheus-remote=name=primary,...` | `PROMETHEUS_PASSWORD_PRIMARY` |
+| `--add-prometheus-remote=name=backup,...` | `PROMETHEUS_PASSWORD_BACKUP` |
+| `--add-loki-remote=name=primary,...` | `LOKI_PASSWORD_PRIMARY` |
+| `--add-loki-remote=name=grafana-cloud,...` | `LOKI_PASSWORD_GRAFANA_CLOUD` |
+
+Create the secret with all required keys:
+```bash
+kubectl create secret generic grafana-alloy-secrets \
+  --namespace=grafana-alloy \
+  --from-literal=PROMETHEUS_PASSWORD_PRIMARY=pass1 \
+  --from-literal=PROMETHEUS_PASSWORD_BACKUP=pass2 \
+  --from-literal=LOKI_PASSWORD_PRIMARY=pass3 \
+  --from-literal=LOKI_PASSWORD_GRAFANA_CLOUD=pass4 \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
 
 ### Managing Remote Endpoints
 
@@ -318,7 +351,7 @@ sudo solo-provisioner alloy cluster install \
   --add-loki-remote=name=primary,url=http://loki1:3100/loki/api/v1/push,username=user1
 ```
 
-**Remove all remotes (local-only mode):**
+**Remove all remotes (install without remotes):**
 ```bash
 sudo solo-provisioner alloy cluster install \
   --cluster-name=vm-cluster
@@ -343,7 +376,7 @@ internal/templates/files/alloy/
 ├── block-node-servicemonitor.yaml  # ServiceMonitor for Block Node metrics
 ├── block-node-podlogs.yaml      # PodLogs for Block Node logs
 ├── configmap.yaml               # ConfigMap manifest template
-└── external-secret.yaml         # ExternalSecret manifest template
+└── namespace.yaml               # Namespace manifest template
 
 grafana-alloy-cm ConfigMap:
 └── config.alloy         # Concatenated modules (used by Alloy)
@@ -366,8 +399,19 @@ To view the current ConfigMap contents:
 kubectl get configmap grafana-alloy-cm -n grafana-alloy -o yaml
 ```
 
-### Manage Vault Separately
+### Vault + ESO (Optional)
 
+For production or when you want secrets synced automatically from Vault:
+
+```bash
+# Start the full stack including Vault
+task alloy:start-with-vault
+
+# Configure ClusterSecretStore (from within the VM)
+task vault:setup-secret-store
+```
+
+Manage Vault separately:
 ```bash
 task vault:start   # Start Vault only
 task vault:stop    # Stop Vault
@@ -403,28 +447,21 @@ You can also access the Vault UI at http://localhost:8200 (token: `devtoken`) af
 
 ### Production Setup
 
-For production, configure ClusterSecretStore to point to your enterprise Vault:
+In production, the K8s Secret `grafana-alloy-secrets` can be created by any mechanism:
 
-```yaml
-apiVersion: external-secrets.io/v1
-kind: ClusterSecretStore
-metadata:
-  name: vault-secret-store
-spec:
-  provider:
-    vault:
-      server: "https://vault.example.com"
-      path: "secret"
-      version: v2
-      auth:
-        userPass:
-          path: userpass
-          username: "production-eso-user"
-          secretRef:
-            name: vault-credentials
-            namespace: kube-system
-            key: password
-```
+**Option 1: ESO + Vault** — Use `solo-provisioner eso` commands to install ESO and create
+ExternalSecret resources that sync passwords from Vault into the K8s Secret automatically.
+
+**Option 2: ESO + Cloud Provider** — Use ESO with AWS Secrets Manager, GCP Secret Manager,
+or Azure Key Vault as the backend.
+
+**Option 3: Terraform / CI pipeline** — Create the K8s Secret as part of your infrastructure
+provisioning.
+
+**Option 4: Manual** — Create the secret with `kubectl` as shown in the Quick Start.
+
+The only requirement is that the K8s Secret named `grafana-alloy-secrets` exists in namespace
+`grafana-alloy` with the expected keys before running `alloy cluster install`.
 
 ---
 
@@ -432,10 +469,27 @@ spec:
 
 | File | Purpose |
 |------|---------|
-| `docker-compose.yml` | Container definitions |
-| `init-vault.sh` | Initialize Vault with dev secrets |
-| `cluster-secret-store-local.yaml` | ESO → Vault connection template |
-| `config_with_alloy.yaml` | Solo Provisioner config with Alloy enabled |
+| `docker-compose.yml` | Container definitions (Prometheus, Loki, Grafana, Vault) |
+| `init-vault.sh` | Initialize Vault with dev secrets (used by `task vault:start`) |
+| `cluster-secret-store-local.yaml` | ESO → Vault connection template (advanced, optional) |
 | `prometheus.yml` | Prometheus configuration |
 | `loki-config.yml` | Loki configuration |
 | `grafana-datasources.yml` | Grafana datasources |
+
+## 🛠️ Task Reference
+
+| Task | Description |
+|------|-------------|
+| `task alloy:start` | Start Prometheus, Loki, Grafana |
+| `task alloy:start-with-vault` | Start full stack including Vault |
+| `task alloy:stop` | Stop all containers |
+| `task alloy:clean` | Stop and remove all data |
+| `task alloy:create-secret` | Create `grafana-alloy-secrets` K8s Secret with dev passwords |
+| `task alloy:delete-secret` | Delete the K8s Secret |
+| `task alloy:status` | Show container status |
+| `task alloy:logs` | Tail container logs |
+| `task vault:start` | Start Vault only |
+| `task vault:stop` | Stop Vault |
+| `task vault:clean` | Remove Vault data |
+| `task vault:setup-secret-store` | Configure ESO ClusterSecretStore → Vault |
+


### PR DESCRIPTION
## Description

This pull request refactors the Alloy stack setup and installation process to simplify secret management by removing the dependency on Vault and the External Secrets Operator (ESO) for remote endpoint passwords. Instead, all remote credentials are now expected to be provided directly via a Kubernetes Secret named `grafana-alloy-secrets` in the `grafana-alloy` namespace. The documentation, CLI flags, and automation tasks have been updated to reflect this change, making local development and deployment more straightforward.

**Secret management simplification:**

* Removed all code, templates, and documentation related to Vault, ClusterSecretStore, and External Secrets Operator for Alloy remote passwords. All passwords are now expected in a K8s Secret (`grafana-alloy-secrets`) with keys following the convention `PROMETHEUS_PASSWORD_<REMOTE_NAME>` and `LOKI_PASSWORD_<REMOTE_NAME>`. [[1]](diffhunk://#diff-9dae149ed1071d4ebde8e7ce54ab44224b690121f3f5485043b40211f8b8bc39L24-L25) [[2]](diffhunk://#diff-ded2f07e8454642a490eacbc8617f413605b90488f4a5abefaa0afb751510218L55-L87) [[3]](diffhunk://#diff-6356027bb2bc8dac1a9a47cbe98437faa96f6d741e7ad968059ce4ea4bbbbb99L148-R150) [[4]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL339-R342) [[5]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL374-R401)
* Updated the Alloy CLI flags and help text to remove or hide Vault/ESO-related options, and to clarify that passwords are sourced from the K8s Secret. [[1]](diffhunk://#diff-6b099a7e5c14bbfa8b26f745f3274c3d414b3e952500eda07cb565ec8be7b5c0L38-R49) [[2]](diffhunk://#diff-5a20d9db5f10db0fb0ae5da2d0b7733004a2f2fedfb0d50200cd0870855c33ccR22-R46)

**Developer workflow and automation improvements:**

* Added new Taskfile tasks: `alloy:create-secret` (to create the required K8s secret for local dev) and `alloy:delete-secret` (to clean up the secret). Updated startup tasks to guide users through secret creation and removed Vault as a default dependency. [[1]](diffhunk://#diff-1552e0a6f970b2191f0e8ef34ac62e41815fc6cdbc213921e915a042e500f03aL1378-R1406) [[2]](diffhunk://#diff-1552e0a6f970b2191f0e8ef34ac62e41815fc6cdbc213921e915a042e500f03aL1400-R1417) [[3]](diffhunk://#diff-1552e0a6f970b2191f0e8ef34ac62e41815fc6cdbc213921e915a042e500f03aR1460-R1504) [[4]](diffhunk://#diff-1552e0a6f970b2191f0e8ef34ac62e41815fc6cdbc213921e915a042e500f03aL1538-R1602)

**Documentation updates:**

* Revised `docs/quickstart.md` to document the new secret management approach, including step-by-step instructions and updated prerequisites. All references to Vault, ESO, and ClusterSecretStore have been removed or replaced. [[1]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL233) [[2]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL339-R342) [[3]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL374-R401) [[4]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL435-R436)

**Code cleanup and refactoring:**

* Removed all code and templates related to generating ESO/ExternalSecret manifests and Vault secret path logic from the Alloy backend. [[1]](diffhunk://#diff-ded2f07e8454642a490eacbc8617f413605b90488f4a5abefaa0afb751510218L55-L87) [[2]](diffhunk://#diff-ded2f07e8454642a490eacbc8617f413605b90488f4a5abefaa0afb751510218L164-L180) [[3]](diffhunk://#diff-9dae149ed1071d4ebde8e7ce54ab44224b690121f3f5485043b40211f8b8bc39L43-L45) [[4]](diffhunk://#diff-6356027bb2bc8dac1a9a47cbe98437faa96f6d741e7ad968059ce4ea4bbbbb99L148-R150)
* Added a new `RequiredSecrets` method to the Alloy config builder to programmatically determine which secret keys must exist for the configured remotes.

These changes make the Alloy stack easier to set up and maintain, especially for local development and non-production environments, by relying solely on standard Kubernetes secrets for remote credentials.

### Related Issues

* Closes #376
