### PR TITLE
feat: bump block node to 0.29.0 and centralize helm chart defaults

### DIFF
--- a/internal/alloy/config.go
+++ b/internal/alloy/config.go
@@ -14,19 +14,8 @@ import (
 
 const (
 	// Kubernetes resource names
-	Namespace     = "grafana-alloy"
-	Release       = "grafana-alloy"
-	Chart         = "grafana/alloy"
-	Version       = "1.4.0"
-	Repo          = "https://grafana.github.io/helm-charts"
 	ConfigMapName = "grafana-alloy-cm"
 	SecretsName   = "grafana-alloy-secrets"
-
-	// Node exporter settings
-	NodeExporterNamespace = "node-exporter"
-	NodeExporterRelease   = "node-exporter"
-	NodeExporterChart     = "oci://registry-1.docker.io/bitnamicharts/node-exporter"
-	NodeExporterVersion   = "4.5.19"
 
 	// Template paths
 	CoreTemplatePath            = "files/alloy/core.alloy"

--- a/internal/alloy/manifest.go
+++ b/internal/alloy/manifest.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/hashgraph/solo-weaver/internal/templates"
+	"github.com/hashgraph/solo-weaver/pkg/deps"
 )
 
 // ConfigMapTemplateData holds data for the ConfigMap template.
@@ -44,7 +45,7 @@ func ConfigMapManifest(modules []ModuleConfig) (string, error) {
 
 	data := ConfigMapTemplateData{
 		ConfigMapName: ConfigMapName,
-		Namespace:     Namespace,
+		Namespace:     deps.ALLOY_NAMESPACE,
 		Modules:       templateModules,
 	}
 
@@ -122,7 +123,7 @@ type NamespaceTemplateData struct {
 // Uses the namespace.yaml template file.
 func NamespaceManifest() (string, error) {
 	data := NamespaceTemplateData{
-		Namespace: Namespace,
+		Namespace: deps.ALLOY_NAMESPACE,
 	}
 
 	return templates.Render("files/alloy/namespace.yaml", data)

--- a/internal/alloy/render_test.go
+++ b/internal/alloy/render_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -151,7 +152,7 @@ func TestConfigMapManifest(t *testing.T) {
 	assert.Contains(t, manifest, "apiVersion: v1")
 	assert.Contains(t, manifest, "kind: ConfigMap")
 	assert.Contains(t, manifest, "name: "+ConfigMapName)
-	assert.Contains(t, manifest, "namespace: "+Namespace)
+	assert.Contains(t, manifest, "namespace: "+deps.ALLOY_NAMESPACE)
 
 	// Verify main config.alloy is present with concatenated content
 	assert.Contains(t, manifest, "config.alloy: |")
@@ -214,7 +215,7 @@ func TestNamespaceManifest(t *testing.T) {
 	// Verify it's a valid namespace manifest
 	assert.Contains(t, manifest, "apiVersion: v1")
 	assert.Contains(t, manifest, "kind: Namespace")
-	assert.Contains(t, manifest, "name: "+Namespace)
+	assert.Contains(t, manifest, "name: "+deps.ALLOY_NAMESPACE)
 }
 
 func TestBuildHelmEnvVars_DefaultSecret(t *testing.T) {

--- a/internal/workflows/steps/step_alloy.go
+++ b/internal/workflows/steps/step_alloy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/alloy"
 	"github.com/hashgraph/solo-weaver/pkg/config"
+	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 
 	"github.com/hashgraph/solo-weaver/internal/kube"
@@ -108,17 +109,17 @@ func preCheckAlloy() automa.Builder {
 				// Verify that required K8s secrets exist with expected keys
 				requiredSecrets := cb.RequiredSecrets()
 				for secretName, expectedKeys := range requiredSecrets {
-					actualKeys, err := k.GetSecretKeys(ctx, alloy.Namespace, secretName)
+					actualKeys, err := k.GetSecretKeys(ctx, deps.ALLOY_NAMESPACE, secretName)
 					if err != nil {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
-							fmt.Errorf("failed to read K8s Secret %q in namespace %q: %w", secretName, alloy.Namespace, err)))
+							fmt.Errorf("failed to read K8s Secret %q in namespace %q: %w", secretName, deps.ALLOY_NAMESPACE, err)))
 					}
 					if actualKeys == nil {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
 							fmt.Errorf("K8s Secret %q not found in namespace %q; expected keys: %v. "+
 								"Create the secret before installing Alloy, e.g.: "+
 								"kubectl create secret generic %s --namespace=%s --from-literal=<KEY>=<password>",
-								secretName, alloy.Namespace, expectedKeys, secretName, alloy.Namespace)))
+								secretName, deps.ALLOY_NAMESPACE, expectedKeys, secretName, deps.ALLOY_NAMESPACE)))
 					}
 
 					// Check that all expected keys are present in the secret
@@ -135,10 +136,10 @@ func preCheckAlloy() automa.Builder {
 					if len(missingKeys) > 0 {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
 							fmt.Errorf("K8s Secret %q in namespace %q is missing required keys: %v; found keys: %v",
-								secretName, alloy.Namespace, missingKeys, actualKeys)))
+								secretName, deps.ALLOY_NAMESPACE, missingKeys, actualKeys)))
 					}
 
-					l.Info().Str("name", secretName).Str("namespace", alloy.Namespace).Strs("expectedKeys", expectedKeys).Msg("Required K8s Secret found")
+					l.Info().Str("name", secretName).Str("namespace", deps.ALLOY_NAMESPACE).Strs("expectedKeys", expectedKeys).Msg("Required K8s Secret found")
 				}
 
 				// Check Prometheus remote endpoints reachability
@@ -232,7 +233,7 @@ func installNodeExporter() automa.Builder {
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(alloy.NodeExporterRelease, alloy.NodeExporterNamespace)
+			isInstalled, err := hm.IsInstalled(deps.NODE_EXPORTER_RELEASE, deps.NODE_EXPORTER_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -259,10 +260,10 @@ func installNodeExporter() automa.Builder {
 
 			_, err = hm.InstallChart(
 				ctx,
-				alloy.NodeExporterRelease,
-				alloy.NodeExporterChart,
-				alloy.NodeExporterVersion,
-				alloy.NodeExporterNamespace,
+				deps.NODE_EXPORTER_RELEASE,
+				deps.NODE_EXPORTER_CHART,
+				deps.NODE_EXPORTER_VERSION,
+				deps.NODE_EXPORTER_NAMESPACE,
 				helm.InstallChartOptions{
 					ValueOpts: &values.Options{
 						Values: helmValues,
@@ -293,7 +294,7 @@ func installNodeExporter() automa.Builder {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(alloy.NodeExporterRelease, alloy.NodeExporterNamespace)
+			err = hm.UninstallChart(deps.NODE_EXPORTER_RELEASE, deps.NODE_EXPORTER_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -322,7 +323,7 @@ func isNodeExporterPodsReady() automa.Builder {
 
 			meta := map[string]string{}
 			// wait for node-exporter pods to be ready
-			err = k.WaitForResources(ctx, kube.KindPod, alloy.NodeExporterNamespace, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "node-exporter"})
+			err = k.WaitForResources(ctx, kube.KindPod, deps.NODE_EXPORTER_NAMESPACE, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "node-exporter"})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -397,7 +398,7 @@ func installAlloy() automa.Builder {
 			meta := map[string]string{}
 
 			// Check if already installed to provide better logging and track for rollback
-			isInstalled, err := hm.IsInstalled(alloy.Release, alloy.Namespace)
+			isInstalled, err := hm.IsInstalled(deps.ALLOY_RELEASE, deps.ALLOY_NAMESPACE)
 			if err != nil {
 				l.Warn().Err(err).Msg("Failed to check if Grafana Alloy is installed, proceeding with install/upgrade")
 			}
@@ -411,7 +412,7 @@ func installAlloy() automa.Builder {
 				l.Info().Msg("Installing Grafana Alloy")
 			}
 
-			_, err = hm.AddRepo("grafana", alloy.Repo, helm.RepoAddOptions{})
+			_, err = hm.AddRepo("grafana", deps.ALLOY_REPO, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -440,10 +441,10 @@ func installAlloy() automa.Builder {
 			// This will install if not present, or upgrade if already installed
 			_, err = hm.DeployChart(
 				ctx,
-				alloy.Release,
-				alloy.Chart,
-				alloy.Version,
-				alloy.Namespace,
+				deps.ALLOY_RELEASE,
+				deps.ALLOY_CHART,
+				deps.ALLOY_VERSION,
+				deps.ALLOY_NAMESPACE,
 				helm.DeployChartOptions{
 					ValueOpts: &values.Options{
 						Values: helmValues,
@@ -480,7 +481,7 @@ func installAlloy() automa.Builder {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(alloy.Release, alloy.Namespace)
+			err = hm.UninstallChart(deps.ALLOY_RELEASE, deps.ALLOY_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -724,7 +725,7 @@ func isAlloyPodsReady() automa.Builder {
 
 			meta := map[string]string{}
 			// wait for alloy pods to be ready
-			err = k.WaitForResources(ctx, kube.KindPod, alloy.Namespace, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "grafana-alloy"})
+			err = k.WaitForResources(ctx, kube.KindPod, deps.ALLOY_NAMESPACE, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "grafana-alloy"})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -755,7 +756,7 @@ func uninstallAlloy() automa.Builder {
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(alloy.Release, alloy.Namespace)
+			isInstalled, err := hm.IsInstalled(deps.ALLOY_RELEASE, deps.ALLOY_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -765,7 +766,7 @@ func uninstallAlloy() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			err = hm.UninstallChart(alloy.Release, alloy.Namespace)
+			err = hm.UninstallChart(deps.ALLOY_RELEASE, deps.ALLOY_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -796,7 +797,7 @@ func uninstallNodeExporter() automa.Builder {
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(alloy.NodeExporterRelease, alloy.NodeExporterNamespace)
+			isInstalled, err := hm.IsInstalled(deps.NODE_EXPORTER_RELEASE, deps.NODE_EXPORTER_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -806,7 +807,7 @@ func uninstallNodeExporter() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			err = hm.UninstallChart(alloy.NodeExporterRelease, alloy.NodeExporterNamespace)
+			err = hm.UninstallChart(deps.NODE_EXPORTER_RELEASE, deps.NODE_EXPORTER_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_external_secrets.go
+++ b/internal/workflows/steps/step_external_secrets.go
@@ -10,16 +10,12 @@ import (
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/kube"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/helm"
 	"helm.sh/helm/v3/pkg/cli/values"
 )
 
 const (
-	ExternalSecretsNamespace     = "external-secrets"
-	ExternalSecretsRelease       = "external-secrets"
-	ExternalSecretsChart         = "external-secrets/external-secrets"
-	ExternalSecretsVersion       = "0.20.2"
-	ExternalSecretsRepo          = "https://charts.external-secrets.io"
 	SetupExternalSecretsStepId   = "setup-external-secrets"
 	InstallExternalSecretsStepId = "install-external-secrets"
 	IsExternalSecretsReadyStepId = "is-external-secrets-ready"
@@ -53,7 +49,7 @@ func installExternalSecrets() automa.Builder {
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(ExternalSecretsRelease, ExternalSecretsNamespace)
+			isInstalled, err := hm.IsInstalled(deps.EXTERNAL_SECRETS_RELEASE, deps.EXTERNAL_SECRETS_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -64,7 +60,7 @@ func installExternalSecrets() automa.Builder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
-			_, err = hm.AddRepo("external-secrets", ExternalSecretsRepo, helm.RepoAddOptions{})
+			_, err = hm.AddRepo("external-secrets", deps.EXTERNAL_SECRETS_REPO, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -76,10 +72,10 @@ func installExternalSecrets() automa.Builder {
 
 			_, err = hm.InstallChart(
 				ctx,
-				ExternalSecretsRelease,
-				ExternalSecretsChart,
-				ExternalSecretsVersion,
-				ExternalSecretsNamespace,
+				deps.EXTERNAL_SECRETS_RELEASE,
+				deps.EXTERNAL_SECRETS_CHART,
+				deps.EXTERNAL_SECRETS_VERSION,
+				deps.EXTERNAL_SECRETS_NAMESPACE,
 				helm.InstallChartOptions{
 					ValueOpts: &values.Options{
 						Values: helmValues,
@@ -110,7 +106,7 @@ func installExternalSecrets() automa.Builder {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(ExternalSecretsRelease, ExternalSecretsNamespace)
+			err = hm.UninstallChart(deps.EXTERNAL_SECRETS_RELEASE, deps.EXTERNAL_SECRETS_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -139,7 +135,7 @@ func isExternalSecretsReady() automa.Builder {
 
 			meta := map[string]string{}
 			// Wait for external-secrets pods to be ready
-			err = k.WaitForResources(ctx, kube.KindPod, ExternalSecretsNamespace, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "external-secrets"})
+			err = k.WaitForResources(ctx, kube.KindPod, deps.EXTERNAL_SECRETS_NAMESPACE, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "external-secrets"})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_metallb.go
+++ b/internal/workflows/steps/step_metallb.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 
 	"github.com/hashgraph/solo-weaver/internal/kube"
@@ -22,11 +23,6 @@ import (
 )
 
 const (
-	MetalLBNamespace             = "metallb-system"
-	MetalLBRelease               = "metallb"
-	MetalLBChart                 = "metallb/metallb"
-	MetalLBVersion               = "0.15.2"
-	MetalLBRepo                  = "https://metallb.github.io/metallb"
 	SetupMetalLBStepId           = "setup-metallb"
 	InstallMetalLBStepId         = "install-metallb"
 	MetalLBTemplatePath          = "files/metallb/metallb.yaml"
@@ -69,7 +65,7 @@ func installMetalLB() automa.Builder {
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(MetalLBRelease, MetalLBNamespace)
+			isInstalled, err := hm.IsInstalled(deps.METALLB_RELEASE, deps.METALLB_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -80,23 +76,23 @@ func installMetalLB() automa.Builder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
-			_, err = hm.AddRepo(MetalLBRelease, MetalLBRepo, helm.RepoAddOptions{})
+			_, err = hm.AddRepo(deps.METALLB_RELEASE, deps.METALLB_REPO, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			// if chartVersion doesn't start with "v", prepend it
-			chartVersion := MetalLBVersion
+			chartVersion := deps.METALLB_VERSION
 			if !strings.HasPrefix(chartVersion, "v") {
 				chartVersion = "v" + chartVersion
 			}
 
 			_, err = hm.InstallChart(
 				ctx,
-				MetalLBRelease,
-				MetalLBChart,
+				deps.METALLB_RELEASE,
+				deps.METALLB_CHART,
 				chartVersion,
-				MetalLBNamespace,
+				deps.METALLB_NAMESPACE,
 				helm.InstallChartOptions{
 					ValueOpts: &values.Options{
 						Values: []string{"speaker.frr.enabled=false"},
@@ -127,7 +123,7 @@ func installMetalLB() automa.Builder {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(MetalLBRelease, MetalLBNamespace)
+			err = hm.UninstallChart(deps.METALLB_RELEASE, deps.METALLB_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -254,7 +250,7 @@ func isMetalLBPodsReady() automa.Builder {
 
 			meta := map[string]string{}
 			// wait for metallb pods to be ready
-			err = k.WaitForResources(ctx, kube.KindPod, MetalLBNamespace, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "metallb"})
+			err = k.WaitForResources(ctx, kube.KindPod, deps.METALLB_NAMESPACE, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "metallb"})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_metrics_server.go
+++ b/internal/workflows/steps/step_metrics_server.go
@@ -9,16 +9,9 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/helm"
 	"helm.sh/helm/v3/pkg/cli/values"
-)
-
-const (
-	MetricsServerNamespace    = "kube-system"
-	MetricsServerRelease      = "metrics-server"
-	MetricsServerChart        = "metrics-server/metrics-server"
-	MetricsServerChartVersion = "3.13.0"
-	MetricsServerRepo         = "https://kubernetes-sigs.github.io/metrics-server"
 )
 
 func DeployMetricsServer(valueOptions *values.Options) *automa.WorkflowBuilder {
@@ -56,7 +49,7 @@ func installMetricsServer(valueOptions *values.Options) *automa.StepBuilder {
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(MetricsServerRelease, MetricsServerNamespace)
+			isInstalled, err := hm.IsInstalled(deps.METRICS_SERVER_RELEASE, deps.METRICS_SERVER_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -67,23 +60,23 @@ func installMetricsServer(valueOptions *values.Options) *automa.StepBuilder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
-			_, err = hm.AddRepo(MetricsServerRelease, MetricsServerRepo, helm.RepoAddOptions{})
+			_, err = hm.AddRepo(deps.METRICS_SERVER_RELEASE, deps.METRICS_SERVER_REPO, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			// if chartVersion doesn't start with "v", prepend it
-			chartVersion := MetricsServerChartVersion
+			chartVersion := deps.METRICS_SERVER_VERSION
 			if !strings.HasPrefix(chartVersion, "v") {
 				chartVersion = "v" + chartVersion
 			}
 
 			_, err = hm.InstallChart(
 				ctx,
-				MetricsServerRelease,
-				MetricsServerChart,
+				deps.METRICS_SERVER_RELEASE,
+				deps.METRICS_SERVER_CHART,
 				chartVersion,
-				MetricsServerNamespace,
+				deps.METRICS_SERVER_NAMESPACE,
 				helm.InstallChartOptions{
 					ValueOpts:       valueOptions,
 					CreateNamespace: true,
@@ -112,7 +105,7 @@ func installMetricsServer(valueOptions *values.Options) *automa.StepBuilder {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(MetricsServerRelease, MetricsServerNamespace)
+			err = hm.UninstallChart(deps.METRICS_SERVER_RELEASE, deps.METRICS_SERVER_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_prometheus_operator_crds.go
+++ b/internal/workflows/steps/step_prometheus_operator_crds.go
@@ -10,18 +10,15 @@ import (
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/kube"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/helm"
 	"github.com/joomcode/errorx"
 )
 
 const (
-	PrometheusOperatorCRDsNamespace = "grafana-alloy"
-	PrometheusOperatorCRDsRelease   = "prometheus-operator-crds"
-	PrometheusOperatorCRDsChart     = "oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds"
-	PrometheusOperatorCRDsVersion   = "24.0.1"
-	SetupPrometheusCRDsStepId       = "setup-prometheus-crds"
-	InstallPrometheusCRDsStepId     = "install-prometheus-crds"
-	IsPrometheusCRDsReadyStepId     = "is-prometheus-crds-ready"
+	SetupPrometheusCRDsStepId   = "setup-prometheus-crds"
+	InstallPrometheusCRDsStepId = "install-prometheus-crds"
+	IsPrometheusCRDsReadyStepId = "is-prometheus-crds-ready"
 )
 
 // SetupPrometheusOperatorCRDs returns a workflow builder that sets up Prometheus Operator CRDs.
@@ -53,7 +50,7 @@ func installPrometheusOperatorCRDs() automa.Builder {
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(PrometheusOperatorCRDsRelease, PrometheusOperatorCRDsNamespace)
+			isInstalled, err := hm.IsInstalled(deps.PROMETHEUS_OPERATOR_CRDS_RELEASE, deps.PROMETHEUS_OPERATOR_CRDS_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -66,10 +63,10 @@ func installPrometheusOperatorCRDs() automa.Builder {
 
 			_, err = hm.InstallChart(
 				ctx,
-				PrometheusOperatorCRDsRelease,
-				PrometheusOperatorCRDsChart,
-				PrometheusOperatorCRDsVersion,
-				PrometheusOperatorCRDsNamespace,
+				deps.PROMETHEUS_OPERATOR_CRDS_RELEASE,
+				deps.PROMETHEUS_OPERATOR_CRDS_CHART,
+				deps.PROMETHEUS_OPERATOR_CRDS_VERSION,
+				deps.PROMETHEUS_OPERATOR_CRDS_NAMESPACE,
 				helm.InstallChartOptions{
 					CreateNamespace: true,
 					Atomic:          true,
@@ -97,7 +94,7 @@ func installPrometheusOperatorCRDs() automa.Builder {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(PrometheusOperatorCRDsRelease, PrometheusOperatorCRDsNamespace)
+			err = hm.UninstallChart(deps.PROMETHEUS_OPERATOR_CRDS_RELEASE, deps.PROMETHEUS_OPERATOR_CRDS_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -182,7 +179,7 @@ func uninstallPrometheusOperatorCRDs() automa.Builder {
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(PrometheusOperatorCRDsRelease, PrometheusOperatorCRDsNamespace)
+			isInstalled, err := hm.IsInstalled(deps.PROMETHEUS_OPERATOR_CRDS_RELEASE, deps.PROMETHEUS_OPERATOR_CRDS_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -192,7 +189,7 @@ func uninstallPrometheusOperatorCRDs() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			err = hm.UninstallChart(PrometheusOperatorCRDsRelease, PrometheusOperatorCRDsNamespace)
+			err = hm.UninstallChart(deps.PROMETHEUS_OPERATOR_CRDS_RELEASE, deps.PROMETHEUS_OPERATOR_CRDS_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_teleport.go
+++ b/internal/workflows/steps/step_teleport.go
@@ -23,11 +23,6 @@ import (
 )
 
 const (
-	TeleportNamespace             = "teleport-agent"
-	TeleportRelease               = "teleport-agent"
-	TeleportChart                 = "teleport/teleport-kube-agent"
-	TeleportRepo                  = "https://charts.releases.teleport.dev"
-	TeleportDefaultVersion        = deps.TELEPORT_VERSION
 	SetupTeleportStepId           = "setup-teleport"
 	InstallTeleportStepId         = "install-teleport"
 	CreateTeleportNamespaceStepId = "create-teleport-namespace"
@@ -252,7 +247,7 @@ func CreateTeleportNamespace() automa.Builder {
 			// Create namespace manifest using template
 			namespaceManifestPath := path.Join(models.Paths().TempDir, "teleport-namespace.yaml")
 			namespaceManifest, err := templates.Render("files/teleport/namespace.yaml", map[string]string{
-				"Namespace": TeleportNamespace,
+				"Namespace": deps.TELEPORT_NAMESPACE,
 			})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
@@ -296,7 +291,7 @@ func InstallTeleportKubeAgent() automa.Builder {
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(TeleportRelease, TeleportNamespace)
+			isInstalled, err := hm.IsInstalled(deps.TELEPORT_RELEASE, deps.TELEPORT_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -307,7 +302,7 @@ func InstallTeleportKubeAgent() automa.Builder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
-			_, err = hm.AddRepo("teleport", TeleportRepo, helm.RepoAddOptions{})
+			_, err = hm.AddRepo("teleport", deps.TELEPORT_REPO, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -315,17 +310,17 @@ func InstallTeleportKubeAgent() automa.Builder {
 			// Determine chart version
 			chartVersion := cfg.Version
 			if chartVersion == "" {
-				chartVersion = TeleportDefaultVersion
+				chartVersion = deps.TELEPORT_VERSION
 			}
 
 			l.Info().Str("path", cfg.ValuesFile).Msg("Using Teleport values file")
 
 			_, err = hm.InstallChart(
 				ctx,
-				TeleportRelease,
-				TeleportChart,
+				deps.TELEPORT_RELEASE,
+				deps.TELEPORT_CHART,
 				chartVersion,
-				TeleportNamespace,
+				deps.TELEPORT_NAMESPACE,
 				helm.InstallChartOptions{
 					ValueOpts: &values.Options{
 						ValueFiles: []string{cfg.ValuesFile},
@@ -356,7 +351,7 @@ func InstallTeleportKubeAgent() automa.Builder {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(TeleportRelease, TeleportNamespace)
+			err = hm.UninstallChart(deps.TELEPORT_RELEASE, deps.TELEPORT_NAMESPACE)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -386,7 +381,7 @@ func IsTeleportPodsReady() automa.Builder {
 
 			meta := map[string]string{}
 			// wait for teleport pods to be ready
-			err = k.WaitForResources(ctx, kube.KindPod, TeleportNamespace, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "teleport-agent"})
+			err = k.WaitForResources(ctx, kube.KindPod, deps.TELEPORT_NAMESPACE, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "teleport-agent"})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -3,11 +3,57 @@
 package deps
 
 const (
+	// Block Node
 	BLOCK_NODE_NAMESPACE         = "block-node"
 	BLOCK_NODE_RELEASE           = "block-node"
 	BLOCK_NODE_CHART             = "oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server"
-	BLOCK_NODE_VERSION           = "0.22.1"
+	BLOCK_NODE_VERSION           = "0.29.0"
 	BLOCK_NODE_STORAGE_BASE_PATH = "/mnt/fast-storage"
 
-	TELEPORT_VERSION = "18.6.4"
+	// Teleport
+	TELEPORT_NAMESPACE = "teleport-agent"
+	TELEPORT_RELEASE   = "teleport-agent"
+	TELEPORT_CHART     = "teleport/teleport-kube-agent"
+	TELEPORT_REPO      = "https://charts.releases.teleport.dev"
+	TELEPORT_VERSION   = "18.6.4"
+
+	// Grafana Alloy
+	ALLOY_NAMESPACE = "grafana-alloy"
+	ALLOY_RELEASE   = "grafana-alloy"
+	ALLOY_CHART     = "grafana/alloy"
+	ALLOY_VERSION   = "1.4.0"
+	ALLOY_REPO      = "https://grafana.github.io/helm-charts"
+
+	// Node Exporter
+	NODE_EXPORTER_NAMESPACE = "node-exporter"
+	NODE_EXPORTER_RELEASE   = "node-exporter"
+	NODE_EXPORTER_CHART     = "oci://registry-1.docker.io/bitnamicharts/node-exporter"
+	NODE_EXPORTER_VERSION   = "4.5.19"
+
+	// MetalLB
+	METALLB_NAMESPACE = "metallb-system"
+	METALLB_RELEASE   = "metallb"
+	METALLB_CHART     = "metallb/metallb"
+	METALLB_VERSION   = "0.15.2"
+	METALLB_REPO      = "https://metallb.github.io/metallb"
+
+	// Metrics Server
+	METRICS_SERVER_NAMESPACE = "kube-system"
+	METRICS_SERVER_RELEASE   = "metrics-server"
+	METRICS_SERVER_CHART     = "metrics-server/metrics-server"
+	METRICS_SERVER_VERSION   = "3.13.0"
+	METRICS_SERVER_REPO      = "https://kubernetes-sigs.github.io/metrics-server"
+
+	// Prometheus Operator CRDs
+	PROMETHEUS_OPERATOR_CRDS_NAMESPACE = "grafana-alloy"
+	PROMETHEUS_OPERATOR_CRDS_RELEASE   = "prometheus-operator-crds"
+	PROMETHEUS_OPERATOR_CRDS_CHART     = "oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds"
+	PROMETHEUS_OPERATOR_CRDS_VERSION   = "24.0.1"
+
+	// External Secrets
+	EXTERNAL_SECRETS_NAMESPACE = "external-secrets"
+	EXTERNAL_SECRETS_RELEASE   = "external-secrets"
+	EXTERNAL_SECRETS_CHART     = "external-secrets/external-secrets"
+	EXTERNAL_SECRETS_VERSION   = "0.20.2"
+	EXTERNAL_SECRETS_REPO      = "https://charts.external-secrets.io"
 )


### PR DESCRIPTION
## Description

This pull request refactors how constants related to Kubernetes resource names, Helm chart releases, and namespaces are managed throughout the codebase. Instead of defining these values directly in multiple files, they are now sourced from the centralized `deps` package. This change improves maintainability and consistency by ensuring that all resource identifiers are defined in a single location.

The most important changes are:

**Centralization of Constants:**

* Removed hardcoded constants for Alloy, Node Exporter, External Secrets, and MetalLB resource names, releases, chart names, versions, and repositories from various files, and now reference them from the `deps` package instead. This affects files such as `internal/alloy/config.go`, `internal/workflows/steps/step_alloy.go`, `internal/workflows/steps/step_external_secrets.go`, and `internal/workflows/steps/step_metallb.go`. [[1]](diffhunk://#diff-9dae149ed1071d4ebde8e7ce54ab44224b690121f3f5485043b40211f8b8bc39L17-L29) [[2]](diffhunk://#diff-90df848dfafa5da062ac69706a6087037a75e17bb69120b6d86a9ab6922465d6R13-L22) [[3]](diffhunk://#diff-08f98e9ffbd684b5d93a7700841a4a166363a112ed24f553ee1253a56b058190L25-L29)

**Refactoring of Function Calls:**

* Updated all usages of the removed constants in function calls and logic to use the corresponding values from `deps`, including Helm chart installation, uninstallation, readiness checks, and manifest rendering. This ensures all workflow steps use the centralized configuration. [[1]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL111-R122) [[2]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL235-R236) [[3]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL262-R266) [[4]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL296-R297) [[5]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL325-R326) [[6]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL400-R401) [[7]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL414-R415) [[8]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL443-R447) [[9]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL483-R484) [[10]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL727-R728) [[11]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL758-R759) [[12]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL768-R769) [[13]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL799-R800) [[14]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eL809-R810) [[15]](diffhunk://#diff-90df848dfafa5da062ac69706a6087037a75e17bb69120b6d86a9ab6922465d6L56-R52) [[16]](diffhunk://#diff-90df848dfafa5da062ac69706a6087037a75e17bb69120b6d86a9ab6922465d6L67-R63) [[17]](diffhunk://#diff-90df848dfafa5da062ac69706a6087037a75e17bb69120b6d86a9ab6922465d6L79-R78) [[18]](diffhunk://#diff-90df848dfafa5da062ac69706a6087037a75e17bb69120b6d86a9ab6922465d6L113-R109) [[19]](diffhunk://#diff-90df848dfafa5da062ac69706a6087037a75e17bb69120b6d86a9ab6922465d6L142-R138)

**Test and Template Adjustments:**

* Updated tests and template data generation to use the new centralized constants, ensuring that test assertions and template rendering remain accurate and consistent with the new source of truth. [[1]](diffhunk://#diff-ded2f07e8454642a490eacbc8617f413605b90488f4a5abefaa0afb751510218L47-R48) [[2]](diffhunk://#diff-ded2f07e8454642a490eacbc8617f413605b90488f4a5abefaa0afb751510218L125-R126) [[3]](diffhunk://#diff-b5455ad091a35e60243ff2518b21eab709e2b4a784b052f3597f8245163d015aL154-R155) [[4]](diffhunk://#diff-b5455ad091a35e60243ff2518b21eab709e2b4a784b052f3597f8245163d015aL217-R218)

**Imports and Cleanup:**

* Added imports for the `deps` package in all affected files and removed now-unnecessary constant definitions, cleaning up the codebase and reducing duplication. [[1]](diffhunk://#diff-ded2f07e8454642a490eacbc8617f413605b90488f4a5abefaa0afb751510218R9) [[2]](diffhunk://#diff-b5455ad091a35e60243ff2518b21eab709e2b4a784b052f3597f8245163d015aR9) [[3]](diffhunk://#diff-703b2320b0eb45c793b270532e7b48db0738875cc11376885a48be17f240a98eR17) [[4]](diffhunk://#diff-90df848dfafa5da062ac69706a6087037a75e17bb69120b6d86a9ab6922465d6R13-L22) [[5]](diffhunk://#diff-08f98e9ffbd684b5d93a7700841a4a166363a112ed24f553ee1253a56b058190R14)

This refactor makes it easier to update resource identifiers in the future and reduces the risk of inconsistencies across the project.

### Related Issues

* Closes #414 
