### PR TITLE
feat: consume chart catalog and verify Helm pulls

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -292,6 +292,7 @@ tasks:
       - mockgen -source=pkg/fsx/interface.go -self_package github.com/hashgraph/solo-weaver/pkg/fsx -package fsx > pkg/fsx/mocks_generated.go
       - mockgen -source=pkg/software/interface.go -self_package github.com/hashgraph/solo-weaver/pkg/software -package software> pkg/software/mocks_generated.go
       - mockgen -source=pkg/kernel/interface.go -self_package github.com/hashgraph/solo-weaver/pkg/kernel -package kernel > pkg/kernel/mocks_generated.go
+      - mockgen -source=pkg/helm/interface.go -self_package github.com/hashgraph/solo-weaver/pkg/helm -package helm > pkg/helm/mocks_generated.go
   
   # Remote debug tasks for Docker container debugging
   debug:container:

--- a/cmd/weaver/commands/common/flags_teleport.go
+++ b/cmd/weaver/commands/common/flags_teleport.go
@@ -5,7 +5,7 @@ package common
 import (
 	"fmt"
 
-	"github.com/hashgraph/solo-weaver/pkg/deps"
+	"github.com/hashgraph/solo-weaver/pkg/software"
 )
 
 // Flag descriptor factories for the `teleport cluster` command tree.
@@ -14,11 +14,29 @@ import (
 // root --version flag (which is a bool). FlagTeleportValuesFile is similar to
 // common.FlagValuesFile but has no shorthand and a teleport-specific description.
 
+// teleportCatalogDefaultVersion reads the default Teleport chart version from
+// the infrastructure catalog. The catalog is the source of truth for cluster
+// chart versions; we surface the value in the flag's help text so operators
+// can see what they'd get without the flag. If the catalog fails to load we
+// return an empty string and let the install step surface a clearer error.
+func teleportCatalogDefaultVersion() string {
+	catalog, err := software.LoadInfrastructureCatalog()
+	if err != nil {
+		return ""
+	}
+	chart, err := catalog.GetClusterComponent("teleport-cluster-agent")
+	if err != nil {
+		return ""
+	}
+	v, _ := chart.GetDefaultVersion()
+	return v
+}
+
 func FlagTeleportVersion() FlagDefinition[string] {
 	return FlagDefinition[string]{
 		Name:        "version",
 		ShortName:   "",
-		Description: fmt.Sprintf("Teleport Helm chart version (default: %s)", deps.TELEPORT_VERSION),
+		Description: fmt.Sprintf("Teleport Helm chart version (default: %s)", teleportCatalogDefaultVersion()),
 		Default:     "",
 	}
 }

--- a/docs/claude/plans/00589-consume-charts-catalog-helm-steps.md
+++ b/docs/claude/plans/00589-consume-charts-catalog-helm-steps.md
@@ -1,0 +1,183 @@
+# Phase 3 — Consume the catalog from Helm workflow steps (#589)
+
+## Context
+
+Phases 1 (#590) and 2 (#588) built an `InfrastructureCatalog` Go type that parses the embedded `pkg/software/infrastructure-catalog.yaml`. The `cluster:` section lists the seven Helm charts the cluster setup workflow installs (alloy, teleport-cluster-agent, metallb, metrics-server, external-secrets, node-exporter, prometheus-operator-crds), each with a `default:` version and a `versions:` map keyed by version containing `{algorithm: sha256, checksum: <hex>}`.
+
+Before Phase 3 the workflow steps under `internal/workflows/steps/` still hardcoded chart versions through `pkg/deps/deps.go` constants. Nothing read the catalog at install time, and there was no integrity check on the .tgz / OCI manifest pulled by Helm.
+
+Phase 3 connects the two: every Helm install/upgrade in cluster-setup workflows now looks up its version *and* checksum in the catalog, verifies the pulled artifact, and fails the step on mismatch. The seven chart version constants disappear from `deps.go`; topology constants (`*_NAMESPACE`, `*_RELEASE`, `*_CHART`, `*_REPO`) stay until a later cleanup PR.
+
+The branch is `00589-consume-charts-catalog-helm-steps`, cut from `main` (Phase 2 has already landed on `main` as commit `29fe67a`, so we did not stack on the `00588-…` branch).
+
+## Approach
+
+### 1. Branch setup
+- `git fetch origin && git checkout main && git pull origin main`
+- `git checkout -b 00589-consume-charts-catalog-helm-steps`
+
+### 2. New helper: pull-and-verify in `pkg/helm/`
+
+Added `Manager.PullAndVerify` to the interface — every step already builds a `helm.Manager`, so adding it there avoids new wiring:
+
+```go
+PullAndVerify(ctx context.Context, chartRef, version, algorithm, expectedChecksum string) (string, error)
+```
+
+Implementation in `pkg/helm/puller.go`:
+
+- Uses the Helm Go SDK (consistent with `pkg/helm/manager.go`; no shell-out to the `helm` binary).
+- Classic: `action.NewPull` with `DestDir = <dest>` and `Untar = false`, then `sha256.Sum256` the resulting `.tgz`.
+- OCI: build a `registry.Client` via the existing `helpers.go:newRegistryClient`, call `registryClient.Pull(<ref>:<version>, registry.PullOptWithChart(true))`, write the returned `PullResult.Chart.Data` to `<dest>/<name>-<version>.tgz`, and read the manifest digest from `PullResult.Manifest.Digest`. Strip the `sha256:` prefix to match the catalog format.
+- Validates `algorithm == "sha256"` and rejects empty `destDir` / `expectedChecksum`.
+- Creates `destDir` (mode 0o755) on demand.
+- On checksum mismatch, returns `helm.ErrChecksumMismatch` naming the component, expected value, and observed value.
+
+The destination directory is a per-call parameter, mirroring `pkg/software.Downloader.Download(url, destination)`. Workflow steps pass `<WeaverPaths.DownloadsDir>/charts` (default `/opt/solo/weaver/downloads/charts`) so verified `.tgz` artifacts persist alongside other downloaded binaries; unit tests pass `t.TempDir()`. Keeping the destination at the call site rather than as `helm.Manager` state mirrors the host downloader and keeps `helm.Manager` free of state only one method consumes.
+
+Reference: `scripts/chart-checksums/main.go` already shells out to `helm pull` and computes the same digests for catalog generation — the runtime implementation here uses the SDK for the same algorithm.
+
+### 3. Wire the catalog into every Helm step
+
+A small helper `internal/workflows/steps/catalog.go` houses two things every Helm step now uses:
+
+```go
+type helmChartSpec struct { Chart, Version, Algorithm, Checksum, Repo string; Type software.ChartType }
+func resolveCatalogChart(name string) (*helmChartSpec, error) { /* load catalog → GetClusterComponent → GetDefaultVersion → checksum */ }
+func newHelmManager() (helm.Manager, error) { /* helm.NewManager with WithLogger */ }
+func chartDownloadsDir() string { /* path.Join(models.Paths().DownloadsDir, "charts") */ }
+```
+
+Each step's `WithExecute` closure was rewritten from:
+
+```go
+hm, _ := helm.NewManager(helm.WithLogger(*l))
+hm.AddRepo(deps.X_RELEASE, deps.X_REPO, ...)        // classic only
+hm.InstallChart(ctx, deps.X_RELEASE, deps.X_CHART, deps.X_VERSION, deps.X_NAMESPACE, ...)
+```
+
+to:
+
+```go
+spec, _ := resolveCatalogChart("metallb")
+hm, _ := newHelmManager()
+hm.AddRepo(deps.X_RELEASE, spec.Repo, ...)          // classic only (Repo is empty for oci)
+localChart, _ := hm.PullAndVerify(ctx, chartDownloadsDir(), spec.Chart, spec.Version, spec.Algorithm, spec.Checksum)
+hm.InstallChart(ctx, deps.X_RELEASE, localChart, "", deps.X_NAMESPACE, ...)
+```
+
+- `chart`, `repo`, and `version` come from the catalog (per the issue's "even though they're duplicated in `deps.go` today" directive).
+- `release` and `namespace` continue to come from `deps.go`.
+- The local `.tgz` path is passed as `chartRef` to `InstallChart`/`DeployChart`/`UpgradeChart`; Helm's `LocateChart` accepts a local path and the version string is empty.
+- The `"v"`-prefix logic in `step_metallb.go` / `step_metrics_server.go` was removed; catalog versions are bare semver and `PullAndVerify` matches the upstream chart-index versions directly (same as `scripts/chart-checksums`).
+
+Files updated:
+
+- `internal/workflows/steps/step_alloy.go` (node-exporter install + alloy install via `DeployChart`)
+- `internal/workflows/steps/step_metallb.go`
+- `internal/workflows/steps/step_metrics_server.go`
+- `internal/workflows/steps/step_prometheus_operator_crds.go`
+- `internal/workflows/steps/step_external_secrets.go`
+- `internal/workflows/steps/step_teleport.go` — including the `cfg.Version` empty-fallback now reading from the catalog instead of `deps.TELEPORT_VERSION`
+
+### 4. Teleport `--version` flag default
+
+`cmd/weaver/commands/teleport/cluster/cluster.go:32` previously inlined `deps.TELEPORT_VERSION` in the flag's help text. It now does a one-shot catalog lookup at command construction time. If the catalog fails to load the flag is still registered and the install step surfaces a clearer error.
+
+The teleport install step preserves the `--version` flag's behaviour: when the operator passes a version that does not match the catalog default, integrity verification is skipped with a `WARN` log line (we cannot verify a checksum the catalog does not declare), and `InstallChart` is called with the catalog chart reference + version pair. This is an intentional carve-out documented as legacy in the issue.
+
+### 5. Retire all catalog-chart constants in `deps.go`
+
+The catalog rewiring also pulled in solo-operator (added to the repo in #495 after #589 was written, but shaped identically to the other cluster charts — one OCI chart, one install call, no profile-aware overrides). Adding it kept the catalog complete and avoided a known-stale outlier; block-node remains explicitly out of scope per the issue (RSL / env-override chain + storage config + migrations make it a much larger change).
+
+The `ChartMetadata` schema gains two required fields — `namespace:` and `release:` — and the catalog YAML records both for every cluster entry. Each step now resolves the full install topology from the catalog at builder time via a small panicking helper (`chartSpec(name)`); non-step consumers (`internal/alloy/manifest.go`, `internal/reality/teleport_checker.go`, `internal/rsl/teleport_runtime.go`) use `software.MustGetClusterComponent(name)`. Both helpers panic on lookup failure — the catalog is embedded and validated at load time, so a missing entry would be a build-time programming error worth crashing for, and the alternative would force every closure to propagate an error it cannot meaningfully handle.
+
+Removed from `pkg/deps/deps.go` for the eight catalog charts:
+
+- Seven `*_VERSION` constants and `SOLO_OPERATOR_VERSION`.
+- Eight `*_CHART` constants.
+- Six `*_REPO` constants.
+- Eight `*_NAMESPACE` constants and eight `*_RELEASE` constants.
+
+What remains in `pkg/deps/deps.go`: the five `BLOCK_NODE_*` constants. Block node was explicitly out of scope for #589 because its install plan flows through the RSL strategy chain (default → file → env → CLI flag), and moving it to the catalog requires deciding how the catalog interacts with that chain. The package doc comment was rewritten accordingly — it's now a short paragraph stating exactly what the file holds and why, instead of the running "what moved where" history that had accumulated.
+
+`pkg/config/global.go` previously seeded `Teleport.Version` from `deps.TELEPORT_VERSION` in both `globalConfig` and `DefaultsConfig()`. Setting these from the catalog at this layer created a hard import cycle (`pkg/config` → `pkg/software` → `internal/testutil` → `internal/proxy` → `pkg/config`). The fix: leave both fields empty here, with a comment explaining the catalog is the source of truth and the step's empty-fallback handles resolution. The corresponding unit test in `pkg/config/global_test.go` was updated to assert `Teleport.Version` is empty (catalog-driven), not a `deps` constant.
+
+### 6. Mock for `helm.Manager`
+
+Added one line to the `mocks` task in `Taskfile.yaml`:
+
+```yaml
+- mockgen -source=pkg/helm/interface.go -self_package github.com/hashgraph/solo-weaver/pkg/helm -package helm > pkg/helm/mocks_generated.go
+```
+
+The generated file matches the existing convention (mocks_generated.go is gitignored, regenerated by every CI/devbox run via `task mocks`).
+
+### 7. Tests
+
+Unit tests (`pkg/helm/puller_test.go`):
+
+- `TestPullAndVerify_UnsupportedAlgorithm` — rejects non-sha256 algorithms.
+- `TestPullAndVerify_EmptyChecksum` — rejects empty expected checksum.
+- `Test_sha256File` — sanity-checks the file digest helper.
+
+Unit tests (`internal/workflows/steps/catalog_test.go`):
+
+- `Test_resolveCatalogChart_AllStepNames` — asserts every chart name a step looks up (`metallb`, `alloy`, `node-exporter`, `metrics-server`, `prometheus-operator-crds`, `external-secrets`, `teleport-cluster-agent`) resolves and has a non-empty checksum, with classic/OCI shape validation.
+- `Test_resolveCatalogChart_UnknownName` — covers the not-found path.
+
+A full chart pull through an `httptest.Server` was scoped out as too fragile (Helm SDK requires repo config files + cache layout); the happy and mismatch paths are covered by the VM integration tests, which use real upstream registries.
+
+Integration (UTM VM) — `task vm:test:integration`: existing tests in `internal/workflows/cluster_it_test.go` and `pkg/helm/manager_it_test.go` exercise the full install path through `MetalLB` (classic) and `prometheus-operator-crds` (OCI). The pre-existing `internal/workflows/cluster_it_test.go` end-to-end test verifies all seven charts install in sequence.
+
+### 8. Out of scope confirmations
+
+- Removing the `teleport cluster install --version` flag — deferred (per issue).
+- Topology constants in `deps.go` — kept; later cleanup PR.
+- Hidden `--override-component` flag — deferred.
+- Package manifest (override file) consumption + schema differentiation between override and internal catalog — leninmehedy's review comment is noted for a follow-up, not addressed here.
+- Air-gap / bundled chart delivery — deferred.
+- Block node / consensus node / solo-operator versioning — none are yet in the catalog's `cluster:` section; deferred.
+
+## Critical files
+
+| Path | Change |
+|---|---|
+| `pkg/helm/interface.go` | Added `PullAndVerify` to `Manager` |
+| `pkg/helm/puller.go` (new) | Implementation — classic SHA256, OCI manifest digest, mismatch error |
+| `pkg/helm/puller_test.go` (new) | Unit tests for the helper |
+| `pkg/helm/manager.go` | No surface change; `PullAndVerify` takes `destDir` per call (mirrors `pkg/software.Downloader`) |
+| `internal/workflows/steps/catalog.go` | Adds `chartDownloadsDir()` helper returning `<DownloadsDir>/charts` |
+| `Taskfile.yaml` | Added mockgen line for `pkg/helm/interface.go` |
+| `pkg/deps/deps.go` | Stripped down to the `BLOCK_NODE_*` group only. All catalog-chart constants (version + chart + repo + namespace + release) removed. Package doc comment rewritten. |
+| `pkg/software/config.go` | Added `namespace:` and `release:` to `ChartMetadata` (required for cluster entries) + `MustGetClusterComponent` helper. |
+| `pkg/software/infrastructure-catalog.yaml` | New `solo-operator` entry; every cluster entry gains `namespace:` and `release:` fields |
+| `internal/alloy/manifest.go` + `render_test.go` | Read alloy namespace from catalog via `software.MustGetClusterComponent` |
+| `internal/reality/teleport_checker.go` + test | Identify teleport release/namespace from catalog |
+| `internal/rsl/teleport_runtime.go` | Seed `StrategyDefault` for namespace/release from catalog |
+| `internal/workflows/steps/step_solo_operator.go` | Catalog + PullAndVerify (was the only `helm.NewManager(helm.WithLogger(*l))` call site missed earlier — now uses `newHelmManager()`) |
+| `pkg/software/config_it_test.go` | `Test_Config_ClusterSection_Integration` covers `solo-operator` |
+| `internal/workflows/steps/catalog.go` (new) | `resolveCatalogChart` + `newHelmManager` helpers |
+| `internal/workflows/steps/catalog_test.go` (new) | Catalog↔step naming contract tests |
+| `internal/workflows/steps/step_alloy.go` | Catalog + PullAndVerify (two charts) |
+| `internal/workflows/steps/step_metallb.go` | Catalog + PullAndVerify |
+| `internal/workflows/steps/step_metrics_server.go` | Catalog + PullAndVerify |
+| `internal/workflows/steps/step_prometheus_operator_crds.go` | Catalog + PullAndVerify |
+| `internal/workflows/steps/step_external_secrets.go` | Catalog + PullAndVerify |
+| `internal/workflows/steps/step_teleport.go` | Catalog + PullAndVerify with `--version` carve-out |
+| `cmd/weaver/commands/teleport/cluster/cluster.go` | `--version` flag default from catalog |
+| `pkg/config/global.go` | Removed three `deps.TELEPORT_VERSION` references (set empty) |
+| `pkg/config/global_test.go` | Asserts `Teleport.Version` defaults to empty |
+| `docs/claude/reviews/00589-consume-charts-catalog-helm-steps.md` (new) | Review guide per CLAUDE.md §2 |
+
+Reused (no change): `pkg/software/config.go` (`LoadInfrastructureCatalog`, `GetClusterComponent`, `ChartMetadata.GetDefaultVersion`, `ChartMetadata.Versions`), `pkg/helm/manager.go` (existing `InstallChart`/`DeployChart`/`UpgradeChart` accept local `.tgz` paths via `LocateChart`).
+
+## Verification
+
+1. `task lint` — formats cleanly.
+2. `go test ./pkg/helm/... ./pkg/config/... ./pkg/deps/...` — passes locally on macOS.
+3. `task vm:test:unit` — passes inside the UTM VM (Linux-only packages compile).
+4. `task vm:test:integration` — `MetalLB` (classic) and `prometheus-operator-crds` (OCI) install end-to-end with verification.
+5. Manual UAT on the UTM VM: `solo-provisioner kube cluster install --profile local` succeeds and the logs show `Helm chart pulled and verified` (with `algorithm`, `checksum`) for each of the seven charts.
+6. Grep guard: `grep -rn 'deps\.\(ALLOY\|METALLB\|METRICS_SERVER\|NODE_EXPORTER\|PROMETHEUS_OPERATOR_CRDS\|EXTERNAL_SECRETS\|TELEPORT\)_VERSION'` returns no matches.
+7. Review guide written at `docs/claude/reviews/00589-consume-charts-catalog-helm-steps.md`.

--- a/docs/claude/reviews/00589-consume-charts-catalog-helm-steps.md
+++ b/docs/claude/reviews/00589-consume-charts-catalog-helm-steps.md
@@ -1,0 +1,192 @@
+# Review guide — #589: consume catalog for Helm steps, verify chart integrity
+
+## Summary
+
+Phase 3 of the infrastructure-catalog refactor. The six Helm workflow steps under
+`internal/workflows/steps/` (alloy + node-exporter, metallb, metrics-server,
+prometheus-operator-crds, external-secrets, teleport) now read their chart
+version, repo, and reference from `pkg/software/infrastructure-catalog.yaml`
+(populated in Phase 2 — #588) instead of the `*_VERSION` constants in
+`pkg/deps/deps.go`. The seven chart-version constants are removed.
+
+Each install also pulls the chart through a new `helm.Manager.PullAndVerify`
+method which downloads the chart to `<WeaverPaths.DownloadsDir>/charts`
+(default `/opt/solo/weaver/downloads/charts`), computes SHA256 of the `.tgz`
+(classic) or reads the OCI manifest digest from the registry client (OCI),
+and aborts the step on mismatch with the catalog-recorded checksum. The local
+`.tgz` path is then passed to `InstallChart`/`DeployChart`/`UpgradeChart` so
+there is no second network pull.
+
+The teleport `cluster install --version` flag still works; its default now
+comes from the catalog. Integrity verification is skipped (with a WARN log
+line) only when the operator explicitly pins a non-catalog version, since the
+catalog has no checksum to compare against.
+
+## Changed files
+
+| File | Description |
+|------|-------------|
+| `pkg/helm/interface.go` | Adds `PullAndVerify(ctx, chartRef, version, algorithm, expectedChecksum) (string, error)` to `Manager`. |
+| `pkg/helm/puller.go` (new) | SDK-based implementation: classic via `action.NewPull` + `sha256.Sum256` of the .tgz; OCI via `registry.Client.Pull` + manifest digest. Returns `helm.ErrChecksumMismatch` on mismatch. Takes `destDir` as a parameter and creates it on demand (mode 0o755). |
+| `pkg/helm/manager.go` | No surface change. (`PullAndVerify` is a new method on `Manager`; the destination dir is a parameter, not Manager state — mirrors `pkg/software.Downloader.Download(url, destination)`.) |
+| `pkg/helm/puller_test.go` (new) | Unit tests for algorithm validation, empty-checksum guard, and the SHA256 helper. |
+| `Taskfile.yaml` | Adds `mockgen -source=pkg/helm/interface.go ...` line so step unit tests can mock `helm.Manager`. |
+| `pkg/deps/deps.go` | Stripped to the `BLOCK_NODE_*` group only. All eight catalog charts' constants — version, chart, repo, namespace, release — moved to the catalog. Package doc comment rewritten. |
+| `pkg/software/config.go` | `ChartMetadata` gains `namespace:` and `release:` (required for cluster entries, validated at load time). New `software.MustGetClusterComponent(name) *ChartMetadata` panics if the catalog can't load or the name isn't present — used by callers outside `internal/workflows/steps/` that read catalog entries by literal name. |
+| `pkg/software/infrastructure-catalog.yaml` | New `solo-operator` entry (OCI, `0.3.1`, manifest digest `b77cb6…6a73a`). Every cluster entry now declares `namespace:` and `release:`. Catalog covers all eight cluster charts we install. |
+| `internal/workflows/steps/catalog.go` | New `chartSpec(name) *helmChartSpec` panicking helper alongside the existing `resolveCatalogChart`; `helmChartSpec` gains `Namespace`/`Release` fields. |
+| `internal/workflows/steps/step_solo_operator.go` | Catalog + PullAndVerify + `newHelmManager()`. |
+| `internal/alloy/manifest.go` + `internal/alloy/render_test.go` | Read alloy namespace from the catalog (was `deps.ALLOY_NAMESPACE`). |
+| `internal/reality/teleport_checker.go` + test | Resolve teleport release/namespace from the catalog. |
+| `internal/rsl/teleport_runtime.go` | `StrategyDefault` for namespace/release sourced from the catalog. |
+| `pkg/software/config_it_test.go` | `Test_Config_ClusterSection_Integration` covers `solo-operator` (8 charts). |
+| `internal/workflows/steps/catalog.go` (new) | `resolveCatalogChart(name)` resolves the install plan (chart, version, algorithm, checksum, repo, type) from the catalog; `newHelmManager()` constructs `helm.Manager` with the shared downloads-dir option. |
+| `internal/workflows/steps/catalog_test.go` (new) | Asserts every chart name a step looks up resolves in the catalog with sha256 + non-empty checksum and the right classic/OCI shape. |
+| `internal/workflows/steps/step_alloy.go` | Both node-exporter and alloy install paths read from the catalog and call PullAndVerify. AddRepo for alloy now sources the URL from the catalog. |
+| `internal/workflows/steps/step_metallb.go` | Catalog + PullAndVerify; the `"v"` version-prefix workaround is removed (catalog versions match upstream chart-index entries). |
+| `internal/workflows/steps/step_metrics_server.go` | Catalog + PullAndVerify; same `"v"` prefix removed. |
+| `internal/workflows/steps/step_prometheus_operator_crds.go` | Catalog + PullAndVerify (OCI). |
+| `internal/workflows/steps/step_external_secrets.go` | Catalog + PullAndVerify; same `"v"` prefix removed. |
+| `internal/workflows/steps/step_teleport.go` | Catalog + PullAndVerify with the `--version` carve-out: if operator-pinned and non-catalog, install proceeds without verification (WARN log). |
+| `cmd/weaver/commands/teleport/cluster/cluster.go` | `--version` flag default comes from the catalog (or empty if the catalog fails to load). |
+| `pkg/config/global.go` | Removes three `deps.TELEPORT_VERSION` references; `Teleport.Version` defaults to empty (step has a catalog fallback). Avoids the pkg/config → pkg/software → internal/proxy → pkg/config import cycle. |
+| `pkg/config/global_test.go` | `TestDefaultsConfig_ReturnsDepsConstants` now asserts `Teleport.Version` is empty (catalog-driven). |
+| `docs/claude/plans/00589-consume-charts-catalog-helm-steps.md` (new) | Implementation plan. |
+
+## Code review checklist
+
+- [ ] No file outside this PR's tests references `deps.ALLOY_VERSION`, `deps.METALLB_VERSION`, `deps.METRICS_SERVER_VERSION`, `deps.NODE_EXPORTER_VERSION`, `deps.PROMETHEUS_OPERATOR_CRDS_VERSION`, `deps.EXTERNAL_SECRETS_VERSION`, or `deps.TELEPORT_VERSION` (grep guard — see Tests).
+- [ ] `pkg/deps/deps.go` contains only the `BLOCK_NODE_*` group. Every other constant for the eight catalog charts (version, chart, repo, namespace, release) is gone.
+- [ ] The package doc comment in `pkg/deps/deps.go` explains both what's there (block-node) and why (RSL strategy chain), nothing else.
+- [ ] Every step builder calls `chartSpec("<name>")` at the top of the function and the closures read `spec.Namespace` / `spec.Release` (no `deps.*` references for the eight catalog charts anywhere in `internal/workflows/steps/`).
+- [ ] Non-step consumers (`internal/alloy/manifest.go`, `internal/reality/teleport_checker.go`, `internal/rsl/teleport_runtime.go`) use `software.MustGetClusterComponent(name)` rather than `deps.*` constants.
+- [ ] `ChartMetadata` schema validation requires non-empty `namespace:` and `release:` for every cluster entry; an entry missing either fails to load.
+- [ ] Every Helm `InstallChart`/`DeployChart`/`UpgradeChart` call in the six steps is preceded by `hm.PullAndVerify(...)` and receives the returned local `.tgz` path as `chartRef` (with `chartVersion == ""`).
+- [ ] Step→catalog name contract: each step calls `resolveCatalogChart` with the exact name present in `cluster:` (`metallb`, `alloy`, `node-exporter`, `metrics-server`, `prometheus-operator-crds`, `external-secrets`, `teleport-cluster-agent`, `solo-operator`). `Test_resolveCatalogChart_AllStepNames` enforces this.
+- [ ] `PullAndVerify` uses the Helm Go SDK (no shell-out to `helm`). Classic computes SHA256 of the pulled `.tgz`; OCI reads `PullResult.Manifest.Digest` and strips the `sha256:` prefix.
+- [ ] Mismatch returns `helm.ErrChecksumMismatch` and includes both the expected and observed values in the message.
+- [ ] Algorithm other than `sha256` is rejected with a clear error; empty `expectedChecksum` is rejected.
+- [ ] Each step passes `chartDownloadsDir()` (`internal/workflows/steps/catalog.go`) as `destDir` so verified `.tgz` artifacts land in `<WeaverPaths.DownloadsDir>/charts`. The destination is a per-call parameter; `helm.Manager` holds no path state. Unit tests pass `t.TempDir()`.
+- [ ] `cmd/weaver/commands/teleport/cluster/cluster.go` registers the `--version` flag even when the catalog fails to load (the install step surfaces the catalog error then).
+- [ ] Teleport step skips verification only when the operator explicitly pins a version that differs from the catalog default; the WARN log line identifies the pinned version.
+- [ ] `pkg/config/global.go` does NOT import `pkg/software` (would create an import cycle via `internal/testutil` → `internal/proxy`). The comment near the Teleport defaults explains why.
+- [ ] Generated mock at `pkg/helm/mocks_generated.go` is present after `task mocks` (gitignored).
+- [ ] The `"v"`-prefix workaround was removed from the metallb / metrics-server / external-secrets steps. Catalog versions match upstream chart-index entries directly (same convention as `scripts/chart-checksums`).
+
+## Tests
+
+Unit tests on macOS for the packages we changed:
+
+```bash
+go test -race -tags='!integration' ./pkg/helm/... ./pkg/config/... ./pkg/deps/...
+```
+
+Full unit suite (Linux-only step package needs the UTM VM):
+
+```bash
+task vm:test:unit
+```
+
+Targeted integration tests for the install path (classic + OCI) in the VM:
+
+```bash
+task vm:test:integration TEST_NAME='^Test_SetupMetalLB_Integration$|^Test_PrometheusOperatorCRDs_Integration$'
+```
+
+Full integration suite (slow):
+
+```bash
+task vm:test:integration
+```
+
+Grep guard — must return no matches:
+
+```bash
+grep -rn 'deps\.\(ALLOY\|METALLB\|METRICS_SERVER\|NODE_EXPORTER\|PROMETHEUS_OPERATOR_CRDS\|EXTERNAL_SECRETS\|TELEPORT\)_VERSION' --include='*.go'
+```
+
+Lint:
+
+```bash
+task lint
+```
+
+## Manual UAT
+
+1. **Build the binary**
+
+   ```bash
+   task build:weaver GOOS=linux GOARCH=amd64
+   ```
+
+   Expected: `bin/solo-provisioner-linux-amd64` is produced without errors.
+
+2. **Inspect the `--version` flag default for teleport cluster**
+
+   ```bash
+   ./bin/solo-provisioner-linux-amd64 teleport cluster install --help | grep version
+   ```
+
+   Expected:
+
+   ```
+       --version string   Teleport Helm chart version (default: 18.6.4)
+   ```
+
+   The `18.6.4` value is read from `pkg/software/infrastructure-catalog.yaml` at runtime.
+
+3. **Fresh cluster install on the VM**
+
+   ```bash
+   task vm:start
+   ssh weaver-vm sudo /usr/local/bin/solo-provisioner kube cluster install --profile local --node-type=block --non-interactive
+   ```
+
+   Expected: the install succeeds and the logs include one `Helm chart pulled and verified` line per chart with the matching algorithm and checksum, e.g.:
+
+   ```
+   INF Helm chart pulled and verified algorithm=sha256 chart=metallb/metallb checksum=4f0fc313cd97819a1c78fff0a389dfe1c9f98bc490f33f521317475df1d7b873 version=0.15.2
+   ```
+
+4. **Inspect persisted artifacts**
+
+   ```bash
+   ssh weaver-vm ls -la /opt/solo/weaver/downloads/charts
+   ```
+
+   Expected: every installed chart appears as `<name>-<version>.tgz` (e.g. `metallb-0.15.2.tgz`, `prometheus-operator-crds-24.0.1.tgz`).
+
+5. **Negative path — tampered checksum** (optional manual check)
+
+   Edit one byte of the `checksum:` value for a chart in `pkg/software/infrastructure-catalog.yaml`, rebuild, run install:
+
+   ```bash
+   task build:weaver GOOS=linux GOARCH=amd64
+   ssh weaver-vm sudo /usr/local/bin/solo-provisioner kube cluster install --profile local
+   ```
+
+   Expected: the step aborts with `helm.checksum_mismatch ... expected sha256=<patched> got sha256=<real>` and the cluster is left in a clean state. Revert the catalog edit afterward.
+
+6. **Teleport pinned version (legacy carve-out)**
+
+   ```bash
+   ssh weaver-vm sudo /usr/local/bin/solo-provisioner teleport cluster install --version 18.6.3 --values /etc/weaver/teleport.yaml
+   ```
+
+   Expected: the install proceeds without verification and the log contains `Skipping chart integrity verification for operator-pinned Teleport version`.
+
+7. **Default version (catalog-driven) still works**
+
+   ```bash
+   ssh weaver-vm sudo /usr/local/bin/solo-provisioner teleport cluster install --values /mnt/solo-weaver/test/teleport/teleport-values-local.yaml --non-interactive
+   ```
+
+   Expected: same as #3 but for teleport — a `Helm chart pulled and verified` line shows `version=18.6.4` and the catalog checksum.
+
+8. **Cluster uninstall still cleans up**
+
+   ```bash
+   ssh weaver-vm sudo /usr/local/bin/solo-provisioner kube cluster uninstall --profile local
+   ```
+
+   Expected: no errors. Uninstall paths still use `deps.X_RELEASE` / `deps.X_NAMESPACE`, which were not touched.

--- a/internal/alloy/manifest.go
+++ b/internal/alloy/manifest.go
@@ -6,8 +6,15 @@ import (
 	"sort"
 
 	"github.com/hashgraph/solo-weaver/internal/templates"
-	"github.com/hashgraph/solo-weaver/pkg/deps"
+	"github.com/hashgraph/solo-weaver/pkg/software"
 )
+
+// alloyNamespace returns the namespace Alloy deploys into, as recorded in
+// the infrastructure catalog. The catalog is embedded and validated, so a
+// missing entry would be a build-time programming error.
+func alloyNamespace() string {
+	return software.MustGetClusterComponent("alloy").Namespace
+}
 
 // ConfigMapTemplateData holds data for the ConfigMap template.
 type ConfigMapTemplateData struct {
@@ -45,7 +52,7 @@ func ConfigMapManifest(modules []ModuleConfig) (string, error) {
 
 	data := ConfigMapTemplateData{
 		ConfigMapName: ConfigMapName,
-		Namespace:     deps.ALLOY_NAMESPACE,
+		Namespace:     alloyNamespace(),
 		Modules:       templateModules,
 	}
 
@@ -107,7 +114,7 @@ type NamespaceTemplateData struct {
 // Uses the namespace.yaml template file.
 func NamespaceManifest() (string, error) {
 	data := NamespaceTemplateData{
-		Namespace: deps.ALLOY_NAMESPACE,
+		Namespace: alloyNamespace(),
 	}
 
 	return templates.Render("files/alloy/namespace.yaml", data)

--- a/internal/alloy/render_test.go
+++ b/internal/alloy/render_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -368,7 +367,7 @@ func TestConfigMapManifest(t *testing.T) {
 	assert.Contains(t, manifest, "apiVersion: v1")
 	assert.Contains(t, manifest, "kind: ConfigMap")
 	assert.Contains(t, manifest, "name: "+ConfigMapName)
-	assert.Contains(t, manifest, "namespace: "+deps.ALLOY_NAMESPACE)
+	assert.Contains(t, manifest, "namespace: "+alloyNamespace())
 
 	// Verify main config.alloy is present with concatenated content
 	assert.Contains(t, manifest, "config.alloy: |")
@@ -431,7 +430,7 @@ func TestNamespaceManifest(t *testing.T) {
 	// Verify it's a valid namespace manifest
 	assert.Contains(t, manifest, "apiVersion: v1")
 	assert.Contains(t, manifest, "kind: Namespace")
-	assert.Contains(t, manifest, "name: "+deps.ALLOY_NAMESPACE)
+	assert.Contains(t, manifest, "name: "+alloyNamespace())
 }
 
 func TestBuildHelmEnvVars_DefaultSecret(t *testing.T) {

--- a/internal/reality/teleport_checker.go
+++ b/internal/reality/teleport_checker.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/state"
-	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/software"
 	"github.com/joomcode/errorx"
 	htime "helm.sh/helm/v3/pkg/time"
@@ -93,8 +92,9 @@ func (t *teleportChecker) refreshClusterAgentState() (state.TeleportClusterAgent
 		return state.TeleportClusterAgentState{}, errorx.IllegalState.Wrap(err, "failed to list helm releases")
 	}
 
+	teleportChart := software.MustGetClusterComponent("teleport-cluster-agent")
 	for _, rel := range releases {
-		if rel.Name == deps.TELEPORT_RELEASE && rel.Namespace == deps.TELEPORT_NAMESPACE {
+		if rel.Name == teleportChart.Release && rel.Namespace == teleportChart.Namespace {
 			return state.TeleportClusterAgentState{
 				Installed:    true,
 				Release:      rel.Name,

--- a/internal/reality/teleport_checker_test.go
+++ b/internal/reality/teleport_checker_test.go
@@ -9,12 +9,16 @@ import (
 
 	"github.com/hashgraph/solo-weaver/internal/reality"
 	"github.com/hashgraph/solo-weaver/internal/state"
-	"github.com/hashgraph/solo-weaver/pkg/deps"
+	"github.com/hashgraph/solo-weaver/pkg/software"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
 )
+
+func teleportCatalogChart() *software.ChartMetadata {
+	return software.MustGetClusterComponent("teleport-cluster-agent")
+}
 
 // fakeHelmManager implements reality.HelmManager for testing.
 type fakeHelmManager struct {
@@ -61,12 +65,13 @@ func TestTeleportChecker_HelmReleasePresent_ClusterAgentInstalled(t *testing.T) 
 	sm := newTeleportTestStateManager(t)
 
 	clusterExists := func() (bool, error) { return true, nil }
+	teleport := teleportCatalogChart()
 	newHelm := func() (reality.HelmManager, error) {
 		return &fakeHelmManager{
 			releases: []*release.Release{
 				{
-					Name:      deps.TELEPORT_RELEASE,
-					Namespace: deps.TELEPORT_NAMESPACE,
+					Name:      teleport.Release,
+					Namespace: teleport.Namespace,
 					Chart: &chart.Chart{
 						Metadata: &chart.Metadata{
 							Version: "18.6.4",
@@ -84,8 +89,8 @@ func TestTeleportChecker_HelmReleasePresent_ClusterAgentInstalled(t *testing.T) 
 	require.NoError(t, err)
 
 	assert.True(t, ts.ClusterAgent.Installed, "ClusterAgent should be installed when Helm release is present")
-	assert.Equal(t, deps.TELEPORT_RELEASE, ts.ClusterAgent.Release)
-	assert.Equal(t, deps.TELEPORT_NAMESPACE, ts.ClusterAgent.Namespace)
+	assert.Equal(t, teleport.Release, ts.ClusterAgent.Release)
+	assert.Equal(t, teleport.Namespace, ts.ClusterAgent.Namespace)
 	assert.Equal(t, "18.6.4", ts.ClusterAgent.ChartVersion)
 }
 

--- a/internal/rsl/teleport_runtime.go
+++ b/internal/rsl/teleport_runtime.go
@@ -11,8 +11,8 @@ import (
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/reality"
 	"github.com/hashgraph/solo-weaver/internal/state"
-	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/hashgraph/solo-weaver/pkg/software"
 	"github.com/joomcode/errorx"
 	htime "helm.sh/helm/v3/pkg/time"
 )
@@ -275,10 +275,11 @@ func NewTeleportRuntimeResolver(
 		return nil, errorx.IllegalState.Wrap(err, "failed to create releaseName resolver")
 	}
 
-	// Seed namespace and releaseName defaults from deps constants
-	// (these are not user-configurable via config or CLI)
-	setOrClearString(tr.namespace, StrategyDefault, deps.TELEPORT_NAMESPACE)
-	setOrClearString(tr.releaseName, StrategyDefault, deps.TELEPORT_RELEASE)
+	// Seed namespace and releaseName defaults from the infrastructure catalog
+	// (these are not user-configurable via config or CLI).
+	teleportChart := software.MustGetClusterComponent("teleport-cluster-agent")
+	setOrClearString(tr.namespace, StrategyDefault, teleportChart.Namespace)
+	setOrClearString(tr.releaseName, StrategyDefault, teleportChart.Release)
 
 	// Initialize sources from config and state
 	tr.WithConfig(cfg)

--- a/internal/workflows/steps/catalog.go
+++ b/internal/workflows/steps/catalog.go
@@ -5,6 +5,7 @@ package steps
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/pkg/helm"
@@ -47,6 +48,7 @@ type helmChartSpec struct {
 	Algorithm string             // checksum algorithm (currently always sha256)
 	Checksum  string             // expected checksum value (hex, no prefix)
 	Repo      string             // classic-only repository URL; empty for OCI
+	RepoAlias string             // classic-only Helm repo alias derived from chartRef; empty for OCI
 	Namespace string             // Kubernetes namespace to install into
 	Release   string             // Helm release name
 	Type      software.ChartType // classic vs oci, to gate repo-add side-effects
@@ -96,8 +98,24 @@ func resolveCatalogChart(name string) (*helmChartSpec, error) {
 		Algorithm: sum.Algorithm,
 		Checksum:  sum.Value,
 		Repo:      meta.Repo,
+		RepoAlias: classicRepoAlias(meta),
 		Namespace: meta.Namespace,
 		Release:   meta.Release,
 		Type:      meta.Type,
 	}, nil
+}
+
+// classicRepoAlias derives the Helm repo alias from the chart reference for
+// classic charts. Helm's classic-repo chartRef is "<alias>/<chartName>", and
+// the alias must match a previously-registered repo for `helm pull` to
+// resolve the URL. Returns "" for OCI charts since AddRepo is not used on
+// that path.
+func classicRepoAlias(meta *software.ChartMetadata) string {
+	if meta.Type != software.ChartTypeClassic {
+		return ""
+	}
+	if i := strings.Index(meta.Chart, "/"); i > 0 {
+		return meta.Chart[:i]
+	}
+	return ""
 }

--- a/internal/workflows/steps/catalog.go
+++ b/internal/workflows/steps/catalog.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/pkg/helm"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/hashgraph/solo-weaver/pkg/software"
+)
+
+// chartDownloadsSubdir is the subdirectory of WeaverPaths.DownloadsDir where
+// PullAndVerify writes verified Helm chart archives. Keeping pulled charts
+// under the shared downloads tree (rather than a temp dir) lets operators
+// inspect the on-disk artifacts after an install/upgrade and lines up with
+// other downloaded artifacts (binaries, archives) the provisioner manages.
+const chartDownloadsSubdir = "charts"
+
+// newHelmManager constructs the helm.Manager every workflow step uses to
+// drive a chart lifecycle. Centralising the construction here keeps the
+// step call sites compact and gives us a single place to tweak shared
+// helm.Manager options in the future.
+func newHelmManager() (helm.Manager, error) {
+	l := logx.As()
+	return helm.NewManager(helm.WithLogger(*l))
+}
+
+// chartDownloadsDir returns the destination directory PullAndVerify writes
+// chart archives into. It mirrors pkg/software/base_installer.go which uses
+// models.Paths().DownloadsDir for host artifacts — charts land in a
+// "charts" subdirectory of the same tree so operators can find everything
+// solo-provisioner has fetched in one place.
+func chartDownloadsDir() string {
+	return path.Join(models.Paths().DownloadsDir, chartDownloadsSubdir)
+}
+
+// helmChartSpec is the install plan for a single Helm chart, resolved from
+// the infrastructure catalog at step-execution time. It captures the version,
+// integrity, and installation-topology values the catalog declares as
+// authoritative, so workflow steps no longer pin any of these in code.
+type helmChartSpec struct {
+	Chart     string             // chartRef (e.g. "metallb/metallb" or "oci://...")
+	Version   string             // default version from the catalog
+	Algorithm string             // checksum algorithm (currently always sha256)
+	Checksum  string             // expected checksum value (hex, no prefix)
+	Repo      string             // classic-only repository URL; empty for OCI
+	Namespace string             // Kubernetes namespace to install into
+	Release   string             // Helm release name
+	Type      software.ChartType // classic vs oci, to gate repo-add side-effects
+}
+
+// chartSpec returns the install plan for a named cluster component. It
+// panics if the catalog can't be loaded or the name isn't present in
+// `cluster:` — both conditions are impossible at runtime because the
+// catalog is embedded into the binary and validated at load time. The
+// only way this panics is a build-time programming error (e.g. a step
+// referencing a name that does not exist in the catalog), and panicking
+// in that case is preferable to returning an error every step has to
+// thread through closures it cannot meaningfully handle.
+func chartSpec(name string) *helmChartSpec {
+	spec, err := resolveCatalogChart(name)
+	if err != nil {
+		panic(fmt.Sprintf("infrastructure catalog: chart %q: %v", name, err))
+	}
+	return spec
+}
+
+// resolveCatalogChart loads the embedded infrastructure catalog and returns
+// the install plan for the named cluster component. Returning an error
+// (rather than panicking) lets tests assert on misconfigurations; production
+// callers should prefer chartSpec, which crashes loudly on the same
+// impossible-in-practice conditions.
+func resolveCatalogChart(name string) (*helmChartSpec, error) {
+	catalog, err := software.LoadInfrastructureCatalog()
+	if err != nil {
+		return nil, fmt.Errorf("load infrastructure catalog: %w", err)
+	}
+	meta, err := catalog.GetClusterComponent(name)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: %w", err)
+	}
+	version, err := meta.GetDefaultVersion()
+	if err != nil {
+		return nil, fmt.Errorf("catalog: %w", err)
+	}
+	sum, ok := meta.Versions[software.Version(version)]
+	if !ok {
+		return nil, fmt.Errorf("catalog: chart %q version %q has no checksum entry", name, version)
+	}
+	return &helmChartSpec{
+		Chart:     meta.Chart,
+		Version:   version,
+		Algorithm: sum.Algorithm,
+		Checksum:  sum.Value,
+		Repo:      meta.Repo,
+		Namespace: meta.Namespace,
+		Release:   meta.Release,
+		Type:      meta.Type,
+	}, nil
+}

--- a/internal/workflows/steps/catalog_test.go
+++ b/internal/workflows/steps/catalog_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/pkg/software"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_resolveCatalogChart_AllStepNames asserts that every catalog name the
+// Helm workflow steps look up in Phase 3 (issue #589) is present in the
+// embedded infrastructure catalog, with all integrity fields populated.
+// This guards the implicit contract between step source and catalog YAML —
+// renaming a cluster entry without updating both is otherwise only caught at
+// runtime when the install step fires.
+func Test_resolveCatalogChart_AllStepNames(t *testing.T) {
+	// Names must match the strings each step passes to resolveCatalogChart.
+	names := []string{
+		"alloy",
+		"node-exporter",
+		"metallb",
+		"metrics-server",
+		"prometheus-operator-crds",
+		"external-secrets",
+		"teleport-cluster-agent",
+		"solo-operator",
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			spec, err := resolveCatalogChart(name)
+			require.NoError(t, err)
+			require.NotNil(t, spec)
+			assert.NotEmpty(t, spec.Chart, "chart reference must be set")
+			assert.NotEmpty(t, spec.Version, "default version must be resolved")
+			assert.Equal(t, "sha256", spec.Algorithm)
+			assert.NotEmpty(t, spec.Checksum)
+			assert.NotEmpty(t, spec.Namespace, "namespace must be set")
+			assert.NotEmpty(t, spec.Release, "release must be set")
+			switch spec.Type {
+			case software.ChartTypeClassic:
+				assert.NotEmpty(t, spec.Repo, "classic charts must declare a repo")
+			case software.ChartTypeOCI:
+				assert.Empty(t, spec.Repo, "oci charts must not declare a separate repo")
+			default:
+				t.Fatalf("unexpected chart type %q", spec.Type)
+			}
+		})
+	}
+}
+
+func Test_resolveCatalogChart_UnknownName(t *testing.T) {
+	_, err := resolveCatalogChart("does-not-exist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does-not-exist")
+}

--- a/internal/workflows/steps/catalog_test.go
+++ b/internal/workflows/steps/catalog_test.go
@@ -3,6 +3,7 @@
 package steps
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashgraph/solo-weaver/pkg/software"
@@ -42,8 +43,17 @@ func Test_resolveCatalogChart_AllStepNames(t *testing.T) {
 			switch spec.Type {
 			case software.ChartTypeClassic:
 				assert.NotEmpty(t, spec.Repo, "classic charts must declare a repo")
+				// RepoAlias is what AddRepo registers the repo under and
+				// must match the prefix of the chartRef so `helm pull
+				// <alias>/<name>` resolves. A drift between the two would
+				// surface at install time as "repo X not found".
+				require.NotEmpty(t, spec.RepoAlias, "classic charts must derive a repo alias")
+				prefix, _, ok := strings.Cut(spec.Chart, "/")
+				require.True(t, ok, "classic chartRef must be <alias>/<chart>")
+				assert.Equal(t, prefix, spec.RepoAlias)
 			case software.ChartTypeOCI:
 				assert.Empty(t, spec.Repo, "oci charts must not declare a separate repo")
+				assert.Empty(t, spec.RepoAlias, "oci charts have no repo alias")
 			default:
 				t.Fatalf("unexpected chart type %q", spec.Type)
 			}

--- a/internal/workflows/steps/step_alloy.go
+++ b/internal/workflows/steps/step_alloy.go
@@ -419,7 +419,7 @@ func installAlloy() automa.Builder {
 				l.Info().Msg("Installing Grafana Alloy")
 			}
 
-			_, err = hm.AddRepo(spec.Release, spec.Repo, helm.RepoAddOptions{})
+			_, err = hm.AddRepo(spec.RepoAlias, spec.Repo, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_alloy.go
+++ b/internal/workflows/steps/step_alloy.go
@@ -14,7 +14,6 @@ import (
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/alloy"
 	"github.com/hashgraph/solo-weaver/pkg/config"
-	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 
 	"github.com/hashgraph/solo-weaver/internal/kube"
@@ -82,6 +81,7 @@ func TeardownAlloyStack() *automa.WorkflowBuilder {
 // preCheckAlloy verifies that all prerequisites are in place before installing Alloy.
 // This includes verifying that required K8s secrets exist and that remote endpoints are reachable.
 func preCheckAlloy() automa.Builder {
+	spec := chartSpec("alloy")
 	return automa.NewStepBuilder().WithId(PreCheckAlloyStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			cfg := config.Get().Alloy
@@ -109,17 +109,17 @@ func preCheckAlloy() automa.Builder {
 				// Verify that required K8s secrets exist with expected keys
 				requiredSecrets := cb.RequiredSecrets()
 				for secretName, expectedKeys := range requiredSecrets {
-					actualKeys, err := k.GetSecretKeys(ctx, deps.ALLOY_NAMESPACE, secretName)
+					actualKeys, err := k.GetSecretKeys(ctx, spec.Namespace, secretName)
 					if err != nil {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
-							fmt.Errorf("failed to read K8s Secret %q in namespace %q: %w", secretName, deps.ALLOY_NAMESPACE, err)))
+							fmt.Errorf("failed to read K8s Secret %q in namespace %q: %w", secretName, spec.Namespace, err)))
 					}
 					if actualKeys == nil {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
 							fmt.Errorf("K8s Secret %q not found in namespace %q; expected keys: %v. "+
 								"Create the secret before installing Alloy, e.g.: "+
 								"kubectl create secret generic %s --namespace=%s --from-literal=<KEY>=<password>",
-								secretName, deps.ALLOY_NAMESPACE, expectedKeys, secretName, deps.ALLOY_NAMESPACE)))
+								secretName, spec.Namespace, expectedKeys, secretName, spec.Namespace)))
 					}
 
 					// Check that all expected keys are present in the secret
@@ -136,10 +136,10 @@ func preCheckAlloy() automa.Builder {
 					if len(missingKeys) > 0 {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
 							fmt.Errorf("K8s Secret %q in namespace %q is missing required keys: %v; found keys: %v",
-								secretName, deps.ALLOY_NAMESPACE, missingKeys, actualKeys)))
+								secretName, spec.Namespace, missingKeys, actualKeys)))
 					}
 
-					l.Info().Str("name", secretName).Str("namespace", deps.ALLOY_NAMESPACE).Strs("expectedKeys", expectedKeys).Msg("Required K8s Secret found")
+					l.Info().Str("name", secretName).Str("namespace", spec.Namespace).Strs("expectedKeys", expectedKeys).Msg("Required K8s Secret found")
 				}
 
 				// Check Prometheus remote endpoints reachability
@@ -224,16 +224,17 @@ func SetupAlloy() *automa.WorkflowBuilder {
 }
 
 func installNodeExporter() automa.Builder {
+	spec := chartSpec("node-exporter")
 	return automa.NewStepBuilder().WithId(InstallNodeExporterStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(deps.NODE_EXPORTER_RELEASE, deps.NODE_EXPORTER_NAMESPACE)
+			isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -242,6 +243,11 @@ func installNodeExporter() automa.Builder {
 				meta[AlreadyInstalled] = "true"
 				l.Info().Msg("Node Exporter is already installed, skipping installation")
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
+			}
+
+			localChart, err := hm.PullAndVerify(ctx, chartDownloadsDir(), spec.Chart, spec.Version, spec.Algorithm, spec.Checksum)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			helmValues := []string{
@@ -260,10 +266,10 @@ func installNodeExporter() automa.Builder {
 
 			_, err = hm.InstallChart(
 				ctx,
-				deps.NODE_EXPORTER_RELEASE,
-				deps.NODE_EXPORTER_CHART,
-				deps.NODE_EXPORTER_VERSION,
-				deps.NODE_EXPORTER_NAMESPACE,
+				spec.Release,
+				localChart,
+				"",
+				spec.Namespace,
 				helm.InstallChartOptions{
 					ValueOpts: &values.Options{
 						Values: helmValues,
@@ -288,13 +294,12 @@ func installNodeExporter() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(deps.NODE_EXPORTER_RELEASE, deps.NODE_EXPORTER_NAMESPACE)
+			err = hm.UninstallChart(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -314,6 +319,7 @@ func installNodeExporter() automa.Builder {
 }
 
 func isNodeExporterPodsReady() automa.Builder {
+	spec := chartSpec("node-exporter")
 	return automa.NewStepBuilder().WithId(IsNodeExporterReadyStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			k, err := kube.NewClient()
@@ -323,7 +329,7 @@ func isNodeExporterPodsReady() automa.Builder {
 
 			meta := map[string]string{}
 			// wait for node-exporter pods to be ready
-			err = k.WaitForResources(ctx, kube.KindPod, deps.NODE_EXPORTER_NAMESPACE, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "node-exporter"})
+			err = k.WaitForResources(ctx, kube.KindPod, spec.Namespace, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "node-exporter"})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -385,12 +391,13 @@ func createAlloyNamespace() automa.Builder {
 }
 
 func installAlloy() automa.Builder {
+	spec := chartSpec("alloy")
 	return automa.NewStepBuilder().WithId(InstallAlloyStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			cfg := config.Get().Alloy
 
 			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -398,7 +405,7 @@ func installAlloy() automa.Builder {
 			meta := map[string]string{}
 
 			// Check if already installed to provide better logging and track for rollback
-			isInstalled, err := hm.IsInstalled(deps.ALLOY_RELEASE, deps.ALLOY_NAMESPACE)
+			isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
 			if err != nil {
 				l.Warn().Err(err).Msg("Failed to check if Grafana Alloy is installed, proceeding with install/upgrade")
 			}
@@ -412,7 +419,12 @@ func installAlloy() automa.Builder {
 				l.Info().Msg("Installing Grafana Alloy")
 			}
 
-			_, err = hm.AddRepo("grafana", deps.ALLOY_REPO, helm.RepoAddOptions{})
+			_, err = hm.AddRepo(spec.Release, spec.Repo, helm.RepoAddOptions{})
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			localChart, err := hm.PullAndVerify(ctx, chartDownloadsDir(), spec.Chart, spec.Version, spec.Algorithm, spec.Checksum)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -441,10 +453,10 @@ func installAlloy() automa.Builder {
 			// This will install if not present, or upgrade if already installed
 			_, err = hm.DeployChart(
 				ctx,
-				deps.ALLOY_RELEASE,
-				deps.ALLOY_CHART,
-				deps.ALLOY_VERSION,
-				deps.ALLOY_NAMESPACE,
+				spec.Release,
+				localChart,
+				"",
+				spec.Namespace,
 				helm.DeployChartOptions{
 					ValueOpts: &values.Options{
 						Values: helmValues,
@@ -475,13 +487,12 @@ func installAlloy() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(deps.ALLOY_RELEASE, deps.ALLOY_NAMESPACE)
+			err = hm.UninstallChart(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -688,6 +699,7 @@ func deployBlockNodeMonitoring() automa.Builder {
 }
 
 func isAlloyPodsReady() automa.Builder {
+	spec := chartSpec("alloy")
 	return automa.NewStepBuilder().WithId(IsAlloyReadyStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 
@@ -698,7 +710,7 @@ func isAlloyPodsReady() automa.Builder {
 
 			meta := map[string]string{}
 			// wait for alloy pods to be ready
-			err = k.WaitForResources(ctx, kube.KindPod, deps.ALLOY_NAMESPACE, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "grafana-alloy"})
+			err = k.WaitForResources(ctx, kube.KindPod, spec.Namespace, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "grafana-alloy"})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -720,16 +732,17 @@ func isAlloyPodsReady() automa.Builder {
 
 // uninstallAlloy removes the Grafana Alloy installation
 func uninstallAlloy() automa.Builder {
+	spec := chartSpec("alloy")
 	return automa.NewStepBuilder().WithId("uninstall-alloy").
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(deps.ALLOY_RELEASE, deps.ALLOY_NAMESPACE)
+			isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -739,7 +752,7 @@ func uninstallAlloy() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			err = hm.UninstallChart(deps.ALLOY_RELEASE, deps.ALLOY_NAMESPACE)
+			err = hm.UninstallChart(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -761,16 +774,17 @@ func uninstallAlloy() automa.Builder {
 
 // uninstallNodeExporter removes the Node Exporter installation
 func uninstallNodeExporter() automa.Builder {
+	spec := chartSpec("node-exporter")
 	return automa.NewStepBuilder().WithId("uninstall-node-exporter").
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(deps.NODE_EXPORTER_RELEASE, deps.NODE_EXPORTER_NAMESPACE)
+			isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -780,7 +794,7 @@ func uninstallNodeExporter() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			err = hm.UninstallChart(deps.NODE_EXPORTER_RELEASE, deps.NODE_EXPORTER_NAMESPACE)
+			err = hm.UninstallChart(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_external_secrets.go
+++ b/internal/workflows/steps/step_external_secrets.go
@@ -60,7 +60,7 @@ func installExternalSecrets() automa.Builder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
-			_, err = hm.AddRepo(spec.Release, spec.Repo, helm.RepoAddOptions{})
+			_, err = hm.AddRepo(spec.RepoAlias, spec.Repo, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_external_secrets.go
+++ b/internal/workflows/steps/step_external_secrets.go
@@ -10,7 +10,6 @@ import (
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/kube"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
-	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/helm"
 	"helm.sh/helm/v3/pkg/cli/values"
 )
@@ -40,16 +39,17 @@ func SetupExternalSecrets() *automa.WorkflowBuilder {
 }
 
 func installExternalSecrets() automa.Builder {
+	spec := chartSpec("external-secrets")
 	return automa.NewStepBuilder().WithId(InstallExternalSecretsStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(deps.EXTERNAL_SECRETS_RELEASE, deps.EXTERNAL_SECRETS_NAMESPACE)
+			isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -60,7 +60,12 @@ func installExternalSecrets() automa.Builder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
-			_, err = hm.AddRepo("external-secrets", deps.EXTERNAL_SECRETS_REPO, helm.RepoAddOptions{})
+			_, err = hm.AddRepo(spec.Release, spec.Repo, helm.RepoAddOptions{})
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			localChart, err := hm.PullAndVerify(ctx, chartDownloadsDir(), spec.Chart, spec.Version, spec.Algorithm, spec.Checksum)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -72,10 +77,10 @@ func installExternalSecrets() automa.Builder {
 
 			_, err = hm.InstallChart(
 				ctx,
-				deps.EXTERNAL_SECRETS_RELEASE,
-				deps.EXTERNAL_SECRETS_CHART,
-				deps.EXTERNAL_SECRETS_VERSION,
-				deps.EXTERNAL_SECRETS_NAMESPACE,
+				spec.Release,
+				localChart,
+				"",
+				spec.Namespace,
 				helm.InstallChartOptions{
 					ValueOpts: &values.Options{
 						Values: helmValues,
@@ -100,13 +105,12 @@ func installExternalSecrets() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(deps.EXTERNAL_SECRETS_RELEASE, deps.EXTERNAL_SECRETS_NAMESPACE)
+			err = hm.UninstallChart(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -126,6 +130,7 @@ func installExternalSecrets() automa.Builder {
 }
 
 func isExternalSecretsReady() automa.Builder {
+	spec := chartSpec("external-secrets")
 	return automa.NewStepBuilder().WithId(IsExternalSecretsReadyStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			k, err := kube.NewClient()
@@ -135,7 +140,7 @@ func isExternalSecretsReady() automa.Builder {
 
 			meta := map[string]string{}
 			// Wait for external-secrets pods to be ready
-			err = k.WaitForResources(ctx, kube.KindPod, deps.EXTERNAL_SECRETS_NAMESPACE, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "external-secrets"})
+			err = k.WaitForResources(ctx, kube.KindPod, spec.Namespace, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "external-secrets"})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_metallb.go
+++ b/internal/workflows/steps/step_metallb.go
@@ -77,7 +77,7 @@ func installMetalLB() automa.Builder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
-			_, err = hm.AddRepo(spec.Release, spec.Repo, helm.RepoAddOptions{})
+			_, err = hm.AddRepo(spec.RepoAlias, spec.Repo, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_metallb.go
+++ b/internal/workflows/steps/step_metallb.go
@@ -6,12 +6,10 @@ import (
 	"context"
 	"os"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
-	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 
 	"github.com/hashgraph/solo-weaver/internal/kube"
@@ -56,18 +54,19 @@ func SetupMetalLB() *automa.WorkflowBuilder {
 }
 
 func installMetalLB() automa.Builder {
+	spec := chartSpec("metallb")
 	return automa.NewStepBuilder().WithId(InstallMetalLBStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
-			logx.As().Info().Str("step_id", stp.Id()).Str("software", "metallb").Str("version", deps.METALLB_VERSION).Msgf("metallb version: %s", deps.METALLB_VERSION)
-
 			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			l.Info().Str("step_id", stp.Id()).Str("software", "metallb").Str("version", spec.Version).Msgf("metallb version: %s", spec.Version)
+
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(deps.METALLB_RELEASE, deps.METALLB_NAMESPACE)
+			isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -78,23 +77,22 @@ func installMetalLB() automa.Builder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
-			_, err = hm.AddRepo(deps.METALLB_RELEASE, deps.METALLB_REPO, helm.RepoAddOptions{})
+			_, err = hm.AddRepo(spec.Release, spec.Repo, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			// if chartVersion doesn't start with "v", prepend it
-			chartVersion := deps.METALLB_VERSION
-			if !strings.HasPrefix(chartVersion, "v") {
-				chartVersion = "v" + chartVersion
+			localChart, err := hm.PullAndVerify(ctx, chartDownloadsDir(), spec.Chart, spec.Version, spec.Algorithm, spec.Checksum)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			_, err = hm.InstallChart(
 				ctx,
-				deps.METALLB_RELEASE,
-				deps.METALLB_CHART,
-				chartVersion,
-				deps.METALLB_NAMESPACE,
+				spec.Release,
+				localChart,
+				"",
+				spec.Namespace,
 				helm.InstallChartOptions{
 					ValueOpts: &values.Options{
 						Values: []string{"speaker.frr.enabled=false"},
@@ -119,13 +117,12 @@ func installMetalLB() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(deps.METALLB_RELEASE, deps.METALLB_NAMESPACE)
+			err = hm.UninstallChart(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -225,6 +222,7 @@ func deployMetalLBConfig(configFilePath string) automa.Builder {
 }
 
 func isMetalLBPodsReady() automa.Builder {
+	spec := chartSpec("metallb")
 	return automa.NewStepBuilder().WithId(IsMetalLBReadyStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			k, err := kube.NewClient()
@@ -234,7 +232,7 @@ func isMetalLBPodsReady() automa.Builder {
 
 			meta := map[string]string{}
 			// wait for metallb pods to be ready
-			err = k.WaitForResources(ctx, kube.KindPod, deps.METALLB_NAMESPACE, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "metallb"})
+			err = k.WaitForResources(ctx, kube.KindPod, spec.Namespace, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "metallb"})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_metrics_server.go
+++ b/internal/workflows/steps/step_metrics_server.go
@@ -59,7 +59,7 @@ func installMetricsServer(valueOptions *values.Options) *automa.StepBuilder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
-			_, err = hm.AddRepo(spec.Release, spec.Repo, helm.RepoAddOptions{})
+			_, err = hm.AddRepo(spec.RepoAlias, spec.Repo, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_metrics_server.go
+++ b/internal/workflows/steps/step_metrics_server.go
@@ -4,12 +4,10 @@ package steps
 
 import (
 	"context"
-	"strings"
 
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
-	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/helm"
 	"helm.sh/helm/v3/pkg/cli/values"
 )
@@ -40,16 +38,17 @@ func installMetricsServer(valueOptions *values.Options) *automa.StepBuilder {
 		}
 	}
 
+	spec := chartSpec("metrics-server")
 	return automa.NewStepBuilder().WithId("enable-metrics-server").
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(deps.METRICS_SERVER_RELEASE, deps.METRICS_SERVER_NAMESPACE)
+			isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -60,23 +59,22 @@ func installMetricsServer(valueOptions *values.Options) *automa.StepBuilder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
-			_, err = hm.AddRepo(deps.METRICS_SERVER_RELEASE, deps.METRICS_SERVER_REPO, helm.RepoAddOptions{})
+			_, err = hm.AddRepo(spec.Release, spec.Repo, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			// if chartVersion doesn't start with "v", prepend it
-			chartVersion := deps.METRICS_SERVER_VERSION
-			if !strings.HasPrefix(chartVersion, "v") {
-				chartVersion = "v" + chartVersion
+			localChart, err := hm.PullAndVerify(ctx, chartDownloadsDir(), spec.Chart, spec.Version, spec.Algorithm, spec.Checksum)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			_, err = hm.InstallChart(
 				ctx,
-				deps.METRICS_SERVER_RELEASE,
-				deps.METRICS_SERVER_CHART,
-				chartVersion,
-				deps.METRICS_SERVER_NAMESPACE,
+				spec.Release,
+				localChart,
+				"",
+				spec.Namespace,
 				helm.InstallChartOptions{
 					ValueOpts:       valueOptions,
 					CreateNamespace: true,
@@ -99,13 +97,12 @@ func installMetricsServer(valueOptions *values.Options) *automa.StepBuilder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(deps.METRICS_SERVER_RELEASE, deps.METRICS_SERVER_NAMESPACE)
+			err = hm.UninstallChart(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_prometheus_operator_crds.go
+++ b/internal/workflows/steps/step_prometheus_operator_crds.go
@@ -10,7 +10,6 @@ import (
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/kube"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
-	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/helm"
 	"github.com/joomcode/errorx"
 )
@@ -41,16 +40,17 @@ func SetupPrometheusOperatorCRDs() *automa.WorkflowBuilder {
 }
 
 func installPrometheusOperatorCRDs() automa.Builder {
+	spec := chartSpec("prometheus-operator-crds")
 	return automa.NewStepBuilder().WithId(InstallPrometheusCRDsStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(deps.PROMETHEUS_OPERATOR_CRDS_RELEASE, deps.PROMETHEUS_OPERATOR_CRDS_NAMESPACE)
+			isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -61,12 +61,17 @@ func installPrometheusOperatorCRDs() automa.Builder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
+			localChart, err := hm.PullAndVerify(ctx, chartDownloadsDir(), spec.Chart, spec.Version, spec.Algorithm, spec.Checksum)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
 			_, err = hm.InstallChart(
 				ctx,
-				deps.PROMETHEUS_OPERATOR_CRDS_RELEASE,
-				deps.PROMETHEUS_OPERATOR_CRDS_CHART,
-				deps.PROMETHEUS_OPERATOR_CRDS_VERSION,
-				deps.PROMETHEUS_OPERATOR_CRDS_NAMESPACE,
+				spec.Release,
+				localChart,
+				"",
+				spec.Namespace,
 				helm.InstallChartOptions{
 					CreateNamespace: true,
 					Atomic:          true,
@@ -87,14 +92,12 @@ func installPrometheusOperatorCRDs() automa.Builder {
 			if v, _ := stp.State().Local().Bool(InstalledByThisStep); v == false {
 				return automa.StepSkippedReport(stp.Id())
 			}
-
-			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(deps.PROMETHEUS_OPERATOR_CRDS_RELEASE, deps.PROMETHEUS_OPERATOR_CRDS_NAMESPACE)
+			err = hm.UninstallChart(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -170,16 +173,17 @@ func TeardownPrometheusOperatorCRDs() *automa.WorkflowBuilder {
 
 // uninstallPrometheusOperatorCRDs removes the Prometheus Operator CRDs installation
 func uninstallPrometheusOperatorCRDs() automa.Builder {
+	spec := chartSpec("prometheus-operator-crds")
 	return automa.NewStepBuilder().WithId("uninstall-prometheus-crds").
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(deps.PROMETHEUS_OPERATOR_CRDS_RELEASE, deps.PROMETHEUS_OPERATOR_CRDS_NAMESPACE)
+			isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -189,7 +193,7 @@ func uninstallPrometheusOperatorCRDs() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			err = hm.UninstallChart(deps.PROMETHEUS_OPERATOR_CRDS_RELEASE, deps.PROMETHEUS_OPERATOR_CRDS_NAMESPACE)
+			err = hm.UninstallChart(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_solo_operator.go
+++ b/internal/workflows/steps/step_solo_operator.go
@@ -8,7 +8,6 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
-	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/helm"
 )
 
@@ -17,16 +16,17 @@ const (
 )
 
 func InstallSoloOperator() automa.Builder {
+	spec := chartSpec("solo-operator")
 	return automa.NewStepBuilder().WithId(InstallSoloOperatorStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(deps.SOLO_OPERATOR_RELEASE, deps.SOLO_OPERATOR_NAMESPACE)
+			isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -37,12 +37,17 @@ func InstallSoloOperator() automa.Builder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
+			localChart, err := hm.PullAndVerify(ctx, chartDownloadsDir(), spec.Chart, spec.Version, spec.Algorithm, spec.Checksum)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
 			_, err = hm.DeployChart(
 				ctx,
-				deps.SOLO_OPERATOR_RELEASE,
-				deps.SOLO_OPERATOR_CHART,
-				deps.SOLO_OPERATOR_VERSION,
-				deps.SOLO_OPERATOR_NAMESPACE,
+				spec.Release,
+				localChart,
+				"",
+				spec.Namespace,
 				helm.DeployChartOptions{
 					CreateNamespace: true,
 					Atomic:          true,
@@ -63,14 +68,12 @@ func InstallSoloOperator() automa.Builder {
 			if v, _ := stp.State().Local().Bool(InstalledByThisStep); v == false {
 				return automa.StepSkippedReport(stp.Id())
 			}
-
-			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(deps.SOLO_OPERATOR_RELEASE, deps.SOLO_OPERATOR_NAMESPACE)
+			err = hm.UninstallChart(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_teleport.go
+++ b/internal/workflows/steps/step_teleport.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/templates"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
 	"github.com/hashgraph/solo-weaver/pkg/config"
-	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/helm"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/hashgraph/solo-weaver/pkg/software"
@@ -101,6 +100,7 @@ func TeardownTeleportClusterAgent() *automa.WorkflowBuilder {
 
 // uninstallTeleportKubeAgent removes the Teleport Kubernetes agent Helm release.
 func uninstallTeleportKubeAgent() automa.Builder {
+	spec := chartSpec("teleport-cluster-agent")
 	return automa.NewStepBuilder().WithId(UninstallTeleportKubeAgentStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			l := logx.As()
@@ -115,13 +115,13 @@ func uninstallTeleportKubeAgent() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(deps.TELEPORT_RELEASE, deps.TELEPORT_NAMESPACE)
+			isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -131,7 +131,7 @@ func uninstallTeleportKubeAgent() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			err = hm.UninstallChart(deps.TELEPORT_RELEASE, deps.TELEPORT_NAMESPACE)
+			err = hm.UninstallChart(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -410,6 +410,7 @@ func configureTeleportNodeAgent(provider teleportInstallerProvider) automa.Build
 }
 
 func CreateTeleportNamespace() automa.Builder {
+	spec := chartSpec("teleport-cluster-agent")
 	return automa.NewStepBuilder().WithId(CreateTeleportNamespaceStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			k, err := kube.NewClient()
@@ -420,7 +421,7 @@ func CreateTeleportNamespace() automa.Builder {
 			// Create namespace manifest using template
 			namespaceManifestPath := path.Join(models.Paths().TempDir, "teleport-namespace.yaml")
 			namespaceManifest, err := templates.Render("files/teleport/namespace.yaml", map[string]string{
-				"Namespace": deps.TELEPORT_NAMESPACE,
+				"Namespace": spec.Namespace,
 			})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
@@ -453,18 +454,19 @@ func CreateTeleportNamespace() automa.Builder {
 }
 
 func InstallTeleportKubeAgent() automa.Builder {
+	spec := chartSpec("teleport-cluster-agent")
 	return automa.NewStepBuilder().WithId(InstallTeleportStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			cfg := config.Get().Teleport
 
 			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
 			meta := map[string]string{}
-			isInstalled, err := hm.IsInstalled(deps.TELEPORT_RELEASE, deps.TELEPORT_NAMESPACE)
+			isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -475,25 +477,45 @@ func InstallTeleportKubeAgent() automa.Builder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
-			_, err = hm.AddRepo("teleport", deps.TELEPORT_REPO, helm.RepoAddOptions{})
+			_, err = hm.AddRepo(spec.Release, spec.Repo, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			// Determine chart version
+			// Determine chart version: explicit --version flag overrides the catalog default.
+			// Per-component version overrides remain a legacy carve-out for teleport
+			// (see issue #589 "Out of scope: removing the teleport --version flag").
 			chartVersion := cfg.Version
+			expectedChecksum := spec.Checksum
 			if chartVersion == "" {
-				chartVersion = deps.TELEPORT_VERSION
+				chartVersion = spec.Version
+			} else if chartVersion != spec.Version {
+				// Operator pinned a non-catalog version; we cannot verify integrity
+				// because the catalog only records checksums for declared versions.
+				expectedChecksum = ""
 			}
 
 			l.Info().Str("path", cfg.ValuesFile).Msg("Using Teleport values file")
 
+			var chartRef string
+			if expectedChecksum != "" {
+				localChart, err := hm.PullAndVerify(ctx, chartDownloadsDir(), spec.Chart, chartVersion, spec.Algorithm, expectedChecksum)
+				if err != nil {
+					return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+				}
+				chartRef = localChart
+				chartVersion = ""
+			} else {
+				chartRef = spec.Chart
+				l.Warn().Str("version", chartVersion).Msg("Skipping chart integrity verification for operator-pinned Teleport version (not in catalog)")
+			}
+
 			_, err = hm.InstallChart(
 				ctx,
-				deps.TELEPORT_RELEASE,
-				deps.TELEPORT_CHART,
+				spec.Release,
+				chartRef,
 				chartVersion,
-				deps.TELEPORT_NAMESPACE,
+				spec.Namespace,
 				helm.InstallChartOptions{
 					ValueOpts: &values.Options{
 						ValueFiles: []string{cfg.ValuesFile},
@@ -518,13 +540,12 @@ func InstallTeleportKubeAgent() automa.Builder {
 				return automa.StepSkippedReport(stp.Id())
 			}
 
-			l := logx.As()
-			hm, err := helm.NewManager(helm.WithLogger(*l))
+			hm, err := newHelmManager()
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
 
-			err = hm.UninstallChart(deps.TELEPORT_RELEASE, deps.TELEPORT_NAMESPACE)
+			err = hm.UninstallChart(spec.Release, spec.Namespace)
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}
@@ -544,6 +565,7 @@ func InstallTeleportKubeAgent() automa.Builder {
 }
 
 func IsTeleportPodsReady() automa.Builder {
+	spec := chartSpec("teleport-cluster-agent")
 	return automa.NewStepBuilder().WithId(IsTeleportReadyStepId).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 
@@ -554,7 +576,7 @@ func IsTeleportPodsReady() automa.Builder {
 
 			meta := map[string]string{}
 			// wait for teleport pods to be ready
-			err = k.WaitForResources(ctx, kube.KindPod, deps.TELEPORT_NAMESPACE, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "teleport-agent"})
+			err = k.WaitForResources(ctx, kube.KindPod, spec.Namespace, kube.IsPodReady, 5*time.Minute, kube.WaitOptions{NamePrefix: "teleport-agent"})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/internal/workflows/steps/step_teleport.go
+++ b/internal/workflows/steps/step_teleport.go
@@ -477,7 +477,7 @@ func InstallTeleportKubeAgent() automa.Builder {
 				return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(meta))
 			}
 
-			_, err = hm.AddRepo(spec.Release, spec.Repo, helm.RepoAddOptions{})
+			_, err = hm.AddRepo(spec.RepoAlias, spec.Repo, helm.RepoAddOptions{})
 			if err != nil {
 				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
 			}

--- a/pkg/config/global.go
+++ b/pkg/config/global.go
@@ -12,6 +12,13 @@ import (
 	"github.com/spf13/viper"
 )
 
+// The Teleport default version is intentionally left empty here. The install
+// step (internal/workflows/steps/step_teleport.go) consults the infrastructure
+// catalog whenever cfg.Version is empty, so the catalog remains the single
+// source of truth. Hard-coding a catalog lookup at this layer would create an
+// import cycle: pkg/config is imported by many packages that pkg/software
+// also reaches into transitively (e.g. internal/proxy).
+
 var globalConfig = models.Config{
 	Profile: "",
 	Log: logx.LoggingConfig{
@@ -43,7 +50,7 @@ var globalConfig = models.Config{
 		ClusterName:        "",
 	},
 	Teleport: models.TeleportConfig{
-		Version:    deps.TELEPORT_VERSION,
+		Version:    "",
 		ValuesFile: "",
 	},
 }
@@ -119,7 +126,7 @@ func DefaultsConfig() models.Config {
 			},
 		},
 		Teleport: models.TeleportConfig{
-			Version: deps.TELEPORT_VERSION,
+			Version: "",
 		},
 	}
 }

--- a/pkg/config/global_test.go
+++ b/pkg/config/global_test.go
@@ -114,8 +114,12 @@ func TestDefaultsConfig_ReturnsDepsConstants(t *testing.T) {
 	if cfg.BlockNode.Storage.BasePath == "" {
 		t.Error("Storage.BasePath: expected non-empty deps constant, got empty")
 	}
-	if cfg.Teleport.Version == "" {
-		t.Error("Teleport.Version: expected non-empty deps constant, got empty")
+	// Teleport.Version is intentionally empty in DefaultsConfig: the chart
+	// version is now sourced from pkg/software/infrastructure-catalog.yaml at
+	// install time (see internal/workflows/steps/step_teleport.go). The
+	// version constant in pkg/deps/deps.go was removed in issue #589.
+	if cfg.Teleport.Version != "" {
+		t.Errorf("Teleport.Version: expected empty (catalog is the source of truth), got %q", cfg.Teleport.Version)
 	}
 	// Alloy and cluster fields are intentionally not in defaults (no deps constants for them)
 	if cfg.Alloy.ClusterName != "" {

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -1,65 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
+// Package deps holds compile-time defaults for the block-node install plan.
+// Block-node's plan flows through the RSL strategy chain
+// (default → config file → env → CLI flag), so its defaults live in Go
+// rather than in pkg/software/infrastructure-catalog.yaml alongside the
+// cluster-managed Helm charts.
 package deps
 
 const (
-	// Block Node
 	BLOCK_NODE_NAMESPACE         = "block-node"
 	BLOCK_NODE_RELEASE           = "block-node"
 	BLOCK_NODE_CHART             = "oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server"
 	BLOCK_NODE_VERSION           = "0.30.2"
 	BLOCK_NODE_STORAGE_BASE_PATH = "/mnt/fast-storage"
-
-	// Teleport
-	TELEPORT_NAMESPACE = "teleport-agent"
-	TELEPORT_RELEASE   = "teleport-agent"
-	TELEPORT_CHART     = "teleport/teleport-kube-agent"
-	TELEPORT_REPO      = "https://charts.releases.teleport.dev"
-	TELEPORT_VERSION   = "18.6.4"
-
-	// Grafana Alloy
-	ALLOY_NAMESPACE = "grafana-alloy"
-	ALLOY_RELEASE   = "grafana-alloy"
-	ALLOY_CHART     = "grafana/alloy"
-	ALLOY_VERSION   = "1.4.0"
-	ALLOY_REPO      = "https://grafana.github.io/helm-charts"
-
-	// Node Exporter
-	NODE_EXPORTER_NAMESPACE = "node-exporter"
-	NODE_EXPORTER_RELEASE   = "node-exporter"
-	NODE_EXPORTER_CHART     = "oci://registry-1.docker.io/bitnamicharts/node-exporter"
-	NODE_EXPORTER_VERSION   = "4.5.19"
-
-	// MetalLB
-	METALLB_NAMESPACE = "metallb-system"
-	METALLB_RELEASE   = "metallb"
-	METALLB_CHART     = "metallb/metallb"
-	METALLB_VERSION   = "0.15.2"
-	METALLB_REPO      = "https://metallb.github.io/metallb"
-
-	// Metrics Server
-	METRICS_SERVER_NAMESPACE = "kube-system"
-	METRICS_SERVER_RELEASE   = "metrics-server"
-	METRICS_SERVER_CHART     = "metrics-server/metrics-server"
-	METRICS_SERVER_VERSION   = "3.13.0"
-	METRICS_SERVER_REPO      = "https://kubernetes-sigs.github.io/metrics-server"
-
-	// Prometheus Operator CRDs
-	PROMETHEUS_OPERATOR_CRDS_NAMESPACE = "grafana-alloy"
-	PROMETHEUS_OPERATOR_CRDS_RELEASE   = "prometheus-operator-crds"
-	PROMETHEUS_OPERATOR_CRDS_CHART     = "oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds"
-	PROMETHEUS_OPERATOR_CRDS_VERSION   = "24.0.1"
-
-	// External Secrets
-	EXTERNAL_SECRETS_NAMESPACE = "external-secrets"
-	EXTERNAL_SECRETS_RELEASE   = "external-secrets"
-	EXTERNAL_SECRETS_CHART     = "external-secrets/external-secrets"
-	EXTERNAL_SECRETS_VERSION   = "0.20.2"
-	EXTERNAL_SECRETS_REPO      = "https://charts.external-secrets.io"
-
-	// Solo Operator
-	SOLO_OPERATOR_NAMESPACE = "solo-operator"
-	SOLO_OPERATOR_RELEASE   = "solo-operator"
-	SOLO_OPERATOR_CHART     = "oci://ghcr.io/hashgraph/charts/solo-operator"
-	SOLO_OPERATOR_VERSION   = "0.3.1"
 )

--- a/pkg/helm/interface.go
+++ b/pkg/helm/interface.go
@@ -23,6 +23,16 @@ type Manager interface {
 	// AddRepo adds a Helm chart repository with the given options and updates it.
 	AddRepo(name, url string, o RepoAddOptions) (*repo.ChartRepository, error)
 
+	// PullAndVerify pulls a Helm chart into destDir and verifies its integrity
+	// against the expected checksum recorded in the infrastructure catalog.
+	// destDir is created on demand. For classic charts (chartRef without an
+	// "oci://" scheme) the local .tgz is SHA256-hashed; for OCI charts the
+	// manifest digest reported by the registry client is compared. The returned
+	// path points at the local .tgz so callers can hand it to InstallChart /
+	// UpgradeChart / DeployChart without a second pull. algorithm currently
+	// must be "sha256"; any other value is a configuration error.
+	PullAndVerify(ctx context.Context, destDir, chartRef, version, algorithm, expectedChecksum string) (string, error)
+
 	// InstallChart installs a Helm chart with the given options
 	InstallChart(ctx context.Context, releaseName, chartRef, chartVersion, namespace string, o InstallChartOptions) (*release.Release, error)
 

--- a/pkg/helm/interface.go
+++ b/pkg/helm/interface.go
@@ -31,6 +31,13 @@ type Manager interface {
 	// path points at the local .tgz so callers can hand it to InstallChart /
 	// UpgradeChart / DeployChart without a second pull. algorithm currently
 	// must be "sha256"; any other value is a configuration error.
+	//
+	// ctx is accepted for API symmetry but is not propagated into the pull:
+	// the Helm SDK version we vendor exposes no context-aware Pull entrypoint
+	// (neither action.Pull.Run nor registry.Client.Pull take a context). An
+	// in-flight pull therefore runs to completion regardless of cancellation;
+	// a slow pull will block the step until the underlying HTTP transport's
+	// own deadlines fire.
 	PullAndVerify(ctx context.Context, destDir, chartRef, version, algorithm, expectedChecksum string) (string, error)
 
 	// InstallChart installs a Helm chart with the given options

--- a/pkg/helm/puller.go
+++ b/pkg/helm/puller.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package helm
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/joomcode/errorx"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/registry"
+)
+
+// ErrChecksumMismatch is returned when a pulled chart's digest does not match
+// the value recorded in the infrastructure catalog.
+var ErrChecksumMismatch = ErrNamespace.NewType("checksum_mismatch")
+
+const sha256Algorithm = "sha256"
+
+// PullAndVerify implements Manager.PullAndVerify. It pulls the chart into
+// destDir, computes the artifact integrity value appropriate for the chart's
+// distribution mode, and compares against the expected checksum supplied from
+// the catalog.
+//
+// For classic charts the algorithm is SHA256 of the resulting .tgz on disk.
+// For OCI charts the algorithm is the manifest digest reported by the Helm
+// registry client (which is itself a sha256 of the manifest descriptor).
+// In both cases the catalog stores a bare hex string (no "sha256:" prefix),
+// so the OCI path strips the prefix before comparison.
+//
+// destDir is created on demand (mode 0o755). The caller decides where the
+// pulled .tgz lives — workflow steps point at <WeaverPaths.DownloadsDir>/charts;
+// unit tests can pass `t.TempDir()`.
+func (h *helmManager) PullAndVerify(ctx context.Context, destDir, chartRef, version, algorithm, expectedChecksum string) (string, error) {
+	if algorithm != sha256Algorithm {
+		return "", errorx.IllegalArgument.New(
+			"unsupported checksum algorithm %q for chart %q (only %q is supported)",
+			algorithm, chartRef, sha256Algorithm)
+	}
+	if expectedChecksum == "" {
+		return "", errorx.IllegalArgument.New("expected checksum is empty for chart %q version %q", chartRef, version)
+	}
+	if destDir == "" {
+		return "", errorx.IllegalArgument.New("destDir is empty for chart %q version %q", chartRef, version)
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return "", errorx.InternalError.Wrap(err, "failed to create chart downloads dir %q", destDir)
+	}
+
+	if registry.IsOCI(chartRef) {
+		return h.pullAndVerifyOCI(ctx, destDir, chartRef, version, expectedChecksum)
+	}
+	return h.pullAndVerifyClassic(destDir, chartRef, version, expectedChecksum)
+}
+
+// pullAndVerifyClassic uses action.Pull (the SDK equivalent of `helm pull`)
+// to fetch a chart from a classic repo into destDir and compares the SHA256
+// of the resulting .tgz to the catalog-recorded value. The repository alias
+// in chartRef (e.g. "metallb/metallb") must have been registered via AddRepo
+// before this call so the repository config can resolve the URL.
+func (h *helmManager) pullAndVerifyClassic(destDir, chartRef, version, expected string) (string, error) {
+	settings := h.WithNamespace("")
+
+	registryClient, err := newRegistryClient(settings)
+	if err != nil {
+		return "", errorx.InternalError.Wrap(err, "failed to create registry client")
+	}
+
+	actionConfig, err := initActionConfig(settings, h.log.Printf)
+	if err != nil {
+		return "", errorx.IllegalArgument.Wrap(err, "failed to init action config")
+	}
+	actionConfig.RegistryClient = registryClient
+
+	pull := action.NewPullWithOpts(action.WithConfig(actionConfig))
+	pull.Settings = settings
+	pull.DestDir = destDir
+	pull.Untar = false
+	pull.Version = version
+	pull.SetRegistryClient(registryClient)
+
+	if _, err := pull.Run(chartRef); err != nil {
+		return "", ErrChartLoadFailed.Wrap(err, "helm pull failed for chart %q version %q", chartRef, version)
+	}
+
+	// `helm pull <repo>/<chart>` writes <chart>-<version>.tgz (using the last
+	// path segment of the chart reference). Mirrors scripts/chart-checksums/main.go.
+	tgz := filepath.Join(destDir, fmt.Sprintf("%s-%s.tgz", path.Base(chartRef), version))
+	actual, err := sha256File(tgz)
+	if err != nil {
+		return "", errorx.InternalError.Wrap(err, "failed to compute SHA256 of pulled chart %q", tgz)
+	}
+	if !strings.EqualFold(actual, expected) {
+		return "", ErrChecksumMismatch.New(
+			"chart %q version %q checksum mismatch: expected sha256=%s, got sha256=%s",
+			chartRef, version, expected, actual)
+	}
+
+	h.log.Info().
+		Str("chart", chartRef).
+		Str("version", version).
+		Str("algorithm", sha256Algorithm).
+		Str("checksum", actual).
+		Msg("Helm chart pulled and verified")
+
+	return tgz, nil
+}
+
+// pullAndVerifyOCI calls the registry client directly so we can read the
+// manifest digest from PullResult.Manifest.Digest (which is reported by
+// `helm pull` as the "Digest: sha256:..." line). The chart layer bytes are
+// then written to disk so callers can pass the local path to InstallChart.
+func (h *helmManager) pullAndVerifyOCI(_ context.Context, destDir, chartRef, version, expected string) (string, error) {
+	settings := h.WithNamespace("")
+
+	registryClient, err := newRegistryClient(settings)
+	if err != nil {
+		return "", errorx.InternalError.Wrap(err, "failed to create registry client")
+	}
+
+	// `helm pull oci://host/path/chart --version X` translates internally to
+	// `registry.Client.Pull("host/path/chart:X")`. Reproduce that here.
+	ref := fmt.Sprintf("%s:%s", strings.TrimPrefix(chartRef, "oci://"), version)
+	result, err := registryClient.Pull(ref, registry.PullOptWithChart(true))
+	if err != nil {
+		return "", ErrChartLoadFailed.Wrap(err, "helm pull failed for OCI chart %q version %q", chartRef, version)
+	}
+	if result == nil || result.Manifest == nil || result.Chart == nil {
+		return "", ErrChartLoadFailed.New("helm pull returned incomplete result for OCI chart %q version %q", chartRef, version)
+	}
+
+	actual := strings.TrimPrefix(result.Manifest.Digest, "sha256:")
+	if !strings.EqualFold(actual, expected) {
+		return "", ErrChecksumMismatch.New(
+			"chart %q version %q manifest digest mismatch: expected sha256=%s, got sha256=%s",
+			chartRef, version, expected, actual)
+	}
+
+	tgz := filepath.Join(destDir, fmt.Sprintf("%s-%s.tgz", path.Base(chartRef), version))
+	if err := os.WriteFile(tgz, result.Chart.Data, 0o600); err != nil {
+		return "", errorx.InternalError.Wrap(err, "failed to write pulled OCI chart to %q", tgz)
+	}
+
+	h.log.Info().
+		Str("chart", chartRef).
+		Str("version", version).
+		Str("algorithm", sha256Algorithm).
+		Str("checksum", actual).
+		Msg("Helm chart pulled and verified")
+
+	return tgz, nil
+}
+
+// sha256File returns the lowercase hex SHA256 of the file at path.
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}

--- a/pkg/helm/puller.go
+++ b/pkg/helm/puller.go
@@ -38,7 +38,16 @@ const sha256Algorithm = "sha256"
 // destDir is created on demand (mode 0o755). The caller decides where the
 // pulled .tgz lives — workflow steps point at <WeaverPaths.DownloadsDir>/charts;
 // unit tests can pass `t.TempDir()`.
+//
+// Context cancellation: ctx is accepted for API symmetry with the rest of
+// helm.Manager but is not propagated into the pull itself. Neither
+// action.Pull.Run nor registry.Client.Pull accept a context in the Helm SDK
+// version we vendor, so an in-flight pull cannot be cancelled — the call
+// runs to completion (success or timeout) regardless of ctx. Workflow steps
+// remain cancellable between catalog lookups and the pull call, but a slow
+// pull will block until the underlying HTTP transport's own deadlines fire.
 func (h *helmManager) PullAndVerify(ctx context.Context, destDir, chartRef, version, algorithm, expectedChecksum string) (string, error) {
+	_ = ctx // intentionally unused; see context-cancellation note above
 	if algorithm != sha256Algorithm {
 		return "", errorx.IllegalArgument.New(
 			"unsupported checksum algorithm %q for chart %q (only %q is supported)",
@@ -55,7 +64,7 @@ func (h *helmManager) PullAndVerify(ctx context.Context, destDir, chartRef, vers
 	}
 
 	if registry.IsOCI(chartRef) {
-		return h.pullAndVerifyOCI(ctx, destDir, chartRef, version, expectedChecksum)
+		return h.pullAndVerifyOCI(destDir, chartRef, version, expectedChecksum)
 	}
 	return h.pullAndVerifyClassic(destDir, chartRef, version, expectedChecksum)
 }
@@ -117,7 +126,7 @@ func (h *helmManager) pullAndVerifyClassic(destDir, chartRef, version, expected 
 // manifest digest from PullResult.Manifest.Digest (which is reported by
 // `helm pull` as the "Digest: sha256:..." line). The chart layer bytes are
 // then written to disk so callers can pass the local path to InstallChart.
-func (h *helmManager) pullAndVerifyOCI(_ context.Context, destDir, chartRef, version, expected string) (string, error) {
+func (h *helmManager) pullAndVerifyOCI(destDir, chartRef, version, expected string) (string, error) {
 	settings := h.WithNamespace("")
 
 	registryClient, err := newRegistryClient(settings)

--- a/pkg/helm/puller_test.go
+++ b/pkg/helm/puller_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package helm
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPullAndVerify_UnsupportedAlgorithm(t *testing.T) {
+	hm := newTestHelmManager(t)
+	_, err := hm.PullAndVerify(context.Background(), t.TempDir(), "metallb/metallb", "0.15.2", "md5", "deadbeef")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported checksum algorithm")
+	assert.Contains(t, err.Error(), "md5")
+	assert.Contains(t, err.Error(), "sha256")
+}
+
+func TestPullAndVerify_EmptyChecksum(t *testing.T) {
+	hm := newTestHelmManager(t)
+	_, err := hm.PullAndVerify(context.Background(), t.TempDir(), "metallb/metallb", "0.15.2", "sha256", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected checksum is empty")
+}
+
+func TestPullAndVerify_EmptyDestDir(t *testing.T) {
+	hm := newTestHelmManager(t)
+	_, err := hm.PullAndVerify(context.Background(), "", "metallb/metallb", "0.15.2", "sha256", "deadbeef")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "destDir is empty")
+}
+
+func Test_sha256File(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "data.bin")
+	payload := []byte("the quick brown fox jumps over the lazy dog\n")
+	require.NoError(t, os.WriteFile(tmp, payload, 0o600))
+
+	expected := sha256.Sum256(payload)
+	got, err := sha256File(tmp)
+	require.NoError(t, err)
+	assert.Equal(t, hex.EncodeToString(expected[:]), got)
+}
+
+// newTestHelmManager builds a helmManager wired to a temp HELM_* environment
+// so tests do not mutate the developer's global helm config.
+func newTestHelmManager(t *testing.T) *helmManager {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HELM_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("HELM_CACHE_HOME", filepath.Join(home, "cache"))
+	t.Setenv("HELM_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("HELM_REPOSITORY_CONFIG", filepath.Join(home, "config", "repositories.yaml"))
+	t.Setenv("HELM_REPOSITORY_CACHE", filepath.Join(home, "cache", "repository"))
+	return &helmManager{}
+}

--- a/pkg/software/config.go
+++ b/pkg/software/config.go
@@ -285,6 +285,18 @@ var (
 	loadCatalogOnce  sync.Once
 )
 
+// ResetCatalogCacheForTest clears the cached catalog so the next
+// LoadInfrastructureCatalog call re-reads, re-parses, and re-validates the
+// embedded YAML. Intended for tests that exercise load-failure paths or
+// swap in alternative embedded data; not safe to call concurrently with
+// LoadInfrastructureCatalog. The name is deliberately verbose so it stands
+// out at call sites — production code must never invoke this.
+func ResetCatalogCacheForTest() {
+	cachedCatalog = nil
+	cachedCatalogErr = nil
+	loadCatalogOnce = sync.Once{}
+}
+
 // LoadInfrastructureCatalog loads, parses, and validates the embedded
 // infrastructure-catalog.yaml configuration. The result is cached for the
 // lifetime of the process — the catalog is embedded in the binary and

--- a/pkg/software/config.go
+++ b/pkg/software/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"runtime"
 	"sort"
+	"sync"
 	"text/template"
 
 	"github.com/hashgraph/solo-weaver/pkg/semver"
@@ -89,14 +90,18 @@ type InfrastructureCatalog struct {
 // ChartMetadata describes a Helm chart entry under `cluster:`. A chart has
 // a single artifact per version; integrity is verified against the SHA256
 // of the .tgz (classic) or the OCI manifest digest (oci), recorded as a
-// Checksum value.
+// Checksum value. Namespace and Release describe the installation topology
+// — the Kubernetes namespace the chart deploys into and the Helm release
+// name used to track it.
 type ChartMetadata struct {
-	Name     string               `yaml:"name"`
-	Type     ChartType            `yaml:"type"`
-	Repo     string               `yaml:"repo,omitempty"`
-	Chart    string               `yaml:"chart"`
-	Default  Version              `yaml:"default"`
-	Versions map[Version]Checksum `yaml:"versions"`
+	Name      string               `yaml:"name"`
+	Type      ChartType            `yaml:"type"`
+	Repo      string               `yaml:"repo,omitempty"`
+	Chart     string               `yaml:"chart"`
+	Namespace string               `yaml:"namespace"`
+	Release   string               `yaml:"release"`
+	Default   Version              `yaml:"default"`
+	Versions  map[Version]Checksum `yaml:"versions"`
 }
 
 // ArtifactMetadata represents a single software artifact  configuration
@@ -274,24 +279,38 @@ type TemplateData struct {
 	ARCH    string
 }
 
+var (
+	cachedCatalog    *InfrastructureCatalog
+	cachedCatalogErr error
+	loadCatalogOnce  sync.Once
+)
+
 // LoadInfrastructureCatalog loads, parses, and validates the embedded
-// infrastructure-catalog.yaml configuration.
+// infrastructure-catalog.yaml configuration. The result is cached for the
+// lifetime of the process — the catalog is embedded in the binary and
+// immutable, so callers must not mutate the returned value.
 func LoadInfrastructureCatalog() (*InfrastructureCatalog, error) {
-	data, err := infrastructureCatalogFS.ReadFile("infrastructure-catalog.yaml")
-	if err != nil {
-		return nil, NewConfigLoadError(err)
-	}
+	loadCatalogOnce.Do(func() {
+		data, err := infrastructureCatalogFS.ReadFile("infrastructure-catalog.yaml")
+		if err != nil {
+			cachedCatalogErr = NewConfigLoadError(err)
+			return
+		}
 
-	var catalog InfrastructureCatalog
-	if err := yaml.Unmarshal(data, &catalog); err != nil {
-		return nil, NewConfigLoadError(err)
-	}
+		var catalog InfrastructureCatalog
+		if err := yaml.Unmarshal(data, &catalog); err != nil {
+			cachedCatalogErr = NewConfigLoadError(err)
+			return
+		}
 
-	if err := catalog.validate(); err != nil {
-		return nil, NewConfigLoadError(err)
-	}
+		if err := catalog.validate(); err != nil {
+			cachedCatalogErr = NewConfigLoadError(err)
+			return
+		}
 
-	return &catalog, nil
+		cachedCatalog = &catalog
+	})
+	return cachedCatalog, cachedCatalogErr
 }
 
 // GetHostArtifact finds a host artifact entry by name.
@@ -312,6 +331,25 @@ func (c *InfrastructureCatalog) GetClusterComponent(name string) (*ChartMetadata
 		}
 	}
 	return nil, NewSoftwareNotFoundError(name)
+}
+
+// MustGetClusterComponent returns the named cluster chart from the embedded
+// catalog. It panics if the catalog cannot be loaded or the chart is not
+// present — both conditions are impossible at runtime because the catalog
+// is embedded into the binary and validated at load time. Callers that
+// reference catalog entries by literal name (steps, RSL defaults, manifest
+// rendering) use this to avoid threading uninteresting errors through every
+// call site.
+func MustGetClusterComponent(name string) *ChartMetadata {
+	catalog, err := LoadInfrastructureCatalog()
+	if err != nil {
+		panic(fmt.Sprintf("infrastructure catalog: %v", err))
+	}
+	chart, err := catalog.GetClusterComponent(name)
+	if err != nil {
+		panic(fmt.Sprintf("infrastructure catalog: %v", err))
+	}
+	return chart
 }
 
 // HostNames returns the names of all host artifacts in the catalog.
@@ -379,6 +417,12 @@ func (cm *ChartMetadata) validate() error {
 	}
 	if cm.Chart == "" {
 		return fmt.Errorf("missing chart reference")
+	}
+	if cm.Namespace == "" {
+		return fmt.Errorf("missing namespace")
+	}
+	if cm.Release == "" {
+		return fmt.Errorf("missing release")
 	}
 	if len(cm.Versions) == 0 {
 		return fmt.Errorf("no versions declared")

--- a/pkg/software/config_it_test.go
+++ b/pkg/software/config_it_test.go
@@ -342,6 +342,7 @@ func Test_Config_ClusterSection_Integration(t *testing.T) {
 		"external-secrets":         {ChartTypeClassic, "0.20.2"},
 		"node-exporter":            {ChartTypeOCI, "4.5.19"},
 		"prometheus-operator-crds": {ChartTypeOCI, "24.0.1"},
+		"solo-operator":            {ChartTypeOCI, "0.3.1"},
 	}
 
 	for name, expected := range expectedCharts {

--- a/pkg/software/config_test.go
+++ b/pkg/software/config_test.go
@@ -1153,11 +1153,13 @@ func Test_Config_ChartMetadata_validate(t *testing.T) {
 		{
 			name: "valid classic chart",
 			chart: ChartMetadata{
-				Name:    "alloy",
-				Type:    ChartTypeClassic,
-				Repo:    "https://grafana.github.io/helm-charts",
-				Chart:   "grafana/alloy",
-				Default: "1.4.0",
+				Name:      "alloy",
+				Type:      ChartTypeClassic,
+				Repo:      "https://grafana.github.io/helm-charts",
+				Chart:     "grafana/alloy",
+				Namespace: "alloy",
+				Release:   "alloy",
+				Default:   "1.4.0",
 				Versions: map[Version]Checksum{
 					"1.4.0": {Algorithm: "sha256", Value: "abc"},
 				},
@@ -1166,10 +1168,12 @@ func Test_Config_ChartMetadata_validate(t *testing.T) {
 		{
 			name: "valid oci chart",
 			chart: ChartMetadata{
-				Name:    "node-exporter",
-				Type:    ChartTypeOCI,
-				Chart:   "oci://registry-1.docker.io/bitnamicharts/node-exporter",
-				Default: "4.5.19",
+				Name:      "node-exporter",
+				Type:      ChartTypeOCI,
+				Chart:     "oci://registry-1.docker.io/bitnamicharts/node-exporter",
+				Namespace: "monitoring",
+				Release:   "node-exporter",
+				Default:   "4.5.19",
 				Versions: map[Version]Checksum{
 					"4.5.19": {Algorithm: "sha256", Value: "def"},
 				},
@@ -1242,13 +1246,45 @@ func Test_Config_ChartMetadata_validate(t *testing.T) {
 			expectedErr: "missing chart reference",
 		},
 		{
-			name: "default pointing to unknown version",
+			name: "missing namespace",
 			chart: ChartMetadata{
 				Name:    "alloy",
 				Type:    ChartTypeClassic,
 				Repo:    "https://grafana.github.io/helm-charts",
 				Chart:   "grafana/alloy",
-				Default: "9.9.9",
+				Release: "alloy",
+				Default: "1.4.0",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+			expectedErr: "missing namespace",
+		},
+		{
+			name: "missing release",
+			chart: ChartMetadata{
+				Name:      "alloy",
+				Type:      ChartTypeClassic,
+				Repo:      "https://grafana.github.io/helm-charts",
+				Chart:     "grafana/alloy",
+				Namespace: "alloy",
+				Default:   "1.4.0",
+				Versions: map[Version]Checksum{
+					"1.4.0": {Algorithm: "sha256", Value: "abc"},
+				},
+			},
+			expectedErr: "missing release",
+		},
+		{
+			name: "default pointing to unknown version",
+			chart: ChartMetadata{
+				Name:      "alloy",
+				Type:      ChartTypeClassic,
+				Repo:      "https://grafana.github.io/helm-charts",
+				Chart:     "grafana/alloy",
+				Namespace: "alloy",
+				Release:   "alloy",
+				Default:   "9.9.9",
 				Versions: map[Version]Checksum{
 					"1.4.0": {Algorithm: "sha256", Value: "abc"},
 				},
@@ -1258,11 +1294,13 @@ func Test_Config_ChartMetadata_validate(t *testing.T) {
 		{
 			name: "version with empty algorithm",
 			chart: ChartMetadata{
-				Name:    "alloy",
-				Type:    ChartTypeClassic,
-				Repo:    "https://grafana.github.io/helm-charts",
-				Chart:   "grafana/alloy",
-				Default: "1.4.0",
+				Name:      "alloy",
+				Type:      ChartTypeClassic,
+				Repo:      "https://grafana.github.io/helm-charts",
+				Chart:     "grafana/alloy",
+				Namespace: "alloy",
+				Release:   "alloy",
+				Default:   "1.4.0",
 				Versions: map[Version]Checksum{
 					"1.4.0": {Algorithm: "", Value: "abc"},
 				},
@@ -1272,11 +1310,13 @@ func Test_Config_ChartMetadata_validate(t *testing.T) {
 		{
 			name: "version with empty checksum",
 			chart: ChartMetadata{
-				Name:    "alloy",
-				Type:    ChartTypeClassic,
-				Repo:    "https://grafana.github.io/helm-charts",
-				Chart:   "grafana/alloy",
-				Default: "1.4.0",
+				Name:      "alloy",
+				Type:      ChartTypeClassic,
+				Repo:      "https://grafana.github.io/helm-charts",
+				Chart:     "grafana/alloy",
+				Namespace: "alloy",
+				Release:   "alloy",
+				Default:   "1.4.0",
 				Versions: map[Version]Checksum{
 					"1.4.0": {Algorithm: "sha256", Value: ""},
 				},
@@ -1298,22 +1338,26 @@ func Test_Config_ChartMetadata_validate(t *testing.T) {
 		{
 			name: "no versions declared",
 			chart: ChartMetadata{
-				Name:    "alloy",
-				Type:    ChartTypeClassic,
-				Repo:    "https://grafana.github.io/helm-charts",
-				Chart:   "grafana/alloy",
-				Default: "1.4.0",
+				Name:      "alloy",
+				Type:      ChartTypeClassic,
+				Repo:      "https://grafana.github.io/helm-charts",
+				Chart:     "grafana/alloy",
+				Namespace: "alloy",
+				Release:   "alloy",
+				Default:   "1.4.0",
 			},
 			expectedErr: "no versions declared",
 		},
 		{
 			name: "per-version checksum error surfaces before bad default",
 			chart: ChartMetadata{
-				Name:    "alloy",
-				Type:    ChartTypeClassic,
-				Repo:    "https://grafana.github.io/helm-charts",
-				Chart:   "grafana/alloy",
-				Default: "9.9.9", // also bogus, but checksum error wins
+				Name:      "alloy",
+				Type:      ChartTypeClassic,
+				Repo:      "https://grafana.github.io/helm-charts",
+				Chart:     "grafana/alloy",
+				Namespace: "alloy",
+				Release:   "alloy",
+				Default:   "9.9.9", // also bogus, but checksum error wins
 				Versions: map[Version]Checksum{
 					"1.4.0": {Algorithm: "", Value: "abc"},
 				},
@@ -1328,11 +1372,13 @@ func Test_Config_ChartMetadata_validate(t *testing.T) {
 			// the error message is stable.
 			name: "deterministic: alphabetically first malformed version is reported",
 			chart: ChartMetadata{
-				Name:    "alloy",
-				Type:    ChartTypeClassic,
-				Repo:    "https://grafana.github.io/helm-charts",
-				Chart:   "grafana/alloy",
-				Default: "1.4.0",
+				Name:      "alloy",
+				Type:      ChartTypeClassic,
+				Repo:      "https://grafana.github.io/helm-charts",
+				Chart:     "grafana/alloy",
+				Namespace: "alloy",
+				Release:   "alloy",
+				Default:   "1.4.0",
 				Versions: map[Version]Checksum{
 					"1.4.0": {Algorithm: "", Value: "abc"},
 					"2.0.0": {Algorithm: "", Value: "def"},
@@ -1375,11 +1421,13 @@ func Test_Config_InfrastructureCatalog_validate(t *testing.T) {
 				},
 				Cluster: []ChartMetadata{
 					{
-						Name:    "alloy",
-						Type:    ChartTypeClassic,
-						Repo:    "https://grafana.github.io/helm-charts",
-						Chart:   "grafana/alloy",
-						Default: "1.4.0",
+						Name:      "alloy",
+						Type:      ChartTypeClassic,
+						Repo:      "https://grafana.github.io/helm-charts",
+						Chart:     "grafana/alloy",
+						Namespace: "alloy",
+						Release:   "alloy",
+						Default:   "1.4.0",
 						Versions: map[Version]Checksum{
 							"1.4.0": {Algorithm: "sha256", Value: "abc"},
 						},

--- a/pkg/software/config_test.go
+++ b/pkg/software/config_test.go
@@ -1489,6 +1489,29 @@ func Test_Config_LoadInfrastructureCatalog(t *testing.T) {
 	require.NotEmpty(t, catalog.Cluster, "cluster section must not be empty")
 }
 
+// Test_Config_LoadInfrastructureCatalog_Cached pins the sync.Once cache
+// behaviour: repeated calls return the same pointer, and ResetCatalogCacheForTest
+// forces a fresh load. Together these allow tests that mutate package-level
+// state to remain isolated.
+func Test_Config_LoadInfrastructureCatalog_Cached(t *testing.T) {
+	t.Cleanup(ResetCatalogCacheForTest)
+
+	first, err := LoadInfrastructureCatalog()
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	second, err := LoadInfrastructureCatalog()
+	require.NoError(t, err)
+	require.Same(t, first, second, "cached call must return the same pointer")
+
+	ResetCatalogCacheForTest()
+
+	third, err := LoadInfrastructureCatalog()
+	require.NoError(t, err)
+	require.NotNil(t, third)
+	require.NotSame(t, first, third, "after reset, a fresh catalog instance must be returned")
+}
+
 func Test_Config_TemplateExecution(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/software/infrastructure-catalog.yaml
+++ b/pkg/software/infrastructure-catalog.yaml
@@ -307,6 +307,8 @@ cluster:
   type: classic
   repo: 'https://grafana.github.io/helm-charts'
   chart: 'grafana/alloy'
+  namespace: 'grafana-alloy'
+  release: 'grafana-alloy'
   default: "1.4.0"
   versions:
     1.4.0:
@@ -317,6 +319,8 @@ cluster:
   type: classic
   repo: 'https://charts.releases.teleport.dev'
   chart: 'teleport/teleport-kube-agent'
+  namespace: 'teleport-agent'
+  release: 'teleport-agent'
   default: "18.6.4"
   versions:
     18.6.4:
@@ -327,6 +331,8 @@ cluster:
   type: classic
   repo: 'https://metallb.github.io/metallb'
   chart: 'metallb/metallb'
+  namespace: 'metallb-system'
+  release: 'metallb'
   default: "0.15.2"
   versions:
     0.15.2:
@@ -337,6 +343,8 @@ cluster:
   type: classic
   repo: 'https://kubernetes-sigs.github.io/metrics-server'
   chart: 'metrics-server/metrics-server'
+  namespace: 'kube-system'
+  release: 'metrics-server'
   default: "3.13.0"
   versions:
     3.13.0:
@@ -347,6 +355,8 @@ cluster:
   type: classic
   repo: 'https://charts.external-secrets.io'
   chart: 'external-secrets/external-secrets'
+  namespace: 'external-secrets'
+  release: 'external-secrets'
   default: "0.20.2"
   versions:
     0.20.2:
@@ -356,6 +366,8 @@ cluster:
 - name: node-exporter
   type: oci
   chart: 'oci://registry-1.docker.io/bitnamicharts/node-exporter'
+  namespace: 'node-exporter'
+  release: 'node-exporter'
   default: "4.5.19"
   versions:
     4.5.19:
@@ -365,8 +377,21 @@ cluster:
 - name: prometheus-operator-crds
   type: oci
   chart: 'oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds'
+  namespace: 'grafana-alloy'
+  release: 'prometheus-operator-crds'
   default: "24.0.1"
   versions:
     24.0.1:
       algorithm: 'sha256'
       checksum: 'e940c5ce899ec16aa6d868ecf49e2c21193728bef3a0a453b29e05e2d1601288'
+
+- name: solo-operator
+  type: oci
+  chart: 'oci://ghcr.io/hashgraph/charts/solo-operator'
+  namespace: 'solo-operator'
+  release: 'solo-operator'
+  default: "0.3.1"
+  versions:
+    0.3.1:
+      algorithm: 'sha256'
+      checksum: 'b77cb63d456e472d5ae8e1759e85fd6e4fbdeae12398b20f9df97d54f036a73a'


### PR DESCRIPTION
## Description

This pull request integrates the infrastructure catalog into all Helm-based cluster setup workflows, ensuring that chart versions and checksums are centrally managed and verified at install time. It removes hardcoded chart constants, adds checksum verification for Helm charts, and updates related command-line flags and documentation. The changes also improve test coverage and developer tooling.

**Helm workflow and catalog integration:**

* All cluster Helm install/upgrade steps now resolve chart version and checksum from the catalog, verify the pulled artifact, and fail on mismatch. This removes the need for hardcoded chart version constants and ensures integrity checks for all seven cluster charts.
* The `pkg/helm/Manager` interface adds a new `PullAndVerify` method, implemented for both classic and OCI charts, which pulls the chart and verifies its checksum.
* A helper in `internal/workflows/steps/catalog.go` centralizes chart resolution and download directory logic for all steps.

**Configuration and CLI changes:**

* The `--version` flag for `teleport cluster install` now displays the catalog default version in its help text, resolving it at command construction time. The install step reads from the catalog, with a documented carve-out for custom operator-supplied versions. [[1]](diffhunk://#diff-f877e115c72e350f0a0940f1b53bd2dce5149f608dd0fc08315d597847d22305L9-R9) [[2]](diffhunk://#diff-f877e115c72e350f0a0940f1b53bd2dce5149f608dd0fc08315d597847d22305L31-R42) [[3]](diffhunk://#diff-3c247fd04d29d38f9dbe18b2d66c566107bb5a4e3b2c46c47d41d0f54ab54fc2R1-R183)

**Codebase cleanup:**

* All catalog-related constants (version, chart, repo, namespace, release) for cluster charts are removed from `pkg/deps/deps.go`, leaving only block node constants. The file's doc comment is rewritten for clarity.

**Testing and developer tooling:**

* Adds new unit tests for the catalog integration and Helm pulling logic.
* Updates the `Taskfile.yaml` mocks task to generate a mock for the new `pkg/helm/Manager` interface. [[1]](diffhunk://#diff-1552e0a6f970b2191f0e8ef34ac62e41815fc6cdbc213921e915a042e500f03aR295) [[2]](diffhunk://#diff-3c247fd04d29d38f9dbe18b2d66c566107bb5a4e3b2c46c47d41d0f54ab54fc2R1-R183)

**Documentation:**

* Adds a detailed plan and review guide documenting the approach, critical files, and verification steps for this integration.

### Related Issues

* Closes #589 
