### PR TITLE
chore(ci): add UAT CI workflow

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -33,11 +33,21 @@ jobs:
     with:
       custom-job-label: Standard
 
+  uat-tests:
+    name: UAT Tests
+    uses: ./.github/workflows/zxc-uat-test.yaml
+    needs:
+      - build
+    with:
+      custom-job-label: Standard
+      vm-os: debian
+
   integration-tests:
     name: Integration Tests
     uses: ./.github/workflows/zxc-integration-test.yaml
     needs:
       - build
+      - uat-tests
     with:
       custom-job-label: Standard
       vm-os: debian

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -33,13 +33,25 @@ jobs:
     with:
       custom-job-label: Standard
 
-  uat-tests:
-    name: UAT Tests
+  uat-compat:
+    name: UAT Backward Compatibility
     uses: ./.github/workflows/zxc-uat-test.yaml
     needs:
       - build
     with:
-      custom-job-label: Standard
+      custom-job-label: UAT Compat
+      uat-scenario: compat
+      vm-os: debian
+
+  uat-core:
+    name: UAT Core Lifecycle
+    uses: ./.github/workflows/zxc-uat-test.yaml
+    needs:
+      - build
+      - uat-compat
+    with:
+      custom-job-label: UAT Core
+      uat-scenario: lifecycle
       vm-os: debian
 
   integration-tests:
@@ -47,7 +59,7 @@ jobs:
     uses: ./.github/workflows/zxc-integration-test.yaml
     needs:
       - build
-      - uat-tests
+      - uat-core
     with:
       custom-job-label: Standard
       vm-os: debian

--- a/.github/workflows/flow-test-uat.yaml
+++ b/.github/workflows/flow-test-uat.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Test UAT"
+on:
+  workflow_dispatch:
+    inputs:
+      uat-scenario:
+        description: "UAT scenario to run"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - setup
+          - core
+          - teleport
+          - alloy
+          - compat
+          - teardown
+      vm-os:
+        description: "VM OS to test"
+        required: true
+        default: "debian"
+        type: choice
+        options:
+          - debian
+          - ubuntu
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  test-uat:
+    name: Test UAT (${{ inputs.vm-os }} / ${{ inputs.uat-scenario }})
+    uses: ./.github/workflows/zxc-uat-test.yaml
+    with:
+      custom-job-label: "Test UAT (${{ inputs.vm-os }} / ${{ inputs.uat-scenario }})"
+      vm-os: ${{ inputs.vm-os }}
+      uat-scenario: ${{ inputs.uat-scenario }}

--- a/.github/workflows/flow-test-uat.yaml
+++ b/.github/workflows/flow-test-uat.yaml
@@ -7,15 +7,16 @@ on:
       uat-scenario:
         description: "UAT scenario to run"
         required: true
-        default: "all"
+        default: "lifecycle"
         type: choice
         options:
+          - lifecycle
+          - compat
           - all
           - setup
           - core
           - teleport
           - alloy
-          - compat
           - teardown
       vm-os:
         description: "VM OS to test"

--- a/.github/workflows/zxc-uat-test.yaml
+++ b/.github/workflows/zxc-uat-test.yaml
@@ -1,0 +1,500 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "ZXC: UAT Test"
+
+on:
+  workflow_call:
+    inputs:
+      uat-scenario:
+        description: "UAT scenario to run (setup, core, teleport, alloy, compat, teardown, all)"
+        type: string
+        required: false
+        default: "all"
+      vm-os:
+        description: "VM OS (debian or ubuntu)"
+        type: string
+        required: false
+        default: "debian"
+      go-version:
+        description: "Go version installed inside the VM"
+        type: string
+        required: false
+        default: "1.25.2"
+      custom-job-label:
+        description: "Custom Job Label"
+        type: string
+        required: false
+        default: "UAT Test"
+      vm-cpus:
+        description: "VM vCPUs"
+        type: number
+        required: false
+        default: 3
+      vm-mem-mb:
+        description: "VM memory (MB)"
+        type: number
+        required: false
+        default: 4096
+      vm-disk-gb:
+        description: "Overlay disk size (GB)"
+        type: number
+        required: false
+        default: 20
+      vm-ready-timeout-minutes:
+        description: "Timeout waiting for VM SSH"
+        type: number
+        required: false
+        default: 10
+      uat-timeout-minutes:
+        description: "Timeout for UAT tests in VM"
+        type: number
+        required: false
+        default: 120
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  uat-test:
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
+    name: "${{ inputs.custom-job-label }}"
+    runs-on: kvm-runner
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Create VM working directory + pick unique SSH port
+        id: vm-vars
+        run: |
+          set -euo pipefail
+
+          JOB_ID="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${RANDOM}"
+          VM_DIR="${RUNNER_TEMP}/weaver-vm-${JOB_ID}"
+          mkdir -p "${VM_DIR}"
+
+          pick_port() {
+            local tries=20
+            while [ $tries -gt 0 ]; do
+              local p=$(( 2200 + (RANDOM % 400) ))
+              if ! ss -lnt "( sport = :$p )" | grep -q ":$p"; then
+                echo "$p"
+                return 0
+              fi
+              tries=$((tries - 1))
+            done
+            return 1
+          }
+
+          VM_PORT="$(pick_port)" || { echo "Failed to pick available port" >&2; exit 1; }
+          echo "VM_DIR=${VM_DIR}" >> "$GITHUB_OUTPUT"
+          echo "VM_PORT=${VM_PORT}" >> "$GITHUB_OUTPUT"
+          echo "JOB_ID=${JOB_ID}" >> "$GITHUB_OUTPUT"
+
+          echo "VM_DIR=${VM_DIR}"
+          echo "VM_PORT=${VM_PORT}"
+
+      - name: Generate SSH key for VM access
+        run: |
+          set -euo pipefail
+          VM_DIR="${{ steps.vm-vars.outputs.VM_DIR }}"
+          mkdir -p "${VM_DIR}/.ssh"
+          ssh-keygen -t ed25519 -f "${VM_DIR}/.ssh/id_ed25519_vm" -N "" -C "ci-vm-key"
+          chmod 600 "${VM_DIR}/.ssh/id_ed25519_vm"
+          chmod 644 "${VM_DIR}/.ssh/id_ed25519_vm.pub"
+
+      - name: Resolve base image path (pre-cached)
+        id: base-image
+        run: |
+          set -euo pipefail
+          VM_OS="${{ inputs.vm-os }}"
+          IMAGE_BASE="/var/lib/weaver/images"
+
+          case "$VM_OS" in
+            debian)
+              BASE_IMAGE="${IMAGE_BASE}/debian-12-genericcloud-amd64.qcow2"
+              ;;
+            ubuntu)
+              BASE_IMAGE="${IMAGE_BASE}/jammy-server-cloudimg-amd64.img"
+              ;;
+            *)
+              echo "Unsupported vm-os: ${VM_OS}"
+              exit 1
+              ;;
+          esac
+
+          if [ ! -f "$BASE_IMAGE" ]; then
+            echo "Base image not found: $BASE_IMAGE"
+            echo "Runner host must pre-cache images under /var/lib/weaver/images"
+            exit 1
+          fi
+
+          echo "BASE_IMAGE=${BASE_IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "VM_OS=${VM_OS}" >> "$GITHUB_OUTPUT"
+          echo "Using base image: ${BASE_IMAGE}"
+
+      - name: Create cloud-init ISO
+        run: |
+          set -euo pipefail
+          VM_DIR="${{ steps.vm-vars.outputs.VM_DIR }}"
+          SSH_PUB_KEY="$(cat "${VM_DIR}/.ssh/id_ed25519_vm.pub")"
+
+          cat > "${VM_DIR}/meta-data" <<EOF
+          instance-id: ci-vm-${{ steps.vm-vars.outputs.JOB_ID }}
+          local-hostname: ci-vm
+          EOF
+
+          cat > "${VM_DIR}/user-data" <<EOF
+          #cloud-config
+          users:
+            - name: provisioner
+              groups: sudo
+              shell: /bin/bash
+              sudo: ['ALL=(ALL) NOPASSWD:ALL']
+              ssh_authorized_keys:
+                - ${SSH_PUB_KEY}
+
+          system_info:
+            default_user:
+              name: provisioner
+
+          bootcmd:
+            - systemctl disable systemd-networkd-wait-online.service || true
+            - systemctl mask systemd-networkd-wait-online.service || true
+            - groupadd -g 2500 weaver || true
+            - useradd -u 2500 -g 2500 -m -s /bin/bash weaver || true
+
+          packages:
+            - openssh-server
+            - sudo
+            - ca-certificates
+            - rsync
+            - git
+            - build-essential
+            - binutils
+            - gcc
+            - libc6-dev
+            - curl
+            - net-tools
+            - netcat-openbsd
+
+          runcmd:
+            - systemctl enable --now ssh || systemctl enable --now sshd
+            - sed -i 's/^#\?PubkeyAuthentication .*/PubkeyAuthentication yes/' /etc/ssh/sshd_config || true
+            - systemctl restart ssh || systemctl restart sshd || true
+          EOF
+
+          genisoimage -output "${VM_DIR}/cloud-init.iso" \
+            -volid cidata \
+            -joliet \
+            -rock \
+            "${VM_DIR}/user-data" "${VM_DIR}/meta-data"
+
+      - name: Create overlay disk from base image
+        run: |
+          set -euo pipefail
+          VM_DIR="${{ steps.vm-vars.outputs.VM_DIR }}"
+          BASE_IMAGE="${{ steps.base-image.outputs.BASE_IMAGE }}"
+          VM_DISK_GB="${{ inputs.vm-disk-gb }}"
+
+          BASE_FMT="$(qemu-img info --output=json "$BASE_IMAGE" | jq -r '.format')"
+          if [ -z "$BASE_FMT" ] || [ "$BASE_FMT" = "null" ]; then
+            echo "Could not determine base format for $BASE_IMAGE"
+            qemu-img info "$BASE_IMAGE"
+            exit 1
+          fi
+
+          echo "Base image format: ${BASE_FMT}"
+          qemu-img create -f qcow2 -F "${BASE_FMT}" -b "$BASE_IMAGE" "${VM_DIR}/vm-disk.qcow2" "${VM_DISK_GB}G"
+
+      - name: Start QEMU VM (KVM)
+        run: |
+          set -euo pipefail
+          VM_DIR="${{ steps.vm-vars.outputs.VM_DIR }}"
+          VM_PORT="${{ steps.vm-vars.outputs.VM_PORT }}"
+          VM_CPUS="${{ inputs.vm-cpus }}"
+          VM_MEM_MB="${{ inputs.vm-mem-mb }}"
+
+          nohup qemu-system-x86_64 \
+            -enable-kvm -cpu host \
+            -m "${VM_MEM_MB}" -smp "${VM_CPUS}" \
+            -drive file="${VM_DIR}/vm-disk.qcow2",if=virtio,format=qcow2 \
+            -drive file="${VM_DIR}/cloud-init.iso",media=cdrom,readonly=on \
+            -nographic \
+            -serial "file:${VM_DIR}/vm-console.log" \
+            -netdev user,id=net0,hostfwd=tcp:127.0.0.1:${VM_PORT}-:22 \
+            -device virtio-net-pci,netdev=net0 \
+            -pidfile "${VM_DIR}/vm.pid" \
+            </dev/null >/dev/null 2>&1 &
+
+          for i in $(seq 1 20); do
+            if [ -f "${VM_DIR}/vm.pid" ]; then
+              break
+            fi
+            sleep 0.2
+          done
+
+          if [ ! -f "${VM_DIR}/vm.pid" ]; then
+            echo "vm.pid not created; QEMU may have failed to start."
+            tail -200 "${VM_DIR}/vm-console.log" || true
+            exit 1
+          fi
+
+          echo "QEMU PID: $(cat "${VM_DIR}/vm.pid")"
+          ss -lntp | grep ":${VM_PORT}" || true
+
+      - name: Wait for VM SSH to be ready
+        timeout-minutes: ${{ inputs.vm-ready-timeout-minutes }}
+        run: |
+          set -euo pipefail
+          VM_DIR="${{ steps.vm-vars.outputs.VM_DIR }}"
+          VM_PORT="${{ steps.vm-vars.outputs.VM_PORT }}"
+          VM_PID="$(cat "${VM_DIR}/vm.pid")"
+
+          echo "Waiting for VM SSH on localhost:${VM_PORT}..."
+
+          MAX_ATTEMPTS=60
+          for ATTEMPT in $(seq 1 "$MAX_ATTEMPTS"); do
+            echo -n "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: "
+
+            if ! kill -0 "$VM_PID" 2>/dev/null; then
+              echo "QEMU process exited (PID: ${VM_PID})"
+              tail -200 "${VM_DIR}/vm-console.log" || true
+              exit 1
+            fi
+
+            if nc -z 127.0.0.1 "${VM_PORT}"; then
+              echo -n "port open; "
+            else
+              echo -n "port closed; "
+            fi
+
+            if ssh -i "${VM_DIR}/.ssh/id_ed25519_vm" \
+                 -o ConnectTimeout=5 \
+                 -o StrictHostKeyChecking=no \
+                 -o UserKnownHostsFile=/dev/null \
+                 -o BatchMode=yes \
+                 -p "${VM_PORT}" \
+                 provisioner@127.0.0.1 \
+                 "echo 'SSH ready'" >/dev/null 2>&1; then
+              echo "VM is ready!"
+              exit 0
+            fi
+
+            echo "not ready yet..."
+            sleep 10
+          done
+
+          echo "VM failed to become ready"
+          tail -200 "${VM_DIR}/vm-console.log" || true
+          exit 1
+
+      - name: Bootstrap VM tools (Go + Task inside VM)
+        timeout-minutes: 20
+        run: |
+          set -euo pipefail
+          VM_DIR="${{ steps.vm-vars.outputs.VM_DIR }}"
+          VM_PORT="${{ steps.vm-vars.outputs.VM_PORT }}"
+          GO_VER="${{ inputs.go-version }}"
+
+          ssh -i "${VM_DIR}/.ssh/id_ed25519_vm" \
+              -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              -o ServerAliveInterval=30 \
+              -o ServerAliveCountMax=10 \
+              -p "${VM_PORT}" \
+              provisioner@127.0.0.1 << EOSSH
+          set -euo pipefail
+
+          GO_VER="${GO_VER}"
+
+          sudo cloud-init status --wait || true
+
+          curl -sSLO "https://go.dev/dl/go\${GO_VER}.linux-amd64.tar.gz"
+          sudo rm -rf /usr/local/go
+          sudo tar -C /usr/local -xzf "go\${GO_VER}.linux-amd64.tar.gz"
+          rm "go\${GO_VER}.linux-amd64.tar.gz"
+
+          echo 'export PATH=\$PATH:/usr/local/go/bin:\$HOME/go/bin' | sudo tee /etc/profile.d/go.sh >/dev/null
+          sudo chmod +x /etc/profile.d/go.sh
+          sudo ln -sf /usr/local/go/bin/go /usr/local/bin/go
+          sudo ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+
+          /usr/local/go/bin/go env -w GOTOOLCHAIN=local
+          /usr/local/bin/go version
+
+          if ! command -v task >/dev/null 2>&1; then
+            curl -1sLf 'https://dl.cloudsmith.io/public/task/task/setup.deb.sh' | sudo -E bash
+            sudo apt-get update
+            sudo apt-get install -y task
+          fi
+
+          task --version
+          EOSSH
+
+      - name: Install Proxy CA Certificates in VM
+        run: |
+          set -euo pipefail
+          VM_DIR="${{ steps.vm-vars.outputs.VM_DIR }}"
+          VM_PORT="${{ steps.vm-vars.outputs.VM_PORT }}"
+          CA_CERT_PATH="/home/github-runner/ca-cert.pem"
+
+          if [ ! -f "${CA_CERT_PATH}" ]; then
+            echo "Error: CA certificate file '${CA_CERT_PATH}' not found. Cannot install proxy CA certificates in VM."
+            exit 1
+          fi
+
+          echo "Copying CA certificate to VM..."
+          rsync -az \
+            -e "ssh -i ${VM_DIR}/.ssh/id_ed25519_vm -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -p ${VM_PORT}" \
+            "${CA_CERT_PATH}" \
+            provisioner@127.0.0.1:/tmp/
+
+          ssh -i "${VM_DIR}/.ssh/id_ed25519_vm" \
+              -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              -o ServerAliveInterval=30 \
+              -o ServerAliveCountMax=10 \
+              -p "${VM_PORT}" \
+              provisioner@127.0.0.1 << 'EOSSH'
+          set -euo pipefail
+          sudo cp /tmp/ca-cert.pem /usr/local/share/ca-certificates/solo-weaver-ca.crt && \
+          sudo chmod 644 /usr/local/share/ca-certificates/solo-weaver-ca.crt && \
+          sudo update-ca-certificates --fresh && \
+          echo 'Verifying CA certificate was added to bundle...' && \
+          if grep -q 'Solo Weaver Cache Proxy CA' /etc/ssl/certs/ca-certificates.crt; then \
+            echo 'CA certificate verified in bundle'; \
+          else \
+            echo 'Warning: CA certificate not found in bundle'; \
+          fi
+          EOSSH
+
+      - name: Sync code to VM
+        run: |
+          set -euo pipefail
+          VM_DIR="${{ steps.vm-vars.outputs.VM_DIR }}"
+          VM_PORT="${{ steps.vm-vars.outputs.VM_PORT }}"
+
+          ssh -i "${VM_DIR}/.ssh/id_ed25519_vm" \
+              -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              -o ServerAliveInterval=30 \
+              -o ServerAliveCountMax=10 \
+              -p "${VM_PORT}" \
+              provisioner@127.0.0.1 \
+              "mkdir -p /home/provisioner/solo-weaver"
+
+          rsync -az \
+            -e "ssh -i ${VM_DIR}/.ssh/id_ed25519_vm -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -p ${VM_PORT}" \
+            --exclude='vendor' \
+            --exclude='bin' \
+            --exclude='*.log' \
+            --exclude='.ssh' \
+            --exclude='*.iso' \
+            --exclude='*.img' \
+            --exclude='*.qcow2' \
+            ./ \
+            provisioner@127.0.0.1:/home/provisioner/solo-weaver/
+
+      - name: Run UAT Tests in VM
+        timeout-minutes: ${{ inputs.uat-timeout-minutes }}
+        run: |
+          set -euo pipefail
+          VM_DIR="${{ steps.vm-vars.outputs.VM_DIR }}"
+          VM_PORT="${{ steps.vm-vars.outputs.VM_PORT }}"
+
+          ssh -i "${VM_DIR}/.ssh/id_ed25519_vm" \
+              -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              -o ServerAliveInterval=30 \
+              -o ServerAliveCountMax=10 \
+              -o TCPKeepAlive=yes \
+              -p "${VM_PORT}" \
+              -R 3128:localhost:3128 \
+              -R 8081:localhost:8081 \
+              -R 5050:localhost:5050 \
+              provisioner@127.0.0.1 << 'EOSSH'
+          set -euo pipefail
+
+          export PATH=/usr/local/go/bin:$HOME/go/bin:/usr/local/bin:$PATH
+          export GOPATH=$HOME/go
+
+          cd /home/provisioner/solo-weaver
+
+          # Verify proxy tunnels
+          echo 'Verifying proxy tunnel connectivity...'
+          check_port() {
+            local host="$1" port="$2" descr="$3"
+            if command -v nc >/dev/null 2>&1; then
+              if nc -z -w 5 "${host}" "${port}" >/dev/null 2>&1; then
+                echo "OK: ${descr} reachable at ${host}:${port}"
+              else
+                echo "WARN: ${descr} not reachable at ${host}:${port} (proxy is optional)"
+              fi
+            fi
+          }
+          check_port localhost 3128 'HTTP/HTTPS proxy'
+          check_port localhost 8081 'Go module proxy'
+          check_port localhost 5050 'registry mirror'
+
+          # Set proxy env vars only if the proxy tunnel is reachable
+          if nc -z -w 2 127.0.0.1 3128 >/dev/null 2>&1; then
+            echo 'Proxy tunnel detected — enabling proxy for build'
+            export HTTP_PROXY=http://127.0.0.1:3128
+            export HTTPS_PROXY=http://127.0.0.1:3128
+            export NO_PROXY=localhost,127.0.0.1,::1,.local,.svc,.cluster.local,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+            export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+            export GOPROXY=http://127.0.0.1:8081,https://proxy.golang.org,direct
+          else
+            echo 'No proxy tunnel — building with direct internet access'
+          fi
+
+          # Build binary
+          echo 'Building solo-provisioner binary...'
+          sudo -E env "PATH=$PATH" "GOPATH=$GOPATH" task generate
+          sudo -E env "PATH=$PATH" "GOPATH=$GOPATH" task build:weaver GOOS=linux GOARCH=amd64
+          echo "Binary built:"
+          ls -la bin/solo-provisioner-linux-amd64
+
+          # UAT tasks use the proxy config from the config file, not env vars.
+          # But we need the binary path to be correct for the VM architecture.
+          # The uat:setup task copies the binary from /mnt/solo-weaver/bin/ but
+          # in CI the code is at /home/provisioner/solo-weaver/bin/ instead.
+          # Create a symlink so the UAT tasks find the binary.
+          sudo mkdir -p /mnt
+          sudo ln -sfn /home/provisioner/solo-weaver /mnt/solo-weaver
+
+          UAT_SCENARIO="${{ inputs.uat-scenario }}"
+          echo "Running UAT scenario: ${UAT_SCENARIO}"
+          sudo --preserve-env=PATH,GOPATH \
+            task "uat:${UAT_SCENARIO}"
+          EOSSH
+
+      - name: Cleanup VM
+        if: always()
+        run: |
+          set -euo pipefail
+          VM_DIR="${{ steps.vm-vars.outputs.VM_DIR }}"
+
+          if [ -f "${VM_DIR}/vm.pid" ]; then
+            VM_PID="$(cat "${VM_DIR}/vm.pid" || true)"
+            if [ -n "${VM_PID}" ]; then
+              echo "Stopping VM (PID: ${VM_PID})..."
+              kill "${VM_PID}" 2>/dev/null || true
+              sleep 2
+              kill -9 "${VM_PID}" 2>/dev/null || true
+            fi
+          fi
+
+          echo "Removing VM working directory..."
+          rm -rf "${VM_DIR}"

--- a/.github/workflows/zxc-uat-test.yaml
+++ b/.github/workflows/zxc-uat-test.yaml
@@ -5,10 +5,10 @@ on:
   workflow_call:
     inputs:
       uat-scenario:
-        description: "UAT scenario to run (setup, core, teleport, alloy, compat, teardown, all)"
+        description: "UAT scenario to run (lifecycle, compat, setup, core, teardown, teleport, alloy, all)"
         type: string
         required: false
-        default: "all"
+        default: "lifecycle"
       vm-os:
         description: "VM OS (debian or ubuntu)"
         type: string

--- a/docs/dev/acceptance-tests.md
+++ b/docs/dev/acceptance-tests.md
@@ -8,13 +8,16 @@ on macOS.
 
 **From inside the VM** (after `task vm:ssh:proxy`):
 ```bash
+task uat:lifecycle  # Core lifecycle: setup → core upgrades → teardown (CI-friendly, no Docker)
+task uat:compat     # Backward compatibility (standalone, installs released version first)
+task uat:all        # Everything: lifecycle + teleport + alloy + compat (requires Docker)
+
+# Individual steps (for debugging or manual runs):
 task uat:setup      # Install cluster + block node (v0.26.0)
 task uat:core       # Block node upgrades + reset (requires setup)
-task uat:teleport   # Teleport install/uninstall (requires setup, starts Teleport server)
-task uat:alloy      # Alloy install/uninstall (requires setup, starts observability stack)
+task uat:teleport   # Teleport install/uninstall (requires setup + Docker)
+task uat:alloy      # Alloy install/uninstall (requires setup + Docker)
 task uat:teardown   # Uninstall everything
-task uat:compat     # Backward compatibility (standalone, installs released version first)
-task uat:all        # setup → core → teleport → alloy → teardown
 ```
 
 These tasks are designed to run inside any Linux VM — both the local UTM VM

--- a/taskfiles/uat.yaml
+++ b/taskfiles/uat.yaml
@@ -15,8 +15,9 @@ tasks:
 
 
         echo -e '\n▶ Self-install'
-        cd /tmp && cp /mnt/solo-weaver/bin/solo-provisioner-linux-arm64 .
-        sudo ./solo-provisioner-linux-arm64 install
+        ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+        cd /tmp && cp /mnt/solo-weaver/bin/solo-provisioner-linux-${ARCH} .
+        sudo ./solo-provisioner-linux-${ARCH} install
 
 
         echo -e '\n▶ Block node install (v0.26.0)'
@@ -123,6 +124,24 @@ tasks:
         kubectl get nodes > /dev/null 2>&1 || { echo "FAIL: Kubernetes cluster not found. Run 'task uat:setup' first."; exit 1; }
 
 
+        # Install Docker if not present (needed for Teleport server container)
+        if ! command -v docker >/dev/null 2>&1; then
+          echo -e '\n▶ Installing Docker...'
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq docker.io
+          # Install compose plugin from Docker's official repo if not available
+          if ! docker compose version >/dev/null 2>&1; then
+            sudo mkdir -p /usr/local/lib/docker/cli-plugins
+            COMPOSE_VER=$(curl -sL https://api.github.com/repos/docker/compose/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
+            sudo curl -SL "https://github.com/docker/compose/releases/download/v${COMPOSE_VER}/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
+            sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+          fi
+          sudo systemctl enable --now docker
+          sudo usermod -aG docker "$(whoami)" || true
+          echo "   Docker $(docker --version) installed"
+          echo "   Compose $(docker compose version) installed"
+        fi
+
         echo -e '\n▶ Step 1: Start Teleport server (Docker)'
         task teleport:start
 
@@ -198,6 +217,24 @@ tasks:
         kubectl get nodes > /dev/null 2>&1 || { echo "FAIL: Kubernetes cluster not found. Run 'task uat:setup' first."; exit 1; }
 
 
+        # Install Docker if not present (needed for observability stack containers)
+        if ! command -v docker >/dev/null 2>&1; then
+          echo -e '\n▶ Installing Docker...'
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq docker.io
+          # Install compose plugin from Docker's official repo if not available
+          if ! docker compose version >/dev/null 2>&1; then
+            sudo mkdir -p /usr/local/lib/docker/cli-plugins
+            COMPOSE_VER=$(curl -sL https://api.github.com/repos/docker/compose/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
+            sudo curl -SL "https://github.com/docker/compose/releases/download/v${COMPOSE_VER}/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
+            sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+          fi
+          sudo systemctl enable --now docker
+          sudo usermod -aG docker "$(whoami)" || true
+          echo "   Docker $(docker --version) installed"
+          echo "   Compose $(docker compose version) installed"
+        fi
+
         echo -e '\n▶ Step 1: Start observability stack (Prometheus, Loki, Grafana)'
         task alloy:start
 
@@ -251,6 +288,22 @@ tasks:
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 
+        # Clean up Docker/containerd if present — they interfere with CRI-O on kubeadm init
+        if command -v docker >/dev/null 2>&1; then
+          echo -e '\n▶ Stopping Docker/containerd to avoid CRI-O conflict...'
+          sudo systemctl stop docker.service docker.socket containerd.service 2>/dev/null || true
+          sudo systemctl disable docker.service docker.socket containerd.service 2>/dev/null || true
+          echo '   Docker/containerd stopped'
+        fi
+
+        # Clean up any leftover kubeadm state from previous runs
+        if command -v kubeadm >/dev/null 2>&1 || [ -f /opt/solo/weaver/sandbox/bin/kubeadm ]; then
+          echo -e '\n▶ Cleaning up leftover kubeadm state...'
+          sudo /opt/solo/weaver/sandbox/bin/kubeadm reset -f 2>/dev/null || sudo kubeadm reset -f 2>/dev/null || true
+          sudo rm -rf /etc/kubernetes /var/lib/kubelet /var/lib/etcd /root/.kube 2>/dev/null || true
+          echo '   Kubeadm state cleaned'
+        fi
+
         echo -e '\n▶ Step 1: Install released version of solo-provisioner'
         cd /tmp
         curl -sSL https://raw.githubusercontent.com/hashgraph/solo-weaver/main/install.sh | bash
@@ -277,8 +330,9 @@ tasks:
 
  
         echo -e '\n▶ Step 6: Upgrade CLI to new binary (from current branch)'
-        cd /tmp && cp /mnt/solo-weaver/bin/solo-provisioner-linux-arm64 .
-        sudo ./solo-provisioner-linux-arm64 install
+        ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+        cd /tmp && cp /mnt/solo-weaver/bin/solo-provisioner-linux-${ARCH} .
+        sudo ./solo-provisioner-linux-${ARCH} install
 
 
         echo -e '\n▶ Step 7: Verify new CLI version'

--- a/taskfiles/uat.yaml
+++ b/taskfiles/uat.yaml
@@ -15,7 +15,19 @@ tasks:
 
 
         echo -e '\n▶ Self-install'
-        ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+        UNAME_ARCH=$(uname -m)
+        case "$UNAME_ARCH" in
+          x86_64)
+            ARCH=amd64
+            ;;
+          aarch64)
+            ARCH=arm64
+            ;;
+          *)
+            echo "FAIL: unsupported architecture '$UNAME_ARCH'. Supported architectures are: x86_64, aarch64."
+            exit 1
+            ;;
+        esac
         cd /tmp && cp /mnt/solo-weaver/bin/solo-provisioner-linux-${ARCH} .
         sudo ./solo-provisioner-linux-${ARCH} install
 
@@ -124,23 +136,9 @@ tasks:
         kubectl get nodes > /dev/null 2>&1 || { echo "FAIL: Kubernetes cluster not found. Run 'task uat:setup' first."; exit 1; }
 
 
-        # Install Docker if not present (needed for Teleport server container)
-        if ! command -v docker >/dev/null 2>&1; then
-          echo -e '\n▶ Installing Docker...'
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq docker.io
-          # Install compose plugin from Docker's official repo if not available
-          if ! docker compose version >/dev/null 2>&1; then
-            sudo mkdir -p /usr/local/lib/docker/cli-plugins
-            COMPOSE_VER=$(curl -sL https://api.github.com/repos/docker/compose/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
-            sudo curl -SL "https://github.com/docker/compose/releases/download/v${COMPOSE_VER}/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
-            sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-          fi
-          sudo systemctl enable --now docker
-          sudo usermod -aG docker "$(whoami)" || true
-          echo "   Docker $(docker --version) installed"
-          echo "   Compose $(docker compose version) installed"
-        fi
+        # Docker + docker compose required for Teleport server container
+        command -v docker >/dev/null 2>&1 || { echo "FAIL: Docker not found. Install docker.io first."; exit 1; }
+        docker compose version >/dev/null 2>&1 || { echo "FAIL: Docker Compose v2 plugin not found. Install docker-compose-plugin first."; exit 1; }
 
         echo -e '\n▶ Step 1: Start Teleport server (Docker)'
         task teleport:start
@@ -217,23 +215,9 @@ tasks:
         kubectl get nodes > /dev/null 2>&1 || { echo "FAIL: Kubernetes cluster not found. Run 'task uat:setup' first."; exit 1; }
 
 
-        # Install Docker if not present (needed for observability stack containers)
-        if ! command -v docker >/dev/null 2>&1; then
-          echo -e '\n▶ Installing Docker...'
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq docker.io
-          # Install compose plugin from Docker's official repo if not available
-          if ! docker compose version >/dev/null 2>&1; then
-            sudo mkdir -p /usr/local/lib/docker/cli-plugins
-            COMPOSE_VER=$(curl -sL https://api.github.com/repos/docker/compose/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
-            sudo curl -SL "https://github.com/docker/compose/releases/download/v${COMPOSE_VER}/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
-            sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-          fi
-          sudo systemctl enable --now docker
-          sudo usermod -aG docker "$(whoami)" || true
-          echo "   Docker $(docker --version) installed"
-          echo "   Compose $(docker compose version) installed"
-        fi
+        # Docker + docker compose required for observability stack containers
+        command -v docker >/dev/null 2>&1 || { echo "FAIL: Docker not found. Install docker.io + docker-compose-plugin first."; exit 1; }
+        docker compose version >/dev/null 2>&1 || { echo "FAIL: Docker Compose plugin not found. Install docker-compose-plugin first."; exit 1; }
 
         echo -e '\n▶ Step 1: Start observability stack (Prometheus, Loki, Grafana)'
         task alloy:start
@@ -287,22 +271,6 @@ tasks:
         echo "  UAT Test: Backward Compatibility"
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-
-        # Clean up Docker/containerd if present — they interfere with CRI-O on kubeadm init
-        if command -v docker >/dev/null 2>&1; then
-          echo -e '\n▶ Stopping Docker/containerd to avoid CRI-O conflict...'
-          sudo systemctl stop docker.service docker.socket containerd.service 2>/dev/null || true
-          sudo systemctl disable docker.service docker.socket containerd.service 2>/dev/null || true
-          echo '   Docker/containerd stopped'
-        fi
-
-        # Clean up any leftover kubeadm state from previous runs
-        if command -v kubeadm >/dev/null 2>&1 || [ -f /opt/solo/weaver/sandbox/bin/kubeadm ]; then
-          echo -e '\n▶ Cleaning up leftover kubeadm state...'
-          sudo /opt/solo/weaver/sandbox/bin/kubeadm reset -f 2>/dev/null || sudo kubeadm reset -f 2>/dev/null || true
-          sudo rm -rf /etc/kubernetes /var/lib/kubelet /var/lib/etcd /root/.kube 2>/dev/null || true
-          echo '   Kubeadm state cleaned'
-        fi
 
         echo -e '\n▶ Step 1: Install released version of solo-provisioner'
         cd /tmp
@@ -364,8 +332,16 @@ tasks:
         echo ''
         echo '✅ Backward Compatibility: PASSED'
 
+  uat:lifecycle:
+    desc: "Run core lifecycle test (inside VM: setup → core upgrades → teardown)"
+    interactive: true
+    cmds:
+      - task: uat:setup
+      - task: uat:core
+      - task: uat:teardown
+
   uat:all:
-    desc: "Run all acceptance tests sequentially (inside VM: setup → tests → teardown)"
+    desc: "Run all acceptance tests (inside VM: lifecycle + teleport + alloy + compat). Requires Docker."
     interactive: true
     cmds:
       - task: uat:setup


### PR DESCRIPTION
Add GitHub Actions workflow for running UAT tests in QEMU VMs on the `kvm-runner`, with each scenario in its own fresh VM to avoid shared state and Docker/CRI-O conflicts.

### PR pipeline

```
build → unit-tests
     → uat-compat (fresh VM, runs first)
     → uat-core (fresh VM: setup → upgrade → reset → teardown)
     → integration-tests (after uat-core)
```

### Files

| File | Action |
|------|--------|
| `.github/workflows/zxc-uat-test.yaml` | **NEW** — Reusable workflow: QEMU VM → build binary → `task uat:<scenario>` |
| `.github/workflows/flow-test-uat.yaml` | **NEW** — Manual dispatch caller with scenario/OS dropdown |
| `.github/workflows/flow-pull-request-checks.yaml` | Add `uat-compat` and `uat-core` jobs |
| `taskfiles/uat.yaml` | Simplify: remove Docker install logic, `uat:all` = setup → core → teardown |

### Design decisions

- **Independent VMs per scenario** — each job gets a fresh QEMU VM with no leftover state. Avoids the Docker/CRI-O conflict that broke chained scenarios.
- **Architecture auto-detection** — uses `uname -m` to select `solo-provisioner-linux-amd64` (CI) or `solo-provisioner-linux-arm64` (local UTM).
- **Proxy is optional** — tunnels are set up but env vars only applied if the proxy is reachable. Falls back to direct internet.
- **Binary built inside VM** — in the same SSH session as the UAT run, with proxy tunnels active for Go module downloads.
- **Teleport/alloy UAT remain manual-dispatch only** — they need Docker which conflicts with CRI-O. Run them via `flow-test-uat.yaml` with a Docker-preinstalled VM, or locally via `task vm:ssh:proxy`.

### Depends on

- #456 (UAT runbook and Taskfile split) — merged

## Test plan

- [x] `uat-compat` passes in CI (backward compatibility: released CLI → upgrade → verify migrations)
- [x] `uat-core` passes in CI (install v0.26.0 → upgrade v0.29.0 → upgrade v0.30.2 → reset → teardown)
- [ ] Manual: trigger `flow-test-uat.yaml` with individual scenarios (setup, core, compat)
- [ ] Manual: `task uat:teleport` works locally via `task vm:ssh:proxy` with Docker pre-installed