### PR TITLE
feat: add support for alloy label profiles

### DIFF
--- a/cmd/weaver/commands/alloy/cluster/cluster.go
+++ b/cmd/weaver/commands/alloy/cluster/cluster.go
@@ -42,10 +42,12 @@ func init() {
 
 	// Multi-remote flags (repeatable)
 	clusterCmd.PersistentFlags().StringArrayVar(&flagPrometheusRemotes, "add-prometheus-remote", nil,
-		"Add a Prometheus remote (format: name=<name>,url=<url>,username=<username>). Can be specified multiple times. "+
+		"Add a Prometheus remote (format: name=<name>,url=<url>,username=<username>[,labelProfile=eng|ops]). Can be specified multiple times. "+
+			"Default labelProfile is 'eng' (cluster label only). "+
 			"Password is expected in K8s Secret 'grafana-alloy-secrets' under key 'PROMETHEUS_PASSWORD_<NAME>'")
 	clusterCmd.PersistentFlags().StringArrayVar(&flagLokiRemotes, "add-loki-remote", nil,
-		"Add a Loki remote (format: name=<name>,url=<url>,username=<username>). Can be specified multiple times. "+
+		"Add a Loki remote (format: name=<name>,url=<url>,username=<username>[,labelProfile=eng|ops]). Can be specified multiple times. "+
+			"Default labelProfile is 'eng' (cluster label only). "+
 			"Password is expected in K8s Secret 'grafana-alloy-secrets' under key 'LOKI_PASSWORD_<NAME>'")
 
 	// Legacy single-remote flags (kept for backward compatibility)

--- a/cmd/weaver/commands/alloy/cluster/parse_remote.go
+++ b/cmd/weaver/commands/alloy/cluster/parse_remote.go
@@ -44,8 +44,10 @@ func parseRemoteFlags(flags []string) ([]models.AlloyRemoteConfig, error) {
 				remote.URL = value
 			case "username":
 				remote.Username = value
+			case "labelprofile":
+				remote.LabelProfile = value
 			default:
-				return nil, fmt.Errorf("unknown key %q in %q, valid keys are: name, url, username", key, flag)
+				return nil, fmt.Errorf("unknown key %q in %q, valid keys are: name, url, username, labelProfile", key, flag)
 			}
 		}
 

--- a/docs/dev/label_profiles.md
+++ b/docs/dev/label_profiles.md
@@ -1,0 +1,87 @@
+# Adding a New Label Profile
+
+Label profiles control which labels are injected into Alloy metrics and logs.
+Each profile is a self-contained Go file implementing the `labels.Profiler` interface.
+
+The `cluster` label is managed by all profiles — every profile must include it.
+The default profile is `eng`, which includes only the `cluster` label.
+
+## Default Profile
+
+The `eng` profile is used by default when no `labelProfile` is specified on a remote.
+It produces only the `cluster` label (derived from `--cluster-name`).
+
+## Architecture
+
+| File / Package            | Role                                                              |
+|---------------------------|-------------------------------------------------------------------|
+| `internal/alloy/labels/profile.go` | `LabelInput` (runtime data bag), `Profiler` interface, shared registry, validation (`IsValid`, `ValidNames`), resolution (`Resolve`), `DefaultProfile` constant |
+| `internal/alloy/labels/render.go`  | Rendering (`RenderLabelRules`, `RenderStaticLabels`)              |
+| `internal/alloy/labels/eng.go`     | Eng profile (default) — cluster label only                        |
+| `internal/alloy/labels/ops.go`     | Ops profile implementation (template to copy) and shared helpers: `ParseClusterName`, `extractAlphaPrefix` |
+
+## Steps
+
+### 1. Create the profile file
+
+Copy `ops.go` to a new file, e.g. `sre.go`, inside `internal/alloy/labels/`:
+
+```go
+package labels
+
+// SreProfile adds labels used by the SRE team.
+type SreProfile struct{}
+
+func init() {
+    Register(SreProfile{})
+}
+
+func (SreProfile) Name() string { return "sre" }
+
+// Labels returns the complete label set for the sre profile.
+//
+// Labels added (from LabelInput):
+//   - cluster        = ClusterName (mandatory)
+//   - environment    = DeployProfile
+//   - instance_type  = alphabetic prefix of first cluster name segment (e.g. "lfh")
+//   - team           = "sre"
+func (SreProfile) Labels(input LabelInput) map[string]string {
+    labels := ParseClusterName(input.ClusterName)
+    if input.ClusterName != "" {
+        labels["cluster"] = input.ClusterName
+    }
+    if input.DeployProfile != "" {
+        labels["environment"] = input.DeployProfile
+    }
+    labels["team"] = "sre"
+    return labels
+}
+```
+
+Every profile **must** include the `cluster` label (derived from `ClusterName`).
+
+`ParseClusterName()` (in `ops.go`) extracts common base labels
+(`instance_type`) from the cluster name.
+Add `cluster` from `input.ClusterName`, `environment` from `input.DeployProfile`,
+and any profile-specific labels on top.
+If your profile needs completely custom labels, skip `ParseClusterName()`
+but still include `cluster`.
+
+Registration via `Register()` in `init()` is all that's needed —
+`pkg/models` validates against the shared registry automatically.
+
+### 2. Update CLI help text
+
+In `cmd/weaver/commands/alloy/cluster/cluster.go`, update the
+`--add-prometheus-remote` and `--add-loki-remote` flag descriptions:
+
+```
+labelProfile=eng|ops|sre
+```
+
+### 3. Add tests
+
+Create `sre_test.go` (or add to `ops_test.go`) verifying
+`SreProfile{}.Labels(LabelInput{ClusterName: "...", DeployProfile: "..."})` returns the expected label map.
+Add validation test cases in `pkg/models/validation_test.go`
+confirming the new profile is accepted.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -371,8 +371,8 @@ sudo solo-provisioner alloy cluster install \
 |------|-------------|
 | `--cluster-name` | Cluster name for metrics/logs labels |
 | `--monitor-block-node` | Enable Block Node specific monitoring |
-| `--add-prometheus-remote` | Add a Prometheus remote (format: `name=<name>,url=<url>,username=<username>`). Repeatable |
-| `--add-loki-remote` | Add a Loki remote (format: `name=<name>,url=<url>,username=<username>`). Repeatable |
+| `--add-prometheus-remote` | Add a Prometheus remote (format: `name=<name>,url=<url>,username=<username>[,labelProfile=eng\|ops]`). Repeatable. Default: `eng` |
+| `--add-loki-remote` | Add a Loki remote (format: `name=<name>,url=<url>,username=<username>[,labelProfile=eng\|ops]`). Repeatable. Default: `eng` |
 | `--prometheus-url` | Prometheus remote write URL *(deprecated: use `--add-prometheus-remote`)* |
 | `--prometheus-username` | Prometheus authentication username *(deprecated)* |
 | `--loki-url` | Loki remote write URL *(deprecated: use `--add-loki-remote`)* |
@@ -382,10 +382,11 @@ sudo solo-provisioner alloy cluster install \
 
 #### Multiple Remote Endpoints
 
-The `--add-prometheus-remote` and `--add-loki-remote` flags use the format `name=<name>,url=<url>,username=<username>`:
+The `--add-prometheus-remote` and `--add-loki-remote` flags use the format `name=<name>,url=<url>,username=<username>[,labelProfile=<profile>]`:
 - **name**: Unique identifier for the remote (e.g., `primary`, `backup`, `grafana-cloud`)
 - **url**: The remote write endpoint URL
 - **username**: Authentication username (password is read from the K8s Secret)
+- **labelProfile** *(optional)*: Label profile to auto-inject additional labels (default: `eng`, which adds only `cluster`). See [Label Profiles](#label-profiles) below
 
 **K8s Secret Keys** (for multiple remotes):
 
@@ -443,6 +444,38 @@ sudo solo-provisioner alloy cluster install \
 ```
 
 > **Important:** Each run replaces the previous remote configuration. Always specify all the remotes you want to keep.
+
+#### Label Profiles
+
+Label profiles auto-inject additional labels into every metric and log stream. The optional `labelProfile` key on any remote activates a profile.
+
+**Available profiles:**
+
+| Profile | Labels Added |
+|---------|-------------|
+| `eng` *(default)* | `cluster` |
+| `ops` | `cluster`, `environment`, `instance_type`, `inventory_name`, `ip` (optional) |
+
+**Example** — install with the `ops` label profile:
+```bash
+sudo solo-provisioner alloy cluster install \
+  --cluster-name=lfh02-previewnet-blocknode \
+  --add-prometheus-remote=name=primary,url=https://prom.example.com/api/v1/write,username=user1,labelProfile=ops \
+  --add-loki-remote=name=primary,url=https://loki.example.com/loki/api/v1/push,username=user1,labelProfile=ops \
+  --monitor-block-node
+```
+
+With `--cluster-name=lfh02-previewnet-blocknode` and `--profile=previewnet`, the `ops` profile derives:
+
+| Label | Value | Source |
+|-------|-------|--------|
+| `cluster` | `lfh02-previewnet-blocknode` | Always set (from `--cluster-name`) |
+| `environment` | `previewnet` | From `--profile` (deploy profile) |
+| `instance_type` | `lfh` | Alphabetic prefix of the first segment of cluster name |
+| `inventory_name` | `lfh02-previewnet-blocknode` | Full cluster name |
+| `ip` | `<ip>` | Optional; set when an IP address label is available for the node |
+
+> **Note:** If `labelProfile` is omitted for a given remote, that remote uses the default `eng` profile (only the `cluster` label). Each remote can specify its own `labelProfile`.
 
 
 #### Uninstall Alloy Stack
@@ -504,10 +537,12 @@ alloy:
     - name: "primary"
       url: "https://prometheus.example.com/api/v1/write"
       username: "metrics"
+      labelProfile: "ops"    # Optional: auto-inject additional labels
   lokiRemotes:
     - name: "primary"
       url: "https://loki.example.com/loki/api/v1/push"
       username: "logs"
+      labelProfile: "ops"    # Optional: auto-inject additional labels
 
 teleport:
   version: "16.0.0"
@@ -702,5 +737,5 @@ solo-provisioner --help
 
 ---
 
-*Document Version: 1.1.0 | Last Updated: February 2026*
+*Document Version: 1.2.0 | Last Updated: March 2026*
 

--- a/internal/alloy/config.go
+++ b/internal/alloy/config.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hashgraph/solo-weaver/internal/alloy/labels"
+	"github.com/hashgraph/solo-weaver/internal/network"
 	"github.com/hashgraph/solo-weaver/internal/templates"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 )
@@ -46,6 +48,7 @@ type Remote struct {
 	URL            string
 	Username       string
 	PasswordEnvVar string
+	LabelProfile   string
 }
 
 // ConfigBuilder helps build Alloy configuration from various sources.
@@ -54,11 +57,13 @@ type ConfigBuilder struct {
 	prometheusRemotes []Remote
 	lokiRemotes       []Remote
 	monitorBlockNode  bool
+	deployProfile     string // stored for per-remote label resolution
+	machineIP         string // host IP for the "ip" label (best-effort)
 }
 
 // NewConfigBuilder creates a new ConfigBuilder from the application config.
 // Returns an error if cluster name cannot be determined (neither provided nor hostname available).
-func NewConfigBuilder(cfg models.AlloyConfig) (*ConfigBuilder, error) {
+func NewConfigBuilder(cfg models.AlloyConfig, deployProfile string) (*ConfigBuilder, error) {
 	cb := &ConfigBuilder{
 		monitorBlockNode: cfg.MonitorBlockNode,
 	}
@@ -79,7 +84,30 @@ func NewConfigBuilder(cfg models.AlloyConfig) (*ConfigBuilder, error) {
 	// Build Loki remotes
 	cb.lokiRemotes = buildLokiRemotes(cfg)
 
+	// Store deployProfile for per-remote label resolution
+	cb.deployProfile = deployProfile
+
+	// Resolve machine IP for the "ip" label (best-effort, non-fatal)
+	if ip, err := network.GetMachineIP(); err == nil {
+		cb.machineIP = ip
+	}
+
 	return cb, nil
+}
+
+// newLabelInput constructs a LabelInput from the builder's fields.
+func (cb *ConfigBuilder) newLabelInput() labels.LabelInput {
+	return labels.LabelInput{
+		ClusterName:   cb.clusterName,
+		DeployProfile: cb.deployProfile,
+		MachineIP:     cb.machineIP,
+	}
+}
+
+// ResolvedLabels returns the resolved label map for the given label profile.
+// If labelProfile is empty, the default profile is used.
+func (cb *ConfigBuilder) ResolvedLabels(labelProfile string) map[string]string {
+	return labels.Resolve(labelProfile, cb.newLabelInput())
 }
 
 // ClusterName returns the cluster name.
@@ -121,6 +149,9 @@ func (cb *ConfigBuilder) LokiForwardTo() string {
 }
 
 // ToTemplateRemotes converts internal remotes to template remotes.
+// The resolved label rules are pre-rendered into AlloyRemote.CustomRules
+// so templates can inject them. Each remote resolves labels from its own
+// LabelProfile (defaulting to "eng", which produces only the cluster label).
 func (cb *ConfigBuilder) ToTemplateRemotes() ([]templates.AlloyRemote, []templates.AlloyRemote) {
 	promRemotes := make([]templates.AlloyRemote, len(cb.prometheusRemotes))
 	for i, r := range cb.prometheusRemotes {
@@ -129,6 +160,10 @@ func (cb *ConfigBuilder) ToTemplateRemotes() ([]templates.AlloyRemote, []templat
 			URL:            r.URL,
 			Username:       r.Username,
 			PasswordEnvVar: r.PasswordEnvVar,
+		}
+		resolved := labels.Resolve(r.LabelProfile, cb.newLabelInput())
+		if len(resolved) > 0 {
+			promRemotes[i].CustomRules = labels.RenderLabelRules(resolved)
 		}
 	}
 
@@ -139,6 +174,10 @@ func (cb *ConfigBuilder) ToTemplateRemotes() ([]templates.AlloyRemote, []templat
 			URL:            r.URL,
 			Username:       r.Username,
 			PasswordEnvVar: r.PasswordEnvVar,
+		}
+		resolved := labels.Resolve(r.LabelProfile, cb.newLabelInput())
+		if len(resolved) > 0 {
+			lokiRemotes[i].CustomRules = labels.RenderLabelRules(resolved)
 		}
 	}
 
@@ -171,6 +210,7 @@ func buildPrometheusRemotes(cfg models.AlloyConfig) []Remote {
 				URL:            r.URL,
 				Username:       r.Username,
 				PasswordEnvVar: "PROMETHEUS_PASSWORD_" + toEnvVarName(r.Name),
+				LabelProfile:   r.LabelProfile,
 			})
 		}
 	} else if cfg.PrometheusURL != "" {
@@ -197,6 +237,7 @@ func buildLokiRemotes(cfg models.AlloyConfig) []Remote {
 				URL:            r.URL,
 				Username:       r.Username,
 				PasswordEnvVar: "LOKI_PASSWORD_" + toEnvVarName(r.Name),
+				LabelProfile:   r.LabelProfile,
 			})
 		}
 	} else if cfg.LokiURL != "" {

--- a/internal/alloy/labels/eng.go
+++ b/internal/alloy/labels/eng.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+package labels
+
+// EngProfile is the default label profile used by engineering.
+// It includes only the mandatory "cluster" label.
+type EngProfile struct{}
+
+func init() {
+	Register(EngProfile{})
+}
+
+func (EngProfile) Name() string { return "eng" }
+
+// Labels returns the label set for the eng profile.
+//
+// Labels added (from LabelInput):
+//   - cluster = ClusterName
+func (EngProfile) Labels(input LabelInput) map[string]string {
+	m := make(map[string]string)
+	if input.ClusterName != "" {
+		m["cluster"] = input.ClusterName
+	}
+	return m
+}

--- a/internal/alloy/labels/eng_test.go
+++ b/internal/alloy/labels/eng_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+package labels
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEngProfile_Labels(t *testing.T) {
+	t.Run("returns only cluster label", func(t *testing.T) {
+		result := EngProfile{}.Labels(LabelInput{ClusterName: "my-cluster", DeployProfile: "previewnet", MachineIP: "10.0.0.1"})
+		assert.Equal(t, map[string]string{
+			"cluster": "my-cluster",
+		}, result)
+	})
+	t.Run("returns empty map when cluster name is empty", func(t *testing.T) {
+		result := EngProfile{}.Labels(LabelInput{})
+		assert.Empty(t, result)
+	})
+}

--- a/internal/alloy/labels/ops.go
+++ b/internal/alloy/labels/ops.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package labels
+
+import (
+	"strings"
+	"unicode"
+)
+
+// OpsProfile adds labels used by DevOps tooling.
+// Copy this file as a template when creating a new label profile.
+type OpsProfile struct{}
+
+func init() {
+	Register(OpsProfile{})
+}
+
+func (OpsProfile) Name() string { return "ops" }
+
+// Labels returns the complete label set for the ops profile.
+//
+// Labels added (from LabelInput):
+//   - cluster        = ClusterName
+//   - environment    = DeployProfile
+//   - instance_type  = alphabetic prefix of first cluster name segment (e.g. "lfh")
+//   - inventory_name = full cluster name (for DevOps inventory systems)
+//   - ip             = MachineIP (when available)
+func (OpsProfile) Labels(input LabelInput) map[string]string {
+	labels := ParseClusterName(input.ClusterName)
+
+	if input.ClusterName != "" {
+		labels["cluster"] = input.ClusterName
+		labels["inventory_name"] = input.ClusterName
+	}
+
+	if input.DeployProfile != "" {
+		labels["environment"] = input.DeployProfile
+	}
+
+	if input.MachineIP != "" {
+		labels["ip"] = input.MachineIP
+	}
+
+	return labels
+}
+
+// ParseClusterName extracts standardized label values from a cluster name
+// following the convention: <instance>-<environment>-<suffix>
+// For example: "lfh02-previewnet-blocknode" yields:
+//   - instance_type = "lfh"  (alphabetic prefix of first segment)
+//
+// Note: The "cluster" label is not included here because it is attached via
+// CustomRules generated from the resolved label profile (see OpsProfile.Labels).
+// Similarly, the "environment" label is provided by deployProfile rather than
+// being derived from the cluster name.
+func ParseClusterName(clusterName string) map[string]string {
+	labels := make(map[string]string)
+	if clusterName == "" {
+		return labels
+	}
+
+	parts := strings.SplitN(clusterName, "-", 3)
+
+	// First segment: derive instance_type as the alphabetic prefix (e.g., "lfh" from "lfh02")
+	if len(parts) >= 1 && parts[0] != "" {
+		instanceType := extractAlphaPrefix(parts[0])
+		if instanceType != "" {
+			labels["instance_type"] = instanceType
+		}
+	}
+
+	return labels
+}
+
+// extractAlphaPrefix returns the leading alphabetic characters of s.
+// For example, "lfh02" → "lfh", "abc" → "abc", "123" → "".
+func extractAlphaPrefix(s string) string {
+	for i, r := range s {
+		if !unicode.IsLetter(r) {
+			return s[:i]
+		}
+	}
+	return s
+}

--- a/internal/alloy/labels/ops_test.go
+++ b/internal/alloy/labels/ops_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package labels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseClusterName(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		expected    map[string]string
+	}{
+		{
+			name:        "full convention: instance-environment-suffix",
+			clusterName: "lfh02-previewnet-blocknode",
+			expected: map[string]string{
+				"instance_type": "lfh",
+			},
+		},
+		{
+			name:        "two segments only",
+			clusterName: "node01-mainnet",
+			expected: map[string]string{
+				"instance_type": "node",
+			},
+		},
+		{
+			name:        "single segment",
+			clusterName: "mycluster",
+			expected: map[string]string{
+				"instance_type": "mycluster",
+			},
+		},
+		{
+			name:        "numeric-only first segment",
+			clusterName: "123-testnet-blocknode",
+			expected:    map[string]string{},
+		},
+		{
+			name:        "empty cluster name",
+			clusterName: "",
+			expected:    map[string]string{},
+		},
+		{
+			name:        "multiple dashes in suffix",
+			clusterName: "bn01-perfnet-block-node-extra",
+			expected: map[string]string{
+				"instance_type": "bn",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseClusterName(tt.clusterName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractAlphaPrefix(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"lfh02", "lfh"},
+		{"bn01", "bn"},
+		{"abc", "abc"},
+		{"123", ""},
+		{"a1b2", "a"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractAlphaPrefix(tt.input))
+		})
+	}
+}
+
+func TestOpsProfile_Labels(t *testing.T) {
+	t.Run("returns all labels including cluster, inventory_name, and ip", func(t *testing.T) {
+		result := OpsProfile{}.Labels(LabelInput{
+			ClusterName:   "lfh02-previewnet-blocknode",
+			DeployProfile: "previewnet",
+			MachineIP:     "10.0.0.1",
+		})
+		assert.Equal(t, map[string]string{
+			"cluster":        "lfh02-previewnet-blocknode",
+			"environment":    "previewnet",
+			"instance_type":  "lfh",
+			"inventory_name": "lfh02-previewnet-blocknode",
+			"ip":             "10.0.0.1",
+		}, result)
+	})
+
+	t.Run("environment derived from deploy profile", func(t *testing.T) {
+		result := OpsProfile{}.Labels(LabelInput{
+			ClusterName:   "mycluster",
+			DeployProfile: "mainnet",
+			MachineIP:     "192.168.1.100",
+		})
+		assert.Equal(t, map[string]string{
+			"cluster":        "mycluster",
+			"environment":    "mainnet",
+			"instance_type":  "mycluster",
+			"inventory_name": "mycluster",
+			"ip":             "192.168.1.100",
+		}, result)
+	})
+
+	t.Run("returns empty map when cluster name is empty", func(t *testing.T) {
+		result := OpsProfile{}.Labels(LabelInput{})
+		assert.Empty(t, result)
+	})
+
+	t.Run("ip label omitted when machineIP is empty", func(t *testing.T) {
+		result := OpsProfile{}.Labels(LabelInput{
+			ClusterName:   "lfh02-previewnet-blocknode",
+			DeployProfile: "previewnet",
+		})
+		assert.NotContains(t, result, "ip")
+		assert.Equal(t, "lfh02-previewnet-blocknode", result["cluster"])
+	})
+}

--- a/internal/alloy/labels/profile.go
+++ b/internal/alloy/labels/profile.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package labels provides a shared label profile registry used by both
+// the alloy rendering engine (internal/alloy) and config validation (pkg/models).
+package labels
+
+import (
+	"sort"
+	"strings"
+)
+
+// LabelInput holds all runtime data sources available for label resolution.
+// Each profile's Labels method picks only the fields it needs.
+type LabelInput struct {
+	ClusterName   string // cluster name (e.g. "lfh02-previewnet-blocknode")
+	DeployProfile string // deployment profile / environment (e.g. "previewnet")
+	MachineIP     string // host's primary IP address (may be empty if unavailable)
+}
+
+// Profiler defines the contract for a label profile.
+// Each implementation returns the full set of labels for that profile,
+// always including the "cluster" label.
+//
+// To add a new profile:
+//  1. Copy ops.go to a new file (e.g. sre.go)
+//  2. Implement Profiler (Name + Labels)
+//  3. Register it via Register() in an init() function
+type Profiler interface {
+	// Name returns the canonical lowercase name of this profile (e.g. "ops").
+	Name() string
+
+	// Labels returns the complete set of labels for this profile.
+	Labels(input LabelInput) map[string]string
+}
+
+// DefaultProfile is the label profile used when none is specified on a remote.
+const DefaultProfile = "eng"
+
+var registry = map[string]Profiler{}
+
+// Register adds a label profile to the global registry.
+// Called from init() in profile implementation files (e.g. ops.go).
+func Register(p Profiler) {
+	registry[p.Name()] = p
+}
+
+// IsValid checks whether the given name is a recognized label profile.
+func IsValid(name string) bool {
+	_, ok := registry[strings.ToLower(name)]
+	return ok
+}
+
+// ValidNames returns all recognized label profile names (sorted).
+func ValidNames() []string {
+	names := make([]string, 0, len(registry))
+	for k := range registry {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Resolve returns the full label map for a given label profile.
+// Uses DefaultProfile when labelProfile is empty.
+func Resolve(labelProfile string, input LabelInput) map[string]string {
+	if labelProfile == "" {
+		labelProfile = DefaultProfile
+	}
+
+	if profiler, ok := registry[strings.ToLower(labelProfile)]; ok {
+		return profiler.Labels(input)
+	}
+
+	return nil
+}

--- a/internal/alloy/labels/profile_test.go
+++ b/internal/alloy/labels/profile_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package labels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testProfile is a minimal Profiler implementation for testing.
+type testProfile struct {
+	name string
+}
+
+func (t testProfile) Name() string { return t.name }
+func (t testProfile) Labels(input LabelInput) map[string]string {
+	return map[string]string{"profile": t.name, "cluster": input.ClusterName}
+}
+
+func TestRegisterAndIsValid(t *testing.T) {
+	Register(testProfile{name: "alpha"})
+
+	assert.True(t, IsValid("alpha"))
+	assert.True(t, IsValid("Alpha"), "should be case-insensitive")
+	assert.False(t, IsValid(""))
+	assert.False(t, IsValid("beta"))
+}
+
+func TestValidNames(t *testing.T) {
+	Register(testProfile{name: "zebra"})
+	Register(testProfile{name: "alpha"})
+
+	names := ValidNames()
+	// Registry includes eng, ops (from init) plus test profiles alpha, zebra
+	require.GreaterOrEqual(t, len(names), 2)
+	assert.Contains(t, names, "alpha")
+	assert.Contains(t, names, "zebra")
+	// Verify sorted order
+	for i := 1; i < len(names); i++ {
+		assert.Less(t, names[i-1], names[i], "names should be sorted alphabetically")
+	}
+}
+
+func TestResolve(t *testing.T) {
+	Register(testProfile{name: "ops"})
+
+	t.Run("empty profile uses default profile", func(t *testing.T) {
+		assert.NotNil(t, Resolve("", LabelInput{ClusterName: "cluster1", DeployProfile: "prod"}))
+	})
+
+	t.Run("unknown profile returns nil", func(t *testing.T) {
+		assert.Nil(t, Resolve("unknown", LabelInput{ClusterName: "cluster1", DeployProfile: "prod"}))
+	})
+
+	t.Run("known profile delegates to Labels()", func(t *testing.T) {
+		result := Resolve("ops", LabelInput{ClusterName: "my-cluster", DeployProfile: "prod"})
+		assert.Equal(t, map[string]string{"profile": "ops", "cluster": "my-cluster"}, result)
+	})
+
+	t.Run("case-insensitive lookup", func(t *testing.T) {
+		result := Resolve("Ops", LabelInput{ClusterName: "my-cluster", DeployProfile: "prod"})
+		assert.NotNil(t, result)
+	})
+}

--- a/internal/alloy/labels/render.go
+++ b/internal/alloy/labels/render.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package labels
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// RenderLabelRules renders labels as Alloy relabel rule blocks.
+// Output is suitable for injection into prometheus.relabel,
+// prometheus.operator.servicemonitors, and loki.relabel blocks.
+//
+// All labels in the map are rendered, including "cluster".
+//
+// Example output:
+//
+//	rule {
+//	  target_label = "cluster"
+//	  replacement  = "my-cluster"
+//	}
+//	rule {
+//	  target_label = "environment"
+//	  replacement  = "previewnet"
+//	}
+func RenderLabelRules(labels map[string]string) string {
+	keys := sortedKeys(labels)
+	if len(keys) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	for _, k := range keys {
+		sb.WriteString(fmt.Sprintf("  rule {\n    target_label = %q\n    replacement  = %q\n  }\n", k, labels[k]))
+	}
+	return sb.String()
+}
+
+var labelNameRE = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+func isValidLabelName(name string) bool {
+	return labelNameRE.MatchString(name)
+}
+
+// RenderStaticLabels renders labels as Alloy static label entries.
+// Output is suitable for injection into loki.source.journal labels blocks.
+//
+// All labels in the map are rendered, including "cluster".
+//
+// Example output:
+//
+//	cluster        = "my-cluster",
+//	environment    = "previewnet",
+//	instance       = "lfh02",
+func RenderStaticLabels(labels map[string]string) string {
+	keys := sortedKeys(labels)
+	if len(keys) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	for _, k := range keys {
+		if !isValidLabelName(k) {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf("    %s = %q,\n", k, labels[k]))
+	}
+	return sb.String()
+}
+
+// sortedKeys returns all keys of m sorted alphabetically.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/alloy/labels/render_test.go
+++ b/internal/alloy/labels/render_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package labels
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderLabelRules(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		expected []string
+	}{
+		{
+			name: "multiple labels sorted alphabetically",
+			labels: map[string]string{
+				"cluster":       "lfh02-previewnet-blocknode",
+				"environment":   "previewnet",
+				"instance_type": "lfh",
+				"ip":            "10.0.0.1",
+			},
+			expected: []string{
+				`target_label = "cluster"`,
+				`replacement  = "lfh02-previewnet-blocknode"`,
+				`target_label = "environment"`,
+				`replacement  = "previewnet"`,
+				`target_label = "instance_type"`,
+				`replacement  = "lfh"`,
+				`target_label = "ip"`,
+				`replacement  = "10.0.0.1"`,
+			},
+		},
+		{
+			name:     "empty labels",
+			labels:   map[string]string{},
+			expected: nil,
+		},
+		{
+			name: "only cluster label is rendered",
+			labels: map[string]string{
+				"cluster": "test",
+			},
+			expected: []string{
+				`target_label = "cluster"`,
+				`replacement  = "test"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RenderLabelRules(tt.labels)
+			if tt.expected == nil {
+				assert.Empty(t, result)
+			} else {
+				for _, exp := range tt.expected {
+					assert.Contains(t, result, exp)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderLabelRules_Ordering(t *testing.T) {
+	labels := map[string]string{
+		"cluster":       "test",
+		"zebra":         "z",
+		"alpha":         "a",
+		"instance_type": "bn",
+	}
+	result := RenderLabelRules(labels)
+
+	clusterPos := strings.Index(result, `"cluster"`)
+	alphaPos := strings.Index(result, `"alpha"`)
+	instancePos := strings.Index(result, `"instance_type"`)
+	zebraPos := strings.Index(result, `"zebra"`)
+
+	require.Greater(t, clusterPos, -1)
+	require.Greater(t, alphaPos, -1)
+	require.Greater(t, instancePos, -1)
+	require.Greater(t, zebraPos, -1)
+
+	assert.Less(t, alphaPos, clusterPos, "alpha should come before cluster")
+	assert.Less(t, clusterPos, instancePos, "cluster should come before instance_type")
+	assert.Less(t, instancePos, zebraPos, "instance_type should come before zebra")
+}
+
+func TestRenderStaticLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		expected []string
+	}{
+		{
+			name: "multiple labels sorted alphabetically",
+			labels: map[string]string{
+				"cluster":     "test-cluster",
+				"environment": "previewnet",
+				"ip":          "10.0.0.1",
+			},
+			expected: []string{
+				`cluster = "test-cluster",`,
+				`environment = "previewnet",`,
+				`ip = "10.0.0.1",`,
+			},
+		},
+		{
+			name:     "empty labels",
+			labels:   map[string]string{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RenderStaticLabels(tt.labels)
+			if tt.expected == nil {
+				assert.Empty(t, result)
+			} else {
+				for _, exp := range tt.expected {
+					assert.Contains(t, result, exp)
+				}
+			}
+		})
+	}
+}

--- a/internal/alloy/render.go
+++ b/internal/alloy/render.go
@@ -25,11 +25,9 @@ func RenderModularConfigs(cb *ConfigBuilder) ([]ModuleConfig, error) {
 	var modules []ModuleConfig
 
 	prometheusRemotes, lokiRemotes := cb.ToTemplateRemotes()
-	prometheusForwardTo := cb.PrometheusForwardTo()
-	lokiForwardTo := cb.LokiForwardTo()
 
-	hasPrometheusRemotes := prometheusForwardTo != ""
-	hasLokiRemotes := lokiForwardTo != ""
+	hasPrometheusRemotes := len(prometheusRemotes) > 0
+	hasLokiRemotes := len(lokiRemotes) > 0
 
 	// 1. Core config (always required)
 	coreConfig, err := templates.Render(CoreTemplatePath, nil)
@@ -61,10 +59,10 @@ func RenderModularConfigs(cb *ConfigBuilder) ([]ModuleConfig, error) {
 	}
 
 	// Common module data for most modules
-	moduleData := templates.AlloyModuleData{
-		ClusterName:         cb.ClusterName(),
-		PrometheusForwardTo: prometheusForwardTo,
-		LokiForwardTo:       lokiForwardTo,
+	moduleData := templates.AlloyData{
+		ClusterName:       cb.ClusterName(),
+		PrometheusRemotes: prometheusRemotes,
+		LokiRemotes:       lokiRemotes,
 	}
 
 	// 3. Agent metrics config (only if Prometheus remotes are configured)

--- a/internal/alloy/render_test.go
+++ b/internal/alloy/render_test.go
@@ -107,7 +107,7 @@ func TestRenderModularConfigs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cb, err := NewConfigBuilder(tt.cfg)
+			cb, err := NewConfigBuilder(tt.cfg, "")
 			require.NoError(t, err)
 			modules, err := RenderModularConfigs(cb)
 			require.NoError(t, err)
@@ -135,6 +135,169 @@ func TestRenderModularConfigs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRenderModularConfigs_WithOpsLabelProfile_AllModules(t *testing.T) {
+	cfg := models.AlloyConfig{
+		ClusterName:      "lfh02-previewnet-blocknode",
+		MonitorBlockNode: true,
+		PrometheusRemotes: []models.AlloyRemoteConfig{
+			{Name: "cloud", URL: "http://prom:9090/api/v1/write", Username: "user", LabelProfile: "ops"},
+		},
+		LokiRemotes: []models.AlloyRemoteConfig{
+			{Name: "cloud", URL: "http://loki:3100/loki/api/v1/push", Username: "user", LabelProfile: "ops"},
+		},
+	}
+
+	cb, err := NewConfigBuilder(cfg, "previewnet")
+	require.NoError(t, err)
+	// Ensure machineIP is set deterministically for tests so ops profile always includes the ip label.
+	cb.machineIP = "10.0.0.1"
+	modules, err := RenderModularConfigs(cb)
+	require.NoError(t, err)
+
+	// Helper to find module content by name
+	findModule := func(name string) string {
+		for _, m := range modules {
+			if m.Name == name {
+				return m.Content
+			}
+		}
+		return ""
+	}
+
+	// Verify derived labels appear as rule blocks in all modules (including syslog via per-remote relabel)
+	for _, moduleName := range []string{"agent-metrics", "kubelet", "node-exporter", "block-node", "syslog"} {
+		content := findModule(moduleName)
+		require.NotEmpty(t, content, "module %s should exist", moduleName)
+		assert.Contains(t, content, `target_label = "cluster"`, "module %s should contain cluster rule", moduleName)
+		assert.Contains(t, content, `replacement  = "lfh02-previewnet-blocknode"`, "module %s should contain cluster name replacement", moduleName)
+		assert.Contains(t, content, `target_label = "environment"`, "module %s should contain environment rule", moduleName)
+		assert.Contains(t, content, `replacement  = "previewnet"`, "module %s should contain previewnet replacement", moduleName)
+		assert.Contains(t, content, `target_label = "instance_type"`, "module %s should contain instance_type rule", moduleName)
+		assert.Contains(t, content, `replacement  = "lfh"`, "module %s should contain lfh replacement", moduleName)
+		assert.Contains(t, content, `target_label = "ip"`, "module %s should contain ip rule", moduleName)
+		// ops profile should include inventory_name
+		assert.Contains(t, content, `target_label = "inventory_name"`, "module %s should contain inventory_name", moduleName)
+		// instance label should NOT be present
+		assert.NotContains(t, content, `target_label = "instance"`, "module %s should not contain instance rule", moduleName)
+	}
+}
+
+func TestRenderModularConfigs_WithOpsLabelProfile(t *testing.T) {
+	cfg := models.AlloyConfig{
+		ClusterName:      "lfh02-previewnet-blocknode",
+		MonitorBlockNode: true,
+		PrometheusRemotes: []models.AlloyRemoteConfig{
+			{Name: "cloud", URL: "http://prom:9090/api/v1/write", Username: "user", LabelProfile: "ops"},
+		},
+		LokiRemotes: []models.AlloyRemoteConfig{
+			{Name: "cloud", URL: "http://loki:3100/loki/api/v1/push", Username: "user", LabelProfile: "ops"},
+		},
+	}
+
+	cb, err := NewConfigBuilder(cfg, "previewnet")
+	require.NoError(t, err)
+	// Ensure machineIP is set deterministically for tests so ops profile behavior is stable.
+	cb.machineIP = "10.0.0.1"
+	modules, err := RenderModularConfigs(cb)
+	require.NoError(t, err)
+
+	findModule := func(name string) string {
+		for _, m := range modules {
+			if m.Name == name {
+				return m.Content
+			}
+		}
+		return ""
+	}
+
+	// Ops profile should include inventory_name
+	for _, moduleName := range []string{"agent-metrics", "kubelet", "node-exporter", "block-node", "syslog"} {
+		content := findModule(moduleName)
+		require.NotEmpty(t, content, "module %s should exist", moduleName)
+		assert.Contains(t, content, `target_label = "inventory_name"`, "module %s should contain inventory_name rule", moduleName)
+		assert.Contains(t, content, `replacement  = "lfh02-previewnet-blocknode"`, "module %s should contain full cluster name as inventory_name", moduleName)
+	}
+}
+
+func TestRenderModularConfigs_DefaultEngProfile(t *testing.T) {
+	cfg := models.AlloyConfig{
+		ClusterName: "test-cluster",
+		PrometheusRemotes: []models.AlloyRemoteConfig{
+			{Name: "primary", URL: "http://prom:9090/api/v1/write", Username: "user"},
+		},
+	}
+
+	cb, err := NewConfigBuilder(cfg, "")
+	require.NoError(t, err)
+	modules, err := RenderModularConfigs(cb)
+	require.NoError(t, err)
+
+	for _, m := range modules {
+		if m.Name == "agent-metrics" {
+			// eng profile (default) should include cluster rule via CustomRules
+			assert.Contains(t, m.Content, `target_label = "cluster"`)
+			assert.Contains(t, m.Content, `replacement  = "test-cluster"`)
+			// No instance/environment/instance_type rules with eng profile
+			assert.NotContains(t, m.Content, `target_label = "instance_type"`)
+			assert.NotContains(t, m.Content, `target_label = "environment"`)
+		}
+	}
+}
+
+func TestRenderModularConfigs_MixedLabelProfiles(t *testing.T) {
+	cfg := models.AlloyConfig{
+		ClusterName:      "lfh02-previewnet-blocknode",
+		MonitorBlockNode: true,
+		PrometheusRemotes: []models.AlloyRemoteConfig{
+			{Name: "local", URL: "http://prom:9090/api/v1/write", Username: "admin", LabelProfile: "ops"},
+			{Name: "backup", URL: "http://prom2:9090/api/v1/write", Username: "admin", LabelProfile: "eng"},
+		},
+		LokiRemotes: []models.AlloyRemoteConfig{
+			{Name: "local", URL: "http://loki:3100/loki/api/v1/push", Username: "admin", LabelProfile: "ops"},
+			{Name: "backup", URL: "http://loki2:3100/loki/api/v1/push", Username: "admin", LabelProfile: "eng"},
+		},
+	}
+
+	cb, err := NewConfigBuilder(cfg, "previewnet")
+	require.NoError(t, err)
+
+	// Verify per-remote label resolution via ToTemplateRemotes
+	promRemotes, lokiRemotes := cb.ToTemplateRemotes()
+	require.Len(t, promRemotes, 2)
+	require.Len(t, lokiRemotes, 2)
+
+	// ops remote should have full ops labels (inventory_name, environment, etc.)
+	assert.Contains(t, promRemotes[0].CustomRules, `target_label = "inventory_name"`)
+	assert.Contains(t, promRemotes[0].CustomRules, `target_label = "environment"`)
+
+	// eng remote should have only cluster label
+	assert.Contains(t, promRemotes[1].CustomRules, `target_label = "cluster"`)
+	assert.NotContains(t, promRemotes[1].CustomRules, `target_label = "inventory_name"`)
+
+	// Same for Loki remotes
+	assert.Contains(t, lokiRemotes[0].CustomRules, `target_label = "inventory_name"`)
+	assert.NotContains(t, lokiRemotes[1].CustomRules, `target_label = "inventory_name"`)
+
+	// Verify rendered modules contain both profiles' rules
+	modules, err := RenderModularConfigs(cb)
+	require.NoError(t, err)
+
+	findModule := func(name string) string {
+		for _, m := range modules {
+			if m.Name == name {
+				return m.Content
+			}
+		}
+		return ""
+	}
+
+	// agent-metrics should have both relabel blocks with different label sets
+	agentMetrics := findModule("agent-metrics")
+	require.NotEmpty(t, agentMetrics)
+	assert.Contains(t, agentMetrics, `prometheus.relabel "alloy_local"`)
+	assert.Contains(t, agentMetrics, `prometheus.relabel "alloy_backup"`)
 }
 
 func TestConfigMapManifest(t *testing.T) {
@@ -268,7 +431,7 @@ func TestRequiredSecrets(t *testing.T) {
 		},
 	}
 
-	cb, err := NewConfigBuilder(cfg)
+	cb, err := NewConfigBuilder(cfg, "")
 	require.NoError(t, err)
 
 	secrets := cb.RequiredSecrets()
@@ -285,7 +448,7 @@ func TestRequiredSecrets_NoRemotes(t *testing.T) {
 		ClusterName: "test-cluster",
 	}
 
-	cb, err := NewConfigBuilder(cfg)
+	cb, err := NewConfigBuilder(cfg, "")
 	require.NoError(t, err)
 
 	secrets := cb.RequiredSecrets()
@@ -304,7 +467,7 @@ func TestRequiredSecrets_MultipleRemotes(t *testing.T) {
 		},
 	}
 
-	cb, err := NewConfigBuilder(cfg)
+	cb, err := NewConfigBuilder(cfg, "")
 	require.NoError(t, err)
 
 	secrets := cb.RequiredSecrets()

--- a/internal/templates/embed.go
+++ b/internal/templates/embed.go
@@ -27,22 +27,14 @@ type AlloyRemote struct {
 	URL            string // Remote write URL
 	Username       string // Basic auth username
 	PasswordEnvVar string // Environment variable name containing the password
+	CustomRules    string // Pre-rendered Alloy rule {} blocks for per-remote relabel injection
 }
 
-// AlloyData contains data for rendering the main Alloy configuration templates.
+// AlloyData contains data for rendering Alloy configuration templates.
+// Used by both the remotes template and individual module templates.
+// Per-remote custom labels are handled via AlloyRemote.CustomRules.
 type AlloyData struct {
-	ClusterName         string
-	PrometheusRemotes   []AlloyRemote
-	LokiRemotes         []AlloyRemote
-	PrometheusForwardTo string // Comma-separated list of prometheus remote receivers
-	LokiForwardTo       string // Comma-separated list of loki remote receivers
-	MonitorBlockNode    bool
-}
-
-// AlloyModuleData contains data for rendering individual Alloy module templates.
-// This is used for modules that only need cluster name and forward-to receivers.
-type AlloyModuleData struct {
-	ClusterName         string
-	PrometheusForwardTo string // Comma-separated list of prometheus remote receivers
-	LokiForwardTo       string // Comma-separated list of loki remote receivers
+	ClusterName       string
+	PrometheusRemotes []AlloyRemote
+	LokiRemotes       []AlloyRemote
 }

--- a/internal/templates/files/alloy/agent-metrics.alloy
+++ b/internal/templates/files/alloy/agent-metrics.alloy
@@ -21,7 +21,7 @@ discovery.relabel "alloy" {
 
 prometheus.scrape "alloy" {
   targets = discovery.relabel.alloy.output
-  forward_to = [prometheus.relabel.alloy.receiver]
+  forward_to = [{{range $i, $r := .PrometheusRemotes}}{{if $i}}, {{end}}prometheus.relabel.alloy_{{$r.Name}}.receiver{{end}}]
 
   scrape_interval = "10s"
 
@@ -29,13 +29,8 @@ prometheus.scrape "alloy" {
     enabled = false
   }
 }
-
-prometheus.relabel "alloy" {
-  forward_to = [{{.PrometheusForwardTo}}]
-
-  rule {
-    target_label = "cluster"
-    replacement  = "{{.ClusterName}}"
-  }
-}
-
+{{range .PrometheusRemotes}}
+prometheus.relabel "alloy_{{.Name}}" {
+  forward_to = [prometheus.remote_write.{{.Name}}.receiver]
+{{.CustomRules}}}
+{{end}}

--- a/internal/templates/files/alloy/block-node.alloy
+++ b/internal/templates/files/alloy/block-node.alloy
@@ -3,7 +3,7 @@
 // Only loaded when block node is installed.
 
 prometheus.operator.servicemonitors "block_node_server" {
-  forward_to = [{{.PrometheusForwardTo}}]
+  forward_to = [{{range $i, $r := .PrometheusRemotes}}{{if $i}}, {{end}}prometheus.relabel.block_node_metrics_{{$r.Name}}.receiver{{end}}]
 
   clustering {
     enabled = false
@@ -21,21 +21,21 @@ prometheus.operator.servicemonitors "block_node_server" {
       values   = ["block-node-server"]
     }
   }
-
-  rule {
-    target_label = "cluster"
-    replacement  = "{{.ClusterName}}"
-  }
 }
+{{range .PrometheusRemotes}}
+prometheus.relabel "block_node_metrics_{{.Name}}" {
+  forward_to = [prometheus.remote_write.{{.Name}}.receiver]
+{{.CustomRules}}}
+{{end}}
 
 loki.relabel "block_node_server" {
-  forward_to = [{{.LokiForwardTo}}]
-
-  rule {
-    target_label = "cluster"
-    replacement  = "{{.ClusterName}}"
-  }
+  forward_to = [{{range $i, $r := .LokiRemotes}}{{if $i}}, {{end}}loki.relabel.block_node_logs_{{$r.Name}}.receiver{{end}}]
 }
+{{range .LokiRemotes}}
+loki.relabel "block_node_logs_{{.Name}}" {
+  forward_to = [loki.write.{{.Name}}.receiver]
+{{.CustomRules}}}
+{{end}}
 
 loki.source.podlogs "block_node_server" {
   forward_to = [loki.relabel.block_node_server.receiver]
@@ -58,4 +58,3 @@ loki.source.podlogs "block_node_server" {
   namespace_selector {
   }
 }
-

--- a/internal/templates/files/alloy/kubelet.alloy
+++ b/internal/templates/files/alloy/kubelet.alloy
@@ -19,7 +19,7 @@ discovery.relabel "kubelet" {
 
 prometheus.scrape "kubelet" {
   job_name    = "integrations/kubernetes/kubelet"
-  forward_to  = [prometheus.relabel.kubelet.receiver]
+  forward_to  = [{{range $i, $r := .PrometheusRemotes}}{{if $i}}, {{end}}prometheus.relabel.kubelet_{{$r.Name}}.receiver{{end}}]
   targets     = discovery.relabel.kubelet.output
   scheme      = "https"
 
@@ -31,15 +31,11 @@ prometheus.scrape "kubelet" {
 
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 }
-
-prometheus.relabel "kubelet" {
-  forward_to = [{{.PrometheusForwardTo}}]
-
-  rule {
-    target_label = "cluster"
-    replacement  = "{{.ClusterName}}"
-  }
-}
+{{range .PrometheusRemotes}}
+prometheus.relabel "kubelet_{{.Name}}" {
+  forward_to = [prometheus.remote_write.{{.Name}}.receiver]
+{{.CustomRules}}}
+{{end}}
 
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
@@ -60,7 +56,7 @@ discovery.relabel "cadvisor" {
 prometheus.scrape "cadvisor" {
   job_name    = "integrations/kubernetes/cadvisor"
   targets     = discovery.relabel.cadvisor.output
-  forward_to  = [prometheus.relabel.cadvisor.receiver]
+  forward_to  = [{{range $i, $r := .PrometheusRemotes}}{{if $i}}, {{end}}prometheus.relabel.cadvisor_{{$r.Name}}.receiver{{end}}]
   scheme      = "https"
 
   tls_config {
@@ -71,13 +67,8 @@ prometheus.scrape "cadvisor" {
 
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 }
-
-prometheus.relabel "cadvisor" {
-  forward_to = [{{.PrometheusForwardTo}}]
-
-  rule {
-    target_label = "cluster"
-    replacement  = "{{.ClusterName}}"
-  }
-}
-
+{{range .PrometheusRemotes}}
+prometheus.relabel "cadvisor_{{.Name}}" {
+  forward_to = [prometheus.remote_write.{{.Name}}.receiver]
+{{.CustomRules}}}
+{{end}}

--- a/internal/templates/files/alloy/node-exporter.alloy
+++ b/internal/templates/files/alloy/node-exporter.alloy
@@ -3,7 +3,7 @@
 
 prometheus.operator.servicemonitors "node_exporter" {
   namespaces = ["node-exporter"]
-  forward_to = [{{.PrometheusForwardTo}}]
+  forward_to = [{{range $i, $r := .PrometheusRemotes}}{{if $i}}, {{end}}prometheus.relabel.node_exporter_{{$r.Name}}.receiver{{end}}]
 
   clustering {
     enabled = false
@@ -21,10 +21,9 @@ prometheus.operator.servicemonitors "node_exporter" {
       values   = ["node-exporter"]
     }
   }
-
-  rule {
-    target_label = "cluster"
-    replacement  = "{{.ClusterName}}"
-  }
 }
-
+{{range .PrometheusRemotes}}
+prometheus.relabel "node_exporter_{{.Name}}" {
+  forward_to = [prometheus.remote_write.{{.Name}}.receiver]
+{{.CustomRules}}}
+{{end}}

--- a/internal/templates/files/alloy/remotes.alloy
+++ b/internal/templates/files/alloy/remotes.alloy
@@ -29,4 +29,3 @@ loki.write "{{.Name}}" {
   }
 }
 {{end}}
-

--- a/internal/templates/files/alloy/syslog.alloy
+++ b/internal/templates/files/alloy/syslog.alloy
@@ -41,14 +41,15 @@ loki.relabel "syslog" {
 }
 
 loki.source.journal "syslog" {
-  forward_to = [{{.LokiForwardTo}}]
+  forward_to = [{{range $i, $r := .LokiRemotes}}{{if $i}}, {{end}}loki.relabel.syslog_{{$r.Name}}.receiver{{end}}]
 
   path = "/host/var/log/journal"
 
-  labels = {
-    cluster = "{{.ClusterName}}",
-  }
 
   relabel_rules = loki.relabel.syslog.rules
 }
-
+{{range .LokiRemotes}}
+loki.relabel "syslog_{{.Name}}" {
+  forward_to = [loki.write.{{.Name}}.receiver]
+{{.CustomRules}}}
+{{end}}

--- a/internal/workflows/steps/step_alloy.go
+++ b/internal/workflows/steps/step_alloy.go
@@ -100,7 +100,7 @@ func preCheckAlloy() automa.Builder {
 				}
 
 				// Build config to determine required secrets
-				cb, err := alloy.NewConfigBuilder(cfg)
+				cb, err := alloy.NewConfigBuilder(cfg, config.Get().Profile)
 				if err != nil {
 					return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 				}
@@ -417,7 +417,7 @@ func installAlloy() automa.Builder {
 			}
 
 			// Build config to check if host network is needed
-			cb, err := alloy.NewConfigBuilder(cfg)
+			cb, err := alloy.NewConfigBuilder(cfg, config.Get().Profile)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -512,7 +512,7 @@ func deployAlloyConfig() automa.Builder {
 			}
 
 			// Build config using the alloy package
-			cb, err := alloy.NewConfigBuilder(cfg)
+			cb, err := alloy.NewConfigBuilder(cfg, config.Get().Profile)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -604,7 +604,7 @@ func deployBlockNodeMonitoring() automa.Builder {
 			l := logx.As()
 			meta := map[string]string{}
 
-			cb, err := alloy.NewConfigBuilder(cfg)
+			cb, err := alloy.NewConfigBuilder(cfg, config.Get().Profile)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/automa-saga/logx"
 
+	"github.com/hashgraph/solo-weaver/internal/alloy/labels"
 	"github.com/hashgraph/solo-weaver/pkg/sanity"
 	"github.com/joomcode/errorx"
 )
@@ -160,9 +161,10 @@ type BlockNodeConfig struct {
 //   - Prometheus: PROMETHEUS_PASSWORD_<NAME>
 //   - Loki: LOKI_PASSWORD_<NAME>
 type AlloyRemoteConfig struct {
-	Name     string `yaml:"name" json:"name"`         // Unique identifier for this remote
-	URL      string `yaml:"url" json:"url"`           // Remote write URL
-	Username string `yaml:"username" json:"username"` // Basic auth username
+	Name         string `yaml:"name" json:"name"`                 // Unique identifier for this remote
+	URL          string `yaml:"url" json:"url"`                   // Remote write URL
+	Username     string `yaml:"username" json:"username"`         // Basic auth username
+	LabelProfile string `yaml:"labelProfile" json:"labelProfile"` // Label profile name (e.g. ops) for auto-derived labels
 }
 
 // AlloyConfig represents the `alloy` configuration block for observability.
@@ -278,6 +280,22 @@ func (c *AlloyConfig) Validate() error {
 		if remote.Username != "" {
 			if err := sanity.ValidateIdentifier(remote.Username); err != nil {
 				return errorx.IllegalArgument.Wrap(err, "loki remote[%d] (%s): invalid username", i, remote.Name)
+			}
+		}
+	}
+
+	// Validate label profiles on each remote.
+	for i, remote := range c.PrometheusRemotes {
+		if remote.LabelProfile != "" {
+			if !labels.IsValid(remote.LabelProfile) {
+				return errorx.IllegalArgument.New("prometheus remote[%d] (%s): invalid labelProfile %q, valid values are: %s", i, remote.Name, remote.LabelProfile, strings.Join(labels.ValidNames(), ", "))
+			}
+		}
+	}
+	for i, remote := range c.LokiRemotes {
+		if remote.LabelProfile != "" {
+			if !labels.IsValid(remote.LabelProfile) {
+				return errorx.IllegalArgument.New("loki remote[%d] (%s): invalid labelProfile %q, valid values are: %s", i, remote.Name, remote.LabelProfile, strings.Join(labels.ValidNames(), ", "))
 			}
 		}
 	}

--- a/pkg/models/validation_test.go
+++ b/pkg/models/validation_test.go
@@ -536,6 +536,63 @@ func TestAlloyConfig_Validate(t *testing.T) {
 			config:      AlloyConfig{},
 			expectError: false,
 		},
+		{
+			name: "valid_eng_label_profile",
+			config: AlloyConfig{
+				ClusterName: "test-cluster",
+				PrometheusRemotes: []AlloyRemoteConfig{
+					{Name: "primary", URL: "http://prom:9090/api/v1/write", Username: "user1", LabelProfile: "eng"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid_ops_label_profile",
+			config: AlloyConfig{
+				ClusterName: "test-cluster",
+				PrometheusRemotes: []AlloyRemoteConfig{
+					{Name: "primary", URL: "http://prom:9090/api/v1/write", Username: "user1", LabelProfile: "ops"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid_mixed_label_profiles",
+			config: AlloyConfig{
+				ClusterName: "lfh02-previewnet-blocknode",
+				PrometheusRemotes: []AlloyRemoteConfig{
+					{Name: "local", URL: "http://prom:9090/api/v1/write", Username: "admin", LabelProfile: "ops"},
+					{Name: "backup", URL: "http://prom2:9090/api/v1/write", Username: "admin", LabelProfile: "eng"},
+				},
+				LokiRemotes: []AlloyRemoteConfig{
+					{Name: "local", URL: "http://loki:3100/loki/api/v1/push", Username: "admin", LabelProfile: "ops"},
+					{Name: "backup", URL: "http://loki2:3100/loki/api/v1/push", Username: "admin", LabelProfile: "eng"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid_prometheus_remote_unknown_label_profile",
+			config: AlloyConfig{
+				ClusterName: "test-cluster",
+				PrometheusRemotes: []AlloyRemoteConfig{
+					{Name: "primary", URL: "http://prom:9090/api/v1/write", Username: "user1", LabelProfile: "unknown"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "invalid labelProfile",
+		},
+		{
+			name: "invalid_loki_remote_unknown_label_profile",
+			config: AlloyConfig{
+				ClusterName: "test-cluster",
+				LokiRemotes: []AlloyRemoteConfig{
+					{Name: "primary", URL: "http://loki:3100/loki/api/v1/push", Username: "user1", LabelProfile: "unknown"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "invalid labelProfile",
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/alloy/README.md
+++ b/test/alloy/README.md
@@ -285,6 +285,54 @@ task vm:alloy:clean
 
 ## 🔧 Advanced
 
+### Custom Profile Labels (`labelProfile`)
+
+You can attach a label profile to any remote. The profile auto-injects additional labels (e.g. `environment`, `instance_type`, `inventory_name`, `ip`) into every metric and log stream.
+
+```bash
+sudo solo-provisioner alloy cluster install \
+  --cluster-name=lfh02-previewnet-blocknode \
+  --add-prometheus-remote=name=local,url=http://$NODE_IP:9090/api/v1/write,username=admin,labelProfile=ops \
+  --add-loki-remote=name=local,url=http://$NODE_IP:3100/loki/api/v1/push,username=admin,labelProfile=ops \
+  --monitor-block-node
+```
+
+With `labelProfile=ops` and `--cluster-name=lfh02-previewnet-blocknode`, the `ops` profile derives the following labels:
+
+| Label | Value | Source |
+|-------|-------|--------|
+| `cluster` | `lfh02-previewnet-blocknode` | Always set (from `--cluster-name`) |
+| `environment` | `previewnet` | From `--profile` (deploy profile) |
+| `instance_type` | `lfh` | Alphabetic prefix of first cluster name segment |
+| `inventory_name` | `lfh02-previewnet-blocknode` | Full cluster name |
+| `ip` | `<machine IP>` | Auto-detected host IP address |
+
+#### Verify Profile Labels in Grafana
+
+**Prometheus queries** — check that custom labels appear on metrics:
+```promql
+# All metrics with custom labels from the ops profile
+up{cluster="lfh02-previewnet-blocknode", instance_type="lfh"}
+
+# Node metrics with environment label
+node_cpu_seconds_total{environment="previewnet", ip="10.0.0.1"}
+
+# Filter by inventory_name
+alloy_build_info{inventory_name="lfh02-previewnet-blocknode"}
+```
+
+**Loki queries** — check that custom labels appear on log streams:
+```logql
+# System logs with profile labels
+{cluster="lfh02-previewnet-blocknode", instance_type="lfh"}
+
+# Filter by environment
+{environment="previewnet"} | priority = "err"
+```
+
+> **Note:** If `labelProfile` is omitted from a remote, the default `eng` profile is used, which applies only the `cluster` label.
+> Each remote can have its own `labelProfile` independently — for example, one remote with `labelProfile=ops` and another without.
+
 ### Multiple Remote Endpoints
 
 You can configure multiple Prometheus and Loki remote endpoints for redundancy or multi-tenancy:


### PR DESCRIPTION
## Description

This pull request introduces support for "label profiles" in Alloy remote configurations, allowing users to specify which set of labels are auto-injected into metrics and logs for each Prometheus or Loki remote. The default profile (`eng`) adds only the `cluster` label, while the new `ops` profile adds additional operational labels. The changes include CLI, documentation, and internal code updates to support and document this feature.

**Label Profile Support for Remotes:**

* Added support for an optional `labelProfile` key in Prometheus and Loki remote definitions, allowing users to select between `eng` (default) and `ops` profiles, with future extensibility for more profiles. This is reflected in CLI flags, YAML config, and internal models. [[1]](diffhunk://#diff-6b099a7e5c14bbfa8b26f745f3274c3d414b3e952500eda07cb565ec8be7b5c0L45-R50) [[2]](diffhunk://#diff-a74974690c195da8ead7b98471f1daaa36ec6f01bd169e30b8718685463eb297R47-R50) [[3]](diffhunk://#diff-9dae149ed1071d4ebde8e7ce54ab44224b690121f3f5485043b40211f8b8bc39R51) [[4]](diffhunk://#diff-9dae149ed1071d4ebde8e7ce54ab44224b690121f3f5485043b40211f8b8bc39R213) [[5]](diffhunk://#diff-9dae149ed1071d4ebde8e7ce54ab44224b690121f3f5485043b40211f8b8bc39R240)

**Internal Implementation of Label Profiles:**

* Introduced the `EngProfile` (default) and `OpsProfile` implementations in `internal/alloy/labels/`, each defining which labels are injected. The `EngProfile` adds only `cluster`, while `OpsProfile` adds `cluster`, `environment`, `instance_type`, `inventory_name`, and `ip`. [[1]](diffhunk://#diff-7488cc0730eaa9dc7ddbe3702d85bf51d45fde4da78b2754fb8de791859ebc00R1-R24) [[2]](diffhunk://#diff-4544839aacbd3cfd6b58e7f4e6b405415d75038f0f35f3e81dcdc33235176b81R1-R84)
* Updated `ConfigBuilder` to resolve and render label rules per remote based on the selected profile, including new helper methods and fields for deploy profile and machine IP. [[1]](diffhunk://#diff-9dae149ed1071d4ebde8e7ce54ab44224b690121f3f5485043b40211f8b8bc39R60-R66) [[2]](diffhunk://#diff-9dae149ed1071d4ebde8e7ce54ab44224b690121f3f5485043b40211f8b8bc39R87-R112) [[3]](diffhunk://#diff-9dae149ed1071d4ebde8e7ce54ab44224b690121f3f5485043b40211f8b8bc39R152-R154) [[4]](diffhunk://#diff-9dae149ed1071d4ebde8e7ce54ab44224b690121f3f5485043b40211f8b8bc39R164-R167) [[5]](diffhunk://#diff-9dae149ed1071d4ebde8e7ce54ab44224b690121f3f5485043b40211f8b8bc39R178-R181)

**Documentation Updates:**

* Updated `docs/quickstart.md` to document the new `labelProfile` option, including usage examples, available profiles, and the labels they add. Also updated CLI help text and YAML configuration examples. [[1]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL374-R375) [[2]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL385-R389) [[3]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aR448-R479) [[4]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aR540-R545)
* Added `docs/dev/label_profiles.md` with detailed developer instructions for adding new label profiles, architecture overview, and required steps.
* Bumped documentation version to 1.2.0.

**Testing:**

* Added unit tests for the `EngProfile` to ensure correct label injection behavior.

**Codebase Maintenance:**

* Updated imports and refactored code to support the new label profile logic and to pass the deploy profile and machine IP as needed.

These changes make label injection for metrics and logs more flexible and extensible, improving operational visibility and supporting future profile additions.

### Related Issues

* Closes #388 
