### PR TITLE
fix: enforce mutual exclusion on execution-mode flags

### DIFF
--- a/cmd/weaver/commands/block/node/node.go
+++ b/cmd/weaver/commands/block/node/node.go
@@ -51,6 +51,11 @@ func init() {
 	common.FlagStopOnError().SetVarP(nodeCmd, &flagStopOnError, false)
 	common.FlagRollbackOnError().SetVarP(nodeCmd, &flagRollbackOnError, false)
 	common.FlagContinueOnError().SetVarP(nodeCmd, &flagContinueOnError, false)
+	nodeCmd.MarkFlagsMutuallyExclusive(
+		common.FlagStopOnError().Name,
+		common.FlagContinueOnError().Name,
+		common.FlagRollbackOnError().Name,
+	)
 
 	// Helm chart configuration flags
 	nodeCmd.PersistentFlags().StringVar(&flagChartVersion, "chart-version", "", "Helm chart version to use")

--- a/cmd/weaver/commands/common/common.go
+++ b/cmd/weaver/commands/common/common.go
@@ -61,8 +61,8 @@ func FlagStopOnError() FlagDefinition[bool] {
 	return FlagDefinition[bool]{
 		Name:        "stop-on-error",
 		ShortName:   "",
-		Description: "Stop execution on first error",
-		Default:     true,
+		Description: "Stop execution on first error (default behaviour when no execution-mode flag is set)",
+		Default:     false,
 	}
 }
 

--- a/cmd/weaver/commands/common/flags.go
+++ b/cmd/weaver/commands/common/flags.go
@@ -375,8 +375,27 @@ func DetectShortNameCollisions(root *cobra.Command) bool {
 		// Collect this command's own flags (local + persistent)
 		own := map[string]string{}
 
+		// Build a set of own persistent flag names first.
+		// cobra's MarkFlagsMutuallyExclusive calls mergePersistentFlags() internally,
+		// which merges a command's own persistent flags into cmd.Flags(). Without this
+		// guard, a persistent flag (e.g. --node-type/-n) would be visited twice —
+		// once by cmd.Flags() and once by cmd.PersistentFlags() — producing a false
+		// shortname collision.
+		// NOTE: do NOT use LocalNonPersistentFlags() here — it calls LocalFlags() →
+		// mergePersistentFlags(), which panics when a parent persistent flag has the
+		// same shortname as a child local flag (the exact collision we want to detect).
+		persistentNames := map[string]struct{}{}
+		cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+			persistentNames[f.Name] = struct{}{}
+		})
+
 		cmd.Flags().VisitAll(func(f *pflag.Flag) {
 			if f.Shorthand == "" {
+				return
+			}
+			// Skip flags covered by the PersistentFlags pass below to avoid
+			// double-counting after mergePersistentFlags() has been called.
+			if _, isPersistent := persistentNames[f.Name]; isPersistent {
 				return
 			}
 			key := cmd.Name() + ":" + f.Name

--- a/cmd/weaver/commands/common/flags_test.go
+++ b/cmd/weaver/commands/common/flags_test.go
@@ -255,6 +255,15 @@ func TestGetExecutionMode_MutuallyExclusiveFlags_ReturnsError(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestFlagStopOnError_DefaultIsFalse guards against the default being flipped back to
+// true. FlagStopOnError must default to false so that GetExecutionMode does not see
+// multiple flags as "set" when the user only passes --continue-on-error or
+// --rollback-on-error. The stop-on-error behaviour when no flag is explicitly provided
+// is handled by GetExecutionMode's else-branch, not by this flag's default value.
+func TestFlagStopOnError_DefaultIsFalse(t *testing.T) {
+	require.False(t, FlagStopOnError().Default)
+}
+
 func TestFlagCloneIndependent(t *testing.T) {
 	orig := FlagConfig()
 	clone := orig.Clone()
@@ -373,4 +382,28 @@ func TestDetectShortNameCollisions_PersistentOnNonRoot(t *testing.T) {
 
 	found := DetectShortNameCollisions(root)
 	require.True(t, found, "should detect collision between persistent and local flags on non-root command")
+}
+
+// TestDetectShortNameCollisions_NoPersistentDoubleCount verifies that a persistent
+// flag with a shortname is NOT reported as a collision with itself after
+// MarkFlagsMutuallyExclusive is called. Cobra's MarkFlagsMutuallyExclusive calls
+// mergePersistentFlags() internally, which merges own persistent flags into
+// cmd.Flags(). Without the guard in DetectShortNameCollisions the same flag would
+// be visited twice (once via cmd.Flags(), once via cmd.PersistentFlags()) producing
+// a false shortname collision.
+func TestDetectShortNameCollisions_NoPersistentDoubleCount(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{Use: "child"}
+	root.AddCommand(child)
+
+	var v bool
+	fp := FlagDefinition[bool]{Name: "myflag", ShortName: "m", Description: "a flag", Default: false}
+	fp.SetVarP(child, &v, false)
+
+	// MarkFlagsMutuallyExclusive internally calls mergePersistentFlags(), causing
+	// the persistent flag to appear in both child.Flags() and child.PersistentFlags().
+	child.MarkFlagsMutuallyExclusive("myflag")
+
+	found := DetectShortNameCollisions(root)
+	require.False(t, found, "persistent flag merged into cmd.Flags() must not be counted as a shortname collision with itself")
 }

--- a/cmd/weaver/commands/kube/cluster/install.go
+++ b/cmd/weaver/commands/kube/cluster/install.go
@@ -82,4 +82,9 @@ func init() {
 	common.FlagStopOnError().SetVarP(installCmd, &flagStopOnError, false)
 	common.FlagRollbackOnError().SetVarP(installCmd, &flagRollbackOnError, false)
 	common.FlagContinueOnError().SetVarP(installCmd, &flagContinueOnError, false)
+	installCmd.MarkFlagsMutuallyExclusive(
+		common.FlagStopOnError().Name,
+		common.FlagContinueOnError().Name,
+		common.FlagRollbackOnError().Name,
+	)
 }

--- a/cmd/weaver/commands/kube/cluster/uninstall.go
+++ b/cmd/weaver/commands/kube/cluster/uninstall.go
@@ -40,4 +40,9 @@ func init() {
 	common.FlagStopOnError().SetVarP(uninstallCmd, &flagStopOnError, false)
 	common.FlagRollbackOnError().SetVarP(uninstallCmd, &flagRollbackOnError, false)
 	common.FlagContinueOnError().SetVarP(uninstallCmd, &flagContinueOnError, false)
+	uninstallCmd.MarkFlagsMutuallyExclusive(
+		common.FlagStopOnError().Name,
+		common.FlagContinueOnError().Name,
+		common.FlagRollbackOnError().Name,
+	)
 }

--- a/cmd/weaver/commands/teleport/cluster/install.go
+++ b/cmd/weaver/commands/teleport/cluster/install.go
@@ -92,4 +92,9 @@ func init() {
 	common.FlagStopOnError().SetVarP(installCmd, &flagStopOnError, false)
 	common.FlagRollbackOnError().SetVarP(installCmd, &flagRollbackOnError, false)
 	common.FlagContinueOnError().SetVarP(installCmd, &flagContinueOnError, false)
+	installCmd.MarkFlagsMutuallyExclusive(
+		common.FlagStopOnError().Name,
+		common.FlagContinueOnError().Name,
+		common.FlagRollbackOnError().Name,
+	)
 }

--- a/cmd/weaver/commands/teleport/cluster/uninstall.go
+++ b/cmd/weaver/commands/teleport/cluster/uninstall.go
@@ -14,26 +14,28 @@ func init() {
 	common.FlagStopOnError().SetVar(uninstallCmd, &flagStopOnError, false)
 	common.FlagContinueOnError().SetVar(uninstallCmd, &flagContinueOnError, false)
 	common.FlagRollbackOnError().SetVar(uninstallCmd, &flagRollbackOnError, false)
+	uninstallCmd.MarkFlagsMutuallyExclusive(
+		common.FlagStopOnError().Name,
+		common.FlagContinueOnError().Name,
+		common.FlagRollbackOnError().Name,
+	)
 }
 
-func uninstallExecutionOptions() models.WorkflowExecutionOptions {
-	switch {
-	case flagRollbackOnError:
-		return models.WorkflowExecutionOptions{
-			ExecutionMode: automa.StopOnError,
-			RollbackMode:  automa.RollbackOnError,
-		}
-	case flagContinueOnError:
-		return models.WorkflowExecutionOptions{
-			ExecutionMode: automa.ContinueOnError,
-			RollbackMode:  automa.ContinueOnError,
-		}
-	default:
-		return models.WorkflowExecutionOptions{
-			ExecutionMode: automa.StopOnError,
-			RollbackMode:  automa.ContinueOnError,
-		}
+func uninstallExecutionOptions() (models.WorkflowExecutionOptions, error) {
+	execMode, err := common.GetExecutionMode(flagContinueOnError, flagStopOnError, flagRollbackOnError)
+	if err != nil {
+		return models.WorkflowExecutionOptions{}, err
 	}
+
+	rollbackMode := automa.ContinueOnError
+	if flagRollbackOnError {
+		rollbackMode = automa.RollbackOnError
+	}
+
+	return models.WorkflowExecutionOptions{
+		ExecutionMode: execMode,
+		RollbackMode:  rollbackMode,
+	}, nil
 }
 
 var uninstallCmd = &cobra.Command{
@@ -45,6 +47,11 @@ var uninstallCmd = &cobra.Command{
 			return err
 		}
 
+		executionOptions, err := uninstallExecutionOptions()
+		if err != nil {
+			return err
+		}
+
 		intent := models.Intent{
 			Action: models.ActionUninstall,
 			Target: models.TargetTeleportCluster,
@@ -52,7 +59,7 @@ var uninstallCmd = &cobra.Command{
 
 		inputs := &models.UserInputs[models.TeleportClusterInputs]{
 			Common: models.CommonInputs{
-				ExecutionOptions: uninstallExecutionOptions(),
+				ExecutionOptions: executionOptions,
 			},
 		}
 

--- a/cmd/weaver/commands/teleport/node/install.go
+++ b/cmd/weaver/commands/teleport/node/install.go
@@ -40,11 +40,21 @@ var installCmd = &cobra.Command{
 			Target: models.TargetTeleportNode,
 		}
 
+		execMode, err := common.GetExecutionMode(flagContinueOnError, flagStopOnError, flagRollbackOnError)
+		if err != nil {
+			return err
+		}
+
+		rollbackMode := automa.ContinueOnError
+		if flagRollbackOnError {
+			rollbackMode = automa.RollbackOnError
+		}
+
 		inputs := &models.UserInputs[models.TeleportNodeInputs]{
 			Common: models.CommonInputs{
 				ExecutionOptions: models.WorkflowExecutionOptions{
-					ExecutionMode: automa.StopOnError,
-					RollbackMode:  automa.ContinueOnError,
+					ExecutionMode: execMode,
+					RollbackMode:  rollbackMode,
 				},
 			},
 			Custom: models.TeleportNodeInputs{
@@ -74,4 +84,9 @@ func init() {
 	common.FlagStopOnError().SetVarP(installCmd, &flagStopOnError, false)
 	common.FlagRollbackOnError().SetVarP(installCmd, &flagRollbackOnError, false)
 	common.FlagContinueOnError().SetVarP(installCmd, &flagContinueOnError, false)
+	installCmd.MarkFlagsMutuallyExclusive(
+		common.FlagStopOnError().Name,
+		common.FlagContinueOnError().Name,
+		common.FlagRollbackOnError().Name,
+	)
 }


### PR DESCRIPTION
## Description

This pull request improves the handling of execution mode flags (`--stop-on-error`, `--continue-on-error`, and `--rollback-on-error`) across several CLI commands by enforcing mutual exclusivity and centralizing execution mode logic. This ensures users cannot specify conflicting execution behaviors and makes the codebase more maintainable.

**Flag handling improvements:**

* Added `MarkFlagsMutuallyExclusive` calls to ensure the execution mode flags cannot be used together for the following commands: `node`, `kube cluster install`, `kube cluster uninstall`, `teleport cluster install`, `teleport cluster uninstall`, and `teleport node install`. [[1]](diffhunk://#diff-18cdcf7a83abd3a9c0bc1d0d507e6756b2409e39cc1442139610c1f8b7e7a793R54-R58) [[2]](diffhunk://#diff-01d1e86936af2723319004052ecb01c19b3924895cadd1fc18ffc5b108e56c35R85-R89) [[3]](diffhunk://#diff-d363374de77a5c161416143a1856194a27bf412a773a92ebf064e6459dbbbe7eR43-R47) [[4]](diffhunk://#diff-ccd71340b3e25f064a17edfc7f8499f3ee39b9a6935216b3c586f3deb9aca162R95-R99) [[5]](diffhunk://#diff-89acf95b933d3d952fa7f2b17429f91224b59677eb473de7fb7bcabe3ceb5522R17-R38) [[6]](diffhunk://#diff-b5f7f579ea9a868f83a7d7ee5eef364f7995b5f27becda77f4e264ab0d0138f8R87-R91)

**Execution mode logic refactoring:**

* Refactored the logic for determining `WorkflowExecutionOptions` in `teleport cluster uninstall` and `teleport node install` to use a centralized `GetExecutionMode` helper, improving consistency and error handling. Now, if conflicting flags are provided, the command will error out. [[1]](diffhunk://#diff-89acf95b933d3d952fa7f2b17429f91224b59677eb473de7fb7bcabe3ceb5522R17-R38) [[2]](diffhunk://#diff-89acf95b933d3d952fa7f2b17429f91224b59677eb473de7fb7bcabe3ceb5522R50-R62) [[3]](diffhunk://#diff-b5f7f579ea9a868f83a7d7ee5eef364f7995b5f27becda77f4e264ab0d0138f8R43-R57)

These changes collectively enhance user experience and reduce the risk of misconfiguration when running these commands.

### Related Issues

* Closes #455 
