### PR TITLE
chore(ci): skip long CI jobs for docs-only pull request changes

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -19,8 +19,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: solo-linux-medium
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            docs_only:
+              - '**/*.md'
+              - 'docs/**'
+
   build:
     name: Build
+    needs: changes
+    if: needs.changes.outputs.docs_only == 'false'
     uses: ./.github/workflows/zxc-code-compiles.yaml
     with:
       custom-job-label: Standard
@@ -29,7 +54,9 @@ jobs:
     name: Unit Tests
     uses: ./.github/workflows/zxc-unit-test.yaml
     needs:
+      - changes
       - build
+    if: needs.changes.outputs.docs_only == 'false'
     with:
       custom-job-label: Standard
 
@@ -37,7 +64,9 @@ jobs:
     name: UAT Backward Compatibility
     uses: ./.github/workflows/zxc-uat-test.yaml
     needs:
+      - changes
       - build
+    if: needs.changes.outputs.docs_only == 'false'
     with:
       custom-job-label: UAT Compat
       uat-scenario: compat
@@ -47,8 +76,10 @@ jobs:
     name: UAT Core Lifecycle
     uses: ./.github/workflows/zxc-uat-test.yaml
     needs:
+      - changes
       - build
       - uat-compat
+    if: needs.changes.outputs.docs_only == 'false'
     with:
       custom-job-label: UAT Core
       uat-scenario: lifecycle
@@ -58,8 +89,10 @@ jobs:
     name: Integration Tests
     uses: ./.github/workflows/zxc-integration-test.yaml
     needs:
+      - changes
       - build
       - uat-core
+    if: needs.changes.outputs.docs_only == 'false'
     with:
       custom-job-label: Standard
       vm-os: debian

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Detect Changes
     runs-on: solo-linux-medium
     outputs:
-      docs_only: ${{ steps.filter.outputs.docs_only }}
+      non_docs: ${{ steps.filter.outputs.non_docs }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -38,14 +38,15 @@ jobs:
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
           filters: |
-            docs_only:
-              - '**/*.md'
-              - 'docs/**'
+            non_docs:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
 
   build:
     name: Build
     needs: changes
-    if: needs.changes.outputs.docs_only == 'false'
+    if: needs.changes.outputs.non_docs == 'true'
     uses: ./.github/workflows/zxc-code-compiles.yaml
     with:
       custom-job-label: Standard
@@ -56,7 +57,7 @@ jobs:
     needs:
       - changes
       - build
-    if: needs.changes.outputs.docs_only == 'false'
+    if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: Standard
 
@@ -66,7 +67,7 @@ jobs:
     needs:
       - changes
       - build
-    if: needs.changes.outputs.docs_only == 'false'
+    if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: UAT Compat
       uat-scenario: compat
@@ -79,7 +80,7 @@ jobs:
       - changes
       - build
       - uat-compat
-    if: needs.changes.outputs.docs_only == 'false'
+    if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: UAT Core
       uat-scenario: lifecycle
@@ -92,7 +93,7 @@ jobs:
       - changes
       - build
       - uat-core
-    if: needs.changes.outputs.docs_only == 'false'
+    if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: Standard
       vm-os: debian


### PR DESCRIPTION
## Summary

- Adds a `changes` job using `dorny/paths-filter` to detect whether a PR touches only docs (`**/*.md`, `docs/**`)
- All heavy jobs (`build`, `unit-tests`, `uat-compat`, `uat-core`, `integration-tests`) are gated on `non_docs == 'true'` — they are skipped entirely for doc-only pushes
- Saves ~1h40m of CI time per docs-only commit

## How it works

```
changes (fast, ~10s)
  └── non_docs=false  → all other jobs skipped (only docs changed)
  └── non_docs=true   → build → unit-tests → uat-compat → uat-core → integration-tests
```

The filter uses an inverted approach: `non_docs` matches `**` minus `**/*.md` and `docs/**`. This correctly handles **mixed PRs** (e.g. `.go` + `.md`) — if any non-docs file changed, `non_docs=true` and the full pipeline runs. A PR that only touches docs gets `non_docs=false` and all heavy jobs are skipped.

## Test plan

- [ ] Push a commit that only changes a `.md` file — verify only the `Detect Changes` job runs
- [ ] Push a commit that changes a `.go` file — verify the full pipeline runs
- [ ] Push a commit that changes both a `.go` and a `.md` file — verify the full pipeline runs (mixed PR)

Closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)