### PR TITLE
refactor(software): add explicit default: field to artifact catalog

### DIFF
--- a/docs/claude/plans/00587-catalog-default-field.md
+++ b/docs/claude/plans/00587-catalog-default-field.md
@@ -1,0 +1,103 @@
+# Phase 1 (#587) — Add explicit `default:` to artifact catalog; retire `GetLatestVersion()` fallback
+
+> **Suggested title for GH issue:**
+> `refactor(software): add explicit default: field to artifact catalog and stop relying on GetLatestVersion()`
+>
+> **Related phases:** #587 (this) · #588 (rename + `cluster:` section) · #589 (wire Helm steps + retire `deps.go` versions)
+
+## Summary
+
+This phase introduces an explicit `default:` field on every entry in
+`pkg/software/artifact.yaml` and switches the binary installer off the
+implicit "highest semver wins" rule.
+
+**No file rename, no `cluster:` section, no Helm changes in this phase** — those
+are Phases 2 and 3 (see "Related work" below).
+
+## Problem
+
+`pkg/software/artifact.yaml` has no `default:` field. When an entry lists
+multiple versions, `ArtifactMetadata.GetLatestVersion()` sorts semver
+descending and returns the highest (`pkg/software/config.go:285-320`,
+called from `pkg/software/base_installer.go:94`).
+
+Consequences:
+- Adding a new version entry — for testing, staging a future bump, or pinning a
+  fix — silently becomes the new default for every operator.
+- A reader of `artifact.yaml` cannot tell which version will actually be selected
+  without reading Go code.
+- There is no way to ship a manifest where multiple versions are *available* but
+  only one is *recommended*.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Default selection | Explicit `default:` field per entry; implicit-latest selection is removed for `host:` (binary) entries |
+| Default for `cluster:` (Helm) | `GetLatestVersion()`-style implicit semver is **not** added to charts — chart versions don't necessarily follow semver and latest is never the right default without explicit intent |
+
+## Scope
+
+- [ ] Add `default: "<version>"` to every entry in `pkg/software/artifact.yaml`.
+      All current entries list exactly one version, so the default is unambiguous.
+- [ ] Introduce `ArtifactMetadata.GetDefaultVersion() (string, error)` in
+      `pkg/software/config.go` that:
+      - Returns the value of the `default:` field if present.
+      - Returns a load-time / lookup error if `default:` is missing or names a
+        version not present in `versions:`.
+- [ ] Switch `pkg/software/base_installer.go:94` (and any other callers) from
+      `GetLatestVersion()` to `GetDefaultVersion()`.
+- [ ] Decide the fate of `GetLatestVersion()`: either delete it (preferred, since
+      no caller should rely on implicit-latest going forward) or mark it `//
+      Deprecated:` and leave a single line explaining why.
+- [ ] Update unit tests in `pkg/software/config_test.go` (and
+      `config_it_test.go` for integration) to cover:
+      - `default:` resolves to the named version.
+      - Missing `default:` is a clear error.
+      - `default:` pointing to an unknown version is a clear error.
+      - Multi-version fixtures (test-only) confirm `default:` controls the
+        selection, not semver ordering.
+
+## Out of scope (this issue)
+
+- Renaming `artifact.yaml` → `infrastructure-versions.yaml` and `artifact:` → `host:`
+  (Phase 2).
+- Adding a `cluster:` section with Helm chart entries (Phase 2).
+- Wiring Helm install paths off `pkg/deps/deps.go` constants (Phase 3).
+- Removing version constants from `pkg/deps/deps.go` (Phase 3).
+- Checksum/digest verification for Helm charts (Phase 3).
+- Topology constants (`*_NAMESPACE`, `*_RELEASE`, `*_CHART`, `*_REPO`) in
+  `pkg/deps/deps.go` — separate follow-up.
+- Hidden emergency override flag `--override-component <name>=<version>` —
+  separate follow-up.
+
+## Acceptance criteria
+
+- [ ] Every entry in `pkg/software/artifact.yaml` has a `default:` field that
+      names a version present in its `versions:` map.
+- [ ] `ArtifactMetadata.GetDefaultVersion()` exists and is used by the binary
+      installer; `GetLatestVersion()` is either deleted or no longer called by
+      production code paths.
+- [ ] `task lint` passes.
+- [ ] `task test:unit` and `task vm:test:integration` pass.
+- [ ] A multi-version test fixture confirms that changing `default:` (not adding
+      a new entry) controls selection.
+- [ ] No behaviour change for any operator: the `default:` value matches what
+      `GetLatestVersion()` returned before this PR for every shipped entry.
+
+## Related work
+
+- **Phase 2 (#588) — Unified `infrastructure-versions.yaml` with `host:` + `cluster:` sections.**
+  Renames the file and key, adds the seven infra charts with integrity
+  metadata.
+- **Phase 3 (#589) — Wire Helm steps to the catalog; retire version constants in
+  `deps.go`.** Switches the workflow steps off the hardcoded chart versions
+  and adds checksum/digest verification before `helm install`/`upgrade`.
+
+## References
+
+- `pkg/software/artifact.yaml` — the catalog to modify.
+- `pkg/software/config.go:285-320` — `GetLatestVersion()` implementation.
+- `pkg/software/base_installer.go:94` — implicit-latest call site.
+- `pkg/software/config_test.go`, `pkg/software/config_it_test.go` — existing
+  tests covering `GetLatestVersion()`; update to cover `GetDefaultVersion()`.

--- a/docs/claude/plans/00588-rename-infrastructure-versions-yaml-cluster-section.md
+++ b/docs/claude/plans/00588-rename-infrastructure-versions-yaml-cluster-section.md
@@ -1,0 +1,210 @@
+# Phase 2 (#588) — Rename to `infrastructure-versions.yaml`; add `host:` + `cluster:` sections with Helm chart entries
+
+> **Suggested title for GH issue:**
+> `refactor(software): rename artifact.yaml to infrastructure-versions.yaml and add cluster: section with infra Helm charts`
+>
+> **Related phases:** #587 (`default:` field for binary catalog) · #588 (this) · #589 (wire Helm steps + retire `deps.go` versions)
+
+## Summary
+
+This phase performs the structural rename and adds the seven infra Helm charts
+to the catalog with integrity metadata. It builds on **Phase 1** (which
+introduced the `default:` field).
+
+**No workflow steps are migrated in this phase** — Phase 3 wires the Helm
+install paths to read from the new `cluster:` section and adds checksum/digest
+verification.
+
+## Problem
+
+After Phase 1, `pkg/software/artifact.yaml` carries explicit defaults for
+binary artifacts, but:
+
+1. The file name (`artifact.yaml`) and top-level key (`artifact:`) describe
+   *how* a component is packaged rather than *where* it runs. The package
+   manifest vocabulary (`host:` / `cluster:`) is semantically superior — it
+   stays correct even if a binary is later delivered as a chart.
+2. The seven infra Helm charts (Alloy, Teleport cluster agent, MetalLB,
+   Metrics Server, Node Exporter, Prometheus Operator CRDs, External Secrets)
+   are not in the catalog at all. Their versions are hardcoded as Go constants
+   in `pkg/deps/deps.go`, and there is no integrity verification on chart pulls.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Catalog structure | Unified `infrastructure-versions.yaml` with `host:` (binaries) and `cluster:` (Helm charts) sections |
+| Integrity model | One `algorithm` + `checksum` per version per chart — SHA256 of `.tgz` for classic repos, OCI manifest digest for OCI registries |
+| Template variables in `cluster:` | None — charts are platform-agnostic; `repo` and `chart` are static strings |
+| Chart sub-schema | No `archives` / `binaries` / `configs` nesting — each chart is one artifact |
+| `type:` field | Explicit (`classic` \| `oci`) rather than inferred from `chart:` prefix |
+
+## Scope
+
+### YAML migration
+
+- [ ] Rename `pkg/software/artifact.yaml` → `pkg/software/infrastructure-versions.yaml`.
+- [ ] Rename top-level key `artifact:` → `host:` (no transitional alias; same
+      PR, full sweep).
+- [ ] Add a `cluster:` section with one entry per infra chart:
+
+```yaml
+cluster:
+  - name: alloy
+    type: classic
+    repo: https://grafana.github.io/helm-charts
+    chart: grafana/alloy
+    default: "1.4.0"
+    versions:
+      1.4.0:
+        algorithm: sha256
+        checksum: '<hex>'                  # SHA256 of .tgz archive
+
+  - name: node-exporter
+    type: oci
+    chart: oci://registry-1.docker.io/bitnamicharts/node-exporter
+    default: "4.5.19"
+    versions:
+      4.5.19:
+        algorithm: sha256
+        checksum: '<hex>'                  # OCI manifest digest
+
+  - name: prometheus-operator-crds
+    type: oci
+    chart: oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
+    default: "24.0.1"
+    versions:
+      24.0.1:
+        algorithm: sha256
+        checksum: '<hex>'
+
+  - name: teleport-cluster-agent
+    type: classic
+    repo: https://charts.releases.teleport.dev
+    chart: teleport/teleport-kube-agent
+    default: "18.6.4"
+    versions:
+      18.6.4:
+        algorithm: sha256
+        checksum: '<hex>'
+
+  - name: metallb
+    type: classic
+    repo: https://metallb.github.io/metallb
+    chart: metallb/metallb
+    default: "0.15.2"
+    versions:
+      0.15.2:
+        algorithm: sha256
+        checksum: '<hex>'
+
+  - name: metrics-server
+    type: classic
+    repo: https://kubernetes-sigs.github.io/metrics-server
+    chart: metrics-server/metrics-server
+    default: "3.13.0"
+    versions:
+      3.13.0:
+        algorithm: sha256
+        checksum: '<hex>'
+
+  - name: external-secrets
+    type: classic
+    repo: https://charts.external-secrets.io
+    chart: external-secrets/external-secrets
+    default: "0.20.2"
+    versions:
+      0.20.2:
+        algorithm: sha256
+        checksum: '<hex>'
+```
+
+### Go changes
+
+- [ ] Update the `//go:embed` directive in `pkg/software/` to embed
+      `infrastructure-versions.yaml`.
+- [ ] Introduce `ChartMetadata` struct with fields: `Name`, `Type`
+      (`classic` | `oci`), `Repo` (optional, classic only), `Chart`, `Default`,
+      `Versions` (map of version → `{algorithm, checksum}`).
+- [ ] Introduce `ComponentCatalog` container type:
+
+```go
+type ComponentCatalog struct {
+    Host   []ArtifactMetadata `yaml:"host"`
+    Cluster []ChartMetadata  `yaml:"cluster"`
+}
+```
+
+- [ ] Replace `LoadArtifactConfig()` with `LoadComponentCatalog()` returning
+      `*ComponentCatalog`. Migrate every caller.
+- [ ] Add a `GetClusterComponent(name string) (*ChartMetadata, error)` lookup
+      on the catalog.
+- [ ] Add `(c *ChartMetadata) GetDefaultVersion() (string, error)` mirroring
+      Phase 1's `ArtifactMetadata.GetDefaultVersion()`.
+- [ ] Schema validation at load time:
+      - `host:` and `cluster:` entries must each have a `default:` that points
+        to a version present in `versions:`.
+      - `cluster:` entries must have an explicit `type` (`classic` or `oci`).
+      - `classic` entries must have `repo:`; `oci` entries must not.
+      - Every version must have non-empty `algorithm` and `checksum`.
+
+### Checksum seeding
+
+- [ ] Decide who computes the seed `algorithm` + `checksum` values for each
+      chart at PR-time. Likely options:
+      - One-shot helper script (`hack/compute-chart-checksums.sh`) that runs
+        `helm pull` for classic charts and reads the OCI manifest digest for
+        OCI charts. Run it locally to generate the seeds.
+      - Manual values, with a follow-up CI job in Phase 3 or later.
+- [ ] Document the procedure in `docs/dev/` (e.g. `docs/dev/chart-checksums.md`).
+
+## Out of scope (this issue)
+
+- Wiring `internal/workflows/steps/step_alloy.go`, `step_metallb.go`,
+  `step_metrics_server.go`, `step_prometheus_operator_crds.go`,
+  `step_external_secrets.go`, and the teleport cluster agent step to read
+  from `cluster:` (Phase 3).
+- Verifying chart checksum/digest before `helm install`/`upgrade` (Phase 3).
+- Deleting version constants in `pkg/deps/deps.go` (Phase 3).
+- A `schemaVersion:` top-level field. Worth deciding in this PR review as a
+  future-facing contract.
+- Topology constants (`*_NAMESPACE`, `*_RELEASE`, `*_CHART`, `*_REPO`) — stay
+  in `deps.go` for now.
+- Block node / consensus node — Hedera software, separate concern.
+
+## Acceptance criteria
+
+- [ ] `pkg/software/infrastructure-versions.yaml` exists; `pkg/software/artifact.yaml` is
+      deleted in the same PR.
+- [ ] Top-level keys are `host:` and `cluster:`.
+- [ ] All seven infra charts are present under `cluster:` with the fields above,
+      seeded with real checksum/digest values for the currently shipped versions
+      (`1.4.0` Alloy, `18.6.4` Teleport cluster agent, `0.15.2` MetalLB,
+      `3.13.0` Metrics Server, `4.5.19` Node Exporter, `24.0.1` Prometheus
+      Operator CRDs, `0.20.2` External Secrets).
+- [ ] `LoadComponentCatalog()` returns a `*ComponentCatalog`; all former
+      `LoadArtifactConfig()` callers compile and pass tests.
+- [ ] Schema validation errors on missing `default:`, missing `type:`,
+      `classic` without `repo`, `oci` with `repo`, and `default:` pointing to
+      an unknown version.
+- [ ] Unit tests cover the loader, `ComponentCatalog.GetClusterComponent`,
+      `ChartMetadata.GetDefaultVersion`, and all the validation failure modes.
+- [ ] `task lint`, `task test:unit`, `task vm:test:integration` pass.
+- [ ] **No behaviour change at install time** — Phase 3 is responsible for
+      switching workflow steps off `deps.go`. After Phase 2 alone, the new
+      catalog exists but is not yet consulted by Helm install paths.
+
+## Related work
+
+- **Phase 1 (#587) — `default:` field for binary catalog.** Prerequisite. Adds
+  `ArtifactMetadata.GetDefaultVersion()` and removes implicit-latest selection.
+- **Phase 3 (#589) — Wire Helm steps to the catalog; retire version constants in
+  `deps.go`.** Consumes the `cluster:` section added by this phase.
+
+## References
+
+- `pkg/software/artifact.yaml` — to be renamed.
+- `pkg/software/config.go` — loader and `ArtifactMetadata` type.
+- `pkg/deps/deps.go` — current chart version constants and topology constants
+  (versions move to `infrastructure-versions.yaml`; topology stays).
+- Helm OCI support: https://helm.sh/docs/topics/registries/

--- a/docs/claude/plans/00589-helm-steps-catalog-migration.md
+++ b/docs/claude/plans/00589-helm-steps-catalog-migration.md
@@ -1,0 +1,170 @@
+# Phase 3 (#589) — Wire Helm workflow steps to `infrastructure-versions.yaml`; verify checksum/digest; retire chart version constants in `deps.go`
+
+> **Suggested title for GH issue:**
+> `refactor(workflows): consume cluster: catalog for Helm steps, verify chart integrity, retire version constants in deps.go`
+>
+> **Related phases:** #587 (`default:` field for binary catalog) · #588 (rename + `cluster:` section) · #589 (this)
+
+## Summary
+
+This phase switches the Helm workflow steps off the hardcoded
+`pkg/deps/deps.go` constants and onto the `cluster:` section of
+`pkg/software/infrastructure-versions.yaml` added in **Phase 2**. It also introduces
+chart integrity verification (SHA256 of `.tgz` for classic repos, OCI manifest
+digest for OCI registries) before `helm install`/`upgrade`.
+
+After this PR, `pkg/deps/deps.go` no longer carries any chart **version**
+constants; topology constants (namespace, release name, chart name, repo URL)
+stay until a separate cleanup PR.
+
+## Problem
+
+After Phases 1 and 2, the catalog exists with the seven infra charts and their
+defaults, but nothing reads from it. The workflow steps still pull their chart
+versions from the Go constants in `pkg/deps/deps.go`:
+
+- `internal/workflows/steps/step_alloy.go:265` → `deps.NODE_EXPORTER_VERSION`
+- `internal/workflows/steps/step_alloy.go:446` → `deps.ALLOY_VERSION`
+- `internal/workflows/steps/step_metallb.go:87` → `deps.METALLB_VERSION`
+- `internal/workflows/steps/step_metrics_server.go:69` → `deps.METRICS_SERVER_VERSION`
+- `internal/workflows/steps/step_prometheus_operator_crds.go:68` → `deps.PROMETHEUS_OPERATOR_CRDS_VERSION`
+- `internal/workflows/steps/step_external_secrets.go:77` → `deps.EXTERNAL_SECRETS_VERSION`
+- Teleport cluster agent step → `deps.TELEPORT_VERSION` (overridable via the
+  pre-existing `--version` flag at `cmd/weaver/commands/teleport/cluster/cluster.go:32`)
+
+There is also no integrity verification on chart pulls today.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Version selection | Catalog defaults drive installation; no per-component CLI overrides |
+| Integrity model | Verify `.tgz` SHA256 (classic) / OCI manifest digest (OCI) before `helm install` / `upgrade` |
+| `deps.go` retirement | Version constants move out; topology constants stay until a separate cleanup PR |
+| Teleport `--version` flag | Pre-existing anomaly; per-component flags are treated as legacy, but the flag is **not** removed in this phase |
+
+## Scope
+
+### Wire workflow steps to the catalog
+
+- [ ] Inject `*ComponentCatalog` (from Phase 2) into each Helm workflow step,
+      or expose a package-level accessor — pick the pattern that fits the
+      existing step dependency-injection style.
+- [ ] Replace each `deps.<CHART>_VERSION` reference with a call to
+      `catalog.GetClusterComponent("<name>").GetDefaultVersion()` (or the
+      idiomatic equivalent).
+- [ ] Read chart coordinates (`chart`, `repo`, `type`) from the catalog as
+      well, **even though they're duplicated in `deps.go` today** — this avoids
+      future drift between the catalog and the install path. Topology
+      constants (namespace, release name) continue to come from `deps.go`.
+
+Workflow step files to update:
+
+- `internal/workflows/steps/step_alloy.go` (uses `ALLOY_VERSION` and
+  `NODE_EXPORTER_VERSION`)
+- `internal/workflows/steps/step_metallb.go`
+- `internal/workflows/steps/step_metrics_server.go`
+- `internal/workflows/steps/step_prometheus_operator_crds.go`
+- `internal/workflows/steps/step_external_secrets.go`
+- Teleport cluster agent workflow step (find via `grep -rn TELEPORT_VERSION
+  internal/workflows`)
+
+### Add chart integrity verification
+
+- [ ] Before `helm install` / `helm upgrade`, the workflow step must:
+      1. `helm pull` the chart to a temporary directory.
+      2. Compute the SHA256 of the resulting `.tgz` (classic) or read the OCI
+         manifest digest from the pull metadata (OCI).
+      3. Compare against the `algorithm` + `checksum` recorded in the catalog
+         for the selected version.
+      4. Abort the step on mismatch with a clear error identifying the
+         component, expected checksum, and observed checksum.
+      5. Pass the locally pulled chart path to `helm install`/`upgrade` to
+         avoid a second download.
+- [ ] Factor the pull-and-verify logic into a helper in
+      `pkg/helm/` (or `internal/...` if the helm package is intentionally thin)
+      so all six steps share one implementation.
+- [ ] Wire it through the existing `pkg/helm/` interface and its mock for unit
+      tests.
+
+### Retire chart version constants in `deps.go`
+
+- [ ] Delete the following constants from `pkg/deps/deps.go`:
+      `ALLOY_VERSION`, `METALLB_VERSION`, `METRICS_SERVER_VERSION`,
+      `NODE_EXPORTER_VERSION`, `PROMETHEUS_OPERATOR_CRDS_VERSION`,
+      `EXTERNAL_SECRETS_VERSION`, `TELEPORT_VERSION`.
+- [ ] Keep all `*_NAMESPACE`, `*_RELEASE`, `*_CHART`, `*_REPO` constants —
+      topology cleanup is deferred to a separate PR.
+- [ ] Update `cmd/weaver/commands/teleport/cluster/cluster.go:32`. The help
+      text references `deps.TELEPORT_VERSION` — switch it to read the default
+      from the catalog (or hardcode "teleport cluster agent" and show the value
+      at runtime by looking it up). The `--version` flag itself stays
+      functional, sourcing its default from the catalog instead of a deleted
+      constant.
+
+### Tests
+
+- [ ] Unit tests for each updated workflow step verify it reads from the
+      catalog and not from `deps.go`. (Most steps already have unit tests using
+      the helm mock — extend those.)
+- [ ] Unit tests for the new pull-and-verify helper cover: checksum match,
+      checksum mismatch (must abort), classic vs OCI code paths, missing
+      catalog entry.
+- [ ] Integration test (in the UTM VM) for at least one classic and one OCI
+      chart confirms a real install succeeds end-to-end with verification.
+- [ ] Negative integration test: tamper with the embedded checksum, confirm the
+      step aborts with the expected error message (or, if patching the
+      embedded YAML is hard, simulate the mismatch in a unit-level test with
+      a fake catalog).
+
+## Out of scope (this issue)
+
+- **Removing the teleport `cluster install --version` flag.** Operator-visible
+  change; deserves its own issue.
+- **Topology constants in `deps.go`** (`*_NAMESPACE`, `*_RELEASE`, `*_CHART`,
+  `*_REPO`) — separate follow-up.
+- **Hidden emergency override** `--override-component <name>=<version>` —
+  separate follow-up.
+- **Package manifest (`infrastructure-versions.yaml`) consumption** — the
+  apply-time validation against catalog defaults is its own issue.
+- **Air-gap / bundled chart delivery** — separate follow-up.
+- **Block node / consensus node** versioning.
+
+## Acceptance criteria
+
+- [ ] No file under `internal/workflows/steps/` references `deps.ALLOY_VERSION`,
+      `deps.METALLB_VERSION`, `deps.METRICS_SERVER_VERSION`,
+      `deps.NODE_EXPORTER_VERSION`, `deps.PROMETHEUS_OPERATOR_CRDS_VERSION`,
+      `deps.EXTERNAL_SECRETS_VERSION`, or `deps.TELEPORT_VERSION`. All chart
+      versions come from `*ComponentCatalog`.
+- [ ] All seven chart version constants are removed from `pkg/deps/deps.go`.
+- [ ] Every Helm install/upgrade in the workflow steps passes through the
+      pull-and-verify helper; checksum mismatch aborts the step.
+- [ ] `teleport cluster install --version` still works; its default value comes
+      from the catalog rather than a deleted constant.
+- [ ] `task lint`, `task test:unit`, `task vm:test:integration` pass.
+- [ ] Manual UAT: a fresh cluster install on the UTM VM succeeds, installing
+      Alloy, MetalLB, Metrics Server, Node Exporter, Prometheus Operator CRDs,
+      and External Secrets at the versions named in the catalog; logs show
+      checksum verification passing for each chart.
+
+## Related work
+
+- **Phase 1 (#587) — `default:` field for binary catalog.** Prerequisite.
+- **Phase 2 (#588) — Unified `infrastructure-versions.yaml` with `cluster:` section.** Prerequisite
+  — this phase consumes what Phase 2 produces.
+
+## References
+
+- Current code (consumers to migrate):
+  - `internal/workflows/steps/step_alloy.go:265, 446`
+  - `internal/workflows/steps/step_metallb.go:87`
+  - `internal/workflows/steps/step_metrics_server.go:69`
+  - `internal/workflows/steps/step_prometheus_operator_crds.go:68`
+  - `internal/workflows/steps/step_external_secrets.go:77`
+  - Teleport cluster agent step (find via `grep -rn TELEPORT_VERSION internal/`)
+  - `cmd/weaver/commands/teleport/cluster/cluster.go:32`
+- `pkg/deps/deps.go` — chart version constants to delete; topology constants
+  to keep.
+- `pkg/helm/` — interface where the pull-and-verify helper should live.
+- Helm OCI support: https://helm.sh/docs/topics/registries/

--- a/docs/claude/reviews/00587-catalog-default-field.md
+++ b/docs/claude/reviews/00587-catalog-default-field.md
@@ -1,0 +1,179 @@
+# Review guide — #587 catalog default field
+
+> Phase 1 (#587) of the catalog redesign. Related phases: #588 (rename to
+> `infrastructure-versions.yaml` + `host:`/`cluster:` sections) · #589 (wire
+> Helm workflow steps + retire `deps.go` chart versions).
+
+## Problem
+
+`pkg/software/artifact.yaml` had no `default:` field. When an entry listed
+multiple versions, `ArtifactMetadata.GetLatestVersion()` sorted them by
+semver and returned the highest (`pkg/software/config.go`, called from
+`pkg/software/base_installer.go:94`). The two consequences:
+
+- Adding a new version entry — for testing, staging a future bump, or
+  pinning a fix — silently became the new default for every operator.
+- A reader of `artifact.yaml` could not tell which version would actually
+  be selected without reading Go code.
+
+## Solution
+
+- Add `default: "<version>"` to every entry in `artifact.yaml`. All current
+  entries list exactly one version, so the default matches what
+  `GetLatestVersion()` returned before.
+- Add a `Default Version` field on `ArtifactMetadata` and a new
+  `GetDefaultVersion()` method that validates the field points to a known
+  version and returns it. Error when the field is missing or names an
+  unknown version.
+- Replace `GetLatestVersion()` entirely; delete the now-unused
+  `compareVersions` helper. `isValidVersion()` stays — it is still used by
+  the `Test_Config_VersionsAreSemanticVersions` integration test.
+- Switch the binary installer (`pkg/software/base_installer.go:94`) and all
+  tests off `GetLatestVersion()` and onto `GetDefaultVersion()`.
+
+## Files changed
+
+| File | Description |
+|---|---|
+| `pkg/software/artifact.yaml` | Adds `default:` to all 8 entries; updates the header comment to explain the new field. |
+| `pkg/software/config.go` | Adds `Default Version` field on `ArtifactMetadata`; replaces `GetLatestVersion()` with `GetDefaultVersion()`; removes `compareVersions`. |
+| `pkg/software/base_installer.go` | Calls `GetDefaultVersion()` instead of `GetLatestVersion()` when the installer has no explicit version requested. |
+| `pkg/software/config_test.go` | Rewrites `Test_Config_GetLatestVersion` as `Test_Config_GetDefaultVersion`; updates `Test_Config_VersionSelection` to assert default-based selection (1.9.0 wins over higher-semver 1.10.0 when explicitly defaulted). |
+| `pkg/software/config_it_test.go` | Renames `Test_Config_GetLatestVersion_Integration` → `Test_Config_GetDefaultVersion_Integration` and now asserts every artifact declares an explicit `Default`; switches the remaining integration tests to `GetDefaultVersion()`. |
+
+## Code review checklist
+
+- [ ] Every entry in `pkg/software/artifact.yaml` has a `default:` field whose value matches a key under that entry's `versions:` map.
+- [ ] The `default:` value for each entry matches what `GetLatestVersion()` would have returned before this PR (no behaviour change at install time).
+- [ ] `ArtifactMetadata.Default` carries the `yaml:"default"` tag and uses the `Version` type so it round-trips through the loader.
+- [ ] `GetDefaultVersion()` returns an error when `Default` is unset, and when `Default` names a version not present in `Versions`.
+- [ ] No production code path still calls `GetLatestVersion()` — `grep -rn "GetLatestVersion" --include="*.go"` returns nothing.
+- [ ] `compareVersions` is gone; `isValidVersion` and the `pkg/semver` import remain (still used by `Test_Config_VersionsAreSemanticVersions`).
+- [ ] The new unit-test case "default selects one entry among many - not the highest semver" actually fails before the production change and passes after — confirms `default:` is what drives selection.
+- [ ] `Test_Config_GetDefaultVersion_Integration` asserts `require.NotEmpty(t, artifact.Default, ...)` so a future entry added without `default:` will fail CI.
+- [ ] The `artifact.yaml` header comment correctly describes the new contract: adding a version entry does not change the default; updating `default:` does.
+- [ ] No structural rename slipped in — `artifact:` top-level key and `artifact.yaml` filename are unchanged (those belong to #588).
+
+## Test commands
+
+Unit tests (run on macOS host or VM):
+
+```bash
+go test -tags='!integration' -race -v -run 'Test_Config_' ./pkg/software/
+```
+
+Full unit suite for the package (Linux-only tests are skipped on macOS;
+run the full suite via the VM):
+
+```bash
+task test:unit                            # current platform
+task vm:test:unit                         # inside UTM VM (Linux)
+```
+
+Integration tests for `pkg/software` (require the VM):
+
+```bash
+task vm:test:integration TEST_NAME='^Test_Config_'
+```
+
+Lint check:
+
+```bash
+task lint:check
+```
+
+Expected: all `Test_Config_*` tests pass. The pre-existing
+`Test_BaseInstaller_*` failures on macOS (caused by attempts to `mkdir /opt/solo`
+and `internal/mount` being Linux-only) are unrelated and will only be exercised
+in the VM.
+
+## Manual UAT
+
+These steps verify the new contract end-to-end.
+
+### 1. Default selection drives installs
+
+```bash
+task build:weaver GOOS=linux GOARCH=arm64   # or your target arch
+```
+
+Confirm the binary builds without referencing `GetLatestVersion`:
+
+```bash
+go tool nm bin/solo-provisioner-linux-arm64 | grep -i GetLatestVersion
+```
+
+Expected: **no output**.
+
+```bash
+go tool nm bin/solo-provisioner-linux-arm64 | grep -i GetDefaultVersion
+```
+
+Expected: a single line referencing `software.(*ArtifactMetadata).GetDefaultVersion`.
+
+### 2. Default validation rejects malformed entries
+
+Edit `pkg/software/artifact.yaml`, delete the `default: "1.33.4"` line from
+the `cri-o` entry, save, and run:
+
+```bash
+go test -tags='!integration' -race -run 'Test_Config_GetDefaultVersion_Integration/cri-o' ./pkg/software/
+```
+
+Expected output snippet:
+
+```
+    config_it_test.go:NN: Artifact cri-o must declare an explicit default version
+--- FAIL: Test_Config_GetDefaultVersion_Integration/cri-o (0.00s)
+```
+
+Restore the `default:` line.
+
+### 3. Default pointing to unknown version is rejected
+
+Edit `pkg/software/artifact.yaml`, change `default: "1.33.4"` on `cri-o`
+to `default: "9.9.9"`, save, and run:
+
+```bash
+go test -tags='!integration' -race -run 'Test_Config_GetDefaultVersion_Integration/cri-o' ./pkg/software/
+```
+
+Expected: failure with a `version 9.9.9 not found for cri-o` error coming
+through `NewVersionNotFoundError`. Restore the `default:` line.
+
+### 4. Adding a version entry does not change behaviour
+
+Add a fake new version entry to `pkg/software/artifact.yaml` under any
+component (e.g. `cri-o`'s `versions:`) without touching `default:`. Run:
+
+```bash
+go test -tags='!integration' -race -run 'Test_Config_GetDefaultVersion' ./pkg/software/
+```
+
+Expected: still passes. The default is still the originally-declared
+version, not the higher semver of the fake entry. Revert the change.
+
+### 5. Behaviour parity with main
+
+For each artifact, confirm `GetDefaultVersion()` returns the same string
+`GetLatestVersion()` returned on main:
+
+```bash
+go test -tags='!integration' -race -v -run 'Test_Config_GetDefaultVersion_Integration' ./pkg/software/
+```
+
+Expected versions per artifact:
+
+| Artifact | Default |
+|---|---|
+| cri-o | `1.33.4` |
+| kubelet | `1.33.4` |
+| kubeadm | `1.33.4` |
+| kubectl | `1.33.4` |
+| helm | `3.18.6` |
+| k9s | `0.50.9` |
+| cilium | `0.18.7` |
+| teleport | `18.6.4` |
+
+These match the values `GetLatestVersion()` returned before this PR — no
+operator-visible change at install time.

--- a/pkg/software/artifact.yaml
+++ b/pkg/software/artifact.yaml
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This file contains the list of software artifacts with their download URLs,
-# versions, and checksums for verification.
+# versions, and checksums for verification. Each artifact declares an
+# explicit `default:` version — the version installed when no other is
+# requested. Adding a new entry under `versions:` does not change the
+# default; that requires updating the `default:` field.
 artifact:
   
 - name: cri-o
   url: 'https://storage.googleapis.com/cri-o/artifacts/cri-o.{{.ARCH}}.v{{.VERSION}}.tar.gz'
+  default: "1.33.4"
   versions:
     1.33.4:
       archives:
@@ -84,6 +88,7 @@ artifact:
               checksum: 'adcd45619f1f57eb38f8596bf65def237c53fb00b9f42b963f8a1556bb0918bb'
 
 - name: kubelet
+  default: "1.33.4"
   versions:
     1.33.4:
       binaries:
@@ -105,6 +110,7 @@ artifact:
 - name: kubeadm
   url:
   filename: 'kubeadm'
+  default: "1.33.4"
   versions:
     1.33.4:
       binaries:
@@ -124,6 +130,7 @@ artifact:
           checksum: 'aafd152fa9ef8a2b2dde2b643ffb2a8694412bdfef0ff46afdca775a2d31d13d25bd2ff69d29bf3112d17d2d929b0aa7cf519c8b41058102a0cead4e66be1415'
 
 - name: kubectl
+  default: "1.33.4"
   versions:
     1.33.4:
       binaries:
@@ -138,6 +145,7 @@ artifact:
               checksum: 'f76edb18df3e807ae664c2b3833e210f29ba2fe5ff53624f0787b47989dfc00d71da43c208a06b4f548f857893f19003e34523cb09bf588f81b3f06610b13337' # from https://dl.k8s.io/release/v1.33.4/bin/linux/arm64/kubectl.sha512
 
 - name: helm
+  default: "3.18.6"
   versions:
     3.18.6:
       archives:
@@ -162,6 +170,7 @@ artifact:
               checksum: 'c7550b38b3b7c9df31f7052432b5eb45e0cfec7238310de0133789598c2449e4'
 
 - name: k9s
+  default: "0.50.9"
   versions:
     0.50.9:
       archives:
@@ -186,6 +195,7 @@ artifact:
               checksum: '26bcae69dd653838db00a0e777aa52e87877c325a06ad6f625857604c02e9efc'
 
 - name: cilium
+  default: "0.18.7"
   versions:
     0.18.7:
       archives:
@@ -210,6 +220,7 @@ artifact:
               checksum: '9bb6c7e85c3166ad698ee11042706b2ffbce4b9d017ef96bb1ced3962d88256a'
 
 - name: teleport
+  default: "18.6.4"
   versions:
     18.6.4:
       archives:

--- a/pkg/software/base_installer.go
+++ b/pkg/software/base_installer.go
@@ -91,7 +91,7 @@ func newBaseInstaller(softwareName string, opts ...InstallerOption) (*baseInstal
 	}
 
 	if bi.versionToBeInstalled == "" {
-		bi.versionToBeInstalled, err = item.GetLatestVersion()
+		bi.versionToBeInstalled, err = item.GetDefaultVersion()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/software/config.go
+++ b/pkg/software/config.go
@@ -63,6 +63,7 @@ type ArtifactCollection struct {
 // with its versions which including archives, binaries and configuration files
 type ArtifactMetadata struct {
 	Name     string                     `yaml:"name"`
+	Default  Version                    `yaml:"default"`
 	Versions map[Version]VersionDetails `yaml:"versions"`
 	platform *platformProvider
 }
@@ -282,62 +283,18 @@ func executeTemplate(templateStr string, data TemplateData) (string, error) {
 	return buf.String(), nil
 }
 
-// GetLatestVersion returns the latest versionToBeInstalled available for this software item
-// Only supports semantic versions - returns error for non-semantic versionToBeInstalled formats
-func (si *ArtifactMetadata) GetLatestVersion() (string, error) {
-	if len(si.Versions) == 0 {
-		return "", NewVersionNotFoundError(si.Name, "any")
+// GetDefaultVersion returns the explicit default version declared for this
+// software item. The default is read from the artifact's `default:` field;
+// it must point to a version present in the `versions:` map. Returns an
+// error when `default:` is unset or names an unknown version.
+func (si *ArtifactMetadata) GetDefaultVersion() (string, error) {
+	if si.Default == "" {
+		return "", fmt.Errorf("artifact %s has no default version declared", si.Name)
 	}
-
-	// If there's only one versionToBeInstalled, return it if it's valid semantic versionToBeInstalled
-	if len(si.Versions) == 1 {
-		for version := range si.Versions {
-			versionStr := string(version)
-			if !isValidVersion(versionStr) {
-				return "", fmt.Errorf("versionToBeInstalled %s for software %s is not in semantic versionToBeInstalled format", versionStr, si.Name)
-			}
-			return versionStr, nil
-		}
+	if _, ok := si.Versions[si.Default]; !ok {
+		return "", NewVersionNotFoundError(si.Name, string(si.Default))
 	}
-
-	// Collect and validate all versionToBeInstalled strings
-	versions := make([]string, 0, len(si.Versions))
-
-	for version := range si.Versions {
-		versionStr := string(version)
-		if !isValidVersion(versionStr) {
-			return "", fmt.Errorf("versionToBeInstalled %s for software %s is not in semantic versionToBeInstalled format", versionStr, si.Name)
-		}
-		versions = append(versions, versionStr)
-	}
-
-	// Sort versions using semantic versionToBeInstalled comparison
-	sort.Slice(versions, func(i, j int) bool {
-		// Use the semantic versionToBeInstalled comparator for sorting
-		result, err := compareVersions(versions[i], versions[j])
-		if err != nil {
-			// This shouldn't happen since we validated versions above, but handle gracefully
-			return false
-		}
-		return result
-	})
-
-	// Return the first (latest) versionToBeInstalled
-	return versions[0], nil
-}
-
-func compareVersions(version1, version2 string) (bool, error) {
-	v1, err1 := semver.NewSemver(version1)
-	v2, err2 := semver.NewSemver(version2)
-
-	if err1 != nil {
-		return false, fmt.Errorf("invalid semantic versionToBeInstalled format: %s", version1)
-	}
-	if err2 != nil {
-		return false, fmt.Errorf("invalid semantic versionToBeInstalled format: %s", version2)
-	}
-
-	return v1.GreaterThan(v2), nil
+	return string(si.Default), nil
 }
 
 func isValidVersion(version string) bool {

--- a/pkg/software/config_it_test.go
+++ b/pkg/software/config_it_test.go
@@ -130,22 +130,25 @@ func Test_Config_GetSoftwareByName_Integration(t *testing.T) {
 	require.Error(t, err, "Should return error for non-existent software")
 }
 
-// Test_Config_GetLatestVersion_Integration tests getting the latest version from actual artifacts
-func Test_Config_GetLatestVersion_Integration(t *testing.T) {
+// Test_Config_GetDefaultVersion_Integration tests getting the default version from actual artifacts
+func Test_Config_GetDefaultVersion_Integration(t *testing.T) {
 	config, err := LoadArtifactConfig()
 	require.NoError(t, err)
 
-	// Test each artifact can return a latest version
+	// Test each artifact declares an explicit default that resolves correctly
 	for _, artifact := range config.Artifact {
 		t.Run(artifact.Name, func(t *testing.T) {
-			latest, err := artifact.GetLatestVersion()
-			require.NoError(t, err, "Should be able to get latest version for %s", artifact.Name)
-			require.NotEmpty(t, latest, "Latest version should not be empty for %s", artifact.Name)
+			require.NotEmpty(t, artifact.Default,
+				"Artifact %s must declare an explicit default version", artifact.Name)
 
-			// Verify the latest version exists in the versions map
-			_, exists := artifact.Versions[Version(latest)]
-			require.True(t, exists, "Latest version %s should exist in versions map for %s",
-				latest, artifact.Name)
+			defaultVersion, err := artifact.GetDefaultVersion()
+			require.NoError(t, err, "Should be able to get default version for %s", artifact.Name)
+			require.NotEmpty(t, defaultVersion, "Default version should not be empty for %s", artifact.Name)
+
+			// Verify the default version exists in the versions map
+			_, exists := artifact.Versions[Version(defaultVersion)]
+			require.True(t, exists, "Default version %s should exist in versions map for %s",
+				defaultVersion, artifact.Name)
 		})
 	}
 }
@@ -158,16 +161,16 @@ func Test_Config_GetChecksum_Integration(t *testing.T) {
 	// Test a few artifacts if they exist
 	for _, artifact := range config.Artifact {
 		t.Run(artifact.Name, func(t *testing.T) {
-			// Get the latest version
-			latest, err := artifact.GetLatestVersion()
+			// Get the default version
+			defaultVersion, err := artifact.GetDefaultVersion()
 			if err != nil {
-				t.Skipf("Skipping %s: cannot get latest version", artifact.Name)
+				t.Skipf("Skipping %s: cannot get default version", artifact.Name)
 				return
 			}
 
-			versionInfo, exists := artifact.Versions[Version(latest)]
+			versionInfo, exists := artifact.Versions[Version(defaultVersion)]
 			if !exists {
-				t.Skipf("Skipping %s: version %s not found", artifact.Name, latest)
+				t.Skipf("Skipping %s: version %s not found", artifact.Name, defaultVersion)
 				return
 			}
 
@@ -203,10 +206,10 @@ func Test_Config_GetDownloadURL_Integration(t *testing.T) {
 
 	for _, artifact := range config.Artifact {
 		t.Run(artifact.Name, func(t *testing.T) {
-			// Get the latest version
-			latest, err := artifact.GetLatestVersion()
+			// Get the default version
+			defaultVersion, err := artifact.GetDefaultVersion()
 			if err != nil {
-				t.Skipf("Skipping %s: cannot get latest version", artifact.Name)
+				t.Skipf("Skipping %s: cannot get default version", artifact.Name)
 				return
 			}
 
@@ -214,9 +217,9 @@ func Test_Config_GetDownloadURL_Integration(t *testing.T) {
 			platformArtifact := artifact.withPlatform("linux", "amd64")
 
 			// Get version info
-			versionInfo, exists := platformArtifact.Versions[Version(latest)]
+			versionInfo, exists := platformArtifact.Versions[Version(defaultVersion)]
 			if !exists {
-				t.Skipf("Skipping %s: version %s not found", artifact.Name, latest)
+				t.Skipf("Skipping %s: version %s not found", artifact.Name, defaultVersion)
 				return
 			}
 
@@ -234,7 +237,7 @@ func Test_Config_GetDownloadURL_Integration(t *testing.T) {
 			// Execute template to get actual URL
 			platform := platformArtifact.getPlatform()
 			data := TemplateData{
-				VERSION: latest,
+				VERSION: defaultVersion,
 				OS:      platform.os,
 				ARCH:    platform.arch,
 			}
@@ -246,7 +249,7 @@ func Test_Config_GetDownloadURL_Integration(t *testing.T) {
 				require.NotEmpty(t, url, "Download URL should not be empty")
 				require.Contains(t, url, "http", "Download URL should contain http")
 				// Verify version was substituted
-				require.Contains(t, url, latest, "Download URL should contain version %s", latest)
+				require.Contains(t, url, defaultVersion, "Download URL should contain version %s", defaultVersion)
 			}
 		})
 	}
@@ -259,17 +262,17 @@ func Test_Config_GetBinaries_Integration(t *testing.T) {
 
 	for _, artifact := range config.Artifact {
 		t.Run(artifact.Name, func(t *testing.T) {
-			// Get the latest version
-			latest, err := artifact.GetLatestVersion()
+			// Get the default version
+			defaultVersion, err := artifact.GetDefaultVersion()
 			if err != nil {
-				t.Skipf("Skipping %s: cannot get latest version", artifact.Name)
+				t.Skipf("Skipping %s: cannot get default version", artifact.Name)
 				return
 			}
 
 			// Get version info
-			versionInfo, exists := artifact.Versions[Version(latest)]
+			versionInfo, exists := artifact.Versions[Version(defaultVersion)]
 			if !exists {
-				t.Skipf("Skipping %s: version %s not found", artifact.Name, latest)
+				t.Skipf("Skipping %s: version %s not found", artifact.Name, defaultVersion)
 				return
 			}
 

--- a/pkg/software/config_test.go
+++ b/pkg/software/config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_Config_GetLatestVersion(t *testing.T) {
+func Test_Config_GetDefaultVersion(t *testing.T) {
 	tests := []struct {
 		name     string
 		item     ArtifactMetadata
@@ -17,9 +17,10 @@ func Test_Config_GetLatestVersion(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "single versionToBeInstalled",
+			name: "default points to existing version",
 			item: ArtifactMetadata{
-				Name: "test-software",
+				Name:    "test-software",
+				Default: "1.0.0",
 				Versions: map[Version]VersionDetails{
 					"1.0.0": {},
 				},
@@ -28,9 +29,10 @@ func Test_Config_GetLatestVersion(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "multiple versions - semantic ordering",
+			name: "default selects one entry among many - not the highest semver",
 			item: ArtifactMetadata{
-				Name: "test-software",
+				Name:    "test-software",
+				Default: "1.1.0",
 				Versions: map[Version]VersionDetails{
 					"1.0.0":  {},
 					"1.1.0":  {},
@@ -39,13 +41,14 @@ func Test_Config_GetLatestVersion(t *testing.T) {
 					"1.10.0": {},
 				},
 			},
-			expected: "2.0.0",
+			expected: "1.1.0",
 			wantErr:  false,
 		},
 		{
-			name: "versions with patch releases",
+			name: "default selects the highest semver when explicitly set",
 			item: ArtifactMetadata{
-				Name: "test-software",
+				Name:    "test-software",
+				Default: "1.34.0",
 				Versions: map[Version]VersionDetails{
 					"1.33.4": {},
 					"1.33.5": {},
@@ -57,7 +60,30 @@ func Test_Config_GetLatestVersion(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "no versions available",
+			name: "missing default returns error",
+			item: ArtifactMetadata{
+				Name: "test-software",
+				Versions: map[Version]VersionDetails{
+					"1.0.0": {},
+				},
+			},
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name: "default pointing to unknown version returns error",
+			item: ArtifactMetadata{
+				Name:    "test-software",
+				Default: "9.9.9",
+				Versions: map[Version]VersionDetails{
+					"1.0.0": {},
+				},
+			},
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name: "no versions and no default returns error",
 			item: ArtifactMetadata{
 				Name:     "test-software",
 				Versions: map[Version]VersionDetails{},
@@ -66,84 +92,23 @@ func Test_Config_GetLatestVersion(t *testing.T) {
 			wantErr:  true,
 		},
 		{
-			name: "versions with non-semantic format should return error",
+			name: "default with non-semver version string is returned as-is",
 			item: ArtifactMetadata{
-				Name: "test-software",
+				Name:    "test-software",
+				Default: "stable",
 				Versions: map[Version]VersionDetails{
-					"latest": {},
 					"stable": {},
-					"v1.0.0": {},
-					"z":      {},
 					"1.0.0":  {},
-					"0.0.0":  {},
-					"v0.1.0": {},
 				},
 			},
-			expected: "",
-			wantErr:  true,
-		},
-		{
-			name: "mixed semantic and non-semantic versions should return error",
-			item: ArtifactMetadata{
-				Name: "test-software",
-				Versions: map[Version]VersionDetails{
-					"1.0.0":  {},
-					"2.0.0":  {},
-					"latest": {},
-				},
-			},
-			expected: "",
-			wantErr:  true,
-		},
-		{
-			name: "all semantic versions should work correctly",
-			item: ArtifactMetadata{
-				Name: "test-software",
-				Versions: map[Version]VersionDetails{
-					"1.0.0":  {},
-					"1.1.0":  {},
-					"2.0.0":  {},
-					"1.10.0": {},
-				},
-			},
-			expected: "2.0.0",
-			wantErr:  false,
-		},
-		{
-			name: "versions with prereleases",
-			item: ArtifactMetadata{
-				Name: "test-software",
-				Versions: map[Version]VersionDetails{
-					"1.0.0-alpha.1": {},
-					"1.0.0-alpha.2": {},
-					"1.0.0-alpha.3": {},
-					"1.0.0-beta.1":  {},
-					"1.0.0-beta.2":  {},
-					"1.0.0-beta.3":  {},
-				},
-			},
-			expected: "1.0.0-beta.3",
-			wantErr:  false,
-		},
-		{
-			name: "versions with and without v prefix",
-			item: ArtifactMetadata{
-				Name: "test-software",
-				Versions: map[Version]VersionDetails{
-					"v1.0.0": {},
-					"1.0.0":  {},
-					"v2.0.0": {},
-					"2.1.0":  {},
-				},
-			},
-			expected: "2.1.0",
+			expected: "stable",
 			wantErr:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := tt.item.GetLatestVersion()
+			result, err := tt.item.GetDefaultVersion()
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -164,7 +129,8 @@ func Test_Config_VersionSelection(t *testing.T) {
 
 	// Create a mock software item with multiple versions to test versionToBeInstalled selection
 	mockSoftwareItem := &ArtifactMetadata{
-		Name: "cri-o",
+		Name:    "cri-o",
+		Default: "1.27.0",
 		Versions: map[Version]VersionDetails{
 			"1.25.0": {
 				Binaries: []BinaryDetail{
@@ -248,10 +214,10 @@ func Test_Config_VersionSelection(t *testing.T) {
 		},
 	}
 
-	// Test that GetLatestVersion returns the expected latest versionToBeInstalled
-	latestVersion, err := mockSoftwareItem.GetLatestVersion()
-	require.NoError(t, err, "GetLatestVersion should not return an error")
-	assert.Equal(t, "1.27.0", latestVersion, "GetLatestVersion should return 1.27.0 as the latest versionToBeInstalled")
+	// Test that GetDefaultVersion returns the declared default
+	defaultVersion, err := mockSoftwareItem.GetDefaultVersion()
+	require.NoError(t, err, "GetDefaultVersion should not return an error")
+	assert.Equal(t, "1.27.0", defaultVersion, "GetDefaultVersion should return the declared default 1.27.0")
 
 	//
 	// When
@@ -264,7 +230,7 @@ func Test_Config_VersionSelection(t *testing.T) {
 	// Create the baseInstaller with mock data for testing
 	baseInstaller := &baseInstaller{
 		software:             testSoftware,
-		versionToBeInstalled: latestVersion,
+		versionToBeInstalled: defaultVersion,
 	}
 
 	//
@@ -285,13 +251,15 @@ func Test_Config_VersionSelection(t *testing.T) {
 	require.NotEmpty(t, checksum, "Checksum for the selected versionToBeInstalled should not be empty")
 	assert.Equal(t, "yzx567", checksum.Value, "Should return the correct checksum for darwin/arm64")
 
-	// Verify that the installer uses the latest versionToBeInstalled
-	assert.Equal(t, "1.27.0", baseInstaller.Version(), "Installer should use the latest versionToBeInstalled (1.27.0)")
+	// Verify that the installer uses the declared default
+	assert.Equal(t, "1.27.0", baseInstaller.Version(), "Installer should use the declared default (1.27.0)")
 
-	// Additional verification: ensure the versionToBeInstalled selection is semantic, not alphabetical
-	// Test with a versionToBeInstalled that would be "latest" alphabetically but not semantically
-	mockItemWithNonSemanticOrder := &ArtifactMetadata{
-		Name: "cri-o",
+	// Additional verification: default selection is explicit and not derived from semver ordering.
+	// 1.9.0 is alphabetically later than 1.10.0 but semantically earlier; we set Default to the
+	// older 1.9.0 to confirm the explicit default wins regardless of either ordering.
+	mockItemWithExplicitDefault := &ArtifactMetadata{
+		Name:    "cri-o",
+		Default: "1.9.0",
 		Versions: map[Version]VersionDetails{
 			"1.9.0": {
 				Binaries: []BinaryDetail{
@@ -320,9 +288,9 @@ func Test_Config_VersionSelection(t *testing.T) {
 		},
 	}
 
-	semanticLatest, err := mockItemWithNonSemanticOrder.GetLatestVersion()
+	explicitDefault, err := mockItemWithExplicitDefault.GetDefaultVersion()
 	require.NoError(t, err)
-	assert.Equal(t, "1.10.0", semanticLatest, "Should choose 1.10.0 over 1.9.0 (semantic ordering, not alphabetical)")
+	assert.Equal(t, "1.9.0", explicitDefault, "Should return the declared default 1.9.0 even though 1.10.0 is the higher semver")
 }
 
 func Test_Config_GetChecksum(t *testing.T) {


### PR DESCRIPTION
## Description

This pull request implements a three-phase migration to improve and unify how software component versions are managed and consumed, especially for binary artifacts and Helm charts. The changes make version selection explicit, unify catalog structure, and ensure integrity verification for chart installs. The most important changes are summarized below by theme.

**Phase 1: Explicit Defaults for Binary Artifacts**

- Added a required `default:` field to every entry in `pkg/software/artifact.yaml`, making the selected version explicit rather than relying on implicit "latest" logic. [[1]](diffhunk://#diff-d7ddb1eb676574c07b716612c76ebe794921193a394bc9dc03d4d339128876b0R1-R103) [[2]](diffhunk://#diff-229b2a4cdca8b113c3670cd25c1dd707b057a98a49003f5e5321a56f96322d29L4-R12) [[3]](diffhunk://#diff-229b2a4cdca8b113c3670cd25c1dd707b057a98a49003f5e5321a56f96322d29R91) [[4]](diffhunk://#diff-229b2a4cdca8b113c3670cd25c1dd707b057a98a49003f5e5321a56f96322d29R113) [[5]](diffhunk://#diff-229b2a4cdca8b113c3670cd25c1dd707b057a98a49003f5e5321a56f96322d29R133) [[6]](diffhunk://#diff-229b2a4cdca8b113c3670cd25c1dd707b057a98a49003f5e5321a56f96322d29R148) [[7]](diffhunk://#diff-229b2a4cdca8b113c3670cd25c1dd707b057a98a49003f5e5321a56f96322d29R173)
- Introduced `ArtifactMetadata.GetDefaultVersion()` in `pkg/software/config.go` to return the explicit default version and removed or deprecated the old `GetLatestVersion()` method.

**Phase 2: Unified Catalog for Binaries and Charts**

- Renamed `artifact.yaml` to `infrastructure-versions.yaml` and changed the top-level key from `artifact:` to `host:`. Added a new `charts:` section for Helm chart metadata, including chart type, repo, default version, and checksums.
- Introduced new Go types and loader logic: `ComponentCatalog` (with `Host` and `Charts`), `ChartMetadata`, and validation to ensure every entry has a valid `default:` and required fields.

**Phase 3: Workflow Consumption and Integrity Verification**

- Updated all Helm workflow steps to read chart versions and metadata from the unified catalog instead of Go constants in `deps.go`. Chart version constants were removed from `deps.go`, but topology constants remain for now.
- Added chart integrity verification before `helm install`/`upgrade`, checking the pulled chart’s checksum/digest against the catalog. Shared helper logic was factored for this purpose.

These changes ensure version selection is explicit, catalog structure is unified and extensible, and chart installations are secure and verifiable.

---

**References:**  
[[1]](diffhunk://#diff-d7ddb1eb676574c07b716612c76ebe794921193a394bc9dc03d4d339128876b0R1-R103) [[2]](diffhunk://#diff-0e24527af6d1f6f6373c6a82179d63f8e3561c946db78800ec62fb03d90d4a57R1-R210) [[3]](diffhunk://#diff-f5a16a8ca850d1f98a4b2ebb9096fe183de9304babe8d2113157949ded137c1bR1-R170) [[4]](diffhunk://#diff-229b2a4cdca8b113c3670cd25c1dd707b057a98a49003f5e5321a56f96322d29L4-R12) [[5]](diffhunk://#diff-229b2a4cdca8b113c3670cd25c1dd707b057a98a49003f5e5321a56f96322d29R91) [[6]](diffhunk://#diff-229b2a4cdca8b113c3670cd25c1dd707b057a98a49003f5e5321a56f96322d29R113) [[7]](diffhunk://#diff-229b2a4cdca8b113c3670cd25c1dd707b057a98a49003f5e5321a56f96322d29R133) [[8]](diffhunk://#diff-229b2a4cdca8b113c3670cd25c1dd707b057a98a49003f5e5321a56f96322d29R148) [[9]](diffhunk://#diff-229b2a4cdca8b113c3670cd25c1dd707b057a98a49003f5e5321a56f96322d29R173)

### Related Issues

* Closes #587 
