### PR TITLE
refactor(sanity): split validators into Sanitize*/Validate* and add skill

### DIFF
--- a/.claude/skills/sanity-validators/SKILL.md
+++ b/.claude/skills/sanity-validators/SKILL.md
@@ -113,13 +113,14 @@ persisted fields, also add a validation pass at the load boundary.
 `ValidateUsername` (and any future validator that permits `.`) rejects `..` as
 a substring before iterating characters. Don't reorder these.
 
-### 5. Shell metachars are a strict superset of what the charset rejects
+### 5. Shell metachars are a separate, smaller gate than the full charset check
 
-`shellMetachars = [;&|$\x60<>(){}[\]*?~]` is intentionally a separate gate so
+`shellMetachars = [;&|$\x60<>(){}[\]*?~]` is intentionally checked separately so
 the error message can distinguish "contains shell metacharacter" from "contains
-invalid character". Both produce safe behavior; only the error text differs. Do
-not collapse them into a single regex unless you also change the error
-messages.
+invalid character". This set is narrower than what the per-validator charset
+rejects: many non-shell characters are still invalid there. Both checks produce
+safe behavior; this split only affects error specificity. Do not collapse them
+into a single regex unless you also change the error messages.
 
 ---
 

--- a/.claude/skills/sanity-validators/SKILL.md
+++ b/.claude/skills/sanity-validators/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: sanity-validators
+description: Use this skill BEFORE writing or modifying any input validation in this repo — e.g. "validate this CLI flag", "sanitize this filename", "check this username", "add a new sanity helper", any edit that touches pkg/sanity/sanity.go or any caller that runs user-supplied / env-derived / config-derived strings through a `sanity.*` helper. Captures the Sanitize* vs Validate* naming pattern, the per-validator character sets, and the decision matrix for picking the right helper. Read this BEFORE relaxing or tightening any validator — the rules are scoped and the wrong helper is what produced issue #600.
+---
+
+# pkg/sanity validators — naming, scope, and decision matrix
+
+`pkg/sanity` is the single chokepoint for validating untrusted strings before they
+reach the OS, the shell, Helm, kubectl, file paths, or NSS lookups. Every helper
+in this package follows one of two patterns; using the wrong one (or reusing a
+helper scoped to a different domain) is how validation bugs slip in.
+
+---
+
+## The two patterns
+
+| Prefix | Signature | Behavior |
+|---|---|---|
+| `Sanitize*` | `(s string) (string, error)` | **Strips** invalid characters and returns the cleaned form. Errors only if nothing valid remains (returns `ErrInvalidName`). The caller is expected to use the returned value, not the input. |
+| `Validate*` | `(s string) error` | **Rejects** any input containing invalid characters. The caller uses the input string as-is when the error is `nil`. |
+
+**Signature is destiny.** A `(string, error)` return means "I might rewrite your
+input" — if the caller doesn't use the returned value, the validation is wasted
+or wrong. An `error` return means "I won't touch it" — the input is safe to use.
+
+**Default to `Validate*` for anything sourced from a user or environment.** Use
+`Sanitize*` only when the codebase itself is constructing a string from
+trusted-but-messy inputs (e.g. deriving a filename from a label).
+
+---
+
+## Function catalog
+
+### Sanitizers (return `(string, error)`)
+
+| Function | Charset | Use for |
+|---|---|---|
+| `SanitizeIdentifier` | `[A-Za-z0-9_-]` | Generic identifiers when no more specific helper fits. |
+| `SanitizeFilename` | `[A-Za-z0-9_-]` (today, same as identifier) | Derived filenames. Standalone so future relaxation (e.g. permit `.`) can land without touching identifier or module-name callers. |
+| `SanitizeModuleName` | `[A-Za-z0-9_-]` (today, same as identifier) | Linux kernel module names. Standalone so future tightening (drop `-`, since kernel modules use `_`) can land without touching identifier or filename callers. |
+| `SanitizePath` | path semantics | File-system paths. Cleans, makes absolute, rejects `..` segments and shell metacharacters. |
+| `Alphanumeric` | `[A-Za-z0-9]` | Pure transformer (`string` return only, no error). For display-string normalisation, not security validation. |
+
+All sanitizers return `ErrInvalidName` when filtering leaves nothing.
+
+### Validators (return `error`)
+
+| Function | Charset / contract | Use for |
+|---|---|---|
+| `ValidateIdentifier` | `[A-Za-z0-9_-]`, non-empty | Namespace / release / profile names; anything that flows into Kubernetes object names. |
+| `ValidateUsername` | `[A-Za-z0-9_.-]`, non-empty, no `..`, no shell metachars | POSIX/Linux usernames (`SUDO_USER`, owner accounts). Permits `.` for `firstname.lastname` accounts. |
+| `ValidateDNSName` | `[A-Za-z0-9.-]` matching RFC 952/1123 host pattern | Hostnames, FQDNs, cluster names derived from DNS. |
+| `ValidateHexToken` | `[0-9a-fA-F]`, length ≤ 4096 | Teleport join tokens and similar hex secrets. |
+| `ValidateHostPort` | hostname or hostname:port; no path components, no shell metachars | `host:port` style endpoints. Use `ValidateURL` for full URLs. |
+| `ValidateChartReference` | OCI URL / classic `repo/chart` / local path | Helm chart references. **Critical** for the block-node `Chart` field. |
+| `ValidateInputFile` | path semantics + file exists + within allowed roots | User-supplied file paths from CLI flags. |
+
+---
+
+## Decision matrix — "which one do I use for X?"
+
+Match by what the string represents in the real world, not by what it looks like:
+
+- **Kubernetes namespace / release / profile name** → `ValidateIdentifier`
+- **Linux user account** (SUDO_USER, file owner, sudoers principal) → `ValidateUsername`
+- **Kernel module name** → `SanitizeModuleName` (current callers want the sanitized form for the modprobe call)
+- **Helm chart reference** → `ValidateChartReference`
+- **Hostname / FQDN / cluster DNS name** → `ValidateDNSName`
+- **host:port endpoint** → `ValidateHostPort`
+- **Hex token / shared secret** → `ValidateHexToken`
+- **Filesystem path from a user** → `SanitizePath` (when you'll use the cleaned form) or `ValidateInputFile` (when you need the file to exist and be in an allowed root)
+- **Derived filename from an internal label** → `SanitizeFilename`
+- **Display-only string normalisation** → `Alphanumeric`
+- **Nothing on this list matches** → do **not** repurpose a near-fit; add a new validator scoped to the actual domain.
+
+---
+
+## Hard rules
+
+### 1. Do not alias one validator to another
+
+Before issue #602, `Filename` and `ModuleName` were literal aliases of `Identifier`.
+That made it impossible to relax the username charset (issue #600) without
+implicitly broadening filenames and kernel-module names too. Each domain gets its
+own function even when the charset is currently identical — future divergence
+should not require touching unrelated callers.
+
+### 2. Validate at the boundary, not in the middle
+
+The right call site is **the first point a string enters the program from an
+untrusted source**:
+
+- CLI flag parsing in `cmd/cli/commands/**/init.go`
+- Config-file unmarshal in `pkg/config/global.go`
+- Env-var reads (e.g. `os.Getenv("SUDO_USER")` in `internal/kube/admin.go`)
+- Public API entry points
+
+Do not assume an upstream caller already validated. If you're about to use a
+string in a Helm/kubectl/shell/path/NSS operation and the validator hasn't run
+in the current function or its immediate caller, run it.
+
+### 3. Don't reuse `Validate*` against persisted state
+
+Validators are designed for fresh user input. When code loads a previously
+persisted value (e.g. `BlockNodeState.ReleaseInfo.ChartRef` from disk) and the
+value will be used as authoritative without re-validation, the validator's
+guarantees no longer hold — a corrupted or pre-relaxation-era state file can
+smuggle in values that the current validator would reject. If you add new
+persisted fields, also add a validation pass at the load boundary.
+
+### 4. The `..` substring check runs **before** the per-char check
+
+`ValidateUsername` (and any future validator that permits `.`) rejects `..` as
+a substring before iterating characters. Don't reorder these.
+
+### 5. Shell metachars are a strict superset of what the charset rejects
+
+`shellMetachars = [;&|$\x60<>(){}[\]*?~]` is intentionally a separate gate so
+the error message can distinguish "contains shell metacharacter" from "contains
+invalid character". Both produce safe behavior; only the error text differs. Do
+not collapse them into a single regex unless you also change the error
+messages.
+
+---
+
+## When adding a new validator
+
+1. **Name it for the domain, not the charset.** `ValidateUsername`, not
+   `ValidateAlnumDotUnderscoreHyphen`.
+2. **Pick the right prefix**: `Validate*` (strict) if any non-empty caller will
+   pass an env/CLI/config string; `Sanitize*` only if every call site wants the
+   cleaned form.
+3. **Don't reuse `isValidIdentifierChar` if your domain might diverge.** Add a
+   domain-specific predicate (`isValidUsernameChar`, `isValidFooBarChar`) even
+   if it returns the same set today.
+4. **Reject empty first.** Every validator should return `"<name> cannot be empty"`
+   on `""`.
+5. **Reject `..` and shell metachars next**, before the per-char loop, when the
+   permitted charset includes any of `. / -`.
+6. **Add tests for**: empty input, valid happy path, every shell metachar, every
+   control byte (`\x00`, `\n`, `\r`, `\t`, `\x07`, `\x1b`), a `..` traversal
+   attempt, a SQL/command-injection attempt, and a path-traversal attempt. Mirror
+   the structure of `TestSanity_ValidateUsername` in `pkg/sanity/sanity_test.go`.
+7. **Update this skill** with the new validator and its decision-matrix row.
+
+---
+
+## History (so the conventions don't drift)
+
+- **Issue #600**: `Username` rejected `firstname.lastname` accounts (e.g.
+  `nana.ec`). Fixed by permitting `.` in the username charset and reaffirming
+  the existing `..` traversal check.
+- **Issue #602**: split the package into `Sanitize*` vs `Validate*` by behavior;
+  dropped the `Filename`/`ModuleName`-as-aliases-of-`Identifier` shortcut so each
+  domain can evolve independently; renamed `Username` → `ValidateUsername` to
+  match its actual semantics (returns `error`, not a sanitized form).

--- a/docs/claude/reviews/00602-sanity-validators-rename-and-skill.md
+++ b/docs/claude/reviews/00602-sanity-validators-rename-and-skill.md
@@ -1,0 +1,166 @@
+# PR Review Guide — refactor(sanity): Sanitize*/Validate* pattern + skill
+
+**Issue:** [#602](https://github.com/hashgraph/solo-weaver/issues/602)  
+**Branch:** `00602-sanity-validators-rename-and-skill` (stacked on `00600-allow-dot-in-username`)
+
+---
+
+## What Was Done
+
+### Problem
+
+`pkg/sanity` exposed ~10 input validators with inconsistent naming and overlapping behavior.
+Half were `Validate*`-prefixed; the other half were bare nouns (`Identifier`, `Filename`,
+`ModuleName`, `Username`) that sometimes stripped invalid characters and sometimes rejected
+them — same naming style, opposite behavior. `Username` even returned `(string, error)`
+like a sanitizer but actually rejected any input that would have been changed. This
+mismatch is what produced issue #600 (SUDO_USER `nana.ec` rejected because `Username`
+silently reused the strict identifier charset).
+
+Additional confusion: `Filename` and `ModuleName` were literal aliases of `Identifier`,
+so relaxing one would have broadened all three even though their domains have different
+real-world rules.
+
+### Solution
+
+Split the API by behavior, let the prefix and signature carry the contract:
+
+| Prefix | Signature | Behavior |
+|---|---|---|
+| `Sanitize*` | `(s string) (string, error)` | Strip invalid chars, return cleaned form |
+| `Validate*` | `(s string) error` | Reject any input containing invalid chars |
+
+Concrete renames:
+
+- `Identifier` → `SanitizeIdentifier`
+- `Filename` → `SanitizeFilename` (now a standalone function, no longer an alias)
+- `ModuleName` → `SanitizeModuleName` (now a standalone function, no longer an alias)
+- `Username` → `ValidateUsername` (returns `error` only; no more deceptive `(string, error)`)
+- `ErrInvalidFilename` → `ErrInvalidName` (one shared sentinel across all sanitizers)
+
+Character sets are unchanged in this PR — the only behavioral change is `Username`'s '.'
+permissiveness, which already landed in #600 and is carried forward here because this
+branch is stacked on it.
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `pkg/sanity/sanity.go` | Rename `Identifier`/`Filename`/`ModuleName` → `Sanitize*` (standalone functions, no longer aliases); rename `Username` → `ValidateUsername` (return `error`); rename sentinel to `ErrInvalidName`; drop unused `filterValidUsernameChars` helper. |
+| `pkg/sanity/sanity_test.go` | Rename test functions (`TestSanity_Filename` → `TestSanity_SanitizeFilename`, `TestSanity_Username` → `TestSanity_ValidateUsername`); drop `expected` fields from username cases (no longer returned); update two cases where the error message changed (`!!!` and `"   "` now report "contains invalid characters" rather than "contains no valid characters" because byte-iteration short-circuits before the empty-result branch). |
+| `internal/kube/admin.go` | Switch `sanity.Username(sudoUser)` → `sanity.ValidateUsername(sudoUser)`; drop the unused `sanitizedUsername` local; use `sudoUser` directly in downstream `LookupUserByName` / log calls. |
+| `pkg/kernel/module.go` | 3x `sanity.ModuleName(name)` → `sanity.SanitizeModuleName(name)`. |
+| `.claude/skills/sanity-validators/SKILL.md` | New skill (directory form) documenting the Sanitize*/Validate* pattern, the decision matrix, and the rules for adding new validators. |
+
+---
+
+## Code Review Checklist
+
+### `pkg/sanity/sanity.go`
+
+- [ ] `SanitizeIdentifier`, `SanitizeFilename`, `SanitizeModuleName` are three **separate** functions even though their bodies are currently identical — no aliasing, no helper-of-helper.
+- [ ] All three return `ErrInvalidName` on empty-after-filter.
+- [ ] `ValidateUsername` returns `error` only.
+- [ ] `ValidateUsername` runs checks in this order: empty → `..` substring → shell metachars → per-char loop.
+- [ ] `isValidUsernameChar` permits `.` (carried from #600); `isValidIdentifierChar` does **not** permit `.` (still strict).
+- [ ] No `Identifier`, `Filename`, `ModuleName`, or `Username` symbol remains exported.
+
+### `pkg/sanity/sanity_test.go`
+
+- [ ] All `ErrInvalidFilename` references are updated to `ErrInvalidName`.
+- [ ] `TestSanity_ValidateUsername` calls `ValidateUsername(tc.input)` and asserts only on `err`.
+- [ ] Existing security regression cases (`..`, shell metachars, control bytes, SQL/command injection) still produce errors.
+- [ ] Positive dotted-username cases from #600 (`john.doe`, `a.b.c`, `.hidden`, `trailing.`, `nana.ec`) all pass.
+
+### `internal/kube/admin.go`
+
+- [ ] `ValidateUsername` is called **before** `LookupUserByName`. The original input (`sudoUser`) is passed downstream — there is no longer a `sanitizedUsername` local.
+- [ ] Log messages and error wrappings reference `sudoUser` consistently.
+
+### `pkg/kernel/module.go`
+
+- [ ] All three call sites updated; the existing `sanitized != name` post-check at lines 130 / 143 still runs (`SanitizeModuleName` preserves the same return contract).
+
+### `.claude/skills/sanity-validators/SKILL.md`
+
+- [ ] Frontmatter `name:` matches the directory name (`sanity-validators`).
+- [ ] `description:` is specific enough to match "validate this", "sanitize this", "check this username", or edits touching `pkg/sanity/sanity.go`.
+- [ ] Decision matrix lists every public validator/sanitizer.
+- [ ] History section references issues #600 and #602.
+
+---
+
+## Commands
+
+### Lint
+
+```bash
+task lint:check
+```
+
+### Unit tests (macOS-compatible packages)
+
+```bash
+go test -race -cover -tags='!integration' \
+  ./pkg/sanity/... \
+  ./pkg/models/... \
+  ./internal/kube/... \
+  ./internal/ui/...
+```
+
+Expected: all packages pass; `pkg/sanity` coverage drops slightly (from ~75% to ~71%)
+because the unused `filterValidUsernameChars` helper was removed.
+
+### Full unit suite (run inside the UTM VM, includes `pkg/kernel/...`)
+
+```bash
+task vm:test:unit
+```
+
+---
+
+## Manual UAT
+
+1. Build for Linux and load into the VM (or a host with a dotted user account):
+
+   ```bash
+   task build:cli GOOS=linux GOARCH=amd64
+   ```
+
+2. Confirm the dotted-username happy path still works (regression on #600):
+
+   ```bash
+   sudo -u nana.ec ./bin/solo-provisioner-linux-amd64 kube cluster install --profile local
+   ```
+
+   Expected: `Initializing Kubernetes cluster` step succeeds; kubeconfig appears at
+   `/home/nana.ec/.kube/config`.
+
+3. Confirm kernel-module install still works (regression on the `SanitizeModuleName`
+   rename):
+
+   ```bash
+   sudo ./bin/solo-provisioner-linux-amd64 kube cluster install --profile local
+   lsmod | grep -E 'overlay|br_netfilter'
+   ```
+
+   Expected: both modules are listed.
+
+4. Confirm the rejection paths still reject:
+
+   ```bash
+   sudo env SUDO_USER='ev..il' ./bin/solo-provisioner-linux-amd64 kube cluster install --profile local
+   ```
+
+   Expected: `invalid SUDO_USER environment variable: ev..il, cause: ... username contains path traversal sequences`.
+
+---
+
+## Out of scope
+
+- Character-set divergence between `SanitizeFilename` / `SanitizeModuleName` /
+  `SanitizeIdentifier` is intentionally **not** done in this PR — bodies are
+  identical so the rename has zero behavior change for those sanitizers. The
+  skill documents the future-divergence intent.
+- Re-validation of persisted state on load (e.g. `BlockNodeState.ReleaseInfo.ChartRef`)
+  is a separate concern that the skill flags but doesn't address here.

--- a/internal/kube/admin.go
+++ b/internal/kube/admin.go
@@ -155,23 +155,21 @@ func (m *KubeConfigManager) configureCurrentUserKubeConfig() error {
 		return nil
 	}
 
-	// Validate and sanitize the SUDO_USER environment variable
-	// This is critical as environment variables can be manipulated by attackers
-	sanitizedUsername, err := sanity.Username(sudoUser)
-	if err != nil {
+	// Reject SUDO_USER values that would be unsafe to pass downstream. Env vars
+	// can be manipulated by attackers so this gate must run before any use of
+	// sudoUser in NSS lookups or path construction.
+	if err := sanity.ValidateUsername(sudoUser); err != nil {
 		return errorx.IllegalState.Wrap(err, "invalid SUDO_USER environment variable: %s", sudoUser)
 	}
 
-	// Lookup the sudo user using the sanitized username
-	currentUser, err := m.principalManager.LookupUserByName(sanitizedUsername)
+	currentUser, err := m.principalManager.LookupUserByName(sudoUser)
 	if err != nil {
-		return errorx.IllegalState.Wrap(err, "failed to lookup current user: %s", sanitizedUsername)
+		return errorx.IllegalState.Wrap(err, "failed to lookup current user: %s", sudoUser)
 	}
 
-	// Get the user's primary group
 	currentGroup := currentUser.PrimaryGroup()
 	if currentGroup == nil {
-		return errorx.IllegalState.New("current user %s has no primary group", sanitizedUsername)
+		return errorx.IllegalState.New("current user %s has no primary group", sudoUser)
 	}
 
 	// Determine kubeconfig directory using the validated user's home directory

--- a/pkg/kernel/module.go
+++ b/pkg/kernel/module.go
@@ -39,7 +39,7 @@ type defaultOperations struct{}
 func NewModule(name string) (Module, error) {
 	// Validate module name to prevent command injection
 	// Kernel module names should only contain alphanumeric, underscore, and hyphen
-	sanitized, err := sanity.ModuleName(name)
+	sanitized, err := sanity.SanitizeModuleName(name)
 	if err != nil {
 		return nil, errorx.IllegalArgument.New(errInvalidModuleName, name, err)
 	}
@@ -123,7 +123,7 @@ var _ moduleOperations = (*defaultOperations)(nil)
 
 func (ops *defaultOperations) load(name string) error {
 	// Validate module name before passing to modprobe to prevent command injection
-	sanitized, err := sanity.ModuleName(name)
+	sanitized, err := sanity.SanitizeModuleName(name)
 	if err != nil {
 		return errorx.IllegalArgument.New(errInvalidModuleName, name, err)
 	}
@@ -136,7 +136,7 @@ func (ops *defaultOperations) load(name string) error {
 
 func (ops *defaultOperations) unload(name string) error {
 	// Validate module name before passing to modprobe to prevent command injection
-	sanitized, err := sanity.ModuleName(name)
+	sanitized, err := sanity.SanitizeModuleName(name)
 	if err != nil {
 		return errorx.IllegalArgument.New(errInvalidModuleName, name, err)
 	}

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -14,7 +14,9 @@ import (
 )
 
 var (
-	ErrInvalidFilename = errorx.IllegalArgument.New("invalid filename")
+	// ErrInvalidName is returned by Sanitize* helpers when the input contains
+	// no valid characters and would otherwise sanitize to an empty string.
+	ErrInvalidName = errorx.IllegalArgument.New("invalid name")
 )
 
 // Security validation patterns for paths
@@ -73,33 +75,45 @@ func filterValidIdentifierChars(s string) (string, int) {
 // In addition to the identifier set (alphanumeric, underscore, hyphen), it
 // allows '.' because POSIX/Linux usernames commonly use the firstname.lastname
 // convention (e.g. via SSSD/AD-joined hosts). The '..' traversal sequence is
-// still rejected upstream in Username().
+// still rejected upstream in ValidateUsername().
 func isValidUsernameChar(b byte) bool {
 	return isValidIdentifierChar(b) || b == '.'
 }
 
-// filterValidUsernameChars filters a string to contain only valid username characters
-// Returns the filtered string and the count of valid characters
-func filterValidUsernameChars(s string) (string, int) {
-	sb := []byte(s)
-	j := 0
-	for _, b := range sb {
-		if isValidUsernameChar(b) {
-			sb[j] = b
-			j++
-		}
-	}
-	return string(sb[:j]), j
-}
-
-// Identifier validates and sanitizes a string to be a safe identifier.
-// It only allows alphanumeric characters (a-z, A-Z, 0-9), underscores, and hyphens.
-// This is useful for validating module names, filenames, usernames, and other identifiers.
-// Returns an error if the identifier is empty or contains no valid characters after sanitization.
-func Identifier(s string) (string, error) {
+// SanitizeIdentifier strips any non-identifier characters from s and returns
+// the cleaned form. Identifier characters are alphanumerics, underscore, and
+// hyphen ([A-Za-z0-9_-]). Returns ErrInvalidName when no valid characters
+// remain. Use ValidateIdentifier when callers must reject (rather than rewrite)
+// inputs containing invalid characters.
+func SanitizeIdentifier(s string) (string, error) {
 	sanitized, count := filterValidIdentifierChars(s)
 	if count == 0 {
-		return "", ErrInvalidFilename
+		return "", ErrInvalidName
+	}
+	return sanitized, nil
+}
+
+// SanitizeFilename strips any non-filename characters from s and returns the
+// cleaned form. Today the character set matches SanitizeIdentifier; the
+// function is kept distinct so future relaxation (e.g. to permit '.' in real
+// filenames) can diverge without touching identifier or kernel-module callers.
+func SanitizeFilename(s string) (string, error) {
+	sanitized, count := filterValidIdentifierChars(s)
+	if count == 0 {
+		return "", ErrInvalidName
+	}
+	return sanitized, nil
+}
+
+// SanitizeModuleName strips any non-module-name characters from s and returns
+// the cleaned form. Today the character set matches SanitizeIdentifier; the
+// function is kept distinct so future tightening (e.g. to drop '-' since the
+// Linux kernel module convention is '_') can diverge without touching
+// identifier or filename callers.
+func SanitizeModuleName(s string) (string, error) {
+	sanitized, count := filterValidIdentifierChars(s)
+	if count == 0 {
+		return "", ErrInvalidName
 	}
 	return sanitized, nil
 }
@@ -218,59 +232,44 @@ func ValidateHostPort(s string) error {
 	return nil
 }
 
-// Filename is an alias for Identifier
-func Filename(s string) (string, error) {
-	return Identifier(s)
-}
-
-// ModuleName is an alias for Identifier
-func ModuleName(s string) (string, error) {
-	return Identifier(s)
-}
-
-// Username validates and sanitizes a username string to prevent security vulnerabilities.
+// ValidateUsername rejects any username string that would be unsafe to pass
+// downstream to OS / shell / Helm operations.
 //
-// This function is particularly important when dealing with environment variables like SUDO_USER
-// that could be manipulated by attackers. It ensures that the username:
-//  1. Is not empty (precondition check)
-//  2. Contains only alphanumeric characters (a-z, A-Z, 0-9), underscores, hyphens, and dots
-//  3. Does not contain path traversal sequences (e.g., "..", "/")
-//  4. Does not contain shell metacharacters or special characters
-//  5. Contains at least one valid character after sanitization
+// It is particularly important for environment variables like SUDO_USER, which
+// can be manipulated by attackers. ValidateUsername errors if the input:
+//  1. Is empty
+//  2. Contains a path-traversal sequence ("..")
+//  3. Contains shell metacharacters
+//  4. Contains any character outside the username set
+//     ([A-Za-z0-9_.-] — alphanumerics, underscore, hyphen, dot)
 //
-// Dots are permitted to support common firstname.lastname Linux account conventions
-// (e.g. SSSD/AD-joined hosts). Path traversal via ".." is still rejected.
+// Dots are permitted to support common firstname.lastname Linux account
+// conventions (e.g. via SSSD/AD-joined hosts); ".." is still rejected.
 //
-// Returns the sanitized username, or an error if the username is invalid or unsafe.
-func Username(s string) (string, error) {
+// Returns nil when the input is safe; the caller can then use s as-is.
+func ValidateUsername(s string) error {
 	if s == "" {
-		return "", errorx.IllegalArgument.New("username cannot be empty")
+		return errorx.IllegalArgument.New("username cannot be empty")
 	}
 
 	// Check for path traversal attempts
 	if strings.Contains(s, "..") {
-		return "", errorx.IllegalArgument.New("username contains path traversal sequences: %s", s)
+		return errorx.IllegalArgument.New("username contains path traversal sequences: %s", s)
 	}
 
 	// Check for shell metacharacters
 	if shellMetachars.MatchString(s) {
-		return "", errorx.IllegalArgument.New("username contains shell metacharacters: %s", s)
+		return errorx.IllegalArgument.New("username contains shell metacharacters: %s", s)
 	}
 
-	// Sanitize: only allow alphanumeric, underscore, hyphen, and dot
-	sanitized, count := filterValidUsernameChars(s)
-
-	if count == 0 {
-		return "", errorx.IllegalArgument.New("username contains no valid characters")
+	// Every byte must be a valid username character
+	for i := 0; i < len(s); i++ {
+		if !isValidUsernameChar(s[i]) {
+			return errorx.IllegalArgument.New("username contains invalid characters: %s", s)
+		}
 	}
 
-	// Verify the sanitized version matches the original
-	// This ensures no characters were removed during sanitization
-	if sanitized != s {
-		return "", errorx.IllegalArgument.New("username contains invalid characters: %s", s)
-	}
-
-	return sanitized, nil
+	return nil
 }
 
 // SanitizePath validates and sanitizes the given path according to strict security rules.

--- a/pkg/sanity/sanity_test.go
+++ b/pkg/sanity/sanity_test.go
@@ -400,7 +400,7 @@ func TestSanity_Alphanumeric(t *testing.T) {
 	}
 }
 
-func TestSanity_Filename(t *testing.T) {
+func TestSanity_SanitizeFilename(t *testing.T) {
 	req := require.New(t)
 	testCases := []struct {
 		input  string
@@ -420,40 +420,41 @@ func TestSanity_Filename(t *testing.T) {
 			output: "u2318",
 		},
 		{
-			// Filename/Identifier still strips dots — the dot relaxation is
-			// scoped to Username only (issue #600).
+			// SanitizeFilename still strips dots today — the '.' allowance is
+			// scoped to ValidateUsername only (issue #600). When SanitizeFilename
+			// eventually diverges (e.g. to permit dots in real filenames), update
+			// this case to expect the dot to be preserved.
 			input:  "name.with.dots",
 			output: "namewithdots",
 		},
 		{
 			input:  "日本語",
 			output: "",
-			err:    ErrInvalidFilename,
+			err:    ErrInvalidName,
 		},
 		{
 			input:  "⌘",
 			output: "",
-			err:    ErrInvalidFilename,
+			err:    ErrInvalidName,
 		},
 		{
 			input:  "",
 			output: "",
-			err:    ErrInvalidFilename,
+			err:    ErrInvalidName,
 		},
 	}
 
 	for _, testCase := range testCases {
-		output, err := Filename(testCase.input)
+		output, err := SanitizeFilename(testCase.input)
 		req.Equal(testCase.output, output, testCase.input)
 		req.Equal(testCase.err, err, testCase.input)
 	}
 }
 
-func TestSanity_Username(t *testing.T) {
+func TestSanity_ValidateUsername(t *testing.T) {
 	testCases := []struct {
 		name      string
 		input     string
-		expected  string
 		shouldErr bool
 		errMsg    string
 	}{
@@ -461,37 +462,31 @@ func TestSanity_Username(t *testing.T) {
 		{
 			name:      "valid simple username",
 			input:     "john",
-			expected:  "john",
 			shouldErr: false,
 		},
 		{
 			name:      "valid username with underscore",
 			input:     "john_doe",
-			expected:  "john_doe",
 			shouldErr: false,
 		},
 		{
 			name:      "valid username with hyphen",
 			input:     "john-doe",
-			expected:  "john-doe",
 			shouldErr: false,
 		},
 		{
 			name:      "valid username with numbers",
 			input:     "user123",
-			expected:  "user123",
 			shouldErr: false,
 		},
 		{
 			name:      "valid username with mixed case",
 			input:     "JohnDoe",
-			expected:  "JohnDoe",
 			shouldErr: false,
 		},
 		{
 			name:      "valid username with all allowed characters",
 			input:     "user_123-test",
-			expected:  "user_123-test",
 			shouldErr: false,
 		},
 
@@ -667,31 +662,26 @@ func TestSanity_Username(t *testing.T) {
 		{
 			name:      "valid username with period (firstname.lastname)",
 			input:     "john.doe",
-			expected:  "john.doe",
 			shouldErr: false,
 		},
 		{
 			name:      "valid username with multiple periods",
 			input:     "a.b.c",
-			expected:  "a.b.c",
 			shouldErr: false,
 		},
 		{
 			name:      "valid username with leading period",
 			input:     ".hidden",
-			expected:  ".hidden",
 			shouldErr: false,
 		},
 		{
 			name:      "valid username with trailing period",
 			input:     "trailing.",
-			expected:  "trailing.",
 			shouldErr: false,
 		},
 		{
 			name:      "valid SUDO_USER-style firstname.lastname",
 			input:     "nana.ec",
-			expected:  "nana.ec",
 			shouldErr: false,
 		},
 		{
@@ -706,13 +696,13 @@ func TestSanity_Username(t *testing.T) {
 			name:      "username with only special characters",
 			input:     "!!!",
 			shouldErr: true,
-			errMsg:    "username contains no valid characters",
+			errMsg:    "username contains invalid characters",
 		},
 		{
 			name:      "username with only spaces",
 			input:     "   ",
 			shouldErr: true,
-			errMsg:    "username contains no valid characters",
+			errMsg:    "username contains invalid characters",
 		},
 
 		// Invalid usernames - control characters
@@ -777,7 +767,7 @@ func TestSanity_Username(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			req := require.New(t)
-			result, err := Username(tc.input)
+			err := ValidateUsername(tc.input)
 			if tc.shouldErr {
 				req.Error(err, "expected error for input: %s", tc.input)
 				if tc.errMsg != "" {
@@ -785,7 +775,6 @@ func TestSanity_Username(t *testing.T) {
 				}
 			} else {
 				req.NoError(err, "expected no error for input: %s", tc.input)
-				req.Equal(tc.expected, result, "output should match expected")
 			}
 		})
 	}


### PR DESCRIPTION
## Description

`pkg/sanity` exposed ~10 input validators with inconsistent naming and overlapping behavior. Bare-noun helpers (`Identifier`, `Filename`, `ModuleName`, `Username`) sometimes stripped invalid characters and sometimes rejected them — same naming style, opposite behavior. `Username` returned `(string, error)` like a sanitizer but actually rejected any input that would have been changed; that mismatch is what produced #600.

This PR splits the API by behavior so the prefix and the signature carry the contract:

| Prefix | Signature | Behavior |
|---|---|---|
| `Sanitize*` | `(s string) (string, error)` | Strip invalid chars, return cleaned form |
| `Validate*` | `(s string) error` | Reject any input containing invalid chars |

### Renames

| Before | After |
|---|---|
| `Identifier` | `SanitizeIdentifier` |
| `Filename` | `SanitizeFilename` (standalone, no longer an alias) |
| `ModuleName` | `SanitizeModuleName` (standalone, no longer an alias) |
| `Username` | `ValidateUsername` (error-only signature) |
| `ErrInvalidFilename` | `ErrInvalidName` (shared by `Sanitize*` helpers) |

Bodies are identical between the three sanitizers in this PR — only the surface area changes. The split lets future divergence (e.g. permit `.` in filenames, drop `-` from kernel module names) land without touching unrelated callers.

### Skill

Adds [`.claude/skills/sanity-validators/SKILL.md`](.claude/skills/sanity-validators/SKILL.md) documenting:

- The `Sanitize*` vs `Validate*` pattern and "signature is destiny" rule.
- Per-validator character sets and the domain each one is scoped to.
- A decision matrix for "which helper do I use for X?"
- Hard rules: no aliasing, validate at boundaries, don't reuse against persisted state.

### Stacking note

This branch is stacked on `00600-allow-dot-in-username` (PR #601). Base is set to that branch; once #601 merges, GitHub will auto-retarget to `main` (or rebase manually).

Full review guide: [`docs/claude/reviews/00602-sanity-validators-rename-and-skill.md`](docs/claude/reviews/00602-sanity-validators-rename-and-skill.md)

### Related Issues

* Closes #602
