### PR TITLE
feat(block-node): add plugin preset selection via TUI and flags

### DIFF
--- a/cmd/weaver/commands/block/node/init.go
+++ b/cmd/weaver/commands/block/node/init.go
@@ -215,11 +215,19 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 	// When only --plugin-preset is set, look up its canonical list.
 	pluginPreset := flagPluginPreset
 	pluginList := flagPlugins
+	if f := cmd.Flag("plugins"); f != nil && f.Changed {
+		if err := models.ValidatePluginList(flagPlugins); err != nil {
+			return nil, errorx.IllegalArgument.Wrap(err, "invalid --plugins value")
+		}
+	}
 	if pluginList == "" && bnpkg.IsKnownPreset(pluginPreset) {
 		pluginList = bnpkg.PluginListForPreset(pluginPreset)
 	}
 	if pluginList != "" && pluginPreset == "" {
-		pluginPreset = models.PluginPresetCustom
+		pluginPreset = bnpkg.PresetCustom
+	}
+	if pluginPreset == bnpkg.PresetCustom && pluginList == "" {
+		return nil, fmt.Errorf("--plugins is required when --plugin-preset=%s", bnpkg.PresetCustom)
 	}
 
 	inputs := &models.UserInputs[models.BlockNodeInputs]{

--- a/cmd/weaver/commands/block/node/init.go
+++ b/cmd/weaver/commands/block/node/init.go
@@ -8,6 +8,7 @@ import (
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/weaver/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/bll/blocknode"
+	bnpkg "github.com/hashgraph/solo-weaver/internal/blocknode"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
 	"github.com/hashgraph/solo-weaver/internal/workflows"
@@ -158,6 +159,11 @@ func promptForMissingFlags(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Plugin preset prompt: two-pass (preset select → conditional custom multi-select).
+	if err := prompt.RunPluginPresetPrompts(cmd, defaults, &flagPluginPreset, &flagPlugins, cv); err != nil {
+		return err
+	}
+
 	_, _ = fmt.Fprintln(cmd.ErrOrStderr())
 	cv.Print("Selected Inputs")
 
@@ -204,6 +210,18 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 	execOpts := workflows.DefaultWorkflowExecutionOptions()
 	execOpts.ExecutionMode = execMode
 
+	// Resolve the effective plugin list.
+	// --plugins overrides --plugin-preset when both are set.
+	// When only --plugin-preset is set, look up its canonical list.
+	pluginPreset := flagPluginPreset
+	pluginList := flagPlugins
+	if pluginList == "" && bnpkg.IsKnownPreset(pluginPreset) {
+		pluginList = bnpkg.PluginListForPreset(pluginPreset)
+	}
+	if pluginList != "" && pluginPreset == "" {
+		pluginPreset = models.PluginPresetCustom
+	}
+
 	inputs := &models.UserInputs[models.BlockNodeInputs]{
 		Common: models.CommonInputs{
 			Force:            parentFlags.Force,
@@ -237,6 +255,8 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 			LoadBalancerEnabled: flagLoadBalancerEnabled,
 			HistoricRetention:   flagHistoricRetention,
 			RecentRetention:     flagRecentRetention,
+			PluginPreset:        pluginPreset,
+			PluginList:          pluginList,
 		},
 	}
 

--- a/cmd/weaver/commands/block/node/node.go
+++ b/cmd/weaver/commands/block/node/node.go
@@ -33,6 +33,8 @@ var (
 	flagPluginsSize         string
 	flagHistoricRetention   string
 	flagRecentRetention     string
+	flagPluginPreset        string
+	flagPlugins             string
 	flagLoadBalancerEnabled bool
 
 	nodeCmd = &cobra.Command{
@@ -83,6 +85,10 @@ func init() {
 	// Block retention configuration flags
 	nodeCmd.PersistentFlags().StringVar(&flagHistoricRetention, "historic-retention", "", "Historic block retention threshold (0 = unlimited, default: 0)")
 	nodeCmd.PersistentFlags().StringVar(&flagRecentRetention, "recent-retention", "", "Recent block retention threshold (default: 96000)")
+
+	// Plugin configuration flags
+	nodeCmd.PersistentFlags().StringVar(&flagPluginPreset, "plugin-preset", "", "Plugin preset to deploy (tier1-lfh, tier1-rfh, or custom); prompts interactively when omitted")
+	nodeCmd.PersistentFlags().StringVar(&flagPlugins, "plugins", "", "Comma-separated plugin list; overrides --plugin-preset when set")
 
 	// LoadBalancer / MetalLB annotation flag
 	nodeCmd.PersistentFlags().BoolVar(&flagLoadBalancerEnabled, "load-balancer-enabled", true, "Inject MetalLB address-pool annotation into the block node service (disable for environments without MetalLB)")

--- a/docs/claude/reviews/00474-block-node-plugin-preset-selection.md
+++ b/docs/claude/reviews/00474-block-node-plugin-preset-selection.md
@@ -1,0 +1,134 @@
+# Review Guide: 00474 — Block Node Plugin Preset Selection
+
+## Summary
+
+- Added interactive TUI prompts (preset select + custom multi-select) and `--plugin-preset` / `--plugins` flags so node operators can choose which block-node plugins are deployed at install, upgrade, and reconfigure time.
+- The preset-to-plugin mapping is owned by solo-weaver (`internal/blocknode/blocknode_plugins.go`) and must be updated in lockstep with block-node chart releases.
+- The resolved plugin list is injected into `plugins.names` in the Helm values file, replacing the previously hardcoded chart default.
+
+## Changed Files
+
+| File | Change |
+|------|--------|
+| `internal/blocknode/blocknode_plugins.go` | **New** — preset IDs, plugin catalog for multi-select, canonical plugin lists, helper functions |
+| `internal/blocknode/blocknode_plugins_test.go` | **New** — unit tests for preset helpers and `injectPluginsConfig` |
+| `internal/blocknode/values.go` | Added `injectPluginsConfig()` method; wired into `ComputeValuesFile` pipeline |
+| `internal/ui/prompt/blocknode.go` | Added `RunPluginPresetPrompts` (two-pass: select + conditional multi-select) |
+| `cmd/weaver/commands/block/node/node.go` | Added `flagPluginPreset` / `flagPlugins` vars and persistent flags |
+| `cmd/weaver/commands/block/node/init.go` | Wired prompt call; resolved plugin list and populated `PluginPreset`/`PluginList` in inputs |
+| `pkg/models/inputs.go` | Added `PluginPreset`, `PluginList` fields + `DefaultPluginPreset`, `PluginPresetCustom` constants + `ValidatePluginList` |
+| `internal/bll/blocknode/helpers.go` | Pass-through for `PluginPreset`/`PluginList`; persistence in `patchBlockNodeState` |
+| `internal/state/state.go` | Added `PluginPreset`, `PluginList` to `BlockNodeState` |
+| `internal/state/state_reader.go` | Added `PluginPreset`/`PluginList` to `PromptDefaultsDoc`, `BlockNodeSummary`, `ReadPromptDefaultsFromDisk` |
+| `internal/state/state_reader_test.go` | Extended `TestReadPromptDefaults_ParsesAllBlockNodeFields` to cover new fields |
+
+## Code Review Checklist
+
+- [ ] `injectPluginsConfig` is called AFTER `injectRetentionConfig` and BEFORE `injectServiceAnnotations` in `ComputeValuesFile`
+- [ ] `--plugins` takes precedence over `--plugin-preset` in `prepareBlocknodeInputs` (see `pluginList := flagPlugins` before preset lookup)
+- [ ] `RunPluginPresetPrompts` is a no-op when either flag was already set on the command line (`flagWasSet` checks)
+- [ ] The custom multi-select pre-fills from the last-used `PluginList` persisted in state (reconfigure default)
+- [ ] `patchBlockNodeState` persists `PluginPreset` and `PluginList` only when `PluginPreset != ""` (no spurious state writes)
+- [ ] `ValidatePluginList` rejects empty entries and entries with surrounding whitespace
+- [ ] `blocknode_plugins.go` lists both Tier 1 presets; Tier 2 presets are not yet included (pending block-node team confirmation)
+- [ ] `AllBlockNodePlugins` contains all selectable plugins for the custom multi-select
+- [ ] The `strings` import was added to `pkg/models/inputs.go` alongside the new validation function
+
+## Tests
+
+```bash
+# Unit tests for blocknode plugins and values injection
+go test -race -tags='!integration' -run 'TestAvailable|TestPluginList|TestPresetLabel|TestIsKnown|TestInjectPlugins' ./internal/blocknode/...
+
+# State reader tests (including new plugin preset fields)
+go test -race -tags='!integration' ./internal/state/...
+
+# Full unit suite (macOS — excludes Linux-only packages)
+go test -race -tags='!integration' ./internal/blocknode/... ./internal/state/... ./internal/ui/prompt/... ./pkg/models/...
+```
+
+## Manual UAT
+
+### Prerequisites
+
+A running block-node environment (kubeconfig, PostgreSQL, Helm).
+
+### 1. Interactive install — preset select
+
+```bash
+sudo solo-provisioner block node install
+```
+
+Expected: after the storage path prompts, a `Block Node Plugin Preset` select appears with options:
+- `Tier 1 — Local Full History  (blocks stored on local disk)`
+- `Tier 1 — Remote Full History  (blocks stored in S3-compatible cloud storage)`
+- `Custom  (select individual plugins)`
+
+Select `Tier 1 — Local Full History` and complete the install.
+
+Verify the deployed Helm values contain:
+```yaml
+plugins:
+  names: facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent,backfill
+```
+
+### 2. Interactive install — custom multi-select
+
+```bash
+sudo solo-provisioner block node install
+```
+
+Select `Custom`. A multi-select appears listing all available plugins.
+Choose `facility-messaging` and `health` only.
+
+Verify the deployed values contain:
+```yaml
+plugins:
+  names: facility-messaging,health
+```
+
+### 3. Non-interactive — `--plugin-preset` flag
+
+```bash
+sudo solo-provisioner block node install --plugin-preset tier1-rfh --non-interactive  -p local
+```
+
+Expected: no prompt shown; deployed values contain the RFH plugin list including `s3-archive`.
+
+### 4. Non-interactive — `--plugins` override
+
+```bash
+sudo solo-provisioner block node install --plugins "facility-messaging,health" --non-interactive  -p local
+```
+
+Expected: deployed values contain `plugins.names: facility-messaging,health`.
+
+### 5. Reconfigure — last preset shown as default
+
+After completing step 1 (Tier 1 LFH), run:
+
+```bash
+sudo solo-provisioner block node reconfigure
+```
+
+Expected: the plugin preset prompt pre-selects `Tier 1 — Local Full History`.
+
+### 6. `--plugins` overrides `--plugin-preset`
+
+```bash
+sudo solo-provisioner block node install --plugin-preset tier1-lfh --plugins "facility-messaging,health" --non-interactive -p local
+```
+
+Expected: `--plugins` wins; deployed values contain `facility-messaging,health` (not the full LFH list).
+
+### 7. Validation — empty plugin list or preset
+
+```bash
+sudo solo-provisioner block node install --plugins "" --non-interactive -p local
+```
+
+```bash
+sudo solo-provisioner block node install --non-interactive
+```
+
+Expected: the block node installation succeeds as previous behaviour with the default set of plugins installed.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -44,6 +44,7 @@ These flags are available for all commands:
 | `--config` | `-c` | Path to configuration file | None |
 | `--profile` | `-p` | Deployment profile | Required for most commands |
 | `--output` | `-o` | Output format (yaml\|json) | `yaml` |
+| `--non-interactive` | — | Disable TUI and output raw logs; useful for CI/pipelines | `false` |
 | `--version` | `-v` | Show version | - |
 | `--help` | `-h` | Show help | - |
 
@@ -147,6 +148,13 @@ sudo solo-provisioner block node install \
 | `--archive-size` | Archive storage size |
 | `--verification-size` | Verification storage size |
 | `--log-size` | Log storage size |
+| `--plugin-preset` | Plugin preset to deploy (`tier1-lfh`, `tier1-rfh`, or `custom`); prompts interactively when omitted |
+| `--plugins` | Comma-separated plugin list; overrides `--plugin-preset` when set |
+| `--plugins-size` | PV/PVC size for plugins storage (e.g., `5Gi`, `10Gi`) |
+| `--plugins-path` | Path for plugins storage |
+| `--historic-retention` | Historic block retention threshold (`0` = unlimited) |
+| `--recent-retention` | Recent block retention threshold (default: `96000`) |
+| `--load-balancer-enabled` | Inject MetalLB address-pool annotation into the block node service; set to `false` for environments without MetalLB (default: `true`) |
 
 #### Upgrade Block Node
 
@@ -217,6 +225,59 @@ sudo solo-provisioner block node upgrade \
   --values=/path/to/new-values.yaml \
   --with-reset
 ```
+
+#### Reconfigure Block Node
+
+Re-apply configuration to an existing Block Node deployment without changing its chart version:
+
+```bash
+# Reconfigure with updated values file
+sudo solo-provisioner block node reconfigure \
+  --profile=mainnet \
+  --values=/path/to/updated-values.yaml
+
+# Reconfigure without reusing previous Helm values
+sudo solo-provisioner block node reconfigure \
+  --profile=mainnet \
+  --values=/path/to/values.yaml \
+  --no-reuse-values
+
+# Reconfigure and skip the pod rollout-restart
+sudo solo-provisioner block node reconfigure \
+  --profile=mainnet \
+  --values=/path/to/values.yaml \
+  --no-restart
+```
+
+**Additional Flags**:
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--no-reuse-values` | Don't reuse previous release values | `false` |
+| `--no-restart` | Skip rollout-restart of the block node pod after reconfiguring | `false` |
+| `--with-reset` | Reset storage (clear all data) before reconfiguring | `false` |
+
+#### Uninstall Block Node
+
+Remove the Hedera Block Node Helm release:
+
+```bash
+# Basic uninstall
+sudo solo-provisioner block node uninstall --profile=mainnet
+
+# Uninstall and clear all storage data
+sudo solo-provisioner block node uninstall \
+  --profile=mainnet \
+  --with-reset
+```
+
+**Additional Flags**:
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--with-reset` | Reset storage (clear all data) before uninstalling | `false` |
+
+> **Warning**: Uninstalling removes the Helm release. Use `--with-reset` to also clear all block data from disk.
 
 ---
 
@@ -771,10 +832,12 @@ log:
 sudo ./solo-provisioner install
 
 # BLOCK NODE
-sudo solo-provisioner block node check   --profile=<profile>
-sudo solo-provisioner block node install --profile=<profile> [--values=<file>]
-sudo solo-provisioner block node upgrade --profile=<profile> [--values=<file>] [--with-reset]
-sudo solo-provisioner block node reset   --profile=<profile>
+sudo solo-provisioner block node check       --profile=<profile>
+sudo solo-provisioner block node install     --profile=<profile> [--values=<file>] [--plugin-preset=<preset>]
+sudo solo-provisioner block node upgrade     --profile=<profile> [--values=<file>] [--with-reset]
+sudo solo-provisioner block node reconfigure --profile=<profile> [--values=<file>] [--no-restart]
+sudo solo-provisioner block node reset       --profile=<profile>
+sudo solo-provisioner block node uninstall   --profile=<profile> [--with-reset]
 
 # KUBERNETES
 sudo solo-provisioner kube cluster install   --profile=<profile> --node-type=block

--- a/internal/bll/blocknode/helpers.go
+++ b/internal/bll/blocknode/helpers.go
@@ -38,6 +38,12 @@ func patchBlockNodeState() func(st *state.State, effectiveInputs models.UserInpu
 				Msg("Persisted block node storage base path into runtime state")
 			st.BlockNodeState.Storage.BasePath = effectiveInputs.Custom.Storage.BasePath
 		}
+		if effectiveInputs.Custom.PluginPreset != "" {
+			logx.As().Debug().Str("pluginPreset", effectiveInputs.Custom.PluginPreset).
+				Msg("Persisted block node plugin preset into runtime state")
+			st.BlockNodeState.PluginPreset = effectiveInputs.Custom.PluginPreset
+			st.BlockNodeState.PluginList = effectiveInputs.Custom.PluginList
+		}
 		return nil
 	}
 }
@@ -136,6 +142,8 @@ func resolveBlocknodeEffectiveInputs(
 			ResetStorage:        inputs.Custom.ResetStorage,
 			NoRestart:           inputs.Custom.NoRestart,
 			LoadBalancerEnabled: inputs.Custom.LoadBalancerEnabled,
+			PluginPreset:        inputs.Custom.PluginPreset,
+			PluginList:          inputs.Custom.PluginList,
 		},
 	}
 

--- a/internal/bll/blocknode/helpers.go
+++ b/internal/bll/blocknode/helpers.go
@@ -42,6 +42,10 @@ func patchBlockNodeState() func(st *state.State, effectiveInputs models.UserInpu
 			logx.As().Debug().Str("pluginPreset", effectiveInputs.Custom.PluginPreset).
 				Msg("Persisted block node plugin preset into runtime state")
 			st.BlockNodeState.PluginPreset = effectiveInputs.Custom.PluginPreset
+		}
+		if effectiveInputs.Custom.PluginList != "" {
+			logx.As().Debug().Str("pluginList", effectiveInputs.Custom.PluginList).
+				Msg("Persisted block node plugin list into runtime state")
 			st.BlockNodeState.PluginList = effectiveInputs.Custom.PluginList
 		}
 		return nil

--- a/internal/blocknode/blocknode_plugins.go
+++ b/internal/blocknode/blocknode_plugins.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package blocknode
+
+// Plugin preset IDs used by the --plugin-preset flag and TUI prompt.
+//
+// Each preset maps to a fixed, ordered plugin list maintained here in lockstep
+// with block-node chart releases. When the block-node team changes a preset's
+// contents or adds/removes presets, this file must be updated in the same
+// release cycle.
+const (
+	// PresetTier1LFH selects Local Full History storage (blocks stored on disk).
+	PresetTier1LFH = "tier1-lfh"
+
+	// PresetTier1RFH selects Remote Full History storage (blocks stored in S3-compatible cloud storage).
+	PresetTier1RFH = "tier1-rfh"
+
+	// PresetCustom indicates the operator selected a custom set of plugins.
+	PresetCustom = "custom"
+)
+
+// AllBlockNodePlugins is the ordered list of available plugins shown in the
+// TUI multi-select when the operator chooses the Custom preset.
+// Source of truth: hiero-block-node block-node/app/build.gradle.kts (blockNodePlugins configuration).
+var AllBlockNodePlugins = []string{
+	"facility-messaging",
+	"block-access-service",
+	"health",
+	"server-status",
+	"stream-publisher",
+	"stream-subscriber",
+	"verification",
+	"blocks-file-historic",
+	"blocks-file-recent",
+	"backfill",
+	"s3-archive",
+}
+
+// presetPlugins maps each preset ID to the canonical comma-separated plugin list.
+// Source of truth: hiero-block-node chart values-overrides/plugin-profile-*.yaml.
+var presetPlugins = map[string]string{
+	PresetTier1LFH: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent,backfill",
+	PresetTier1RFH: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-recent,backfill,s3-archive",
+}
+
+// presetLabels maps preset IDs to human-readable labels for TUI display.
+var presetLabels = map[string]string{
+	PresetTier1LFH: "Tier 1 — Local Full History  (blocks stored on local disk)",
+	PresetTier1RFH: "Tier 1 — Remote Full History  (blocks stored in S3-compatible cloud storage)",
+	PresetCustom:   "Custom  (select individual plugins)",
+}
+
+// orderedPresets is the display order for the TUI select prompt.
+var orderedPresets = []string{PresetTier1LFH, PresetTier1RFH, PresetCustom}
+
+// AvailablePresets returns the ordered preset IDs for TUI display.
+func AvailablePresets() []string {
+	result := make([]string, len(orderedPresets))
+	copy(result, orderedPresets)
+	return result
+}
+
+// PluginListForPreset returns the canonical comma-separated plugin list for a
+// named preset, or an empty string when the preset ID is not recognised.
+func PluginListForPreset(presetID string) string {
+	return presetPlugins[presetID]
+}
+
+// PresetLabel returns the human-readable TUI label for a preset ID,
+// or the preset ID itself when no label is registered.
+func PresetLabel(presetID string) string {
+	if label, ok := presetLabels[presetID]; ok {
+		return label
+	}
+	return presetID
+}
+
+// IsKnownPreset returns true when presetID is a recognised non-custom preset.
+func IsKnownPreset(presetID string) bool {
+	_, ok := presetPlugins[presetID]
+	return ok
+}

--- a/internal/blocknode/blocknode_plugins_test.go
+++ b/internal/blocknode/blocknode_plugins_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package blocknode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// ── AvailablePresets ─────────────────────────────────────────────────────────
+
+func TestAvailablePresets_ContainsExpectedPresets(t *testing.T) {
+	presets := AvailablePresets()
+	assert.Contains(t, presets, PresetTier1LFH)
+	assert.Contains(t, presets, PresetTier1RFH)
+	assert.Contains(t, presets, PresetCustom)
+}
+
+func TestAvailablePresets_ReturnsACopy(t *testing.T) {
+	a := AvailablePresets()
+	b := AvailablePresets()
+	a[0] = "mutated"
+	assert.NotEqual(t, "mutated", b[0], "AvailablePresets must return an independent copy")
+}
+
+// ── PluginListForPreset ──────────────────────────────────────────────────────
+
+func TestPluginListForPreset_Tier1LFH(t *testing.T) {
+	list := PluginListForPreset(PresetTier1LFH)
+	assert.NotEmpty(t, list)
+	assert.Contains(t, list, "facility-messaging")
+	assert.Contains(t, list, "blocks-file-historic")
+	assert.Contains(t, list, "blocks-file-recent")
+	assert.NotContains(t, list, "s3-archive")
+}
+
+func TestPluginListForPreset_Tier1RFH(t *testing.T) {
+	list := PluginListForPreset(PresetTier1RFH)
+	assert.NotEmpty(t, list)
+	assert.Contains(t, list, "facility-messaging")
+	assert.Contains(t, list, "s3-archive")
+	assert.NotContains(t, list, "blocks-file-historic")
+}
+
+func TestPluginListForPreset_UnknownReturnsEmpty(t *testing.T) {
+	assert.Empty(t, PluginListForPreset("does-not-exist"))
+}
+
+func TestPluginListForPreset_CustomReturnsEmpty(t *testing.T) {
+	assert.Empty(t, PluginListForPreset(PresetCustom), "custom preset has no predefined plugin list")
+}
+
+// ── PresetLabel ──────────────────────────────────────────────────────────────
+
+func TestPresetLabel_KnownPresets(t *testing.T) {
+	assert.NotEmpty(t, PresetLabel(PresetTier1LFH))
+	assert.NotEmpty(t, PresetLabel(PresetTier1RFH))
+	assert.NotEmpty(t, PresetLabel(PresetCustom))
+}
+
+func TestPresetLabel_UnknownReturnsFallback(t *testing.T) {
+	assert.Equal(t, "unknown-preset", PresetLabel("unknown-preset"))
+}
+
+// ── IsKnownPreset ────────────────────────────────────────────────────────────
+
+func TestIsKnownPreset_RecognisedPresets(t *testing.T) {
+	assert.True(t, IsKnownPreset(PresetTier1LFH))
+	assert.True(t, IsKnownPreset(PresetTier1RFH))
+}
+
+func TestIsKnownPreset_CustomIsFalse(t *testing.T) {
+	assert.False(t, IsKnownPreset(PresetCustom), "custom has no predefined list so IsKnownPreset must be false")
+}
+
+func TestIsKnownPreset_UnknownIsFalse(t *testing.T) {
+	assert.False(t, IsKnownPreset("not-a-preset"))
+}
+
+// ── injectPluginsConfig ──────────────────────────────────────────────────────
+
+// injectPluginsConfig_ReturnsUnchangedWhenPluginListEmpty verifies that an empty
+// PluginList leaves the values content untouched.
+func TestInjectPluginsConfig_NoOpWhenPluginListEmpty(t *testing.T) {
+	m := managerWithInputs(t, "", "")
+	input := []byte("plugins:\n  names: original-list\n")
+	result, err := m.injectPluginsConfig(input)
+	require.NoError(t, err)
+	assert.Equal(t, string(input), string(result))
+}
+
+func TestInjectPluginsConfig_SetsPluginsNames(t *testing.T) {
+	m := managerWithInputs(t, PresetTier1LFH, PluginListForPreset(PresetTier1LFH))
+	input := []byte("plugins:\n  mavenImage: some-image\n")
+
+	result, err := m.injectPluginsConfig(input)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+
+	plugins, ok := vals["plugins"].(map[string]interface{})
+	require.True(t, ok, "plugins key must be a map")
+	assert.Equal(t, PluginListForPreset(PresetTier1LFH), plugins["names"])
+}
+
+func TestInjectPluginsConfig_CreatesPluginsMapWhenAbsent(t *testing.T) {
+	m := managerWithInputs(t, PresetTier1RFH, PluginListForPreset(PresetTier1RFH))
+	input := []byte("blockNode:\n  config: {}\n")
+
+	result, err := m.injectPluginsConfig(input)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+
+	plugins, ok := vals["plugins"].(map[string]interface{})
+	require.True(t, ok, "plugins map must be created when absent")
+	assert.Equal(t, PluginListForPreset(PresetTier1RFH), plugins["names"])
+}
+
+func TestInjectPluginsConfig_OverridesExistingPluginsNames(t *testing.T) {
+	newList := "facility-messaging,health"
+	m := managerWithInputs(t, PresetCustom, newList)
+	input := []byte("plugins:\n  names: old-list\n  mavenImage: img\n")
+
+	result, err := m.injectPluginsConfig(input)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+
+	plugins := vals["plugins"].(map[string]interface{})
+	assert.Equal(t, newList, plugins["names"])
+	assert.Equal(t, "img", plugins["mavenImage"], "existing sibling keys must be preserved")
+}
+
+func TestInjectPluginsConfig_CustomListNoWhitespace(t *testing.T) {
+	list := "facility-messaging,health,server-status"
+	m := managerWithInputs(t, PresetCustom, list)
+	input := []byte("{}\n")
+
+	result, err := m.injectPluginsConfig(input)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+
+	names := vals["plugins"].(map[string]interface{})["names"].(string)
+	for _, entry := range strings.Split(names, ",") {
+		assert.Equal(t, strings.TrimSpace(entry), entry, "no surrounding whitespace per plugin entry")
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// managerWithInputs builds a minimal Manager with PluginPreset and PluginList set.
+func managerWithInputs(t *testing.T, preset, list string) *Manager {
+	t.Helper()
+	m := &Manager{}
+	m.blockNodeInputs.PluginPreset = preset
+	m.blockNodeInputs.PluginList = list
+	return m
+}

--- a/internal/blocknode/values.go
+++ b/internal/blocknode/values.go
@@ -47,6 +47,12 @@ func (m *Manager) ComputeValuesFile(profile string, valuesFile string) (string, 
 		return "", errorx.InternalError.Wrap(err, "failed to inject retention config into values file")
 	}
 
+	// Inject resolved plugin list into plugins.names when set.
+	valuesContent, err = m.injectPluginsConfig(valuesContent)
+	if err != nil {
+		return "", errorx.InternalError.Wrap(err, "failed to inject plugins config into values file")
+	}
+
 	// Inject MetalLB service annotation into Helm values when LoadBalancerEnabled is set so that
 	// the annotation is managed natively by Helm across install and upgrade.
 	valuesContent, err = m.injectServiceAnnotations(valuesContent)
@@ -263,6 +269,42 @@ func (m *Manager) injectRetentionConfig(valuesContent []byte) ([]byte, error) {
 	result, err := yaml.Marshal(vals)
 	if err != nil {
 		return nil, errorx.InternalError.Wrap(err, "failed to marshal values YAML after retention config injection")
+	}
+
+	return result, nil
+}
+
+// injectPluginsConfig injects the resolved plugin list into plugins.names in the Helm values
+// when PluginList is non-empty. If PluginList is empty the values content is returned unchanged,
+// leaving the chart's built-in default plugin list intact.
+func (m *Manager) injectPluginsConfig(valuesContent []byte) ([]byte, error) {
+	pluginList := m.blockNodeInputs.PluginList
+	if pluginList == "" {
+		return valuesContent, nil
+	}
+
+	var vals map[string]interface{}
+	if err := yaml.Unmarshal(valuesContent, &vals); err != nil {
+		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse values YAML for plugins config injection")
+	}
+
+	// Navigate to plugins, creating the path if needed.
+	plugins, ok := vals["plugins"].(map[string]interface{})
+	if !ok {
+		plugins = make(map[string]interface{})
+		vals["plugins"] = plugins
+	}
+
+	logx.As().Info().
+		Str("preset", m.blockNodeInputs.PluginPreset).
+		Str("plugins_names", pluginList).
+		Msg("Applying plugin list to block node config")
+
+	plugins["names"] = pluginList
+
+	result, err := yaml.Marshal(vals)
+	if err != nil {
+		return nil, errorx.InternalError.Wrap(err, "failed to marshal values YAML after plugins config injection")
 	}
 
 	return result, nil

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -149,6 +149,8 @@ type BlockNodeState struct {
 	Storage           models.BlockNodeStorage `yaml:"storage" json:"storage"`
 	HistoricRetention string                  `yaml:"historicRetention,omitempty" json:"historicRetention,omitempty"`
 	RecentRetention   string                  `yaml:"recentRetention,omitempty" json:"recentRetention,omitempty"`
+	PluginPreset      string                  `yaml:"pluginPreset,omitempty" json:"pluginPreset,omitempty"`
+	PluginList        string                  `yaml:"pluginList,omitempty" json:"pluginList,omitempty"`
 	LastSync          htime.Time              `yaml:"lastSync,omitempty" json:"lastSync,omitempty"` // last time state was reconciled
 }
 

--- a/internal/state/state_reader.go
+++ b/internal/state/state_reader.go
@@ -73,6 +73,8 @@ type PromptDefaultsDoc struct {
 			ChartVersion      string `yaml:"version"`
 			HistoricRetention string `yaml:"historicRetention"`
 			RecentRetention   string `yaml:"recentRetention"`
+			PluginPreset      string `yaml:"pluginPreset"`
+			PluginList        string `yaml:"pluginList"`
 			Storage           struct {
 				BasePath         string `yaml:"basePath"`
 				ArchivePath      string `yaml:"archivePath"`
@@ -111,6 +113,8 @@ type BlockNodeSummary struct {
 	ChartVersion      string
 	HistoricRetention string
 	RecentRetention   string
+	PluginPreset      string
+	PluginList        string
 	Storage           models.BlockNodeStorage
 }
 
@@ -146,6 +150,8 @@ func ReadPromptDefaultsFromDisk() (PromptDefaults, error) {
 			ChartVersion:      bn.ChartVersion,
 			HistoricRetention: bn.HistoricRetention,
 			RecentRetention:   bn.RecentRetention,
+			PluginPreset:      bn.PluginPreset,
+			PluginList:        bn.PluginList,
 			Storage: models.BlockNodeStorage{
 				BasePath:         bn.Storage.BasePath,
 				ArchivePath:      bn.Storage.ArchivePath,

--- a/internal/state/state_reader_test.go
+++ b/internal/state/state_reader_test.go
@@ -51,6 +51,8 @@ state:
     version: "0.8.1"
     historicRetention: "500"
     recentRetention: "12000"
+    pluginPreset: "tier1-lfh"
+    pluginList: "facility-messaging,health"
     storage:
       basePath: /mnt/data
       archivePath: /mnt/archive
@@ -82,6 +84,12 @@ state:
 	}
 	if bn.RecentRetention != "12000" {
 		t.Errorf("expected RecentRetention '12000', got %q", bn.RecentRetention)
+	}
+	if bn.PluginPreset != "tier1-lfh" {
+		t.Errorf("expected PluginPreset 'tier1-lfh', got %q", bn.PluginPreset)
+	}
+	if bn.PluginList != "facility-messaging,health" {
+		t.Errorf("expected PluginList 'facility-messaging,health', got %q", bn.PluginList)
 	}
 	if bn.Storage.BasePath != "/mnt/data" {
 		t.Errorf("expected Storage.BasePath '/mnt/data', got %q", bn.Storage.BasePath)

--- a/internal/ui/handler.go
+++ b/internal/ui/handler.go
@@ -32,15 +32,19 @@ func NewTUIHandler(program *tea.Program) *notify.Handler {
 		return "  "
 	}
 
+	printProgressHeader := func() {
+		if !headerPrinted {
+			program.Println("")
+			program.Println(sectionHeaderStyle.Render("Progress"))
+			headerPrinted = true
+		}
+	}
+
 	return &notify.Handler{
 		PhaseStart: func(ctx context.Context, stp automa.Step, msg string, args ...interface{}) {
 			name := fmt.Sprintf(msg, args...)
 			// Print the "Progress" section header once, before the first phase.
-			if !headerPrinted {
-				program.Println("")
-				program.Println(sectionHeaderStyle.Render("Progress"))
-				headerPrinted = true
-			}
+			printProgressHeader()
 			// Print the running phase header permanently above the TUI.
 			if VerboseLevel >= 1 && name != "" {
 				if insidePhase {
@@ -84,6 +88,7 @@ func NewTUIHandler(program *tea.Program) *notify.Handler {
 		StepCompletion: func(ctx context.Context, stp automa.Step, report *automa.Report, msg string, args ...interface{}) {
 			name := fmt.Sprintf(msg, args...)
 			dur := report.Duration()
+			printProgressHeader()
 			// Print the completed step line above the TUI at level 1+.
 			if VerboseLevel >= 1 {
 				icon := completionIcon(report.Status)
@@ -99,6 +104,7 @@ func NewTUIHandler(program *tea.Program) *notify.Handler {
 			if report.Error != nil {
 				errMsg = report.Error.Error()
 			}
+			printProgressHeader()
 			if VerboseLevel >= 1 {
 				indent := stepIndent()
 				program.Println(fmt.Sprintf("%s%s %s", indent, failedIcon, stepNameStyle.Render(name)))

--- a/internal/ui/prompt/blocknode.go
+++ b/internal/ui/prompt/blocknode.go
@@ -484,25 +484,55 @@ func RunPluginPresetPrompts(
 		return nil
 	}
 
-	// Pre-select the plugins from the last-used custom list (if any).
-	var preSelected []string
-	if defaults.BlockNode.PluginList != "" {
-		preSelected = strings.Split(defaults.BlockNode.PluginList, ",")
-	}
-
-	var selectedPlugins []string = preSelected
-
+	// Pre-select the plugins from the last-used custom list (if any),
+	// but filter out any entries that no longer exist in the current
+	// available plugin list so the UI does not silently drop them.
+	validPlugins := make(map[string]struct{}, len(blocknode.AllBlockNodePlugins))
 	var pluginOptions []huh.Option[string]
 	for _, p := range blocknode.AllBlockNodePlugins {
+		validPlugins[p] = struct{}{}
 		pluginOptions = append(pluginOptions, huh.NewOption(p, p))
+	}
+
+	var preSelected []string
+	var unknownPlugins []string
+	if defaults.BlockNode.PluginList != "" {
+		for _, plugin := range strings.Split(defaults.BlockNode.PluginList, ",") {
+			plugin = strings.TrimSpace(plugin)
+			if plugin == "" {
+				continue
+			}
+			if _, ok := validPlugins[plugin]; ok {
+				preSelected = append(preSelected, plugin)
+				continue
+			}
+			unknownPlugins = append(unknownPlugins, plugin)
+		}
+	}
+
+	selectedPlugins := preSelected
+
+	description := "Choose the individual plugins to install"
+	if len(unknownPlugins) > 0 {
+		description = fmt.Sprintf(
+			"%s\nWarning: previously saved plugins are no longer available and were not pre-selected: %s",
+			description,
+			strings.Join(unknownPlugins, ", "),
+		)
 	}
 
 	customField := huh.NewMultiSelect[string]().
 		Key("plugins").
 		Title("Select Plugins").
-		Description("Choose the individual plugins to install").
+		Description(description).
 		Options(pluginOptions...).
-		Value(&selectedPlugins)
+		Value(&selectedPlugins).
+		Validate(func(selected []string) error {
+			if len(selected) == 0 {
+				return fmt.Errorf("at least one plugin must be selected for the Custom preset")
+			}
+			return nil
+		})
 
 	customForm := huh.NewForm(huh.NewGroup(customField)).
 		WithTheme(SoloTheme()).

--- a/internal/ui/prompt/blocknode.go
+++ b/internal/ui/prompt/blocknode.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/huh"
+	"github.com/hashgraph/solo-weaver/internal/blocknode"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/deps"
@@ -415,6 +416,106 @@ func BlockNodeReconfigureInputPrompts(
 		historicRetentionInputPrompt(resolveEffective(defaults.BlockNode.HistoricRetention, cfg.BlockNode.HistoricRetention, models.DefaultHistoricRetention), flagHistoricRetention),
 		recentRetentionInputPrompt(resolveEffective(defaults.BlockNode.RecentRetention, cfg.BlockNode.RecentRetention, models.DefaultRecentRetention), flagRecentRetention),
 	}
+}
+
+// RunPluginPresetPrompts presents a two-pass interactive plugin preset prompt.
+//
+// Pass 1 — preset select: asks which preset to deploy, pre-selecting the last
+// used preset read from the on-disk state file.
+//
+// Pass 2 — custom plugin multi-select (conditional): when the operator selects
+// the Custom preset, a multi-select is shown listing all known block-node
+// plugins. The resulting selection is joined as a comma-separated string and
+// written to *flagPlugins.
+//
+// The function is a no-op when either flag was already supplied on the command
+// line — the caller's values are respected as-is.
+//
+// Parameters:
+//   - cmd:             the Cobra command (used for flag-changed detection)
+//   - defaults:        prompt defaults read from the on-disk state file
+//   - flagPluginPreset: pointer to the --plugin-preset flag variable
+//   - flagPlugins:     pointer to the --plugins flag variable
+//   - cv:              chosen-values collector for summary printing
+func RunPluginPresetPrompts(
+	cmd *cobra.Command,
+	defaults state.PromptDefaults,
+	flagPluginPreset *string,
+	flagPlugins *string,
+	cv *ChosenValues,
+) error {
+	// If the operator already supplied --plugins, no prompting is needed.
+	if flagWasSet(cmd, "plugins") {
+		return nil
+	}
+	// If the operator already supplied --plugin-preset, no prompting is needed.
+	if flagWasSet(cmd, "plugin-preset") {
+		return nil
+	}
+
+	// ── Pass 1: preset selection ───────────────────────────────────────────────
+	effectivePreset := resolveEffective(defaults.BlockNode.PluginPreset, "", blocknode.PresetTier1LFH)
+	*flagPluginPreset = effectivePreset
+
+	var options []huh.Option[string]
+	for _, id := range blocknode.AvailablePresets() {
+		options = append(options, huh.NewOption(blocknode.PresetLabel(id), id))
+	}
+
+	presetField := huh.NewSelect[string]().
+		Key("plugin-preset").
+		Title("Block Node Plugin Preset").
+		Description("Select the plugin set to deploy with this block node").
+		Options(options...).
+		Value(flagPluginPreset)
+
+	presetForm := huh.NewForm(huh.NewGroup(presetField)).
+		WithTheme(SoloTheme()).
+		WithShowHelp(true)
+
+	if err := presetForm.Run(); err != nil {
+		return wrapFormError(err)
+	}
+
+	cv.add("Plugin Preset", blocknode.PresetLabel(*flagPluginPreset))
+
+	// ── Pass 2: custom multi-select (only when Custom was chosen) ─────────────
+	if *flagPluginPreset != blocknode.PresetCustom {
+		return nil
+	}
+
+	// Pre-select the plugins from the last-used custom list (if any).
+	var preSelected []string
+	if defaults.BlockNode.PluginList != "" {
+		preSelected = strings.Split(defaults.BlockNode.PluginList, ",")
+	}
+
+	var selectedPlugins []string = preSelected
+
+	var pluginOptions []huh.Option[string]
+	for _, p := range blocknode.AllBlockNodePlugins {
+		pluginOptions = append(pluginOptions, huh.NewOption(p, p))
+	}
+
+	customField := huh.NewMultiSelect[string]().
+		Key("plugins").
+		Title("Select Plugins").
+		Description("Choose the individual plugins to install").
+		Options(pluginOptions...).
+		Value(&selectedPlugins)
+
+	customForm := huh.NewForm(huh.NewGroup(customField)).
+		WithTheme(SoloTheme()).
+		WithShowHelp(true)
+
+	if err := customForm.Run(); err != nil {
+		return wrapFormError(err)
+	}
+
+	*flagPlugins = strings.Join(selectedPlugins, ",")
+	cv.add("Custom Plugins", *flagPlugins)
+
+	return nil
 }
 
 // resolveEffective returns the first non-empty value from the priority chain:

--- a/pkg/models/inputs.go
+++ b/pkg/models/inputs.go
@@ -4,6 +4,7 @@ package models
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/automa-saga/automa"
 	"github.com/hashgraph/solo-weaver/pkg/sanity"
@@ -54,6 +55,14 @@ const (
 	DefaultRecentRetention   = "96000"
 )
 
+// DefaultPluginPreset is used when no preset is specified. An empty string means
+// the chart's built-in default plugin list is left unchanged.
+const DefaultPluginPreset = ""
+
+// PluginPresetCustom is the preset ID used when the operator supplies a
+// manual plugin list via --plugins or the TUI multi-select.
+const PluginPresetCustom = "custom"
+
 type BlockNodeInputs struct {
 	Profile             string
 	Namespace           string
@@ -70,6 +79,8 @@ type BlockNodeInputs struct {
 	LoadBalancerEnabled bool   // true = inject metallb.io/address-pool annotation via Helm values
 	HistoricRetention   string // FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD (0 = unlimited)
 	RecentRetention     string // FILES_RECENT_BLOCK_RETENTION_THRESHOLD (~96000 default)
+	PluginPreset        string // preset ID (e.g. "tier1-lfh") or "custom"; empty = chart default
+	PluginList          string // resolved comma-separated plugin list injected into plugins.names
 }
 
 type ClusterInputs struct {
@@ -212,6 +223,30 @@ func (c *BlockNodeInputs) Validate() error {
 		}
 	}
 
+	// Validate plugin list format when set: comma-separated, no surrounding whitespace per entry.
+	if c.PluginList != "" {
+		if err := ValidatePluginList(c.PluginList); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ValidatePluginList returns an error when s is not a valid comma-separated
+// plugin list (non-empty, no surrounding whitespace per entry, no empty tokens).
+func ValidatePluginList(s string) error {
+	if s == "" {
+		return errorx.IllegalArgument.New("plugin list cannot be empty")
+	}
+	for _, entry := range strings.Split(s, ",") {
+		if entry != strings.TrimSpace(entry) {
+			return errorx.IllegalArgument.New("plugin list entry %q must not have surrounding whitespace", entry)
+		}
+		if entry == "" {
+			return errorx.IllegalArgument.New("plugin list must not contain empty entries")
+		}
+	}
 	return nil
 }
 

--- a/pkg/models/inputs.go
+++ b/pkg/models/inputs.go
@@ -55,14 +55,6 @@ const (
 	DefaultRecentRetention   = "96000"
 )
 
-// DefaultPluginPreset is used when no preset is specified. An empty string means
-// the chart's built-in default plugin list is left unchanged.
-const DefaultPluginPreset = ""
-
-// PluginPresetCustom is the preset ID used when the operator supplies a
-// manual plugin list via --plugins or the TUI multi-select.
-const PluginPresetCustom = "custom"
-
 type BlockNodeInputs struct {
 	Profile             string
 	Namespace           string


### PR DESCRIPTION
## Description

This pull request introduces support for selecting block node plugin presets both interactively (via TUI prompts) and non-interactively (via new CLI flags). Node operators can now choose which plugins are deployed at install, upgrade, and reconfigure time, either by selecting a preset or specifying a custom plugin list. These changes are reflected throughout the CLI, state management, and documentation, ensuring the selected plugins are correctly injected into the Helm values file and persisted in state.

**Block Node Plugin Preset Selection:**

- Added new `--plugin-preset` and `--plugins` flags to the block node CLI commands, allowing operators to select a plugin preset or provide a custom plugin list. The `--plugins` flag takes precedence when both are set. [[1]](diffhunk://#diff-18cdcf7a83abd3a9c0bc1d0d507e6756b2409e39cc1442139610c1f8b7e7a793R36-R37) [[2]](diffhunk://#diff-18cdcf7a83abd3a9c0bc1d0d507e6756b2409e39cc1442139610c1f8b7e7a793R89-R92) [[3]](diffhunk://#diff-b2452db34055c176b626b8ad6298cadf1da7416e4b52f26dcb99e9ab3418d7dcR213-R232)
- Implemented interactive TUI prompts for plugin selection: a preset select prompt followed by a conditional custom multi-select if "Custom" is chosen. The prompt is skipped if either flag is set on the command line.
- Introduced a new `internal/blocknode/blocknode_plugins.go` file as the source of truth for available plugins, preset IDs, mappings, and helper functions.

**State and Input Handling:**

- Extended the block node input and state models to include `PluginPreset` and `PluginList` fields, ensuring these values are persisted and passed through the workflow. [[1]](diffhunk://#diff-25198b7cd818d73a100dd93f36fd4629dfa88c3abe4777b996e14eedcf26909cR41-R50) [[2]](diffhunk://#diff-25198b7cd818d73a100dd93f36fd4629dfa88c3abe4777b996e14eedcf26909cR149-R150) [[3]](diffhunk://#diff-b2452db34055c176b626b8ad6298cadf1da7416e4b52f26dcb99e9ab3418d7dcR266-R267)
- Added logic to resolve the effective plugin list based on flag precedence and preset validity, with validation for custom plugin lists.

**Documentation Updates:**

- Updated the quickstart and review guide documentation to describe the new flags, interactive flows, and expected behaviors for install, upgrade, reconfigure, and uninstall commands. This includes flag tables, usage examples, and manual UAT steps. [[1]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aR47) [[2]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aR151-R157) [[3]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aR229-R281) [[4]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aL775-R840) [[5]](diffhunk://#diff-4f70e2ebdb33c6a495ef7f3cdfa0b01e9699cc22122c7b370f5818cb34d05868R1-R134)

These changes provide a flexible and robust mechanism for managing block node plugins, improving both user experience and operational control.

### Related Issues

* Closes #474