### PR TITLE
chore: fix semantic release workflow

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -126,8 +126,8 @@ jobs:
               echo "::notice::Dry-run mode - no release would be created"
             fi
           else
-            if [[ -f "internal/version/VERSION" ]]; then
-              echo "number=$(cat internal/version/VERSION | tr -d '[:space:]')" >> "${GITHUB_OUTPUT}"
+            if [[ -f "pkg/version/VERSION" ]]; then
+              echo "number=$(cat pkg/version/VERSION | tr -d '[:space:]')" >> "${GITHUB_OUTPUT}"
             else
               echo "::error::VERSION file not found after release"
               exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -355,8 +355,8 @@ dist/
 /bin/
 
 ### Application Version Info ###
-internal/version/COMMIT
-internal/version/VERSION
+pkg/version/COMMIT
+pkg/version/VERSION
 
 ### Generated Files ###
 **/mocks_generated.go
@@ -372,9 +372,4 @@ docs/playbooks/production/dir-structure.txt
 .ssh/
 integration-test-report.md
 integration-test.json
-
-pkg/version/VERSION
-pkg/version/COMMIT
 .aiassistant
-pkg/version/COMMIT
-pkg/version/VERSION


### PR DESCRIPTION
## Description

This pull request makes a minor update to the release artifact workflow by changing the location of the `VERSION` file used during deployment.

* Updated the workflow to read the `VERSION` file from `pkg/version/VERSION` instead of `internal/version/VERSION` in `.github/workflows/flow-deploy-release-artifact.yaml`.

### Related Issues

* Closes #
