### PR TITLE
fix(release): align CLI/daemon tag namespaces and unpin daemon from "Latest"

### DIFF
--- a/.github/workflows/flow-deploy-release-cli.yaml
+++ b/.github/workflows/flow-deploy-release-cli.yaml
@@ -121,7 +121,7 @@ jobs:
             NEXT_VERSION=$(sed -n 's/.*The next release version is \([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\).*/\1/p' semantic-release-output.txt || echo "")
             if [[ -n "$NEXT_VERSION" ]]; then
               echo "next-version=${NEXT_VERSION}" >> "${GITHUB_OUTPUT}"
-              echo "::notice::Dry-run: Next CLI release would be solo-provisioner-v${NEXT_VERSION}"
+              echo "::notice::Dry-run: Next CLI release would be v${NEXT_VERSION}"
             else
               echo "::notice::Dry-run: No new CLI release would be created"
             fi

--- a/.github/workflows/flow-deploy-release-cli.yaml
+++ b/.github/workflows/flow-deploy-release-cli.yaml
@@ -118,7 +118,7 @@ jobs:
 
           # Extract the next version from semantic-release output for dry-run
           if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
-            NEXT_VERSION=$(sed -n 's/.*The next release version is \([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\).*/\1/p' semantic-release-output.txt || echo "")
+            NEXT_VERSION=$(sed -n 's/.*The next release version is \([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\(-[0-9A-Za-z.-]\{1,\}\)\{0,1\}\).*/\1/p' semantic-release-output.txt || echo "")
             if [[ -n "$NEXT_VERSION" ]]; then
               echo "next-version=${NEXT_VERSION}" >> "${GITHUB_OUTPUT}"
               echo "::notice::Dry-run: Next CLI release would be v${NEXT_VERSION}"

--- a/.github/workflows/flow-deploy-release-daemon.yaml
+++ b/.github/workflows/flow-deploy-release-daemon.yaml
@@ -118,7 +118,7 @@ jobs:
 
           # Extract the next version from semantic-release output for dry-run
           if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
-            NEXT_VERSION=$(sed -n 's/.*The next release version is \([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\).*/\1/p' semantic-release-output.txt || echo "")
+            NEXT_VERSION=$(sed -n 's/.*The next release version is \([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\(-[0-9A-Za-z.-]\{1,\}\)\{0,1\}\).*/\1/p' semantic-release-output.txt || echo "")
             if [[ -n "$NEXT_VERSION" ]]; then
               echo "next-version=${NEXT_VERSION}" >> "${GITHUB_OUTPUT}"
               echo "::notice::Dry-run: Next daemon release would be daemon-v${NEXT_VERSION}"

--- a/.github/workflows/flow-deploy-release-daemon.yaml
+++ b/.github/workflows/flow-deploy-release-daemon.yaml
@@ -121,7 +121,7 @@ jobs:
             NEXT_VERSION=$(sed -n 's/.*The next release version is \([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\).*/\1/p' semantic-release-output.txt || echo "")
             if [[ -n "$NEXT_VERSION" ]]; then
               echo "next-version=${NEXT_VERSION}" >> "${GITHUB_OUTPUT}"
-              echo "::notice::Dry-run: Next daemon release would be solo-provisioner-daemon-v${NEXT_VERSION}"
+              echo "::notice::Dry-run: Next daemon release would be daemon-v${NEXT_VERSION}"
             else
               echo "::notice::Dry-run: No new daemon release would be created"
             fi

--- a/.releaserc_cli.json
+++ b/.releaserc_cli.json
@@ -1,5 +1,5 @@
 {
-  "tagFormat": "solo-provisioner-v${version}",
+  "tagFormat": "v${version}",
   "plugins": [
     ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
     ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],

--- a/.releaserc_daemon.json
+++ b/.releaserc_daemon.json
@@ -1,5 +1,5 @@
 {
-  "tagFormat": "solo-provisioner-daemon-v${version}",
+  "tagFormat": "daemon-v${version}",
   "plugins": [
     ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
     ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],
@@ -29,6 +29,9 @@
   ],
   "prepare": [
     ["@semantic-release/exec", { "cmd": "task sign:daemon:all" }]
+  ],
+  "success": [
+    ["@semantic-release/exec", { "cmd": "gh release edit ${nextRelease.gitTag} --repo \"$GITHUB_REPOSITORY\" --latest=false" }]
   ],
   "branches": [
     { "name": "main" },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,7 @@ Detailed framework docs live in `docs/dev/`:
 
 - All dependencies are vendored in `/vendor` — run `go mod vendor` after updating `go.mod`
 - Builds produce two binaries at `bin/solo-provisioner-{OS}-{ARCH}` (CLI) and `bin/solo-provisioner-daemon-{OS}-{ARCH}` (daemon); `task build` produces both, and hashing/signing are done via the per-binary tasks `hash:cli:all`, `hash:daemon:all`, `sign:cli:all`, and `sign:daemon:all`
-- Each binary has its own release pipeline and tag namespace: CLI → `solo-provisioner-vX.Y.Z` driven by `.releaserc_cli.json` and `.github/workflows/flow-deploy-release-cli.yaml`; daemon → `solo-provisioner-daemon-vX.Y.Z` driven by `.releaserc_daemon.json` and `flow-deploy-release-daemon.yaml`. They can be released independently
+- Each binary has its own release pipeline and tag namespace: CLI → `vX.Y.Z` driven by `.releaserc_cli.json` and `.github/workflows/flow-deploy-release-cli.yaml`; daemon → `daemon-vX.Y.Z` driven by `.releaserc_daemon.json` and `flow-deploy-release-daemon.yaml`. They can be released independently. Daemon releases also set `make_latest=false` on the GitHub release so the repo's "Latest" badge stays pinned to the CLI namespace.
 - Each binary embeds its own VERSION/COMMIT at `pkg/version/cli/` and `pkg/version/daemon/`; the `pkg/version` parent package exposes `Get`/`Number`/`Commit` whose values are registered at init time by whichever subpackage the running binary imports
 - Deployment profiles: `local`, `perfnet`, `testnet`, `previewnet`, `mainnet`
 - PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/)

--- a/docs/claude/reviews/00617-fix-release-cli-tagformat-and-make-latest.md
+++ b/docs/claude/reviews/00617-fix-release-cli-tagformat-and-make-latest.md
@@ -1,0 +1,134 @@
+# Review guide — release-pipeline follow-up fixes (refs #617)
+
+## Summary
+
+Follow-up to #618 (which fixed plugin loading). Two issues surfaced once the
+two new release workflows were exercised end-to-end:
+
+1. **CLI tag namespace jumped to `1.0.0`.** `solo-provisioner-v${version}` had no
+   prior tags in that namespace, so semantic-release fell back to its hardcoded
+   first-release default of `1.0.0` and produced `solo-provisioner-v1.0.0-rc.1`
+   instead of continuing the existing `v0.17.0 → v0.18.0` lineage. Reverting the
+   CLI `tagFormat` to `v${version}` lets semantic-release see the existing
+   `v0.17.0` / `v0.17.0-rc.2` tags as prior releases and compute the next bump
+   normally. As a bonus, the existing `refs/tags/v*` tag-protection ruleset
+   automatically re-covers CLI tags.
+
+2. **Daemon release claimed the homepage "Latest" badge.** Once
+   `solo-provisioner-daemon-v0.1.0` was published, GitHub auto-promoted it to
+   "Latest" by recency, kicking the CLI's `v0.17.0` out of the homepage sidebar.
+   The daemon is internal infrastructure — the user-facing artifact is the CLI.
+   Fixed by adding a `success` hook to `.releaserc_daemon.json` that calls
+   `gh release edit ... --latest=false` after publication.
+
+While here, the daemon `tagFormat` was also shortened from
+`solo-provisioner-daemon-v${version}` to `daemon-v${version}` so the release
+list reads more cleanly.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `.releaserc_cli.json` | `tagFormat`: `solo-provisioner-v${version}` → `v${version}`. Restores the pre-#614 tag namespace so semantic-release sees `v0.17.0` lineage. |
+| `.releaserc_daemon.json` | `tagFormat`: `solo-provisioner-daemon-v${version}` → `daemon-v${version}`. Added `success` step that runs `gh release edit ${nextRelease.gitTag} --repo "$GITHUB_REPOSITORY" --latest=false`. |
+| `.github/workflows/flow-deploy-release-cli.yaml` | Dry-run echo updated to print `v${VERSION}` instead of `solo-provisioner-v${VERSION}`. |
+| `.github/workflows/flow-deploy-release-daemon.yaml` | Dry-run echo updated to print `daemon-v${VERSION}` instead of `solo-provisioner-daemon-v${VERSION}`. |
+| `CLAUDE.md` | Updated the tag-namespace bullet under "Key Conventions" to match new formats and document the daemon `make_latest=false` post-publish step. |
+
+## Review checklist
+
+- [ ] `.releaserc_cli.json`: `tagFormat` is `v${version}` (single line).
+- [ ] `.releaserc_daemon.json`: `tagFormat` is `daemon-v${version}`; new `success` array contains exactly the one `@semantic-release/exec` call.
+- [ ] The daemon `success` cmd quotes `"$GITHUB_REPOSITORY"` (shell expansion at runtime, not lodash-template-time) and uses `${nextRelease.gitTag}` (templated by semantic-release/exec before shell sees it).
+- [ ] Dry-run echo messages in both workflows match the new formats.
+- [ ] `CLAUDE.md:239` reflects both new namespaces and the `make_latest=false` note.
+- [ ] Historical plan/epic docs under `docs/claude/plans/00516-*.md` and `docs/claude/epics/00498-*.md` are intentionally **not** rewritten — they describe what was planned at the time and remain accurate as a record.
+
+## Test commands
+
+```bash
+# Sanity-check the two releaserc files are valid JSON
+jq . .releaserc_cli.json .releaserc_daemon.json
+
+# Lint (no Go was touched, but the project rule says to run lint after every change)
+task lint
+
+# License-header check
+task license:check
+```
+
+There are no unit or integration tests that exercise the release configs directly. End-to-end validation is via the workflow runs below.
+
+## Manual UAT
+
+### After merge
+
+1. **Delete the dangling tags + releases left over from the failed bootstrap runs.**
+   The CLI `solo-provisioner-v1.0.0-rc.1` and the daemon's
+   `solo-provisioner-daemon-v0.0.0` seed and `solo-provisioner-daemon-v0.1.0`
+   release all live in namespaces that the new configs no longer consult, but
+   they should be cleaned up to avoid noise on the Releases page.
+
+   ```bash
+   # CLI 1.0.0-rc.1 (release + tag)
+   gh release delete solo-provisioner-v1.0.0-rc.1 --repo hashgraph/solo-weaver --yes
+   git push --delete origin solo-provisioner-v1.0.0-rc.1
+
+   # Daemon 0.1.0 (release + tag)
+   gh release delete solo-provisioner-daemon-v0.1.0 --repo hashgraph/solo-weaver --yes
+   git push --delete origin solo-provisioner-daemon-v0.1.0
+
+   # Daemon seed tag (no release attached)
+   git push --delete origin solo-provisioner-daemon-v0.0.0
+   ```
+
+2. **Plant a daemon seed tag in the new namespace** so the first daemon run
+   produces `daemon-v0.1.0` instead of `daemon-v1.0.0`. Use the parent of the
+   daemon-introducing commit so the auto-generated release notes scope cleanly:
+
+   ```bash
+   git tag daemon-v0.0.0 8a562a7   # parent of b294657 feat(cmd): two-binary build layout
+   git push origin daemon-v0.0.0
+   ```
+
+3. **Re-trigger `Deploy Release Artifact (CLI)` on `rc/purge-storage`.**
+   Expected:
+
+   ```
+   [semantic-release] › ℹ  The next release version is 0.18.0-rc.1
+   …
+   [semantic-release] › ✔  Created tag v0.18.0-rc.1
+   ```
+
+   Verify on GitHub: a new `Pre-release` `v0.18.0-rc.1` appears.
+   The repo home "Latest" badge should still read `v0.17.0` (CLI's last stable),
+   not `daemon-v0.1.0`.
+
+4. **Re-trigger `Deploy Release Artifact (Daemon)` on `main`.** Expected:
+
+   ```
+   [semantic-release] › ℹ  The next release version is 0.1.0
+   …
+   [semantic-release] › ✔  Created tag daemon-v0.1.0
+   …
+   [semantic-release] [@semantic-release/exec] › ℹ  Call script gh release edit daemon-v0.1.0 --repo "$GITHUB_REPOSITORY" --latest=false
+   ```
+
+   Verify on GitHub: `daemon-v0.1.0` exists as a regular release (not
+   pre-release) but does **not** carry the `Latest` chip; that chip stays on
+   `v0.17.0` until the next CLI stable.
+
+   ```bash
+   gh release view daemon-v0.1.0 --repo hashgraph/solo-weaver \
+     --json tagName,isPrerelease | jq .
+   # Cross-check via API that make_latest is no longer "true":
+   gh api repos/hashgraph/solo-weaver/releases/tags/daemon-v0.1.0 \
+     --jq '{tag: .tag_name, draft: .draft, prerelease: .prerelease, make_latest: .make_latest}'
+   # Expected: make_latest = "false"
+   ```
+
+5. **(Optional follow-up, not in this PR)** The `refs/tags/v*` ruleset now
+   covers CLI tags again, but the new `daemon-v*` namespace is unprotected.
+   Open a follow-up to add a sibling ruleset entry covering `refs/tags/daemon-v*`
+   with the same `non_fast_forward` / `deletion` / `update` /
+   `required_signatures` rules.


### PR DESCRIPTION
## Description

Follow-up to #618 (which fixed plugin loading in the new release workflows). Two issues surfaced once both workflows were actually exercised end-to-end:

**1. CLI tag namespace jumped to `1.0.0`.** When `tagFormat` became `solo-provisioner-v${version}` in #614, semantic-release saw no prior tags in that namespace and fell back to its hardcoded first-release default. The bootstrap run produced `solo-provisioner-v1.0.0-rc.1` instead of continuing the existing `v0.17.0 → v0.18.0` lineage. Reverting CLI `tagFormat` to `v${version}` lets semantic-release see `v0.17.0` / `v0.17.0-rc.2` as prior releases and compute the next bump normally. As a bonus, the existing `refs/tags/v*` tag-protection ruleset automatically re-covers CLI tags.

**2. Daemon release claimed the homepage "Latest" badge.** Once `solo-provisioner-daemon-v0.1.0` was published, GitHub auto-promoted it to "Latest" by recency, kicking the CLI's `v0.17.0` out of the repo home page sidebar. The daemon is internal infrastructure — the user-facing artifact is the CLI. Fixed by adding a `success` hook to `.releaserc_daemon.json` that runs `gh release edit ${nextRelease.gitTag} --repo "$GITHUB_REPOSITORY" --latest=false` after publication. The release remains a normal published release in its own namespace, but GitHub won't use it for the homepage "Latest" widget.

While here, the daemon `tagFormat` was also shortened from `solo-provisioner-daemon-v${version}` to `daemon-v${version}` for a cleaner Releases page. The daemon binary, asset names, and changelog content are unchanged.

### Files changed

| File | Change |
|---|---|
| `.releaserc_cli.json` | `tagFormat`: `solo-provisioner-v${version}` → `v${version}` |
| `.releaserc_daemon.json` | `tagFormat`: `solo-provisioner-daemon-v${version}` → `daemon-v${version}`; new `success` step calling `gh release edit … --latest=false` |
| `.github/workflows/flow-deploy-release-cli.yaml` | Dry-run notice message updated to match new tag format |
| `.github/workflows/flow-deploy-release-daemon.yaml` | Dry-run notice message updated to match new tag format |
| `CLAUDE.md` | Updated the tag-namespace bullet under "Key Conventions"; documented the daemon `make_latest=false` post-publish step |
| `docs/claude/reviews/00617-fix-release-cli-tagformat-and-make-latest.md` | New review guide covering the change and the post-merge cleanup/UAT steps |

### Post-merge cleanup (UAT)

Some dangling tags + releases from the failed bootstrap runs need to be deleted, and a daemon seed tag re-planted in the new namespace, before re-triggering the workflows. Full step list is in the review guide; the short version:

```bash
gh release delete solo-provisioner-v1.0.0-rc.1   --repo hashgraph/solo-weaver --yes
gh release delete solo-provisioner-daemon-v0.1.0 --repo hashgraph/solo-weaver --yes
git push --delete origin solo-provisioner-v1.0.0-rc.1 \
                          solo-provisioner-daemon-v0.1.0 \
                          solo-provisioner-daemon-v0.0.0
git tag daemon-v0.0.0 8a562a7   # parent of b294657, the daemon-introducing commit
git push origin daemon-v0.0.0
```

Then re-trigger `Deploy Release Artifact (CLI)` on `rc/purge-storage` (expect `v0.18.0-rc.1`) and `Deploy Release Artifact (Daemon)` on `main` (expect `daemon-v0.1.0` with `make_latest=false`).

### Follow-up not in this PR

The `refs/tags/v*` ruleset now re-covers the CLI namespace, but the new `daemon-v*` namespace is unprotected. Worth a follow-up to extend the ruleset (`non_fast_forward`, `deletion`, `update`, `required_signatures`) to `refs/tags/daemon-v*`.

### Related Issues

* Refs #617
