### PR TITLE
refactor(software): rename artifact.yaml to infrastructure-catalog.yaml and add cluster section

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -61,6 +61,11 @@ tasks:
   vendor:
     cmds:
       - "go mod vendor"
+
+  chart-checksums:
+    desc: "Recompute SHA256 / OCI digests for every chart and version listed under cluster: in infrastructure-catalog.yaml. Requires 'helm' on PATH."
+    cmds:
+      - "go run ./scripts/chart-checksums"
   
   lint:
     cmds:

--- a/docs/claude/plans/00588-rename-infrastructure-versions-yaml-cluster-section.md
+++ b/docs/claude/plans/00588-rename-infrastructure-versions-yaml-cluster-section.md
@@ -1,7 +1,29 @@
-# Phase 2 (#588) — Rename to `infrastructure-versions.yaml`; add `host:` + `cluster:` sections with Helm chart entries
+# Phase 2 (#588) — Rename to `infrastructure-catalog.yaml`; add `host:` + `cluster:` sections with Helm chart entries
+
+> **Status:** Shipped as PR #592. Final naming and helper choices differ
+> slightly from this plan — see
+> [`docs/claude/reviews/00588-rename-infrastructure-versions-yaml-cluster-section.md`](../reviews/00588-rename-infrastructure-versions-yaml-cluster-section.md)
+> for what actually landed. Notable divergences:
+>
+> - The embedded catalog file ships as `infrastructure-catalog.yaml`
+>   (not `infrastructure-versions.yaml`). The `versions` filename is
+>   reserved for the CN release package's
+>   `manifests/infrastructure-versions.yaml` audit manifest (minimal
+>   `name`+`version` schema, declarative). A future hidden CLI flag
+>   (`--override-component <name>=<version>` +
+>   `--confirm-untested-combination`) will additionally allow overriding
+>   a single component's version, but only among the versions the
+>   catalog already declares. See `docs/dev/chart-checksums.md` ("Future
+>   overrides") for the planned design.
+> - The container type is named `InfrastructureCatalog` (not
+>   `ComponentCatalog`).
+> - Per-version integrity reuses the existing `Checksum` struct rather
+>   than introducing a new type.
+> - The checksum helper is a Go program exposed as `task chart-checksums`
+>   (under `scripts/`, not `hack/`).
 
 > **Suggested title for GH issue:**
-> `refactor(software): rename artifact.yaml to infrastructure-versions.yaml and add cluster: section with infra Helm charts`
+> `refactor(software): rename artifact.yaml to infrastructure-catalog.yaml and add cluster: section with infra Helm charts`
 >
 > **Related phases:** #587 (`default:` field for binary catalog) · #588 (this) · #589 (wire Helm steps + retire `deps.go` versions)
 

--- a/docs/claude/reviews/00588-rename-infrastructure-versions-yaml-cluster-section.md
+++ b/docs/claude/reviews/00588-rename-infrastructure-versions-yaml-cluster-section.md
@@ -1,0 +1,158 @@
+# Review guide — #588: rename `artifact.yaml` to `infrastructure-catalog.yaml` and add `cluster:` section
+
+## Summary
+
+Phase 2 of the artifact catalog refactor. The host-only `pkg/software/artifact.yaml`
+file is renamed to `pkg/software/infrastructure-catalog.yaml`. The top-level key
+`artifact:` is renamed to `host:`, and a new `cluster:` section is introduced for
+Helm charts installed into Kubernetes. Seven infrastructure charts are added with
+integrity values (SHA256 of `.tgz` for classic charts, OCI manifest digest for
+OCI charts).
+
+The `-catalog` suffix is deliberate: the CN release package ships a
+separate `manifests/infrastructure-versions.yaml` audit manifest with a
+minimal (`name`+`version`) schema that the provisioner cross-checks
+against this catalog at apply time. A future hidden CLI flag
+(`--override-component <name>=<version>` + `--confirm-untested-combination`)
+will additionally allow overriding a single component's version, but
+only among the versions this catalog already declares. The intentional
+filename split (`-catalog` vs `-versions`) avoids any suggestion that
+the two files are interchangeable. See the "Future overrides" section
+in `docs/dev/chart-checksums.md` for the planned design.
+
+The Go side gains an `InfrastructureCatalog` type containing `Host` and `Cluster`
+slices, plus a `ChartMetadata` struct. `LoadArtifactConfig()` is replaced by
+`LoadInfrastructureCatalog()`, which validates the schema at load time. No workflow
+step is migrated to read from `cluster:` in this PR — that is Phase 3 (#589).
+
+## Changed files
+
+| File | Description |
+|------|-------------|
+| `pkg/software/artifact.yaml` → `pkg/software/infrastructure-catalog.yaml` | File rename; top-level key `artifact:` becomes `host:`; new `cluster:` section with seven charts and their integrity records. |
+| `pkg/software/config.go` | Embed directive updated; introduces `InfrastructureCatalog`, `ChartMetadata`, `ChartType` (`classic`/`oci`); replaces `LoadArtifactConfig()` with `LoadInfrastructureCatalog()`; adds `GetHostArtifact`, `GetClusterComponent`, `HostNames`, `ClusterNames`; adds schema validation and `ChartMetadata.GetDefaultVersion`. Reuses the existing `Checksum` struct for per-version chart integrity. |
+| `pkg/software/base_installer.go` | Switches from `LoadArtifactConfig()`/`GetArtifactByName()` to `LoadInfrastructureCatalog()`/`GetHostArtifact()`. |
+| `pkg/software/config_test.go` | Renames the collection test to use `InfrastructureCatalog`; adds tests for `GetClusterComponent`, `ChartMetadata.GetDefaultVersion`, chart-level `validate()`, catalog-level `validate()`, and the load path. |
+| `pkg/software/config_it_test.go` | Migrates all integration tests to `LoadInfrastructureCatalog` and `Host`; adds `Test_Config_ClusterSection_Integration` covering all seven charts. |
+| `scripts/chart-checksums/main.go` + `Taskfile.yaml` (`chart-checksums` target) | New Go helper that loads the catalog via `software.LoadInfrastructureCatalog()`, runs `helm pull` for every (chart, version) pair, and prints the SHA256 of each `.tgz` plus the OCI manifest digest. Sandboxes `HELM_CONFIG_HOME`/`HELM_CACHE_HOME`/`HELM_DATA_HOME` so the developer's global `repositories.yaml` is untouched, uses `helm repo add --force-update`, surfaces helm errors, and rejects catalog entries that share an alias but disagree on the repo URL. Exposed as `task chart-checksums`. |
+| `docs/dev/chart-checksums.md` | New doc describing the integrity model, how to recompute values, and the schema invariants the loader enforces. |
+
+## Code review checklist
+
+- [ ] `pkg/software/artifact.yaml` is **deleted** (no transitional alias).
+- [ ] `pkg/software/infrastructure-catalog.yaml` exists with top-level keys `host:` and `cluster:` only.
+- [ ] All seven infra charts are present under `cluster:`: `alloy` (1.4.0), `teleport-cluster-agent` (18.6.4), `metallb` (0.15.2), `metrics-server` (3.13.0), `external-secrets` (0.20.2), `node-exporter` (4.5.19), `prometheus-operator-crds` (24.0.1).
+- [ ] Each `cluster:` entry declares `type:` (`classic` or `oci`), `chart:`, `default:`, and at least one `versions:` record.
+- [ ] Classic charts declare `repo:`; OCI charts do not.
+- [ ] The Go `//go:embed` directive points to the new file name.
+- [ ] `LoadInfrastructureCatalog()` returns `(*InfrastructureCatalog, error)` and validates the catalog before returning.
+- [ ] Validation errors out on: missing `default:` on either section; `default:` pointing to an unknown version; missing/unknown `type:`; `classic` without `repo:`; `oci` with `repo:`; missing `chart:`; empty `versions:`; empty `algorithm:` or `checksum:` for any version.
+- [ ] Validation checks run from most fundamental to most derived (type/repo → chart → versions presence → per-version integrity → default resolution), so a chart missing both `chart:` and `default:` reports the chart error first.
+- [ ] Per-version iteration sorts version keys alphabetically before checking, so when multiple versions are malformed the same one is named on every run (Go map iteration is randomized).
+- [ ] `ChartMetadata.GetDefaultVersion()` mirrors `ArtifactMetadata.GetDefaultVersion()` (explicit default, errors on missing/unknown).
+- [ ] No workflow step under `internal/workflows/steps/` reads from `cluster:` yet — Phase 3 (#589) does that wiring.
+- [ ] No version constants are deleted from `pkg/deps/deps.go` yet — also Phase 3.
+- [ ] All previous `LoadArtifactConfig()` callers are migrated to `LoadInfrastructureCatalog()`.
+
+### `task chart-checksums` helper
+
+- [ ] Loads the catalog via `software.LoadInfrastructureCatalog()` so the chart/version list always matches the YAML (no hardcoded duplicates).
+- [ ] Sandboxes Helm: sets `HELM_CONFIG_HOME`, `HELM_CACHE_HOME`, `HELM_DATA_HOME`, `HELM_REPOSITORY_CONFIG`, `HELM_REPOSITORY_CACHE` to subdirectories under a per-run temp dir. The developer's global `repositories.yaml` is left byte-identical after a run.
+- [ ] Calls `helm repo add --force-update` and surfaces `helm` exit codes (combined output is included in the returned error) — no silent failures.
+- [ ] Detects catalog-level alias conflicts (same first-segment alias with different `repo:` URLs) and fails before any network call.
+- [ ] Derives the pulled `.tgz` filename via `path.Base(chartRef)` so chart references of any depth produce the right path.
+
+## Tests
+
+Unit tests for the loader and catalog APIs (macOS or VM):
+
+```bash
+go test -race -tags='!integration' ./pkg/software/... -run '^Test_Config_'
+```
+
+Integration tests that exercise the embedded YAML (no cluster required):
+
+```bash
+go test -tags='integration' ./pkg/software/... -run '^Test_Config_'
+```
+
+Full unit suite (CLAUDE.md notes that the full suite needs the UTM VM for Linux-only paths):
+
+```bash
+task vm:test:unit
+```
+
+Full integration suite in the VM:
+
+```bash
+task vm:test:integration
+```
+
+## Manual UAT
+
+These steps verify that the catalog loads, the schema validator runs, and that
+no behaviour has changed at install time (workflow steps still consume the
+constants in `pkg/deps/deps.go`).
+
+1. **Build the binary**
+
+   ```bash
+   task build:weaver GOOS=linux GOARCH=amd64
+   ```
+
+   Expect: `bin/solo-provisioner-linux-amd64` is produced without errors.
+
+2. **Smoke-test the catalog loader** from a one-off Go program (run from the repo root):
+
+   ```bash
+   cat > /tmp/load_catalog.go <<'EOF'
+   package main
+
+   import (
+       "fmt"
+
+       "github.com/hashgraph/solo-weaver/pkg/software"
+   )
+
+   func main() {
+       cat, err := software.LoadInfrastructureCatalog()
+       if err != nil {
+           fmt.Println("ERROR:", err)
+           return
+       }
+       fmt.Println("host:   ", cat.HostNames())
+       fmt.Println("cluster:", cat.ClusterNames())
+   }
+   EOF
+   go run /tmp/load_catalog.go
+   ```
+
+   Expected output (order may vary):
+
+   ```
+   host:    [cri-o kubelet kubeadm kubectl helm k9s cilium teleport]
+   cluster: [alloy teleport-cluster-agent metallb metrics-server external-secrets node-exporter prometheus-operator-crds]
+   ```
+
+3. **Verify the chart checksum helper reproduces committed values**:
+
+   ```bash
+   task chart-checksums
+   ```
+
+   Expected: every printed digest matches the `checksum:` value committed
+   under the corresponding chart's `versions:` entry in
+   `pkg/software/infrastructure-catalog.yaml`.
+
+4. **No-op behaviour check** — run a clean cluster install on the VM and
+   confirm that the seven infra charts still install with the same versions as
+   before:
+
+   ```bash
+   task vm:test:integration TEST_NAME='^Test_StepKubeadm_Fresh_Integration$'
+   ```
+
+   Expected: integration tests pass with no version drift. Because Phase 3
+   has not yet rewired the Helm install steps to read from `cluster:`, the
+   installer continues to consume `pkg/deps/deps.go` constants and produces
+   the same result as before this PR.

--- a/docs/dev/chart-checksums.md
+++ b/docs/dev/chart-checksums.md
@@ -1,0 +1,150 @@
+# Chart checksums
+
+Helm charts under `cluster:` in `pkg/software/infrastructure-catalog.yaml`
+are pinned by an integrity record. There is one record per version:
+
+```yaml
+versions:
+  1.4.0:
+    algorithm: sha256
+    checksum: '<hex>'
+```
+
+The semantics of `checksum:` depend on the chart `type:`:
+
+| `type:`   | `checksum:` value                                  |
+|-----------|----------------------------------------------------|
+| `classic` | SHA256 of the chart `.tgz` produced by `helm pull` |
+| `oci`     | OCI manifest digest (the `Digest:` line emitted by `helm pull`) |
+
+## Updating an existing chart version
+
+1. Bump the `default:` field for the chart (and add the new entry under
+   `versions:` if it is not yet present).
+2. Recompute the checksum for every version listed under that chart.
+3. Run `task lint` and the unit/integration tests so the schema validator
+   catches typos and unknown versions.
+
+## Computing the values
+
+Run the Task target from the repository root:
+
+```bash
+task chart-checksums
+```
+
+It does the following:
+
+- Loads `pkg/software/infrastructure-catalog.yaml` via the same
+  `software.LoadInfrastructureCatalog()` used at runtime — so the chart
+  list, repo, and version list come straight from the catalog (no
+  hardcoded duplicates) and are validated by the schema before any
+  network call is made.
+- Adds the upstream Helm repositories used by classic charts.
+- Runs `helm pull` for every chart/version pair currently shipped under
+  `cluster:`.
+- Prints the SHA256 of each `.tgz` and the OCI manifest digest for each
+  OCI chart.
+
+Source lives in `scripts/chart-checksums/main.go`. Requires `helm` on
+PATH.
+
+Copy the values into `pkg/software/infrastructure-catalog.yaml` under
+the matching `versions:` entry. The target is also handy as a
+verification step before a release: rerun it and confirm the printed
+digests match the values committed to the catalog.
+
+## Adding a new chart
+
+1. Add a new entry under `cluster:` in
+   `pkg/software/infrastructure-catalog.yaml` with `type`, `chart`
+   (and `repo` for classic charts), `default`, and at least one
+   `versions:` record.
+2. Run `task chart-checksums` — it picks up the new chart automatically
+   because it reads the catalog. Paste the printed checksum into the new
+   `versions:` entry.
+3. Run `task test:unit` — the catalog loader validates every chart at
+   load time, so a missing/empty checksum is reported as a schema error
+   rather than failing later at install time.
+
+## Schema invariants
+
+The loader in `pkg/software/config.go` rejects the catalog at startup if
+any of the following hold:
+
+- A `host:` or `cluster:` entry has no `default:`, or `default:` points to
+  a version absent from `versions:`.
+- A `cluster:` entry has no `type:` or a `type:` that is neither `classic`
+  nor `oci`.
+- A `classic` entry is missing `repo:`, or an `oci` entry declares `repo:`.
+- A `cluster:` entry has no `chart:` reference.
+- A `versions:` record has an empty `algorithm:` or `checksum:`.
+
+## Future overrides
+
+> **Not implemented yet.** This section captures the planned design from
+> the alternatives analysis (see HIP draft
+> `solo-weaver-catalog-alternatives.md` §8) so the catalog rename is
+> grounded in concrete intent.
+
+The embedded `infrastructure-catalog.yaml` is the in-binary manifest of
+*what this build of `solo-provisioner` is able to install*. The default
+version for every component is set by the catalog's `default:` field —
+that is the single source of truth at install time. Two future
+mechanisms relate to that default; neither lives in this PR.
+
+### CN release package audit manifest (declarative, not an override)
+
+The CN release package (`build-v<semver>.zip`) ships a file named
+`manifests/infrastructure-versions.yaml` with the same top-level
+`host:` and `cluster:` keys as our catalog, but a **minimal schema**:
+each entry lists only `name` + `version`. Filename collision with the
+embedded catalog is the primary reason the embedded file is named
+`infrastructure-catalog.yaml` — the two files have distinct schemas,
+distinct producers, and distinct roles, and the filenames need to make
+that obvious.
+
+The audit manifest is **declarative**, not imperative: at apply time
+the provisioner validates that every listed version equals the
+embedded catalog's `default:` for that component, and aborts on the
+first mismatch. The provisioner still installs from its catalog — the
+audit manifest does not direct version selection, it just records the
+combination that the CN release pipeline has validated for the council
+member to inspect.
+
+### Hidden CLI flag for emergency overrides
+
+`solo-provisioner` will expose a hidden flag for last-resort,
+operator-controlled overrides of the catalog default for a single
+component (`solo-weaver-catalog-alternatives.md` §8, "Exception —
+hidden emergency flag"):
+
+```
+--override-component <name>=<version>
+--confirm-untested-combination
+```
+
+Contract:
+
+- The requested version **must** exist in the embedded catalog's
+  `versions:` map. The flag selects among versions the running binary
+  already supports; it cannot introduce new components or new versions.
+- The companion `--confirm-untested-combination` flag is required —
+  the override fails closed without it.
+- The provisioner prints a prominent warning naming the exact
+  (component, version) combination applied, so support traces can
+  reconstruct the run from logs.
+- The flag is hidden from `--help` (see `docs/dev/hidden-flags.md` for
+  the existing pattern, e.g. `--skip-hardware-checks`) so it is not
+  used casually.
+
+Catalog access at flag-handling time is via the existing
+`(*InfrastructureCatalog).GetHostArtifact(name)` /
+`GetClusterComponent(name)` lookups and `cm.Versions[Version(req)]`
+existence check. On miss, the abort message names the supported
+versions, e.g.
+
+```
+--override-component alloy=1.5.0 requests a version not supported by
+this build of solo-provisioner (supported versions for alloy: 1.4.0)
+```

--- a/pkg/software/base_installer.go
+++ b/pkg/software/base_installer.go
@@ -64,12 +64,12 @@ var _ Software = (*baseInstaller)(nil)
 // struct to install and configure the .conf and .service files.
 // Packages other than software, such as internal/workflows, should use the Software interface instead.
 func newBaseInstaller(softwareName string, opts ...InstallerOption) (*baseInstaller, error) {
-	config, err := LoadArtifactConfig()
+	catalog, err := LoadInfrastructureCatalog()
 	if err != nil {
 		return nil, NewConfigLoadError(err)
 	}
 
-	item, err := config.GetArtifactByName(softwareName)
+	item, err := catalog.GetHostArtifact(softwareName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/software/config.go
+++ b/pkg/software/config.go
@@ -14,8 +14,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-//go:embed artifact.yaml
-var artifactConfigFS embed.FS
+//go:embed infrastructure-catalog.yaml
+var infrastructureCatalogFS embed.FS
+
+// ChartType identifies how a Helm chart is distributed.
+type ChartType string
+
+const (
+	ChartTypeClassic ChartType = "classic"
+	ChartTypeOCI     ChartType = "oci"
+)
 
 // Semantic types + enums
 
@@ -54,9 +62,41 @@ func (si *ArtifactMetadata) getPlatform() platformProvider {
 	return *si.platform
 }
 
-// ArtifactCollection represents the root configuration structure
-type ArtifactCollection struct {
-	Artifact []ArtifactMetadata `yaml:"artifact"`
+// InfrastructureCatalog is the root structure of the embedded
+// infrastructure-catalog.yaml file shipped inside the solo-provisioner
+// binary. It groups infrastructure components by where they run: `host:`
+// for binaries installed on the host, `cluster:` for Helm charts
+// installed into Kubernetes. The catalog's `default:` field is the
+// single source of truth for which version of each component gets
+// installed at runtime.
+//
+// A separate file named `manifests/infrastructure-versions.yaml`
+// (shipped inside the CN release package, minimal `name`+`version`
+// schema) acts as a declarative audit list that the provisioner
+// cross-checks against this catalog at apply time — it does not direct
+// version selection. The intentional filename split (`-catalog` vs
+// `-versions`) avoids any suggestion that the two are interchangeable.
+// A hidden emergency CLI flag (`--override-component <name>=<version>`,
+// guarded by `--confirm-untested-combination`) will additionally allow
+// overriding a single component's version, but only among versions the
+// catalog already declares. See docs/dev/chart-checksums.md
+// ("Future overrides") for details.
+type InfrastructureCatalog struct {
+	Host    []ArtifactMetadata `yaml:"host"`
+	Cluster []ChartMetadata    `yaml:"cluster"`
+}
+
+// ChartMetadata describes a Helm chart entry under `cluster:`. A chart has
+// a single artifact per version; integrity is verified against the SHA256
+// of the .tgz (classic) or the OCI manifest digest (oci), recorded as a
+// Checksum value.
+type ChartMetadata struct {
+	Name     string               `yaml:"name"`
+	Type     ChartType            `yaml:"type"`
+	Repo     string               `yaml:"repo,omitempty"`
+	Chart    string               `yaml:"chart"`
+	Default  Version              `yaml:"default"`
+	Versions map[Version]Checksum `yaml:"versions"`
 }
 
 // ArtifactMetadata represents a single software artifact  configuration
@@ -234,38 +274,151 @@ type TemplateData struct {
 	ARCH    string
 }
 
-// LoadArtifactConfig loads and parses the artifact.yaml configuration
-func LoadArtifactConfig() (*ArtifactCollection, error) {
-	data, err := artifactConfigFS.ReadFile("artifact.yaml")
+// LoadInfrastructureCatalog loads, parses, and validates the embedded
+// infrastructure-catalog.yaml configuration.
+func LoadInfrastructureCatalog() (*InfrastructureCatalog, error) {
+	data, err := infrastructureCatalogFS.ReadFile("infrastructure-catalog.yaml")
 	if err != nil {
 		return nil, NewConfigLoadError(err)
 	}
 
-	var config ArtifactCollection
-	if err := yaml.Unmarshal(data, &config); err != nil {
+	var catalog InfrastructureCatalog
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
 		return nil, NewConfigLoadError(err)
 	}
 
-	return &config, nil
+	if err := catalog.validate(); err != nil {
+		return nil, NewConfigLoadError(err)
+	}
+
+	return &catalog, nil
 }
 
-// GetArtifactByName finds a artifact item by name
-func (sc *ArtifactCollection) GetArtifactByName(name string) (*ArtifactMetadata, error) {
-	for i, item := range sc.Artifact {
+// GetHostArtifact finds a host artifact entry by name.
+func (c *InfrastructureCatalog) GetHostArtifact(name string) (*ArtifactMetadata, error) {
+	for i, item := range c.Host {
 		if item.Name == name {
-			return &sc.Artifact[i], nil
+			return &c.Host[i], nil
 		}
 	}
 	return nil, NewSoftwareNotFoundError(name)
 }
 
-// Names returns the names of all managed software artifacts.
-func (sc *ArtifactCollection) Names() []string {
-	names := make([]string, 0, len(sc.Artifact))
-	for _, item := range sc.Artifact {
+// GetClusterComponent finds a cluster Helm chart entry by name.
+func (c *InfrastructureCatalog) GetClusterComponent(name string) (*ChartMetadata, error) {
+	for i, item := range c.Cluster {
+		if item.Name == name {
+			return &c.Cluster[i], nil
+		}
+	}
+	return nil, NewSoftwareNotFoundError(name)
+}
+
+// HostNames returns the names of all host artifacts in the catalog.
+func (c *InfrastructureCatalog) HostNames() []string {
+	names := make([]string, 0, len(c.Host))
+	for _, item := range c.Host {
 		names = append(names, item.Name)
 	}
 	return names
+}
+
+// ClusterNames returns the names of all cluster components in the catalog.
+func (c *InfrastructureCatalog) ClusterNames() []string {
+	names := make([]string, 0, len(c.Cluster))
+	for _, item := range c.Cluster {
+		names = append(names, item.Name)
+	}
+	return names
+}
+
+// validate enforces the catalog schema invariants documented in
+// infrastructure-catalog.yaml: every entry must declare an explicit default
+// that resolves to a known version, cluster entries must declare a valid
+// type, classic entries must carry a repo (and oci entries must not), and
+// every chart version must have a non-empty algorithm and checksum.
+func (c *InfrastructureCatalog) validate() error {
+	for i := range c.Host {
+		host := &c.Host[i]
+		if _, err := host.GetDefaultVersion(); err != nil {
+			return fmt.Errorf("host[%s]: %w", host.Name, err)
+		}
+	}
+	for i := range c.Cluster {
+		chart := &c.Cluster[i]
+		if err := chart.validate(); err != nil {
+			return fmt.Errorf("cluster[%s]: %w", chart.Name, err)
+		}
+	}
+	return nil
+}
+
+// validate enforces ChartMetadata invariants. It is called by
+// InfrastructureCatalog.validate() at load time so callers never observe a
+// malformed chart entry.
+//
+// Checks are ordered from most fundamental to most derived: the type/repo
+// shape comes first, then the chart reference, then per-version integrity
+// records, and finally the default resolution. This keeps validation
+// deterministic and ensures malformed structural fields are rejected before
+// derived semantic checks such as resolving the default version.
+func (cm *ChartMetadata) validate() error {
+	switch cm.Type {
+	case ChartTypeClassic:
+		if cm.Repo == "" {
+			return fmt.Errorf("classic chart must declare a repo")
+		}
+	case ChartTypeOCI:
+		if cm.Repo != "" {
+			return fmt.Errorf("oci chart must not declare a repo (repo is encoded in the chart reference)")
+		}
+	case "":
+		return fmt.Errorf("missing type (must be %q or %q)", ChartTypeClassic, ChartTypeOCI)
+	default:
+		return fmt.Errorf("unknown type %q (must be %q or %q)", cm.Type, ChartTypeClassic, ChartTypeOCI)
+	}
+	if cm.Chart == "" {
+		return fmt.Errorf("missing chart reference")
+	}
+	if len(cm.Versions) == 0 {
+		return fmt.Errorf("no versions declared")
+	}
+	// Iterate over versions in a stable, alphabetical order so that when
+	// more than one version is malformed the error message always names
+	// the same one (Go map iteration order is randomized). Mirrors the
+	// convention used by VersionDetails.GetArchives/Binaries/Configs.
+	versions := make([]Version, 0, len(cm.Versions))
+	for v := range cm.Versions {
+		versions = append(versions, v)
+	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
+	for _, version := range versions {
+		details := cm.Versions[version]
+		if details.Algorithm == "" {
+			return fmt.Errorf("version %s: empty algorithm", version)
+		}
+		if details.Value == "" {
+			return fmt.Errorf("version %s: empty checksum", version)
+		}
+	}
+	if _, err := cm.GetDefaultVersion(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetDefaultVersion returns the explicit default version declared for this
+// chart. The default is read from the chart's `default:` field; it must point
+// to a version present in the `versions:` map. Returns an error when
+// `default:` is unset or names an unknown version.
+func (cm *ChartMetadata) GetDefaultVersion() (string, error) {
+	if cm.Default == "" {
+		return "", fmt.Errorf("chart %s has no default version declared", cm.Name)
+	}
+	if _, ok := cm.Versions[cm.Default]; !ok {
+		return "", NewVersionNotFoundError(cm.Name, string(cm.Default))
+	}
+	return string(cm.Default), nil
 }
 
 // executeTemplate executes a template string with the given data

--- a/pkg/software/config_it_test.go
+++ b/pkg/software/config_it_test.go
@@ -8,19 +8,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test_Config_LoadArtifactYAML is an integration test that verifies the artifact.yaml file
-// can be loaded and parsed correctly into the ArtifactCollection structure
-func Test_Config_LoadArtifactYAML(t *testing.T) {
-	// Load the actual artifact.yaml file
-	config, err := LoadArtifactConfig()
-	require.NoError(t, err, "Should be able to load artifact.yaml")
+// Test_Config_LoadInfrastructureCatalogYAML is an integration test that verifies the
+// embedded infrastructure-catalog.yaml file can be loaded and parsed correctly into
+// the InfrastructureCatalog structure.
+func Test_Config_LoadInfrastructureCatalogYAML(t *testing.T) {
+	config, err := LoadInfrastructureCatalog()
+	require.NoError(t, err, "Should be able to load infrastructure-catalog.yaml")
 	require.NotNil(t, config, "Config should not be nil")
 
 	// Verify that we have artifacts defined
-	require.NotEmpty(t, config.Artifact, "Should have at least one artifact defined")
+	require.NotEmpty(t, config.Host, "Should have at least one artifact defined")
 
 	// Test each artifact in the configuration
-	for _, artifact := range config.Artifact {
+	for _, artifact := range config.Host {
 		t.Run("Artifact_"+artifact.Name, func(t *testing.T) {
 			// Verify basic fields
 			require.NotEmpty(t, artifact.Name, "Artifact name should not be empty")
@@ -111,13 +111,13 @@ func Test_Config_LoadArtifactYAML(t *testing.T) {
 	}
 }
 
-// Test_Config_GetSoftwareByName_Integration tests retrieving actual software from artifact.yaml
+// Test_Config_GetSoftwareByName_Integration tests retrieving actual software from infrastructure-catalog.yaml
 func Test_Config_GetSoftwareByName_Integration(t *testing.T) {
-	config, err := LoadArtifactConfig()
+	config, err := LoadInfrastructureCatalog()
 	require.NoError(t, err)
 
-	// Test that we can find cri-o (which should be in the artifact.yaml based on the sample)
-	crioSoftware, err := config.GetArtifactByName("cri-o")
+	// Test that we can find cri-o (which is shipped under host: in infrastructure-catalog.yaml)
+	crioSoftware, err := config.GetHostArtifact("cri-o")
 	if err == nil {
 		// If cri-o exists, validate it
 		require.NotNil(t, crioSoftware)
@@ -126,17 +126,17 @@ func Test_Config_GetSoftwareByName_Integration(t *testing.T) {
 	}
 
 	// Test non-existent software
-	_, err = config.GetArtifactByName("non-existent-software")
+	_, err = config.GetHostArtifact("non-existent-software")
 	require.Error(t, err, "Should return error for non-existent software")
 }
 
 // Test_Config_GetDefaultVersion_Integration tests getting the default version from actual artifacts
 func Test_Config_GetDefaultVersion_Integration(t *testing.T) {
-	config, err := LoadArtifactConfig()
+	config, err := LoadInfrastructureCatalog()
 	require.NoError(t, err)
 
 	// Test each artifact declares an explicit default that resolves correctly
-	for _, artifact := range config.Artifact {
+	for _, artifact := range config.Host {
 		t.Run(artifact.Name, func(t *testing.T) {
 			require.NotEmpty(t, artifact.Default,
 				"Artifact %s must declare an explicit default version", artifact.Name)
@@ -155,11 +155,11 @@ func Test_Config_GetDefaultVersion_Integration(t *testing.T) {
 
 // Test_Config_GetChecksum_Integration tests getting checksums from actual artifacts
 func Test_Config_GetChecksum_Integration(t *testing.T) {
-	config, err := LoadArtifactConfig()
+	config, err := LoadInfrastructureCatalog()
 	require.NoError(t, err)
 
 	// Test a few artifacts if they exist
-	for _, artifact := range config.Artifact {
+	for _, artifact := range config.Host {
 		t.Run(artifact.Name, func(t *testing.T) {
 			// Get the default version
 			defaultVersion, err := artifact.GetDefaultVersion()
@@ -201,10 +201,10 @@ func Test_Config_GetChecksum_Integration(t *testing.T) {
 
 // Test_Config_GetDownloadURL_Integration tests getting download URLs from actual artifacts
 func Test_Config_GetDownloadURL_Integration(t *testing.T) {
-	config, err := LoadArtifactConfig()
+	config, err := LoadInfrastructureCatalog()
 	require.NoError(t, err)
 
-	for _, artifact := range config.Artifact {
+	for _, artifact := range config.Host {
 		t.Run(artifact.Name, func(t *testing.T) {
 			// Get the default version
 			defaultVersion, err := artifact.GetDefaultVersion()
@@ -257,10 +257,10 @@ func Test_Config_GetDownloadURL_Integration(t *testing.T) {
 
 // Test_Config_GetBinaries_Integration tests getting binaries from actual artifacts
 func Test_Config_GetBinaries_Integration(t *testing.T) {
-	config, err := LoadArtifactConfig()
+	config, err := LoadInfrastructureCatalog()
 	require.NoError(t, err)
 
-	for _, artifact := range config.Artifact {
+	for _, artifact := range config.Host {
 		t.Run(artifact.Name, func(t *testing.T) {
 			// Get the default version
 			defaultVersion, err := artifact.GetDefaultVersion()
@@ -293,18 +293,76 @@ func Test_Config_GetBinaries_Integration(t *testing.T) {
 	}
 }
 
-// Test_Config_VersionsAreSemanticVersions verifies all versions in artifact.yaml use semantic versioning
+// Test_Config_VersionsAreSemanticVersions verifies that every version declared
+// under `host:` and `cluster:` uses semantic versioning.
 func Test_Config_VersionsAreSemanticVersions(t *testing.T) {
-	config, err := LoadArtifactConfig()
+	config, err := LoadInfrastructureCatalog()
 	require.NoError(t, err)
 
-	for _, artifact := range config.Artifact {
-		t.Run(artifact.Name, func(t *testing.T) {
+	for _, artifact := range config.Host {
+		t.Run("host_"+artifact.Name, func(t *testing.T) {
 			for version := range artifact.Versions {
 				versionStr := string(version)
 				require.True(t, isValidVersion(versionStr),
-					"Version %s for artifact %s should be a valid semantic version",
+					"Version %s for host artifact %s should be a valid semantic version",
 					versionStr, artifact.Name)
+			}
+		})
+	}
+
+	for _, chart := range config.Cluster {
+		t.Run("cluster_"+chart.Name, func(t *testing.T) {
+			for version := range chart.Versions {
+				versionStr := string(version)
+				require.True(t, isValidVersion(versionStr),
+					"Version %s for cluster chart %s should be a valid semantic version",
+					versionStr, chart.Name)
+			}
+		})
+	}
+}
+
+// Test_Config_ClusterSection_Integration verifies the cluster section of the
+// embedded catalog: every expected chart is present, every entry declares the
+// fields enforced by the schema, and every version carries a non-empty
+// algorithm/checksum.
+func Test_Config_ClusterSection_Integration(t *testing.T) {
+	config, err := LoadInfrastructureCatalog()
+	require.NoError(t, err)
+	require.NotEmpty(t, config.Cluster, "cluster section must not be empty")
+
+	expectedCharts := map[string]struct {
+		chartType ChartType
+		version   string
+	}{
+		"alloy":                    {ChartTypeClassic, "1.4.0"},
+		"teleport-cluster-agent":   {ChartTypeClassic, "18.6.4"},
+		"metallb":                  {ChartTypeClassic, "0.15.2"},
+		"metrics-server":           {ChartTypeClassic, "3.13.0"},
+		"external-secrets":         {ChartTypeClassic, "0.20.2"},
+		"node-exporter":            {ChartTypeOCI, "4.5.19"},
+		"prometheus-operator-crds": {ChartTypeOCI, "24.0.1"},
+	}
+
+	for name, expected := range expectedCharts {
+		t.Run(name, func(t *testing.T) {
+			chart, err := config.GetClusterComponent(name)
+			require.NoError(t, err, "chart %s should be present in catalog", name)
+			require.Equal(t, expected.chartType, chart.Type, "type mismatch for %s", name)
+			require.NotEmpty(t, chart.Chart, "chart reference must not be empty for %s", name)
+			if expected.chartType == ChartTypeClassic {
+				require.NotEmpty(t, chart.Repo, "classic chart %s must declare a repo", name)
+			} else {
+				require.Empty(t, chart.Repo, "oci chart %s must not declare a repo", name)
+			}
+			defaultVersion, err := chart.GetDefaultVersion()
+			require.NoError(t, err, "default version should resolve for %s", name)
+			require.Equal(t, expected.version, defaultVersion, "default version mismatch for %s", name)
+			for version, details := range chart.Versions {
+				require.NotEmpty(t, details.Algorithm,
+					"chart %s version %s: algorithm must not be empty", name, version)
+				require.NotEmpty(t, details.Value,
+					"chart %s version %s: checksum must not be empty", name, version)
 			}
 		})
 	}

--- a/pkg/software/config_test.go
+++ b/pkg/software/config_test.go
@@ -973,9 +973,9 @@ func Test_Config_GetConfigByName(t *testing.T) {
 	}
 }
 
-func Test_Config_SoftwareCollection_GetSoftwareByName(t *testing.T) {
-	collection := &ArtifactCollection{
-		Artifact: []ArtifactMetadata{
+func Test_Config_InfrastructureCatalog_GetHostArtifact(t *testing.T) {
+	catalog := &InfrastructureCatalog{
+		Host: []ArtifactMetadata{
 			{
 				Name: "software1",
 			},
@@ -1006,7 +1006,7 @@ func Test_Config_SoftwareCollection_GetSoftwareByName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := collection.GetArtifactByName(tt.softwareName)
+			result, err := catalog.GetHostArtifact(tt.softwareName)
 
 			if tt.expectedErr {
 				assert.Error(t, err)
@@ -1018,6 +1018,427 @@ func Test_Config_SoftwareCollection_GetSoftwareByName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_Config_InfrastructureCatalog_GetClusterComponent(t *testing.T) {
+	catalog := &InfrastructureCatalog{
+		Cluster: []ChartMetadata{
+			{
+				Name:    "alloy",
+				Type:    ChartTypeClassic,
+				Repo:    "https://grafana.github.io/helm-charts",
+				Chart:   "grafana/alloy",
+				Default: "1.4.0",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+			{
+				Name:    "node-exporter",
+				Type:    ChartTypeOCI,
+				Chart:   "oci://registry-1.docker.io/bitnamicharts/node-exporter",
+				Default: "4.5.19",
+				Versions: map[Version]Checksum{
+					"4.5.19": {Algorithm: "sha256", Value: "def"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		componentKey string
+		expectedErr  bool
+		expectedName string
+	}{
+		{
+			name:         "classic chart found",
+			componentKey: "alloy",
+			expectedErr:  false,
+			expectedName: "alloy",
+		},
+		{
+			name:         "oci chart found",
+			componentKey: "node-exporter",
+			expectedErr:  false,
+			expectedName: "node-exporter",
+		},
+		{
+			name:         "chart not found",
+			componentKey: "nonexistent",
+			expectedErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := catalog.GetClusterComponent(tt.componentKey)
+
+			if tt.expectedErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.expectedName, result.Name)
+			}
+		})
+	}
+}
+
+func Test_Config_ChartMetadata_GetDefaultVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		chart    ChartMetadata
+		expected string
+		wantErr  bool
+	}{
+		{
+			name: "default points to existing version",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Type:    ChartTypeClassic,
+				Repo:    "https://grafana.github.io/helm-charts",
+				Chart:   "grafana/alloy",
+				Default: "1.4.0",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+			expected: "1.4.0",
+		},
+		{
+			name: "missing default returns error",
+			chart: ChartMetadata{
+				Name: "alloy",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "default pointing to unknown version returns error",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Default: "9.9.9",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.chart.GetDefaultVersion()
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func Test_Config_ChartMetadata_validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		chart       ChartMetadata
+		expectedErr string
+	}{
+		{
+			name: "valid classic chart",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Type:    ChartTypeClassic,
+				Repo:    "https://grafana.github.io/helm-charts",
+				Chart:   "grafana/alloy",
+				Default: "1.4.0",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+		},
+		{
+			name: "valid oci chart",
+			chart: ChartMetadata{
+				Name:    "node-exporter",
+				Type:    ChartTypeOCI,
+				Chart:   "oci://registry-1.docker.io/bitnamicharts/node-exporter",
+				Default: "4.5.19",
+				Versions: map[Version]Checksum{
+					"4.5.19": {Algorithm: "sha256", Value: "def"},
+				},
+			},
+		},
+		{
+			name: "missing type",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Repo:    "https://grafana.github.io/helm-charts",
+				Chart:   "grafana/alloy",
+				Default: "1.4.0",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+			expectedErr: "missing type",
+		},
+		{
+			name: "unknown type",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Type:    ChartType("ftp"),
+				Chart:   "grafana/alloy",
+				Default: "1.4.0",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+			expectedErr: "unknown type",
+		},
+		{
+			name: "classic without repo",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Type:    ChartTypeClassic,
+				Chart:   "grafana/alloy",
+				Default: "1.4.0",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+			expectedErr: "classic chart must declare a repo",
+		},
+		{
+			name: "oci with repo",
+			chart: ChartMetadata{
+				Name:    "node-exporter",
+				Type:    ChartTypeOCI,
+				Repo:    "https://example.com",
+				Chart:   "oci://registry-1.docker.io/bitnamicharts/node-exporter",
+				Default: "4.5.19",
+				Versions: map[Version]Checksum{
+					"4.5.19": {Algorithm: "sha256", Value: "def"},
+				},
+			},
+			expectedErr: "oci chart must not declare a repo",
+		},
+		{
+			name: "missing chart reference",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Type:    ChartTypeClassic,
+				Repo:    "https://grafana.github.io/helm-charts",
+				Default: "1.4.0",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+			expectedErr: "missing chart reference",
+		},
+		{
+			name: "default pointing to unknown version",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Type:    ChartTypeClassic,
+				Repo:    "https://grafana.github.io/helm-charts",
+				Chart:   "grafana/alloy",
+				Default: "9.9.9",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+			expectedErr: "not found",
+		},
+		{
+			name: "version with empty algorithm",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Type:    ChartTypeClassic,
+				Repo:    "https://grafana.github.io/helm-charts",
+				Chart:   "grafana/alloy",
+				Default: "1.4.0",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "", Value: "abc"},
+				},
+			},
+			expectedErr: "empty algorithm",
+		},
+		{
+			name: "version with empty checksum",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Type:    ChartTypeClassic,
+				Repo:    "https://grafana.github.io/helm-charts",
+				Chart:   "grafana/alloy",
+				Default: "1.4.0",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: ""},
+				},
+			},
+			expectedErr: "empty checksum",
+		},
+		{
+			name: "missing both chart reference and default surfaces chart error first",
+			chart: ChartMetadata{
+				Name: "alloy",
+				Type: ChartTypeClassic,
+				Repo: "https://grafana.github.io/helm-charts",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+			expectedErr: "missing chart reference",
+		},
+		{
+			name: "no versions declared",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Type:    ChartTypeClassic,
+				Repo:    "https://grafana.github.io/helm-charts",
+				Chart:   "grafana/alloy",
+				Default: "1.4.0",
+			},
+			expectedErr: "no versions declared",
+		},
+		{
+			name: "per-version checksum error surfaces before bad default",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Type:    ChartTypeClassic,
+				Repo:    "https://grafana.github.io/helm-charts",
+				Chart:   "grafana/alloy",
+				Default: "9.9.9", // also bogus, but checksum error wins
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "", Value: "abc"},
+				},
+			},
+			expectedErr: "empty algorithm",
+		},
+		{
+			// Pins the deterministic-iteration contract: when multiple
+			// versions are malformed, the validator must always report
+			// the alphabetically smallest one, regardless of Go's map
+			// iteration order. Re-run with `go test -count=N` to confirm
+			// the error message is stable.
+			name: "deterministic: alphabetically first malformed version is reported",
+			chart: ChartMetadata{
+				Name:    "alloy",
+				Type:    ChartTypeClassic,
+				Repo:    "https://grafana.github.io/helm-charts",
+				Chart:   "grafana/alloy",
+				Default: "1.4.0",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "", Value: "abc"},
+					"2.0.0": {Algorithm: "", Value: "def"},
+				},
+			},
+			expectedErr: "version 1.4.0: empty algorithm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.chart.validate()
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}
+
+func Test_Config_InfrastructureCatalog_validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		catalog     InfrastructureCatalog
+		expectedErr string
+	}{
+		{
+			name: "valid catalog",
+			catalog: InfrastructureCatalog{
+				Host: []ArtifactMetadata{
+					{
+						Name:    "kubectl",
+						Default: "1.33.4",
+						Versions: map[Version]VersionDetails{
+							"1.33.4": {},
+						},
+					},
+				},
+				Cluster: []ChartMetadata{
+					{
+						Name:    "alloy",
+						Type:    ChartTypeClassic,
+						Repo:    "https://grafana.github.io/helm-charts",
+						Chart:   "grafana/alloy",
+						Default: "1.4.0",
+						Versions: map[Version]Checksum{
+							"1.4.0": {Algorithm: "sha256", Value: "abc"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "host entry missing default",
+			catalog: InfrastructureCatalog{
+				Host: []ArtifactMetadata{
+					{
+						Name: "kubectl",
+						Versions: map[Version]VersionDetails{
+							"1.33.4": {},
+						},
+					},
+				},
+			},
+			expectedErr: "host[kubectl]",
+		},
+		{
+			name: "cluster entry invalid",
+			catalog: InfrastructureCatalog{
+				Cluster: []ChartMetadata{
+					{
+						Name:    "alloy",
+						Type:    ChartTypeClassic,
+						Chart:   "grafana/alloy",
+						Default: "1.4.0",
+						Versions: map[Version]Checksum{
+							"1.4.0": {Algorithm: "sha256", Value: "abc"},
+						},
+					},
+				},
+			},
+			expectedErr: "cluster[alloy]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.catalog.validate()
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			}
+		})
+	}
+}
+
+func Test_Config_LoadInfrastructureCatalog(t *testing.T) {
+	catalog, err := LoadInfrastructureCatalog()
+	require.NoError(t, err, "embedded infrastructure-catalog.yaml must load")
+	require.NotNil(t, catalog)
+	require.NotEmpty(t, catalog.Host, "host section must not be empty")
+	require.NotEmpty(t, catalog.Cluster, "cluster section must not be empty")
 }
 
 func Test_Config_TemplateExecution(t *testing.T) {

--- a/pkg/software/infrastructure-catalog.yaml
+++ b/pkg/software/infrastructure-catalog.yaml
@@ -1,12 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This file contains the list of software artifacts with their download URLs,
-# versions, and checksums for verification. Each artifact declares an
-# explicit `default:` version — the version installed when no other is
-# requested. Adding a new entry under `versions:` does not change the
-# default; that requires updating the `default:` field.
-artifact:
-  
+# Infrastructure catalog.
+#
+# This file is embedded into the solo-provisioner binary (via //go:embed)
+# and lists every component version that this build is able to install,
+# together with the integrity metadata needed to verify each artifact.
+# The `default:` field per entry is the single source of truth for which
+# version is installed at runtime.
+#
+# The CN release package ships a separate audit manifest named
+# `manifests/infrastructure-versions.yaml` (minimal `name`+`version`
+# schema, declarative); a hidden emergency CLI flag
+# (`--override-component <name>=<version>`) may additionally override a
+# single component's version, but only among the versions this catalog
+# already declares. See docs/dev/chart-checksums.md ("Future overrides").
+#
+# `host:` lists software artifacts installed on the host (binaries, archives,
+# configs). `cluster:` lists Helm charts installed into the Kubernetes
+# cluster. Each entry declares an explicit `default:` version — the version
+# installed when no other is requested. Adding a new entry under `versions:`
+# does not change the default; that requires updating the `default:` field.
+#
+# `cluster:` entries declare:
+#   - type: "classic" (Helm chart from a classic repository) or "oci"
+#     (Helm chart pulled directly from an OCI registry).
+#   - repo: required for classic charts, must be omitted for oci charts.
+#   - chart: chart reference (e.g. "grafana/alloy" for classic,
+#     "oci://registry/path" for oci).
+#   - versions: per-version integrity records. The checksum is the SHA256
+#     of the chart .tgz for classic repos, and the OCI manifest digest for
+#     OCI registries.
+host:
+
 - name: cri-o
   url: 'https://storage.googleapis.com/cri-o/artifacts/cri-o.{{.ARCH}}.v{{.VERSION}}.tar.gz'
   default: "1.33.4"
@@ -276,3 +301,72 @@ artifact:
           algorithm: 'sha256'
           checksum: 'd3a4773d2402b72a257ab187b8a2771d45747876320679fe8eaf267ed1a40c41'
 
+cluster:
+
+- name: alloy
+  type: classic
+  repo: 'https://grafana.github.io/helm-charts'
+  chart: 'grafana/alloy'
+  default: "1.4.0"
+  versions:
+    1.4.0:
+      algorithm: 'sha256'
+      checksum: 'b1adbb6344301b8353c9d5d39bb5de196e3735441ca1742913d60922a96bffcb'
+
+- name: teleport-cluster-agent
+  type: classic
+  repo: 'https://charts.releases.teleport.dev'
+  chart: 'teleport/teleport-kube-agent'
+  default: "18.6.4"
+  versions:
+    18.6.4:
+      algorithm: 'sha256'
+      checksum: 'f657f1f216ebfe6bd074d5c3509b6617205ae956d3e73b895e20d71b26002201'
+
+- name: metallb
+  type: classic
+  repo: 'https://metallb.github.io/metallb'
+  chart: 'metallb/metallb'
+  default: "0.15.2"
+  versions:
+    0.15.2:
+      algorithm: 'sha256'
+      checksum: '4f0fc313cd97819a1c78fff0a389dfe1c9f98bc490f33f521317475df1d7b873'
+
+- name: metrics-server
+  type: classic
+  repo: 'https://kubernetes-sigs.github.io/metrics-server'
+  chart: 'metrics-server/metrics-server'
+  default: "3.13.0"
+  versions:
+    3.13.0:
+      algorithm: 'sha256'
+      checksum: 'fb929902e3b7565663cdd1734f31d63735c932be1541a7228b5aeef6d2348a1f'
+
+- name: external-secrets
+  type: classic
+  repo: 'https://charts.external-secrets.io'
+  chart: 'external-secrets/external-secrets'
+  default: "0.20.2"
+  versions:
+    0.20.2:
+      algorithm: 'sha256'
+      checksum: 'f8e0b2f4f22fab223f79567df4786ae1873d5f45b993c9f94419650462d937be'
+
+- name: node-exporter
+  type: oci
+  chart: 'oci://registry-1.docker.io/bitnamicharts/node-exporter'
+  default: "4.5.19"
+  versions:
+    4.5.19:
+      algorithm: 'sha256'
+      checksum: '2d782dc996bda9424a80f060481ab137865a6f89f56ddbe777e82f3e9e513214'
+
+- name: prometheus-operator-crds
+  type: oci
+  chart: 'oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds'
+  default: "24.0.1"
+  versions:
+    24.0.1:
+      algorithm: 'sha256'
+      checksum: 'e940c5ce899ec16aa6d868ecf49e2c21193728bef3a0a453b29e05e2d1601288'

--- a/scripts/chart-checksums/main.go
+++ b/scripts/chart-checksums/main.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// chart-checksums recomputes the integrity values stored in
+// pkg/software/infrastructure-catalog.yaml under cluster:*.versions.
+//
+// For classic charts it prints the SHA256 of the chart .tgz fetched with
+// `helm pull`. For OCI charts it prints the OCI manifest digest reported
+// by `helm pull`.
+//
+// The chart list and version list are read from the catalog itself, so
+// every version recorded under each cluster: entry is regenerated on
+// every run. To add a chart or bump a version, edit the catalog and
+// re-run this program.
+//
+// Invoke via the Taskfile:
+//
+//	task chart-checksums
+//
+// Requires `helm` on PATH.
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/hashgraph/solo-weaver/pkg/software"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if _, err := exec.LookPath("helm"); err != nil {
+		return fmt.Errorf("'helm' is required on PATH: %w", err)
+	}
+
+	catalog, err := software.LoadInfrastructureCatalog()
+	if err != nil {
+		return fmt.Errorf("load catalog: %w", err)
+	}
+
+	workdir, err := os.MkdirTemp("", "chart-checksums-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(workdir)
+
+	h, err := newHelmRunner(workdir)
+	if err != nil {
+		return err
+	}
+
+	if err := h.configureClassicRepos(catalog.Cluster); err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println("=== Classic charts (SHA256 of .tgz) ===")
+	for _, chart := range catalog.Cluster {
+		if chart.Type != software.ChartTypeClassic {
+			continue
+		}
+		for version := range chart.Versions {
+			digest, err := h.classicDigest(chart.Chart, string(version))
+			if err != nil {
+				return fmt.Errorf("classic %s %s: %w", chart.Name, version, err)
+			}
+			printRow(chart.Name, string(version), digest)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("=== OCI charts (manifest digest) ===")
+	for _, chart := range catalog.Cluster {
+		if chart.Type != software.ChartTypeOCI {
+			continue
+		}
+		for version := range chart.Versions {
+			digest, err := h.ociDigest(chart.Chart, string(version))
+			if err != nil {
+				return fmt.Errorf("oci %s %s: %w", chart.Name, version, err)
+			}
+			printRow(chart.Name, string(version), digest)
+		}
+	}
+
+	return nil
+}
+
+// helmRunner wraps a workdir-scoped helm environment. Setting
+// HELM_CONFIG_HOME / HELM_CACHE_HOME / HELM_DATA_HOME under workdir means
+// every `helm repo add` and `helm pull` mutates only the temporary tree
+// — the developer's global repositories.yaml (typically under
+// ~/Library/Preferences/helm on macOS or ~/.config/helm on Linux) is
+// untouched, so we never overwrite an alias they already use locally and
+// nothing is left behind when workdir is removed.
+type helmRunner struct {
+	workdir string
+	env     []string
+}
+
+func newHelmRunner(workdir string) (*helmRunner, error) {
+	configHome := filepath.Join(workdir, "helm-config")
+	cacheHome := filepath.Join(workdir, "helm-cache")
+	dataHome := filepath.Join(workdir, "helm-data")
+	for _, d := range []string{configHome, cacheHome, dataHome} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			return nil, err
+		}
+	}
+	env := append(os.Environ(),
+		"HELM_CONFIG_HOME="+configHome,
+		"HELM_CACHE_HOME="+cacheHome,
+		"HELM_DATA_HOME="+dataHome,
+		"HELM_REPOSITORY_CONFIG="+filepath.Join(configHome, "repositories.yaml"),
+		"HELM_REPOSITORY_CACHE="+filepath.Join(cacheHome, "repository"),
+	)
+	return &helmRunner{workdir: workdir, env: env}, nil
+}
+
+func (h *helmRunner) command(args ...string) *exec.Cmd {
+	cmd := exec.Command("helm", args...)
+	cmd.Dir = h.workdir
+	cmd.Env = h.env
+	return cmd
+}
+
+// runChecked invokes helm with the workdir-scoped environment, captures
+// combined output, and returns any non-zero exit as an error that also
+// includes the captured output. Errors from helm — bad alias, network
+// failures, signature mismatches — are surfaced rather than silently
+// swallowed.
+func (h *helmRunner) runChecked(args ...string) error {
+	cmd := h.command(args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("helm %s: %w\n%s",
+			strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// configureClassicRepos invokes `helm repo add --force-update` for every
+// distinct (alias, repo URL) pair declared under cluster: entries of type
+// classic, then runs `helm repo update`. Two catalog entries that share
+// an alias but disagree on the repo URL are reported as a catalog bug
+// before any network call. `--force-update` is defensive: the sandboxed
+// config starts empty but this keeps the helper correct even if a future
+// caller points HELM_REPOSITORY_CONFIG at a pre-populated file.
+func (h *helmRunner) configureClassicRepos(charts []software.ChartMetadata) error {
+	fmt.Fprintln(os.Stderr, "Configuring classic Helm repositories (scoped to a temp dir)...")
+	aliasToRepo := map[string]string{}
+	for _, c := range charts {
+		if c.Type != software.ChartTypeClassic {
+			continue
+		}
+		alias, _, _ := strings.Cut(c.Chart, "/")
+		if existing, ok := aliasToRepo[alias]; ok {
+			if existing != c.Repo {
+				return fmt.Errorf(
+					"catalog conflict: cluster alias %q is declared with both %q and %q "+
+						"— rename one of the charts so each alias resolves to a single repo URL",
+					alias, existing, c.Repo)
+			}
+			continue
+		}
+		aliasToRepo[alias] = c.Repo
+		if err := h.runChecked("repo", "add", "--force-update", alias, c.Repo); err != nil {
+			return err
+		}
+	}
+	if err := h.runChecked("repo", "update"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// classicDigest pulls a classic chart and returns the SHA256 of the
+// resulting .tgz archive. Helm names the archive after the last path
+// segment of the chart reference (e.g. `helm pull foo/bar/baz`
+// produces `baz-<version>.tgz`), so we use path.Base — not the first
+// `strings.Cut` segment — to derive the filename. `path.Base` is
+// preferable to `filepath.Base` here because chart references use
+// forward slashes regardless of OS.
+func (h *helmRunner) classicDigest(chartRef, version string) (string, error) {
+	if err := h.runChecked("pull", chartRef, "--version", version); err != nil {
+		return "", err
+	}
+	tgz := filepath.Join(h.workdir, fmt.Sprintf("%s-%s.tgz", path.Base(chartRef), version))
+	return sha256File(tgz)
+}
+
+var ociDigestRE = regexp.MustCompile(`Digest:\s*sha256:([a-f0-9]{64})`)
+
+// ociDigest pulls an OCI chart and returns the manifest digest reported
+// by `helm pull` on stdout.
+func (h *helmRunner) ociDigest(chartRef, version string) (string, error) {
+	cmd := h.command("pull", chartRef, "--version", version)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("helm pull: %w: %s", err, out.String())
+	}
+	m := ociDigestRE.FindSubmatch(out.Bytes())
+	if m == nil {
+		return "", fmt.Errorf("no Digest line in helm pull output:\n%s", out.String())
+	}
+	return string(m[1]), nil
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func printRow(name, version, digest string) {
+	fmt.Printf("%-32s %s\n", fmt.Sprintf("%s (%s)", name, version), digest)
+}


### PR DESCRIPTION
## Description

Phase 2 (#588) of the artifact catalog refactor.

The host-only `pkg/software/artifact.yaml` is renamed to `pkg/software/infrastructure-catalog.yaml`, the top-level key `artifact:` becomes `host:`, and a new `cluster:` section lists the seven infra Helm charts (alloy, teleport-cluster-agent, metallb, metrics-server, external-secrets, node-exporter, prometheus-operator-crds) with per-version integrity records — SHA256 of the chart `.tgz` for classic charts, OCI manifest digest for OCI charts.

The `-catalog` filename is deliberate. The CN release package will ship a separate `manifests/infrastructure-versions.yaml` audit manifest with a minimal (`name`+`version`) schema, and a future hidden CLI flag (`--override-component <name>=<version>` guarded by `--confirm-untested-combination`) will allow last-resort single-component overrides — restricted to versions the catalog already declares. The intentional filename split avoids any suggestion that the audit manifest is a drop-in replacement for the embedded catalog. See [`docs/dev/chart-checksums.md` — "Future
overrides"](docs/dev/chart-checksums.md) and the alternatives doc (`solo-weaver-catalog-alternatives.md` §8).

**Go side.** `pkg/software/config.go` introduces:

- `InfrastructureCatalog` (the root type, containing `Host` and `Cluster` slices), `ChartMetadata`, and `ChartType` (`classic` / `oci`).
- `LoadInfrastructureCatalog()` replacing `LoadArtifactConfig()`. It validates the schema at load time:
  - explicit `default:` resolvable to a known version on both `host:` and `cluster:` entries;
  - valid `type:` (`classic` or `oci`) on each cluster entry;
  - `classic` charts must declare `repo:`; OCI charts must not;
  - `chart:` reference present on each cluster entry;
  - non-empty `versions:` map;
  - non-empty `algorithm:` + `checksum:` per version.
- Lookups: `GetHostArtifact`, `GetClusterComponent`, `HostNames`, `ClusterNames`.
- `ChartMetadata.GetDefaultVersion()` mirroring the existing one on `ArtifactMetadata`. Reuses the existing `Checksum` struct for chart integrity rather than introducing a new type.

Validation checks run from most fundamental to most derived (type/repo → chart reference → versions presence → per-version integrity → default resolution), and per-version iteration sorts keys alphabetically so error messages are stable across Go's randomized map iteration. The single previous `LoadArtifactConfig` caller in `pkg/software/base_installer.go` is migrated.

**Catalog maintenance.** A new Go helper at `scripts/chart-checksums/main.go` exposed as `task chart-checksums` recomputes the integrity values for every `(chart, version)` pair listed under `cluster:`. It loads the catalog via `software.LoadInfrastructureCatalog()` so the chart/version list always matches the YAML, sandboxes Helm via per-run `HELM_CONFIG_HOME` / `HELM_CACHE_HOME` / `HELM_DATA_HOME` env vars under a temp dir (the developer's global `repositories.yaml` is left byte-identical), uses `helm repo add --force-update`, surfaces helm exit codes (no silent failures), detects catalog-level alias conflicts before any network call, and derives the `.tgz` filename via `path.Base(chartRef)` so chart references of any depth produce the correct path.

Documented in `docs/dev/chart-checksums.md`, which also captures the "Future overrides" design that justifies the rename.

**Out of scope.** No workflow step under `internal/workflows/steps/` reads from `cluster:` yet, and no version constants are deleted from `pkg/deps/deps.go` — that is Phase 3 (#589).

### Changed files

| File | Change |
|---|---|
| `pkg/software/artifact.yaml` → `pkg/software/infrastructure-catalog.yaml` | Rename via `git mv`; top-level key `artifact:` → `host:`; new `cluster:` section with seven charts and their integrity records. |
| `pkg/software/config.go` | New embed directive; introduces `InfrastructureCatalog`, `ChartMetadata`, `ChartType`; replaces `LoadArtifactConfig` with `LoadInfrastructureCatalog`; adds lookups and `ChartMetadata.GetDefaultVersion`; schema validation. |
| `pkg/software/base_installer.go` | Single caller migrated to the new loader. |
| `pkg/software/config_test.go` | Tests for `GetHostArtifact`, `GetClusterComponent`, `ChartMetadata.GetDefaultVersion`, chart-level `validate()` (including the deterministic-iteration contract), catalog-level `validate()`, and the load path. |
| `pkg/software/config_it_test.go` | Migrated to `LoadInfrastructureCatalog`; new `Test_Config_ClusterSection_Integration` covering all seven charts. |
| `scripts/chart-checksums/main.go` + `Taskfile.yaml` (`chart-checksums`) | Sandboxed Go helper to recompute integrity values for every `(chart, version)` pair in the catalog. |
| `docs/dev/chart-checksums.md` | New doc covering the integrity model, the helper, schema invariants, and the planned future overrides. |
| `docs/claude/plans/00588-rename-infrastructure-versions-yaml-cluster-section.md` | Status block noting what shipped and the divergences from the original plan. |
| `docs/claude/reviews/00588-rename-infrastructure-versions-yaml-cluster-section.md` | New review guide for the PR. |

### Test plan

- [ ] `task lint:check`
- [ ] `go test -tags='!integration' -run '^Test_Config_' ./pkg/software/...`
- [ ] `go test -tags='integration'  -run '^Test_Config_' ./pkg/software/...`
- [ ] `task vm:test:unit`
- [ ] `task vm:test:integration`
- [ ] `LoadInfrastructureCatalog()` returns 8 entries under `Host` and 7 under `Cluster`.
- [ ] `task chart-checksums` reproduces the integrity values committed to `pkg/software/infrastructure-catalog.yaml`.
- [ ] `task chart-checksums` does not mutate the developer's global Helm `repositories.yaml` (`diff` before vs after is empty).
- [ ] No behaviour change at install time: a fresh cluster install on the VM produces the same Helm release versions as before — workflow steps still consume `pkg/deps/deps.go` constants until Phase 3.

### Related Issues

* Closes #588