### PR TITLE
feat(lint): enforce errorx and migrate stdlib error construction (#628)

### DIFF
--- a/.claude/skills/errorx-conventions/SKILL.md
+++ b/.claude/skills/errorx-conventions/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: errorx-conventions
+description: Use this skill BEFORE writing or modifying any Go error construction in this repo — e.g. "add error handling", "return an error from this function", any edit that introduces a new `return err` site, any urge to type `errors.New` or `fmt.Errorf` in production code under `cmd/`, `internal/`, `pkg/`. Production code must use `github.com/joomcode/errorx` and is enforced by `golangci-lint` (forbidigo). Captures the rule, the namespace mapping table, the sentinel pattern using `errors.Join`, and the test-file exemption. Read this BEFORE picking an errorx namespace — the wrong namespace silently degrades the doctor layer's error styling and exit-code mapping.
+---
+
+# errorx conventions for solo-weaver
+
+`github.com/joomcode/errorx` is the standard error library for all production code under `cmd/`, `internal/`, and `pkg/`. The stdlib `errors.New` and `fmt.Errorf` are **forbidden** in production code — the `.golangci.yml` `forbidigo` linter rejects new occurrences via the `lint:errorx` task wired into `task lint` and `task lint:check`.
+
+This skill captures *which* `errorx.<Type>` to pick for each shape of error and the few migration traps that catch the unwary.
+
+---
+
+## The rule
+
+| Where | Allowed | Forbidden |
+|---|---|---|
+| Production code (`cmd/`, `internal/`, `pkg/`, excluding `*_test.go`) | `errorx.<Type>.New(...)`, `errorx.<Type>.Wrap(err, ...)` | `errors.New(...)`, `fmt.Errorf(...)` |
+| Test files (`*_test.go`) | Anything — `errors.New`, `fmt.Errorf`, `errorx.*`, custom types | (linter is exempted) |
+| Generated code (`*.gen.go`, `*_generated.go`, `/generated/`) | Whatever the generator emits | (linter is exempted) |
+
+The lint scope is `new-from-rev: origin/main`: only **lines you change relative to main** are checked. Pre-existing neighbouring `fmt.Errorf` lines are not your problem unless you touch them.
+
+`errors.Is`, `errors.As`, `errors.Join`, and `errors.Unwrap` remain allowed and **are the right tools** for testing typed/sentinel errors — `errorx` errors implement the `Unwrap()` contract and play well with the stdlib `errors` utility functions. The skill bans construction primitives, not inspection primitives.
+
+---
+
+## Namespace mapping table
+
+Pick the namespace by the *shape of the failure*, not by the file the code lives in.
+
+| Call site shape | `errorx` target | Example |
+|---|---|---|
+| File I/O failure (`os.Open`, `os.Stat`, `os.ReadFile`) | `errorx.ExternalError.Wrap(err, "...")` | `errorx.ExternalError.Wrap(err, "failed to open %s", path)` |
+| Shell / exec command failure (`exec.Command`, `automa_steps.RunBashScript`) | `errorx.ExternalError.Wrap` | `errorx.ExternalError.Wrap(err, "failed to initialize cluster with kubeadm")` |
+| Helm / kubectl / kubernetes API call failure | `errorx.ExternalError.Wrap` | `errorx.ExternalError.Wrap(err, "failed to read K8s Secret %q in namespace %q", name, ns)` |
+| `crypto/rand`, `net.Dial`, HTTP request failure | `errorx.ExternalError.Wrap` | `errorx.ExternalError.Wrap(err, "endpoint %s is not reachable", url)` |
+| Template render / `text/template` `Execute` failure | `errorx.InternalError.Wrap` | `errorx.InternalError.Wrap(err, "failed to render core config")` |
+| Internal computation that should not have failed but did | `errorx.InternalError.Wrap` | `errorx.InternalError.Wrap(err, "failed to create kubeconfig manager")` |
+| `json.Unmarshal` / `yaml.Unmarshal` / malformed payload | `errorx.IllegalFormat.Wrap` or `.New` | `errorx.IllegalFormat.New("invalid user entry at line %d, no colons present", index)` |
+| Catalog / config / schema validation failure | `errorx.IllegalFormat.New` (or `.Wrap` over a sub-error) | `errorx.IllegalFormat.New("missing type (must be %q or %q)", classic, oci)` |
+| Invariant breach ("should never happen", "redirect loop", unreachable type switch default) | `errorx.AssertionFailed.New` | `errorx.AssertionFailed.New("unsupported flag type: %T", zero)` |
+| User-supplied CLI flag value, config value, or flag combination rejected | `errorx.IllegalArgument.New` or `.Wrap` | `errorx.IllegalArgument.New("--plugins is required when --plugin-preset=%s", custom)` |
+| User cancelled an operation; permission/authorization refused; policy rejection | `errorx.RejectedOperation.New` or `.Wrap` | `errorx.RejectedOperation.New("aborted by user")` |
+| Inconsistent runtime state (cluster missing required resource, unexpected enum value, wrong phase) | `errorx.IllegalState.New` | `errorx.IllegalState.New("K8s Secret %q not found in namespace %q", name, ns)` |
+| Hardware / environment doesn't meet requirements | `errorx.IllegalState.New` | `errorx.IllegalState.New("CPU does not meet %s requirements (minimum %d cores)", t, n)` |
+
+When the right namespace is genuinely ambiguous, prefer the one that gives the **user the most actionable signal** when surfaced by `internal/doctor/`. `IllegalArgument` ("the operator can fix their input") is preferable to `IllegalState` ("something is wrong with the cluster") when the failing operation is gated by a CLI flag the user just passed.
+
+---
+
+## Decision matrix — common solo-weaver shapes
+
+These are the cases that come up most often when editing this codebase:
+
+- `os.Stat(...) failed` / `os.Open(...) failed` → **`ExternalError.Wrap`**
+- `kubectl get ... failed` / `kube.Client(...).Foo(...)` returned err → **`ExternalError.Wrap`**
+- `helm install/upgrade/uninstall ...` returned err → **`ExternalError.Wrap`** (or one of the `pkg/helm/errors.go` typed errors if it's there — keep those)
+- `automa_steps.RunBashScript(...)` returned err → **`ExternalError.Wrap`**
+- Bad `--profile`, `--release-name`, `--plugins`, etc. → **`IllegalArgument.New`** (or `.Wrap` if there's an upstream parse error)
+- Unexpected enum value, missing required state field after it should have been set → **`IllegalState.New`**
+- "should never happen" type-switch default branch in a generic function → **`AssertionFailed.New`**
+- User pressed Ctrl-C in a `huh` prompt; intentional cancel → **`RejectedOperation.New`**
+- Template `Execute` failed; `tmpl.Parse` failed → **`InternalError.Wrap`**
+- YAML/JSON unmarshal failed on data already in the binary or under our control → **`IllegalFormat.Wrap`**
+
+When wrapping, the message should describe *what we were trying to do*, not the underlying cause (that's already in the wrapped error). `errorx.ExternalError.Wrap(err, "failed to open %s", path)` — not `"failed to open %s: %w"` and not `"open %s returned an error: %v"`. `errorx` handles the wrap formatting.
+
+---
+
+## Sentinel errors — `errors.Join`, not `fmt.Errorf`
+
+When you need a sentinel that callers can detect with `errors.Is`, define it once at package scope as an `errorx` typed value:
+
+```go
+// internal/ui/prompt/prompt.go
+var ErrAborted = errorx.RejectedOperation.New("aborted by user")
+```
+
+To wrap a sentinel with a runtime cause, **use `errors.Join`**, not `fmt.Errorf("%w: %w", ...)`. `errors.Join` produces a multi-error whose `errors.Is` walks both sides — callers can match either the sentinel or the cause:
+
+```go
+// Wrong (and forbidden by the lint):
+return fmt.Errorf("%w: %w", ErrAborted, cause)
+
+// Right:
+return errors.Join(ErrAborted, cause)
+```
+
+`errors.Is(result, ErrAborted)` and `errors.Is(result, cause)` both return `true` after the `errors.Join` call. The `fmt.Errorf("%w: %w", ...)` pattern (Go 1.20+) is technically equivalent for inspection but uses the forbidden constructor, so the lint rejects it.
+
+For pure sentinel returns (no runtime cause to attach), just return the sentinel value directly:
+
+```go
+if errors.Is(err, huh.ErrUserAborted) {
+    return ErrAborted
+}
+```
+
+---
+
+## Migration traps
+
+Things that catch people during a `fmt.Errorf` → `errorx.*.Wrap` conversion:
+
+1. **Don't drop the `fmt` import when the file still uses `fmt.Sprintf` / `fmt.Fprintln` / `fmt.Printf`.** A `goimports` pass after the conversion will tell you, but it's easy to over-trim by hand. Look for any remaining `fmt.*` calls before deleting the import.
+
+2. **Keep the format-string verbs intact.** `errorx.<Type>.New` and `.Wrap` accept printf-style verbs (`%s`, `%q`, `%d`, etc.). Just drop the `%w` for the wrapped error — `.Wrap(err, "...")` handles the wrapping for you. `errorx.ExternalError.Wrap(err, "failed to open %s", path)` — not `"failed to open %s: %w"`.
+
+3. **`errors.Is` against an `errorx`-typed sentinel still works**, but the sentinel must be the same variable identity (`var ErrFoo = errorx.<Type>.New(...)` declared once at package scope, never re-created per call). `errorx` types implement an `Is(target error) bool` method that matches on value identity, so `errors.Is(err, ErrFoo)` returns `true` whether `err` is `ErrFoo` directly or `errors.Join(ErrFoo, cause)`.
+
+4. **Custom inner-wrapping constructors** (e.g. `software.NewExtractionError(innerErr, ...)`): convert the inner argument to `errorx.<Type>.New(...)` rather than rewriting the constructor. The custom constructor stays; only the inner stdlib error becomes errorx.
+
+5. **Existing custom namespaces in `pkg/os/errors.go`, `pkg/helm/errors.go`, `pkg/fsx/errors.go` are grandfathered** — they predate the standardisation and use `errorx.NewNamespace(...)` plus typed errors like `helm.ErrNotFound`. Don't replace them with the built-in namespaces; do use them via `errorx.IsOfType(err, helm.ErrNotFound)` when checking specific helm conditions.
+
+6. **No new custom `errorx.NewNamespace` declarations.** Stick to the eight built-in `errorx.<Type>` namespaces in the mapping table. The custom namespaces above are technical debt we tolerate, not a pattern to copy.
+
+---
+
+## Why tests are exempted
+
+`*_test.go` files keep `errors.New` / `fmt.Errorf` because:
+
+- Test assertions usually check error *shape* (`require.ErrorContains(t, err, "...")`) or *identity* against a test-local sentinel, not namespace.
+- Rich `errorx` typing in a test body adds noise that obscures what the assertion is actually checking.
+- Tests are local to a package and don't flow through `internal/doctor/`, so the namespace metadata isn't used downstream.
+
+If you find yourself wanting an `errorx` type in a test, it's a signal that the test is exercising production behaviour better expressed in a non-test helper.
+
+---
+
+## When to *not* return an error
+
+Independent of the construct rule: don't add error returns that the caller can't act on. Some shapes that look like errors but aren't:
+
+- "I detected drift but I'm continuing" — log at `Warn`, return `nil`.
+- "This optional feature isn't configured" — return a zero value, `nil`, and let the caller's nil-check skip the feature.
+- Genuine programming-error states reachable only via a broken refactor — `panic` with a descriptive message rather than `errorx.AssertionFailed.New`. `chartSpec` in `internal/workflows/steps/catalog.go` is the existing example: the surrounding code can't meaningfully recover, so panicking surfaces the bug at the development boundary.
+
+Errors that *don't* belong here go via these three escape hatches, not via clever errorx typing.

--- a/.github/workflows/zxc-code-compiles.yaml
+++ b/.github/workflows/zxc-code-compiles.yaml
@@ -34,6 +34,10 @@ jobs:
 
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history so golangci-lint's `new-from-rev: origin/main` can
+          # diff the PR head against the base commit. Used by `task lint:errorx`.
+          fetch-depth: 0
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# golangci-lint v2 configuration.
+#
+# Scope is intentionally narrow: only forbidigo is enabled, and only to
+# enforce that production code uses github.com/joomcode/errorx for error
+# construction and wrapping rather than the stdlib errors.New / fmt.Errorf.
+# Other linters are not enabled here so adopting this config does not
+# require a large pre-existing-issues cleanup.
+#
+# Pre-existing call sites are exempted via `issues.new-from-rev: origin/main`,
+# which scopes findings to lines changed relative to main. CI must check
+# out with `fetch-depth: 0` so the base commit is available.
+version: "2"
+
+run:
+  timeout: 5m
+  build-tags: []
+  # Default mode (no explicit `modules-download-mode`) lets golangci-lint
+  # auto-pick between vendor and module cache the same way `go build` and
+  # `go vet` do, avoiding spurious vendor-consistency errors during lint.
+
+linters:
+  default: none
+  enable:
+    - forbidigo
+
+  settings:
+    forbidigo:
+      analyze-types: true
+      exclude-godoc-examples: true
+      forbid:
+        - pattern: '^errors\.New$'
+          msg: >-
+            solo-weaver standard: use github.com/joomcode/errorx instead of
+            errors.New, e.g. errorx.IllegalState.New("...") or
+            errorx.IllegalArgument.New("...").
+        - pattern: '^fmt\.Errorf$'
+          msg: >-
+            solo-weaver standard: use github.com/joomcode/errorx instead of
+            fmt.Errorf. Use errorx.<Type>.Wrap(err, "...") to add context
+            to an existing error, or errorx.<Type>.New("...") for a new
+            one.
+
+  exclusions:
+    # Tests are allowed to use errors.New / fmt.Errorf — error semantics
+    # in tests are local to the test and don't need rich typing.
+    rules:
+      - path: _test\.go
+        linters:
+          - forbidigo
+      # Generated code (e.g. mocks_generated.go produced by `task mocks`) is
+      # outside the contributor's control.
+      - path: '(\.gen\.go|_generated\.go|/generated/)$'
+        linters:
+          - forbidigo
+
+issues:
+  # Only flag findings on lines changed relative to origin/main. Existing
+  # call sites are out of scope for this gate; they are migrated in the
+  # same PR but the gate itself only polices new code going forward.
+  new-from-rev: origin/main
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -116,7 +116,6 @@ tasks:
         silent: true
       - cmd: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
         silent: true
-        silent: true
   
   license:check:
     desc: "Check if all source files have SPDX license headers"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -108,12 +108,14 @@ tasks:
     desc: "Install golangci-lint v2.12.2 (used by lint:errorx to enforce errorx)"
     internal: true
     status:
-      # Treat any v2.x install as satisfying the dep; force a reinstall if missing or on v1.
-      - 'golangci-lint --version 2>/dev/null | grep -q "version v2"'
+      # Require the pinned version exactly, so developers running `task lint:errorx`
+      # use the same binary version as CI.
+      - 'golangci-lint --version 2>/dev/null | grep -q "version v2.12.2"'
     cmds:
       - cmd: echo "Installing golangci-lint v2.12.2..."
         silent: true
       - cmd: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+        silent: true
         silent: true
   
   license:check:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -78,10 +78,43 @@ tasks:
   lint:
     cmds:
       - "go fmt -x ./..."
-  
+      - task: lint:errorx
+
   lint:check:
     cmds:
       - "R=$(go fmt ./...) && if [[ -n \"$R\" ]]; then echo \"The following files require formatting:\"; echo \"$R\"; exit 1; fi"
+      - task: lint:errorx
+
+  lint:errorx:
+    internal: true
+    desc: "Enforce errorx over errors.New / fmt.Errorf in production code (only lines new vs origin/main)"
+    deps:
+      - task: setup:golangci-lint
+      # `generate` produces the embedded VERSION/COMMIT files under pkg/version/{cli,daemon};
+      # `mocks` produces *_generated.go test mocks. Both are required by forbidigo's
+      # type-aware analysis (analyze-types: true) to typecheck the tree cleanly.
+      - task: generate
+      - task: mocks
+    env:
+      # Run as Linux so platform-tagged files (e.g. internal/mount/*_unix.go, pkg/kernel
+      # via pault.ag/go/modprobe) typecheck on developer macOS the same way they do in CI.
+      GOOS: linux
+    cmds:
+      - cmd: git fetch --no-tags origin main >/dev/null 2>&1 || true
+        silent: true
+      - golangci-lint run --config .golangci.yml ./...
+
+  setup:golangci-lint:
+    desc: "Install golangci-lint v2.12.2 (used by lint:errorx to enforce errorx)"
+    internal: true
+    status:
+      # Treat any v2.x install as satisfying the dep; force a reinstall if missing or on v1.
+      - 'golangci-lint --version 2>/dev/null | grep -q "version v2"'
+    cmds:
+      - cmd: echo "Installing golangci-lint v2.12.2..."
+        silent: true
+      - cmd: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+        silent: true
   
   license:check:
     desc: "Check if all source files have SPDX license headers"

--- a/cmd/cli/commands/alloy/cluster/install.go
+++ b/cmd/cli/commands/alloy/cluster/install.go
@@ -3,15 +3,15 @@
 package cluster
 
 import (
-	"fmt"
-
 	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/workflows"
 	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
 	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/models"
-	"github.com/spf13/cobra"
 )
 
 var installCmd = &cobra.Command{
@@ -49,12 +49,12 @@ Examples:
 		// Parse multi-remote flags
 		prometheusRemotes, err := parseRemoteFlags(flagPrometheusRemotes)
 		if err != nil {
-			return fmt.Errorf("invalid --add-prometheus-remote flag: %w", err)
+			return errorx.IllegalArgument.Wrap(err, "invalid --add-prometheus-remote flag")
 		}
 
 		lokiRemotes, err := parseRemoteFlags(flagLokiRemotes)
 		if err != nil {
-			return fmt.Errorf("invalid --add-loki-remote flag: %w", err)
+			return errorx.IllegalArgument.Wrap(err, "invalid --add-loki-remote flag")
 		}
 
 		// Validate that legacy and new flags are not mixed
@@ -62,7 +62,7 @@ Examples:
 		hasNewFlags := len(prometheusRemotes) > 0 || len(lokiRemotes) > 0
 
 		if hasLegacyFlags && hasNewFlags {
-			return fmt.Errorf("cannot mix legacy flags (--prometheus-url, --prometheus-username, --loki-url, --loki-username) with new flags (--add-prometheus-remote, --add-loki-remote); use one style or the other")
+			return errorx.IllegalArgument.New("cannot mix legacy flags (--prometheus-url, --prometheus-username, --loki-url, --loki-username) with new flags (--add-prometheus-remote, --add-loki-remote); use one style or the other")
 		}
 
 		// Apply Alloy configuration overrides
@@ -81,7 +81,7 @@ Examples:
 
 		// Validate configuration before proceeding
 		if err := alloyOverrides.Validate(); err != nil {
-			return fmt.Errorf("invalid configuration: %w", err)
+			return errorx.IllegalArgument.Wrap(err, "invalid configuration")
 		}
 
 		config.OverrideAlloyConfig(alloyOverrides)

--- a/cmd/cli/commands/alloy/cluster/parse_remote.go
+++ b/cmd/cli/commands/alloy/cluster/parse_remote.go
@@ -3,9 +3,10 @@
 package cluster
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/joomcode/errorx"
 
 	"github.com/hashgraph/solo-weaver/pkg/models"
 )
@@ -31,7 +32,7 @@ func parseRemoteFlags(flags []string) ([]models.AlloyRemoteConfig, error) {
 		for _, pair := range splitKeyValuePairs(flag) {
 			eqIdx := strings.Index(pair, "=")
 			if eqIdx == -1 {
-				return nil, fmt.Errorf("invalid key=value pair %q in %q, expected format: name=<name>,url=<url>,username=<username>", pair, flag)
+				return nil, errorx.IllegalArgument.New("invalid key=value pair %q in %q, expected format: name=<name>,url=<url>,username=<username>", pair, flag)
 			}
 
 			key := strings.TrimSpace(pair[:eqIdx])
@@ -47,16 +48,16 @@ func parseRemoteFlags(flags []string) ([]models.AlloyRemoteConfig, error) {
 			case "labelprofile":
 				remote.LabelProfile = value
 			default:
-				return nil, fmt.Errorf("unknown key %q in %q, valid keys are: name, url, username, labelProfile", key, flag)
+				return nil, errorx.IllegalArgument.New("unknown key %q in %q, valid keys are: name, url, username, labelProfile", key, flag)
 			}
 		}
 
 		// Validate required fields
 		if remote.Name == "" {
-			return nil, fmt.Errorf("missing required 'name' in %q", flag)
+			return nil, errorx.IllegalArgument.New("missing required 'name' in %q", flag)
 		}
 		if remote.URL == "" {
-			return nil, fmt.Errorf("missing required 'url' in %q", flag)
+			return nil, errorx.IllegalArgument.New("missing required 'url' in %q", flag)
 		}
 
 		remotes = append(remotes, remote)

--- a/cmd/cli/commands/block/node/init.go
+++ b/cmd/cli/commands/block/node/init.go
@@ -227,7 +227,7 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 		pluginPreset = bnpkg.PresetCustom
 	}
 	if pluginPreset == bnpkg.PresetCustom && pluginList == "" {
-		return nil, fmt.Errorf("--plugins is required when --plugin-preset=%s", bnpkg.PresetCustom)
+		return nil, errorx.IllegalArgument.New("--plugins is required when --plugin-preset=%s", bnpkg.PresetCustom)
 	}
 
 	inputs := &models.UserInputs[models.BlockNodeInputs]{

--- a/cmd/cli/commands/common/flags.go
+++ b/cmd/cli/commands/common/flags.go
@@ -4,15 +4,15 @@ package common
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
-	"github.com/hashgraph/solo-weaver/internal/doctor"
 	"github.com/joomcode/errorx"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/hashgraph/solo-weaver/internal/doctor"
 )
 
 // FlagDefinition defines a command-line flag typed by T.
@@ -82,7 +82,7 @@ func (fp FlagDefinition[T]) valueFrom(flags *pflag.FlagSet) (T, error) {
 		}
 		return any(v).(T), nil
 	default:
-		return zero, fmt.Errorf("unsupported flag type: %T", zero)
+		return zero, errorx.AssertionFailed.New("unsupported flag type: %T", zero)
 	}
 }
 
@@ -114,7 +114,7 @@ func (fp FlagDefinition[T]) Value(cmd *cobra.Command, args []string) (T, error) 
 		return val, nil
 	}
 
-	return zero, fmt.Errorf("flag %s not found in local, own-persistent, or inherited flag sets", fp.Name)
+	return zero, errorx.IllegalArgument.New("flag %s not found in local, own-persistent, or inherited flag sets", fp.Name)
 }
 
 func (fp FlagDefinition[T]) ValueLocal(cmd *cobra.Command, args []string) (T, error) {
@@ -258,7 +258,7 @@ func (fp FlagDefinition[T]) setFlagVar(flags *pflag.FlagSet, cmd *cobra.Command,
 		flags.DurationVarP(pd, fp.Name, fp.ShortName, def, fp.Description)
 
 	default:
-		return fmt.Errorf("unsupported flag type: %T", zero)
+		return errorx.AssertionFailed.New("unsupported flag type: %T", zero)
 	}
 
 	return nil
@@ -328,7 +328,7 @@ func (fp CommaSplitStringsFlagDefinition) Value(cmd *cobra.Command, args []strin
 	if val, err := fp.ValueOwnPersistent(cmd, args); err == nil {
 		return val, nil
 	}
-	return nil, fmt.Errorf("flag %s not found in local, own-persistent, or inherited flag sets", fp.Name)
+	return nil, errorx.IllegalArgument.New("flag %s not found in local, own-persistent, or inherited flag sets", fp.Name)
 }
 
 func (fp CommaSplitStringsFlagDefinition) ValueLocal(cmd *cobra.Command, args []string) ([]string, error) {
@@ -457,7 +457,7 @@ func (fp RepeatableStringFlagDefinition) Value(cmd *cobra.Command, args []string
 	if val, err := fp.ValueOwnPersistent(cmd, args); err == nil {
 		return val, nil
 	}
-	return nil, fmt.Errorf("flag %s not found in local, own-persistent, or inherited flag sets", fp.Name)
+	return nil, errorx.IllegalArgument.New("flag %s not found in local, own-persistent, or inherited flag sets", fp.Name)
 }
 
 func (fp RepeatableStringFlagDefinition) ValueLocal(cmd *cobra.Command, args []string) ([]string, error) {

--- a/cmd/cli/commands/common/run.go
+++ b/cmd/cli/commands/common/run.go
@@ -13,6 +13,9 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+
 	"github.com/hashgraph/solo-weaver/internal/doctor"
 	"github.com/hashgraph/solo-weaver/internal/migration"
 	"github.com/hashgraph/solo-weaver/internal/state"
@@ -23,7 +26,6 @@ import (
 	pkgconfig "github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	version "github.com/hashgraph/solo-weaver/pkg/version/cli"
-	"github.com/spf13/cobra"
 )
 
 const KeyRequireGlobalChecks = "requireGlobalChecks"
@@ -101,7 +103,7 @@ func RunWorkflow(ctx context.Context, fn func() (*automa.Report, error)) error {
 
 	result, ok := finalModel.(ui.Model)
 	if !ok {
-		return fmt.Errorf("unexpected TUI model type")
+		return errorx.AssertionFailed.New("unexpected TUI model type")
 	}
 
 	if result.Err() != nil {
@@ -176,7 +178,7 @@ func deepestFailureError(r *automa.Report) error {
 		if sr.Error != nil {
 			return sr.Error
 		}
-		return fmt.Errorf("step %q failed", sr.Id)
+		return errorx.IllegalState.New("step %q failed", sr.Id)
 	}
 	return nil
 }

--- a/cmd/cli/commands/demo.go
+++ b/cmd/cli/commands/demo.go
@@ -8,9 +8,11 @@ import (
 	"time"
 
 	"github.com/automa-saga/automa"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
-	"github.com/spf13/cobra"
 )
 
 var flagDemoStress bool
@@ -127,7 +129,7 @@ func demoStep(id, name string, duration time.Duration, outcome demoOutcome) *aut
 			time.Sleep(duration)
 			switch outcome {
 			case statusFail:
-				return automa.FailureReport(stp, automa.WithError(fmt.Errorf("simulated failure in %s", name)))
+				return automa.FailureReport(stp, automa.WithError(errorx.IllegalState.New("simulated failure in %s", name)))
 			case statusSkip:
 				return automa.SkippedReport(stp)
 			default:

--- a/docs/claude/plans/00628-enforce-errorx.md
+++ b/docs/claude/plans/00628-enforce-errorx.md
@@ -1,0 +1,175 @@
+# #628 — Enforce errorx as the standard for error construction
+
+> **Issue:** https://github.com/hashgraph/solo-weaver/issues/628
+> **Story branch:** `00628-enforce-errorx`
+> **PR base:** `main` (branched from `origin/main` @ `3866a9c`)
+> **PR closes:** #628 — all three deliverables (lint gate + migration + skill) land in this single PR
+
+## Summary
+
+`github.com/joomcode/errorx` was adopted as the standard error library by PR #15 (2025-07-24), but with no CI gate the codebase has drifted — 105 `fmt.Errorf` and 1 `errors.New` call sites have re-accumulated in production Go code under `cmd/`, `internal/`, `pkg/`. This work re-enforces the standard by mirroring the chewie rollout (swirldslabs/chewie#232, #233) in three deliverables: a `forbidigo` lint gate scoped to new code, a mass migration of the 106 pre-existing call sites, and a Claude skill that documents the namespace-mapping decision matrix so future code starts conformant.
+
+## Problem
+
+Today's situation (recounted in this branch as of `origin/main`):
+
+| Construct | Count | Where |
+|---|---|---|
+| `errorx.<Type>.<New\|Wrap>` | 100+ files already import `errorx` | broad coverage |
+| `fmt.Errorf(` | **105 call sites across 24 files** | `cmd/cli/commands/**`, `internal/{alloy,network,state,ui,workflows}/**`, `pkg/{hardware,helm,security,software}/**` |
+| `errors.New(` | **1 call site** | `internal/ui/prompt/prompt.go:30` (`var ErrAborted = errors.New("aborted by user")`) |
+
+The issue body cites slightly different numbers (118 errorx / 114 stdlib) — close enough; the gap is normal drift between issue authoring and today. Confirmed exact counts to use for the migration PR's "before / after" claim.
+
+Three concrete pain points:
+
+1. **No lint gate.** `task lint` is `go fmt -x ./...` and `task lint:check` adds nothing else — there is no mechanism blocking a contributor (or Claude) from typing `fmt.Errorf` again.
+2. **Drift after one prior migration.** PR #15 already did this migration once. Without enforcement it slowly reversed; another mass rewrite is wasted effort unless the gate lands first.
+3. **No documented namespace mapping.** Existing `errorx` usage in the repo is uneven: `IllegalState` (359 instances), `IllegalArgument` (292), `InternalError` (97), `IllegalFormat` (28), `ExternalError` (14). Some shapes that should map to `ExternalError` (file I/O, shell exec, helm) currently use `IllegalState`. The skill captures the intended mapping so converters and reviewers can disagree against a written rule, not vibes.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Land as one PR or three? | **One PR** (overriding the issue's "ideally separate PRs" preference per user direction). The gate + migration are tightly coupled — landing the gate without the migration leaves contributors unable to add lines near pre-existing `fmt.Errorf` neighborhoods without picking them up under `new-from-rev`. Bundling avoids that awkward window. |
+| Use chewie's `.golangci.yml` verbatim or adapt? | **Adapt** — copy structure, swap "chewie standard" → "solo-weaver standard" in the `forbidigo` messages. Same `forbidigo` patterns, same `analyze-types: true`, same exclusions, same `new-from-rev: origin/main`. Add SPDX header (this repo enforces them; chewie's already has one). |
+| Pin `golangci-lint` version? | **Yes, v2.12.2** — same pin as chewie. Locks reproducibility; bumps are explicit. |
+| Where do `setup:golangci-lint` and `lint:errorx` live — `Taskfile.yaml` root or a new `taskfiles/lint.yaml`? | **Root `Taskfile.yaml`.** The existing `lint` / `lint:check` are already at the root and tiny (3 lines each). Extracting now would just spread two tasks across two files. The taskfile-conventions skill rule of thumb: extract when a family grows past ~30 lines or develops its own OS/arch fan-out. We're not there yet. |
+| Wire `lint:errorx` into `lint` (auto-format) or only `lint:check` (CI)? | **Both** — match chewie's structure. `lint` is the "make my changes pass" entry; `lint:check` is the CI verification. If a contributor runs `task lint` and a forbidigo finding appears, they want to know now, not when CI fails. |
+| What to do about the lone `errors.New` sentinel `ErrAborted` in `prompt.go`? | Convert to `errorx.RejectedOperation.New("aborted by user")` in the migration PR. `errorx` types still satisfy `error` and `errors.Is(err, ErrAborted)` works as long as `ErrAborted` is the exact value being checked, which is how it's used today. Verify the one caller (`fmt.Errorf("prompt error: %w", err)` at `prompt.go:89`) — that becomes `errorx.ExternalError.Wrap(err, "prompt error")` (user-facing prompt = external I/O). |
+| How to handle `NewExtractionError(fmt.Errorf(...), ...)` patterns in `pkg/software/downloader.go`? | The inner `fmt.Errorf` is being consumed by a custom constructor `NewExtractionError`. Convert each inner call to `errorx.IllegalState.New(...)` (these are integrity-violation conditions: "path traversal attempt", "absolute symlink not allowed", etc. — they signal corrupted/malicious archive state). `NewExtractionError` itself stays untouched. |
+| Custom `errorx.NewNamespace` declarations already in the repo (e.g. `pkg/os/errors.go`, `pkg/helm/errors.go`, `pkg/fsx/errors.go`)? | **Leave them alone.** They predate this work and are correct. The skill discourages *new* custom namespaces, not existing ones. |
+| Should the lint config also flag `errors.Is`, `errors.As`, `errors.Unwrap`? | **No** — those are stdlib utilities that work with `errorx` errors too (errorx implements the `Unwrap()` contract). The skill explicitly calls out that `errors.Is` / `errors.As` remain the right way to test sentinel/typed errors. |
+| Where does the Claude skill live? | `.claude/skills/errorx-conventions/SKILL.md` — same shape as the existing `sanity-validators` and `taskfile-conventions` skills (single `SKILL.md` file, no helpers). |
+
+## Scope
+
+### Part 1 — Lint gate
+
+- [ ] New file: `.golangci.yml` at repo root. Mirror swirldslabs/chewie#232 with these edits:
+  - Add `# SPDX-License-Identifier: Apache-2.0` as the first comment line.
+  - Replace "chewie standard" → "solo-weaver standard" in both `forbid` messages.
+  - Keep `forbidigo` as the only enabled linter, `default: none`, same `analyze-types: true`, same `exclude-godoc-examples: true`.
+  - Keep the exclusions: `_test\.go`, `(\.gen\.go|_generated\.go|/generated/)$`.
+  - Keep `issues.new-from-rev: origin/main`.
+- [ ] `Taskfile.yaml` root: add tasks
+  - `setup:golangci-lint` (internal, `status: which golangci-lint`, installs `github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2`).
+  - `lint:errorx` (internal, deps `setup:golangci-lint`, fetches `origin/main` then runs `golangci-lint run --config .golangci.yml ./...`).
+  - Wire `lint:errorx` into both `lint` and `lint:check` (after the existing `go fmt` lines).
+- [ ] `.github/workflows/zxc-code-compiles.yaml`: add `with: fetch-depth: 0` to the existing `actions/checkout` step (line 36) so `new-from-rev: origin/main` can resolve the base.
+- [ ] **No production code changes in this PR.** Verify on this branch that `task lint:check` runs cleanly (since the rule only flags lines changed relative to `origin/main`, and this branch only touches lint infra, there should be zero findings).
+
+### Part 2 — Mass conversion
+
+- [ ] Convert the 105 `fmt.Errorf` call sites across the 24 production files (see file list below) using the mapping below. **Per-file commits** so each can be reviewed independently — at this scale, a single 100-site commit is unreviewable.
+- [ ] Convert the 1 `errors.New` site in `internal/ui/prompt/prompt.go:30` (`ErrAborted`).
+- [ ] Replace any `fmt.Errorf("%w: %w", sentinel, cause)` patterns with `errors.Join(sentinel, cause)` (none found in current scan, but a grep over the changed lines as a safety net is cheap).
+- [ ] After each file's conversion, run `task lint` to keep `goimports`/`gofmt` happy. After the full migration, verify:
+  - `grep -rE 'errors\.New\(|fmt\.Errorf\(' --include='*.go' cmd internal pkg | grep -v _test.go` → **0** matches.
+  - `task lint:check` passes.
+  - `task test:unit` passes (still on macOS for the OS-portable subset).
+  - In the VM: `task vm:test:unit` and `task vm:test:integration TEST_NAME='…'` for any handlers touched.
+
+**Namespace mapping (this is the canonical version — the skill copies from here):**
+
+| Call site shape | `errorx` target |
+|---|---|
+| `os.Open`/`os.Stat`/`os.ReadFile` failure; shell/exec command failure; helm CLI failure; kubectl/kube API failure; GitHub API failure; DB query | `errorx.ExternalError.Wrap(err, "…")` |
+| Template render failure; internal `text/template` / `html/template` execute; expected-impossible internal computation that did error | `errorx.InternalError.Wrap(err, "…")` |
+| `json.Unmarshal` / `yaml.Unmarshal` / `toml.Unmarshal` failure; malformed checksum string; bad version string format | `errorx.IllegalFormat.Wrap(err, "…")` or `.New(…)` |
+| Invariant breach ("should never happen", "redirect loop", "unreachable") | `errorx.AssertionFailed.New(…)` |
+| User CLI flag value or config-file value rejected at validation | `errorx.IllegalArgument.New(…)` (or `.Wrap` if there's an upstream parse error to wrap) |
+| Permission / authorization / user-cancelled-operation | `errorx.RejectedOperation.New(…)` |
+| Inconsistent runtime state (unexpected enum, wrong phase, missing required field at a point it should have been set) | `errorx.IllegalState.New(…)` |
+
+**Files in scope (24):**
+
+```
+cmd/cli/commands/alloy/cluster/install.go
+cmd/cli/commands/alloy/cluster/parse_remote.go
+cmd/cli/commands/block/node/init.go
+cmd/cli/commands/common/flags.go
+cmd/cli/commands/common/run.go
+cmd/cli/commands/demo.go
+internal/alloy/config.go
+internal/alloy/render.go
+internal/network/network.go
+internal/state/cluster_state.go
+internal/ui/prompt/blocknode.go
+internal/ui/prompt/prompt.go
+internal/workflows/steps/catalog.go
+internal/workflows/steps/step_alloy.go
+internal/workflows/steps/step_cluster_crds.go
+internal/workflows/steps/step_kubeadm.go
+pkg/hardware/base_node.go
+pkg/hardware/node_spec.go
+pkg/helm/manager.go
+pkg/security/principal/provider_utils_unix.go
+pkg/security/sudoers/sudoers.go
+pkg/software/config.go
+pkg/software/downloader.go
+pkg/software/kubeadm_installer.go
+```
+
+**Special cases identified during exploration:**
+
+- `pkg/software/downloader.go` — wraps `fmt.Errorf` inside `NewExtractionError(...)`. Convert the inner argument to `errorx.IllegalState.New(...)` (integrity-violation conditions). `NewExtractionError` itself is unchanged.
+- `internal/ui/prompt/prompt.go:30` — `var ErrAborted = errors.New("aborted by user")` becomes `var ErrAborted = errorx.RejectedOperation.New("aborted by user")`. Existing `errors.Is(err, ErrAborted)` callers continue to work.
+- `internal/ui/prompt/prompt.go:89` — `fmt.Errorf("prompt error: %w", err)` becomes `errorx.ExternalError.Wrap(err, "prompt error")` (user-input I/O failure, e.g. terminal closed).
+- Several files retain `fmt.Sprintf` after the conversion. Keep the `fmt` import in those files; only remove `fmt` when no other `fmt.*` call remains.
+
+### Part 3 — Claude skill `errorx-conventions`
+
+- [ ] New file: `.claude/skills/errorx-conventions/SKILL.md`. Follow the structure of `.claude/skills/sanity-validators/SKILL.md`:
+  - Frontmatter (`name`, `description`). The `description` triggers when Claude is about to write/modify Go error construction — phrased to match the triggering style of `sanity-validators` ("Use this skill BEFORE writing or modifying any … in this repo — e.g. \"…\", \"…\", any edit that …"). Include the literal tokens `errors.New`, `fmt.Errorf`, and `errorx` so the description-matcher picks it up reliably.
+  - Sections:
+    1. **The rule** — "no `errors.New` / `fmt.Errorf` in production code; `*_test.go` is exempt." Cite the `forbidigo` lint and where the config lives.
+    2. **Namespace mapping table** — copy the canonical table from this plan.
+    3. **Decision matrix** — short solo-weaver-specific examples: `os.Stat` failure → `ExternalError`; bad CLI flag → `IllegalArgument`; `kubectl` exec failure → `ExternalError`; helm install failure → `ExternalError`; unexpected enum value → `AssertionFailed`; user pressed Ctrl-C in prompt → `RejectedOperation`; template execute failure → `InternalError`.
+    4. **Sentinel pattern** — `errors.Join(sentinel, cause)` instead of `fmt.Errorf("%w: %w", sentinel, cause)`. Sentinels themselves should be `errorx.<Type>.New(...)` typed values. Note that `errors.Is` walks the joined slice so checking either side works.
+    5. **`errors.Is` / `errors.As` are still allowed** — they're stdlib utilities that work with `errorx`. The skill is about *constructing* errors, not testing them.
+    6. **Tests are exempt and why** — rich error typing in tests obscures the assertion; tests should fail on the value/shape they expect.
+    7. **No new custom namespaces** — stick to built-in `errorx.<Type>` namespaces. Existing custom namespaces in `pkg/os/errors.go`, `pkg/helm/errors.go`, `pkg/fsx/errors.go` are grandfathered; don't add more.
+    8. **Common refactoring traps** — keep the `fmt` import if `fmt.Sprintf` is still used; don't fold `errorx.Decorate` (legacy) into `Wrap` (we use `Wrap` only).
+- [ ] Add a one-line entry to the root `CLAUDE.md` "Key Conventions" section linking the skill (mirroring how the sanity skill is implicitly discoverable). Actually — review the existing CLAUDE.md: skills are auto-discovered from `.claude/skills/*/SKILL.md`, so no explicit link is needed. Skip this step unless the user disagrees.
+
+## Out of scope
+
+- Replacing existing custom-namespace declarations in `pkg/os/errors.go`, `pkg/helm/errors.go`, `pkg/fsx/errors.go` with built-in namespaces. They work and removing them is its own design question (loses type-safe `errorx.IsOfType` checks).
+- Converting `*_test.go` files. The lint exempts them by design.
+- Adding additional `golangci-lint` checkers (e.g. `staticcheck`, `govet` beyond the existing inline rules, `gosec`). The lint config is intentionally narrow — broadening it would require a pre-existing-issues cleanup that this issue doesn't fund.
+- Wiring `lint:errorx` into the daemon-specific CI flow (`flow-deploy-release-daemon.yaml`) — release workflows don't run `task lint:check` today and adding it is a separate concern.
+- Touching `internal/doctor/` exit-code mapping to take advantage of the now-uniform errorx namespaces. Worthwhile follow-up, but separate issue.
+
+## Test plan
+
+### Part 1 (lint gate)
+
+- [ ] `task setup:golangci-lint` installs the binary.
+- [ ] `task lint:errorx` runs cleanly against the current `main` (since `new-from-rev: origin/main` scopes findings to changed lines; only `.golangci.yml` / `Taskfile.yaml` / workflow change here).
+- [ ] Negative test: temporarily add a `_ = errors.New("test")` to any non-test file, confirm `task lint:errorx` fails with the configured message. Revert before commit.
+- [ ] `task lint:check` (full pipeline) passes.
+- [ ] `task build` still passes — `golangci-lint` shouldn't affect compilation.
+- [ ] CI: push the branch, confirm the new "Code Style" step still runs and that `fetch-depth: 0` doesn't break any other step.
+
+### Part 2 (mass conversion)
+
+- [ ] `grep -rE 'errors\.New\(|fmt\.Errorf\(' --include='*.go' cmd internal pkg | grep -v _test.go` → 0 matches.
+- [ ] `task lint:check` clean.
+- [ ] `task test:unit` clean on macOS (covers the OS-portable subset).
+- [ ] `task vm:test:unit` clean (full unit suite incl. Linux-only packages).
+- [ ] `task vm:test:integration` clean — at least the workflows that touch the changed files (`Test_StepAlloy_*`, `Test_StepKubeadm_*`, `Test_StepClusterCRDs_*`, `Test_BlockNode_*`).
+- [ ] Spot-check sentinel behavior: `errors.Is(err, prompt.ErrAborted)` still works after `ErrAborted` becomes an `errorx` value (Go playground / a quick unit test).
+- [ ] Manual UAT: run `solo-provisioner` against the VM end-to-end (`kube cluster install` → `block node install`) and confirm error paths produce sensible messages — typed errors flow through `internal/doctor/` which formats them via `errorx`'s stack-trace-aware printer.
+
+### Part 3 (skill)
+
+- [ ] Manually trigger the skill in a fresh Claude session: ask Claude to add a `fmt.Errorf("foo: %w", err)` somewhere; confirm it picks up the skill and writes `errorx.<Type>.Wrap(...)` instead.
+- [ ] Confirm the frontmatter `description` triggers on the right keywords by inspecting the skill listing (`/skills` or harness output) in a session where the user mentions error handling.
+
+## Risks / rollbacks
+
+- **Lint gate — `new-from-rev: origin/main` boundary edge case.** If a contributor branches off a different branch (e.g. an epic branch), `golangci-lint` may not have `origin/main` as a direct ancestor and could report false positives. Mitigation: the `lint:errorx` task explicitly `git fetch origin main`s before invoking the linter. Rollback: revert the workflow + Taskfile change; the config file alone is inert.
+- **Migration — semantic drift during 100+ conversions.** A wrong namespace doesn't break behavior but loses signal for `internal/doctor/` and any future `errorx.IsOfType` callers. Mitigation: per-file edits + reviewer can sample-check the trickiest 5-10 files. The migration is mechanical, so file-level reverts are safe if a specific conversion was wrong.
+- **Migration — `ErrAborted` becomes an `errorx` value.** Existing `errors.Is(err, ErrAborted)` callers compare against the variable's identity, which Go's `errors.Is` does via `==` on terminal errors. `errorx` errors implement `Is(target error) bool` to handle wrapping, so identity check still works as long as the variable itself is preserved. Mitigation: add a tiny unit test pinning the `errors.Is(ErrAborted, ErrAborted) == true` invariant before the change.
+- **Skill — description doesn't trigger.** If the description string doesn't include the tokens Claude's harness greps for, the skill won't load when needed. Mitigation: literally include `errors.New`, `fmt.Errorf`, and `errorx` in the description; mirror the sanity-validators description structure (which is known to trigger reliably).

--- a/docs/claude/reviews/00628-enforce-errorx.md
+++ b/docs/claude/reviews/00628-enforce-errorx.md
@@ -1,0 +1,120 @@
+# #628 — Review guide: enforce errorx as the standard for error construction
+
+> **Issue:** https://github.com/hashgraph/solo-weaver/issues/628
+> **Branch:** `00628-enforce-errorx`
+> **Base:** `main`
+
+## Problem and solution
+
+`github.com/joomcode/errorx` was adopted as the standard error library by PR #15 (2025-07-24), but without a CI gate the codebase drifted — 105 `fmt.Errorf` + 1 `errors.New` re-accumulated across 24 production files. This PR delivers all three parts of the chewie rollout (mirroring swirldslabs/chewie#232 + #233) in one branch:
+
+1. **Lint gate** — `.golangci.yml` v2 with `forbidigo` forbidding `errors.New` and `fmt.Errorf` in non-test, non-generated Go files, scoped to lines new vs `origin/main`. Wired into `task lint` and `task lint:check` via a new `lint:errorx` task, with `setup:golangci-lint` pinning `v2.12.2`.
+2. **Mass migration** — 106 call sites converted to the appropriate `errorx.<Type>` namespace per the mapping table in the plan.
+3. **Claude skill** — `.claude/skills/errorx-conventions/SKILL.md` captures the rule, namespace mapping, `errors.Join` sentinel pattern, and the migration traps.
+
+CI checkout now uses `fetch-depth: 0` so `new-from-rev: origin/main` can resolve.
+
+## Changed files
+
+| File | What changed |
+|---|---|
+| `.golangci.yml` (new) | v2 config; only `forbidigo` enabled; SPDX header; "solo-weaver standard" guidance messages; `new-from-rev: origin/main` |
+| `Taskfile.yaml` | Added `setup:golangci-lint` (pinned v2.12.2, version-aware `status` check), `lint:errorx` (deps: `setup:golangci-lint`, `generate`, `mocks`; env `GOOS=linux`); wired into `lint` + `lint:check` |
+| `.github/workflows/zxc-code-compiles.yaml` | `actions/checkout` now uses `fetch-depth: 0` |
+| `.claude/skills/errorx-conventions/SKILL.md` (new) | New skill; same shape as `sanity-validators` / `taskfile-conventions` |
+| `docs/claude/plans/00628-enforce-errorx.md` (new) | Plan file capturing decisions and scope boundaries |
+| `cmd/cli/commands/alloy/cluster/install.go` | 4× `fmt.Errorf` → `errorx.IllegalArgument` (CLI flag validation) |
+| `cmd/cli/commands/alloy/cluster/parse_remote.go` | 4× `fmt.Errorf` → `errorx.IllegalArgument` (key=value parsing) |
+| `cmd/cli/commands/block/node/init.go` | 1× `fmt.Errorf` → `errorx.IllegalArgument` (`--plugins` required when preset=Custom) |
+| `cmd/cli/commands/common/flags.go` | 5× converted; unsupported-type defaults → `errorx.AssertionFailed`, flag-not-found → `errorx.IllegalArgument` |
+| `cmd/cli/commands/common/run.go` | 2× converted; TUI model type-assertion → `errorx.AssertionFailed`, step-failed → `errorx.IllegalState` |
+| `cmd/cli/commands/demo.go` | 1× converted; simulated failure → `errorx.IllegalState` |
+| `internal/alloy/config.go` | 1× `errorx.ExternalError.Wrap` for `os.Hostname` failure |
+| `internal/alloy/render.go` | 7× `errorx.InternalError.Wrap` for template render failures |
+| `internal/network/network.go` | 1× `errorx.IllegalState.New("no connected network interface found")` |
+| `internal/state/cluster_state.go` | 2× converted; helm manager init → `errorx.InternalError`, list releases → `errorx.ExternalError` |
+| `internal/ui/prompt/blocknode.go` | 7× `errorx.IllegalArgument.New` (form validation closures) |
+| `internal/ui/prompt/prompt.go` | `ErrAborted` sentinel rewired to `errorx.RejectedOperation.New(...)`; `wrapFormError` returns `errorx.ExternalError.Wrap` |
+| `internal/workflows/steps/catalog.go` | 4× converted across catalog-resolution errors (`IllegalFormat` / `IllegalArgument`) |
+| `internal/workflows/steps/step_alloy.go` | 9× converted; secret read/endpoint reach failures → `errorx.ExternalError`, secret-missing → `errorx.IllegalState` |
+| `internal/workflows/steps/step_cluster_crds.go` | 1× CRD-meta failure → `errorx.InternalError` |
+| `internal/workflows/steps/step_kubeadm.go` | 4× converted; kubeadm image-pull/init/configure → `errorx.ExternalError`, kubeconfig manager init → `errorx.InternalError` |
+| `pkg/hardware/base_node.go` | 5× hardware-requirement failures → `errorx.IllegalState` |
+| `pkg/hardware/node_spec.go` | 1× unknown node type/profile combo → `errorx.IllegalArgument` |
+| `pkg/helm/manager.go` | 3× chart-dependency and reload-after-update failures → `errorx.ExternalError`; `fmt` import removed |
+| `pkg/security/principal/provider_utils_unix.go` | 8× `/etc/passwd` and `/etc/group` parsing → `errorx.IllegalFormat` |
+| `pkg/security/sudoers/sudoers.go` | 5× converted; syntax validation → `errorx.IllegalFormat`, write failure → `errorx.ExternalError`; `fmt` import removed |
+| `pkg/software/config.go` | 12× catalog YAML validation failures → `errorx.IllegalFormat` / `errorx.IllegalArgument` |
+| `pkg/software/downloader.go` | 7× converted; redirect-rejection → `errorx.RejectedOperation`, tar-extraction integrity violations → `errorx.IllegalState` (wrapped by existing `NewExtractionError` constructor) |
+| `pkg/software/kubeadm_installer.go` | 1× crypto/rand failure → `errorx.ExternalError` |
+
+## Code review checklist
+
+- [ ] **Lint gate is scoped correctly.** Negative test: temporarily add `_ = errors.New("test")` to any non-test production file, confirm `task lint:check` fails with the configured message; revert.
+- [ ] **`new-from-rev: origin/main` works in CI.** The workflow's `fetch-depth: 0` change is what makes this possible; sanity-check the diff against `main` in the GitHub Actions log on the first CI run.
+- [ ] **Namespace mapping is consistent with the table.** Sample-check 5 files across different shape categories:
+  - `pkg/helm/manager.go` — external (helm calls) → `ExternalError`
+  - `pkg/software/config.go` — schema/format validation → `IllegalFormat`
+  - `internal/workflows/steps/step_alloy.go` — mixed external/state shapes
+  - `cmd/cli/commands/common/flags.go` — programmer-error type-switch defaults → `AssertionFailed`
+  - `internal/ui/prompt/prompt.go` — user cancel sentinel → `RejectedOperation`
+- [ ] **`ErrAborted` semantics preserved.** `var ErrAborted = errorx.RejectedOperation.New("aborted by user")` is identity-comparable; `errors.Is(err, ErrAborted)` still matches whether `err` is `ErrAborted` directly or has it joined into a multi-error. There are no current external callers doing `errors.Is(..., prompt.ErrAborted)`, but the contract is intentionally preserved for future use.
+- [ ] **`fmt` imports**: every file that converted away from `fmt.Errorf` either drops the `fmt` import entirely (verify: `goimports` did not flag anything) or keeps it because the file still uses `fmt.Sprintf` / `fmt.Fprint*` / `fmt.Printf`. Spot-check `pkg/helm/manager.go` (removed), `pkg/security/sudoers/sudoers.go` (removed), `pkg/hardware/base_node.go` (kept for `fmt.Sprintf`), `internal/ui/prompt/blocknode.go` (kept for `fmt.Sprintf` in the multi-select description).
+- [ ] **Special wrapper preserved**: `NewExtractionError(errorx.IllegalState.New(...), ...)` in `pkg/software/downloader.go` — confirm the outer constructor is untouched and the inner stdlib `fmt.Errorf` is now an errorx value.
+- [ ] **Skill triggers reliably.** Description includes the literal tokens `errors.New`, `fmt.Errorf`, `errorx` so a fresh Claude session picks it up before generating new error construction.
+- [ ] **`task lint:errorx` developer ergonomics**: deps run `generate` and `mocks` so a fresh checkout / clean cache produces a clean lint without manual setup. `GOOS=linux` env makes the linter see the same code CI does (`internal/mount`, `pkg/kernel/module` typecheck OK).
+
+## Test commands
+
+```bash
+# Lint pipeline (gate, format, vet)
+task lint:check
+
+# Full unit test suite (Linux-only paths require the VM)
+task vm:test:unit
+
+# Targeted unit tests for changed packages
+go test -race -tags='!integration' ./pkg/hardware/... ./pkg/helm/... ./pkg/security/... \
+    ./internal/alloy/... ./internal/network/... ./internal/state/... ./internal/ui/prompt/... \
+    ./internal/workflows/steps/...
+
+# Integration smoke tests (UTM VM)
+task vm:test:integration TEST_NAME='^Test_StepKubeadm_Fresh_Integration$'
+task vm:test:integration TEST_NAME='^Test_StepAlloy_'
+task vm:test:integration TEST_NAME='^Test_BlockNode_'
+
+# Negative test for the lint gate (manual)
+# 1. Add `_ = errors.New("test")` to any production .go file
+# 2. Run: task lint:check  → expect non-zero exit with forbidigo message
+# 3. Revert the change
+```
+
+## Manual UAT
+
+```bash
+# 1. Confirm setup task installs golangci-lint v2.12.2
+golangci-lint --version
+# Expect: golangci-lint has version v2.12.2 built with ...
+
+# 2. Confirm task aggregator runs the gate
+task lint:check
+# Expect tail output:
+#   task: [lint:errorx] golangci-lint run --config .golangci.yml ./...
+#   [lint:errorx] 0 issues.
+
+# 3. Confirm task lint (auto-format path) also runs the gate
+task lint
+# Expect the same "0 issues" tail.
+
+# 4. End-to-end sanity (in UTM VM)
+solo-provisioner kube cluster install --profile local
+solo-provisioner block node install
+# Watch for any error path; confirm the doctor layer's styled output still
+# renders the errorx namespace icon / category correctly.
+```
+
+## Risks and rollback
+
+- **`new-from-rev` boundary edge case.** Contributors who branch from a non-main starting point may see false positives the first time CI runs. The `lint:errorx` task `git fetch origin main`s before invoking the linter to keep this rare; if it bites, revert just the workflow + Taskfile changes — the `.golangci.yml` alone is inert without the task wiring.
+- **`ErrAborted` regression.** Identity-comparison still works because the variable is declared once at package scope. If a downstream callee starts re-creating the value per call, `errors.Is` would silently stop matching. The skill calls this out under "Migration traps #3".
+- **Per-file rollback.** Each file's migration is mechanical and isolated; a wrong namespace can be reverted on its own without affecting the lint gate or other files.

--- a/internal/alloy/config.go
+++ b/internal/alloy/config.go
@@ -4,9 +4,10 @@
 package alloy
 
 import (
-	"fmt"
 	"os"
 	"strings"
+
+	"github.com/joomcode/errorx"
 
 	"github.com/hashgraph/solo-weaver/internal/alloy/labels"
 	"github.com/hashgraph/solo-weaver/internal/network"
@@ -61,7 +62,7 @@ func NewConfigBuilder(cfg models.AlloyConfig, deployProfile string) (*ConfigBuil
 	if cb.clusterName == "" {
 		hostname, err := os.Hostname()
 		if err != nil {
-			return nil, fmt.Errorf("cluster name not provided and failed to get hostname: %w", err)
+			return nil, errorx.ExternalError.Wrap(err, "cluster name not provided and failed to get hostname")
 		}
 		cb.clusterName = hostname
 	}

--- a/internal/alloy/render.go
+++ b/internal/alloy/render.go
@@ -3,9 +3,10 @@
 package alloy
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/joomcode/errorx"
 
 	"github.com/hashgraph/solo-weaver/internal/templates"
 	"github.com/hashgraph/solo-weaver/pkg/models"
@@ -32,7 +33,7 @@ func RenderModularConfigs(cb *ConfigBuilder) ([]ModuleConfig, error) {
 	// 1. Core config (always required)
 	coreConfig, err := templates.Render(CoreTemplatePath, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to render core config: %w", err)
+		return nil, errorx.InternalError.Wrap(err, "failed to render core config")
 	}
 	modules = append(modules, ModuleConfig{
 		Name:     "core",
@@ -49,7 +50,7 @@ func RenderModularConfigs(cb *ConfigBuilder) ([]ModuleConfig, error) {
 		}
 		remotesConfig, err := templates.Render(RemotesTemplatePath, remotesData)
 		if err != nil {
-			return nil, fmt.Errorf("failed to render remotes config: %w", err)
+			return nil, errorx.InternalError.Wrap(err, "failed to render remotes config")
 		}
 		modules = append(modules, ModuleConfig{
 			Name:     "remotes",
@@ -69,7 +70,7 @@ func RenderModularConfigs(cb *ConfigBuilder) ([]ModuleConfig, error) {
 	if hasPrometheusRemotes {
 		agentMetricsConfig, err := templates.Render(AgentMetricsTemplatePath, moduleData)
 		if err != nil {
-			return nil, fmt.Errorf("failed to render agent-metrics config: %w", err)
+			return nil, errorx.InternalError.Wrap(err, "failed to render agent-metrics config")
 		}
 		modules = append(modules, ModuleConfig{
 			Name:     "agent-metrics",
@@ -82,7 +83,7 @@ func RenderModularConfigs(cb *ConfigBuilder) ([]ModuleConfig, error) {
 	if hasPrometheusRemotes {
 		nodeExporterConfig, err := templates.Render(NodeExporterTemplatePath, moduleData)
 		if err != nil {
-			return nil, fmt.Errorf("failed to render node-exporter config: %w", err)
+			return nil, errorx.InternalError.Wrap(err, "failed to render node-exporter config")
 		}
 		modules = append(modules, ModuleConfig{
 			Name:     "node-exporter",
@@ -95,7 +96,7 @@ func RenderModularConfigs(cb *ConfigBuilder) ([]ModuleConfig, error) {
 	if hasPrometheusRemotes {
 		kubeletConfig, err := templates.Render(KubeletTemplatePath, moduleData)
 		if err != nil {
-			return nil, fmt.Errorf("failed to render kubelet config: %w", err)
+			return nil, errorx.InternalError.Wrap(err, "failed to render kubelet config")
 		}
 		modules = append(modules, ModuleConfig{
 			Name:     "kubelet",
@@ -108,7 +109,7 @@ func RenderModularConfigs(cb *ConfigBuilder) ([]ModuleConfig, error) {
 	if hasLokiRemotes {
 		syslogConfig, err := templates.Render(SyslogTemplatePath, moduleData)
 		if err != nil {
-			return nil, fmt.Errorf("failed to render syslog config: %w", err)
+			return nil, errorx.InternalError.Wrap(err, "failed to render syslog config")
 		}
 		modules = append(modules, ModuleConfig{
 			Name:     "syslog",
@@ -122,7 +123,7 @@ func RenderModularConfigs(cb *ConfigBuilder) ([]ModuleConfig, error) {
 	if cb.MonitorBlockNode() && hasPrometheusRemotes && hasLokiRemotes {
 		blockNodeConfig, err := templates.Render(BlockNodeTemplatePath, moduleData)
 		if err != nil {
-			return nil, fmt.Errorf("failed to render block-node config: %w", err)
+			return nil, errorx.InternalError.Wrap(err, "failed to render block-node config")
 		}
 		modules = append(modules, ModuleConfig{
 			Name:     "block-node",

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -4,7 +4,6 @@ package network
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -47,7 +46,7 @@ func GetMachineIP() (string, error) {
 			return ip.String(), nil
 		}
 	}
-	return "", fmt.Errorf("no connected network interface found")
+	return "", errorx.IllegalState.New("no connected network interface found")
 }
 
 // CheckEndpointReachable verifies that a URL endpoint is reachable.

--- a/internal/state/cluster_state.go
+++ b/internal/state/cluster_state.go
@@ -6,7 +6,7 @@
 package state
 
 import (
-	"fmt"
+	"github.com/joomcode/errorx"
 
 	"github.com/hashgraph/solo-weaver/pkg/helm"
 )
@@ -22,12 +22,12 @@ const (
 func GetBlockNodeNamespace() (string, error) {
 	hm, err := helm.NewManager()
 	if err != nil {
-		return "", fmt.Errorf("failed to create helm manager: %w", err)
+		return "", errorx.InternalError.Wrap(err, "failed to create helm manager")
 	}
 
 	releases, err := hm.ListAll()
 	if err != nil {
-		return "", fmt.Errorf("failed to list helm releases: %w", err)
+		return "", errorx.ExternalError.Wrap(err, "failed to list helm releases")
 	}
 
 	for _, rel := range releases {

--- a/internal/ui/prompt/blocknode.go
+++ b/internal/ui/prompt/blocknode.go
@@ -9,13 +9,15 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/huh"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+
 	"github.com/hashgraph/solo-weaver/internal/blocknode"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/deps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/hashgraph/solo-weaver/pkg/sanity"
-	"github.com/spf13/cobra"
 )
 
 // storagePathMode constants define the two mutually exclusive storage configuration modes.
@@ -27,14 +29,14 @@ const (
 // validateRetentionThreshold validates that a retention threshold is a non-negative integer.
 func validateRetentionThreshold(s string) error {
 	if s == "" {
-		return fmt.Errorf("retention threshold cannot be empty")
+		return errorx.IllegalArgument.New("retention threshold cannot be empty")
 	}
 	n, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		return fmt.Errorf("retention threshold must be a non-negative integer")
+		return errorx.IllegalArgument.New("retention threshold must be a non-negative integer")
 	}
 	if n < 0 {
-		return fmt.Errorf("retention threshold must be a non-negative integer")
+		return errorx.IllegalArgument.New("retention threshold must be a non-negative integer")
 	}
 	return nil
 }
@@ -54,7 +56,7 @@ func validateOptionalPath(s string) error {
 // individual-paths mode, where every path must be provided.
 func validateRequiredPath(s string) error {
 	if s == "" {
-		return fmt.Errorf("path cannot be empty in individual paths mode")
+		return errorx.IllegalArgument.New("path cannot be empty in individual paths mode")
 	}
 	_, err := sanity.SanitizePath(s)
 	return err
@@ -74,7 +76,7 @@ func namespaceInputPrompt(eff string, target *string) InputPrompt {
 		Target:         target,
 		Validate: func(s string) error {
 			if s == "" {
-				return fmt.Errorf("namespace cannot be empty")
+				return errorx.IllegalArgument.New("namespace cannot be empty")
 			}
 			return sanity.ValidateIdentifier(s)
 		},
@@ -91,7 +93,7 @@ func releaseNameInputPrompt(eff string, target *string) InputPrompt {
 		Target:         target,
 		Validate: func(s string) error {
 			if s == "" {
-				return fmt.Errorf("release name cannot be empty")
+				return errorx.IllegalArgument.New("release name cannot be empty")
 			}
 			return sanity.ValidateIdentifier(s)
 		},
@@ -108,7 +110,7 @@ func chartVersionInputPrompt(eff string, target *string) InputPrompt {
 		Target:         target,
 		Validate: func(s string) error {
 			if s == "" {
-				return fmt.Errorf("chart version cannot be empty")
+				return errorx.IllegalArgument.New("chart version cannot be empty")
 			}
 			return sanity.ValidateVersion(s)
 		},
@@ -529,7 +531,7 @@ func RunPluginPresetPrompts(
 		Value(&selectedPlugins).
 		Validate(func(selected []string) error {
 			if len(selected) == 0 {
-				return fmt.Errorf("at least one plugin must be selected for the Custom preset")
+				return errorx.IllegalArgument.New("at least one plugin must be selected for the Custom preset")
 			}
 			return nil
 		})

--- a/internal/ui/prompt/prompt.go
+++ b/internal/ui/prompt/prompt.go
@@ -22,12 +22,16 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/hashgraph/solo-weaver/internal/ui"
+	"github.com/joomcode/errorx"
 	"github.com/spf13/cobra"
+
+	"github.com/hashgraph/solo-weaver/internal/ui"
 )
 
 // ErrAborted is returned when the user cancels out of an interactive prompt.
-var ErrAborted = errors.New("aborted by user")
+// It is an errorx-typed sentinel so callers can `errors.Is(err, ErrAborted)`
+// and the doctor layer can branch on the RejectedOperation namespace.
+var ErrAborted = errorx.RejectedOperation.New("aborted by user")
 
 // chosenPair holds a title/value pair for summary printing.
 type chosenPair struct {
@@ -86,7 +90,7 @@ func wrapFormError(err error) error {
 	if errors.Is(err, huh.ErrUserAborted) {
 		return ErrAborted
 	}
-	return fmt.Errorf("prompt error: %w", err)
+	return errorx.ExternalError.Wrap(err, "prompt error")
 }
 
 // SelectPrompt defines an interactive select prompt for a flag with a fixed set of choices.

--- a/internal/workflows/steps/catalog.go
+++ b/internal/workflows/steps/catalog.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+
 	"github.com/hashgraph/solo-weaver/pkg/helm"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/hashgraph/solo-weaver/pkg/software"
@@ -78,19 +80,19 @@ func chartSpec(name string) *helmChartSpec {
 func resolveCatalogChart(name string) (*helmChartSpec, error) {
 	catalog, err := software.LoadInfrastructureCatalog()
 	if err != nil {
-		return nil, fmt.Errorf("load infrastructure catalog: %w", err)
+		return nil, errorx.IllegalFormat.Wrap(err, "load infrastructure catalog")
 	}
 	meta, err := catalog.GetClusterComponent(name)
 	if err != nil {
-		return nil, fmt.Errorf("catalog: %w", err)
+		return nil, errorx.IllegalArgument.Wrap(err, "catalog")
 	}
 	version, err := meta.GetDefaultVersion()
 	if err != nil {
-		return nil, fmt.Errorf("catalog: %w", err)
+		return nil, errorx.IllegalFormat.Wrap(err, "catalog")
 	}
 	sum, ok := meta.Versions[software.Version(version)]
 	if !ok {
-		return nil, fmt.Errorf("catalog: chart %q version %q has no checksum entry", name, version)
+		return nil, errorx.IllegalFormat.New("catalog: chart %q version %q has no checksum entry", name, version)
 	}
 	return &helmChartSpec{
 		Chart:     meta.Chart,

--- a/internal/workflows/steps/step_alloy.go
+++ b/internal/workflows/steps/step_alloy.go
@@ -4,7 +4,6 @@ package steps
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -12,16 +11,17 @@ import (
 
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
-	"github.com/hashgraph/solo-weaver/internal/alloy"
-	"github.com/hashgraph/solo-weaver/pkg/config"
-	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+	"helm.sh/helm/v3/pkg/cli/values"
 
+	"github.com/hashgraph/solo-weaver/internal/alloy"
 	"github.com/hashgraph/solo-weaver/internal/kube"
 	"github.com/hashgraph/solo-weaver/internal/network"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/helm"
-	"helm.sh/helm/v3/pkg/cli/values"
+	"github.com/hashgraph/solo-weaver/pkg/models"
 )
 
 const (
@@ -97,7 +97,7 @@ func preCheckAlloy() automa.Builder {
 				k, err := kube.NewClient()
 				if err != nil {
 					return automa.StepFailureReport(stp.Id(), automa.WithError(
-						fmt.Errorf("failed to create kubernetes client: %w", err)))
+						errorx.ExternalError.Wrap(err, "failed to create kubernetes client")))
 				}
 
 				// Build config to determine required secrets
@@ -112,11 +112,11 @@ func preCheckAlloy() automa.Builder {
 					actualKeys, err := k.GetSecretKeys(ctx, spec.Namespace, secretName)
 					if err != nil {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
-							fmt.Errorf("failed to read K8s Secret %q in namespace %q: %w", secretName, spec.Namespace, err)))
+							errorx.ExternalError.Wrap(err, "failed to read K8s Secret %q in namespace %q", secretName, spec.Namespace)))
 					}
 					if actualKeys == nil {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
-							fmt.Errorf("K8s Secret %q not found in namespace %q; expected keys: %v. "+
+							errorx.IllegalState.New("K8s Secret %q not found in namespace %q; expected keys: %v. "+
 								"Create the secret before installing Alloy, e.g.: "+
 								"kubectl create secret generic %s --namespace=%s --from-literal=<KEY>=<password>",
 								secretName, spec.Namespace, expectedKeys, secretName, spec.Namespace)))
@@ -135,7 +135,7 @@ func preCheckAlloy() automa.Builder {
 					}
 					if len(missingKeys) > 0 {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
-							fmt.Errorf("K8s Secret %q in namespace %q is missing required keys: %v; found keys: %v",
+							errorx.IllegalState.New("K8s Secret %q in namespace %q is missing required keys: %v; found keys: %v",
 								secretName, spec.Namespace, missingKeys, actualKeys)))
 					}
 
@@ -146,7 +146,7 @@ func preCheckAlloy() automa.Builder {
 				for _, remote := range cfg.PrometheusRemotes {
 					if err := network.CheckEndpointReachable(ctx, remote.URL, 10*time.Second); err != nil {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
-							fmt.Errorf("Prometheus remote %q at %s is not reachable: %w", remote.Name, remote.URL, err)))
+							errorx.ExternalError.Wrap(err, "Prometheus remote %q at %s is not reachable", remote.Name, remote.URL)))
 					}
 					l.Info().Str("name", remote.Name).Str("url", remote.URL).Msg("Prometheus remote is reachable")
 				}
@@ -154,7 +154,7 @@ func preCheckAlloy() automa.Builder {
 				if cfg.PrometheusURL != "" {
 					if err := network.CheckEndpointReachable(ctx, cfg.PrometheusURL, 10*time.Second); err != nil {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
-							fmt.Errorf("Prometheus remote at %s is not reachable: %w", cfg.PrometheusURL, err)))
+							errorx.ExternalError.Wrap(err, "Prometheus remote at %s is not reachable", cfg.PrometheusURL)))
 					}
 					l.Info().Str("url", cfg.PrometheusURL).Msg("Prometheus remote is reachable")
 				}
@@ -163,7 +163,7 @@ func preCheckAlloy() automa.Builder {
 				for _, remote := range cfg.LokiRemotes {
 					if err := network.CheckEndpointReachable(ctx, remote.URL, 10*time.Second); err != nil {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
-							fmt.Errorf("Loki remote %q at %s is not reachable: %w", remote.Name, remote.URL, err)))
+							errorx.ExternalError.Wrap(err, "Loki remote %q at %s is not reachable", remote.Name, remote.URL)))
 					}
 					l.Info().Str("name", remote.Name).Str("url", remote.URL).Msg("Loki remote is reachable")
 				}
@@ -171,7 +171,7 @@ func preCheckAlloy() automa.Builder {
 				if cfg.LokiURL != "" {
 					if err := network.CheckEndpointReachable(ctx, cfg.LokiURL, 10*time.Second); err != nil {
 						return automa.StepFailureReport(stp.Id(), automa.WithError(
-							fmt.Errorf("Loki remote at %s is not reachable: %w", cfg.LokiURL, err)))
+							errorx.ExternalError.Wrap(err, "Loki remote at %s is not reachable", cfg.LokiURL)))
 					}
 					l.Info().Str("url", cfg.LokiURL).Msg("Loki remote is reachable")
 				}
@@ -634,7 +634,7 @@ func deployBlockNodeMonitoring() automa.Builder {
 			// Discover block node namespace from Helm
 			blockNodeNamespace, err := state.GetBlockNodeNamespace()
 			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(fmt.Errorf("failed to discover block node namespace: %w", err)))
+				return automa.StepFailureReport(stp.Id(), automa.WithError(errorx.ExternalError.Wrap(err, "failed to discover block node namespace")))
 			}
 			if blockNodeNamespace == "" {
 				l.Warn().Msg("Block node monitoring enabled but block node not found; skipping ServiceMonitor deployment")

--- a/internal/workflows/steps/step_cluster_crds.go
+++ b/internal/workflows/steps/step_cluster_crds.go
@@ -4,11 +4,12 @@ package steps
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/automa-saga/automa"
+	"github.com/joomcode/errorx"
+
 	"github.com/hashgraph/solo-weaver/internal/kube"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
 )
@@ -33,7 +34,7 @@ func CheckClusterCRDs(id string, crds []string, timeout time.Duration, provider 
 			// update meta with the checked CRDs and their details
 			foundCRDs, err := prepareCRDMeta(ctx, k)
 			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(fmt.Errorf("failed to prepare CRD meta: %w", err)))
+				return automa.StepFailureReport(stp.Id(), automa.WithError(errorx.InternalError.Wrap(err, "failed to prepare CRD meta")))
 			}
 
 			meta := map[string]string{}

--- a/internal/workflows/steps/step_kubeadm.go
+++ b/internal/workflows/steps/step_kubeadm.go
@@ -9,10 +9,11 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/automa/automa_steps"
 	"github.com/automa-saga/logx"
-	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
 
 	"github.com/hashgraph/solo-weaver/internal/kube"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/hashgraph/solo-weaver/pkg/software"
 )
 
@@ -205,7 +206,7 @@ func InitializeCluster() *automa.StepBuilder {
 
 			_, err = automa_steps.RunBashScript(pullImageCmd, "")
 			if err != nil {
-				return automa.FailureReport(stp, automa.WithError(fmt.Errorf("failed to pull kubeadm images: %w", err)))
+				return automa.FailureReport(stp, automa.WithError(errorx.ExternalError.Wrap(err, "failed to pull kubeadm images")))
 			}
 			logx.As().Info().Msg("Kubeadm images pulled successfully.")
 
@@ -216,17 +217,17 @@ func InitializeCluster() *automa.StepBuilder {
 
 			_, err = automa_steps.RunBashScript(initCmd, "")
 			if err != nil {
-				return automa.FailureReport(stp, automa.WithError(fmt.Errorf("failed to initialize cluster with kubeadm: %w", err)))
+				return automa.FailureReport(stp, automa.WithError(errorx.ExternalError.Wrap(err, "failed to initialize cluster with kubeadm")))
 			}
 
 			// Step 3: Configure kubeconfig
 			kubeConfigManager, err := kube.NewKubeConfigManager()
 			if err != nil {
-				return automa.FailureReport(stp, automa.WithError(fmt.Errorf("failed to create kubeconfig manager: %w", err)))
+				return automa.FailureReport(stp, automa.WithError(errorx.InternalError.Wrap(err, "failed to create kubeconfig manager")))
 			}
 			err = kubeConfigManager.Configure()
 			if err != nil {
-				return automa.FailureReport(stp, automa.WithError(fmt.Errorf("failed to configure kubeconfig: %w", err)))
+				return automa.FailureReport(stp, automa.WithError(errorx.ExternalError.Wrap(err, "failed to configure kubeconfig")))
 			}
 
 			return automa.SuccessReport(stp, automa.WithDetail("Cluster initialized successfully"))

--- a/pkg/hardware/base_node.go
+++ b/pkg/hardware/base_node.go
@@ -5,6 +5,8 @@ package hardware
 import (
 	"fmt"
 	"strings"
+
+	"github.com/joomcode/errorx"
 )
 
 const (
@@ -22,7 +24,7 @@ type baseNode struct {
 // ValidateOS validates OS requirements using common logic
 func (b *baseNode) ValidateOS() error {
 	if !validateOS(b.minimalRequirements.MinSupportedOS, b.actualHostProfile) {
-		return fmt.Errorf("OS does not meet %s requirements (supported: %v)", b.nodeType, b.minimalRequirements.MinSupportedOS)
+		return errorx.IllegalState.New("OS does not meet %s requirements (supported: %v)", b.nodeType, b.minimalRequirements.MinSupportedOS)
 	}
 	return nil
 }
@@ -31,7 +33,7 @@ func (b *baseNode) ValidateOS() error {
 func (b *baseNode) ValidateCPU() error {
 	cores := b.actualHostProfile.GetCPUCores()
 	if int(cores) < b.minimalRequirements.MinCpuCores {
-		return fmt.Errorf("CPU does not meet %s requirements (minimum %d cores)", b.nodeType, b.minimalRequirements.MinCpuCores)
+		return errorx.IllegalState.New("CPU does not meet %s requirements (minimum %d cores)", b.nodeType, b.minimalRequirements.MinCpuCores)
 	}
 	return nil
 }
@@ -44,7 +46,7 @@ func (b *baseNode) ValidateMemory() error {
 
 	// Check total memory first
 	if int(totalMemoryGB) < b.minimalRequirements.MinMemoryGB {
-		return fmt.Errorf("total memory does not meet %s requirements (minimum %d GB, found %d GB total)",
+		return errorx.IllegalState.New("total memory does not meet %s requirements (minimum %d GB, found %d GB total)",
 			b.nodeType, b.minimalRequirements.MinMemoryGB, totalMemoryGB)
 	}
 
@@ -54,7 +56,7 @@ func (b *baseNode) ValidateMemory() error {
 	if isApplicationRunning {
 		// If app is running, we just need enough for system operations
 		if float64(availableMemoryGB) < SystemBufferGB {
-			return fmt.Errorf("insufficient available memory for system operations while %s is running (need %.1f GB, have %.1f GB available)",
+			return errorx.IllegalState.New("insufficient available memory for system operations while %s is running (need %.1f GB, have %.1f GB available)",
 				b.nodeType, SystemBufferGB, float64(availableMemoryGB))
 		}
 	} else {
@@ -64,7 +66,7 @@ func (b *baseNode) ValidateMemory() error {
 			// Calculate how much memory might be used by existing processes
 			usedMemoryGB := totalMemoryGB - availableMemoryGB
 
-			return fmt.Errorf("insufficient available memory for fresh %s installation (need %.1f GB including system buffer, have %.1f GB available, %.1f GB currently used)",
+			return errorx.IllegalState.New("insufficient available memory for fresh %s installation (need %.1f GB including system buffer, have %.1f GB available, %.1f GB currently used)",
 				b.nodeType, requiredAvailableGB, float64(availableMemoryGB), float64(usedMemoryGB))
 		}
 	}
@@ -84,7 +86,7 @@ func (b *baseNode) ValidateStorage() error {
 	// Default: validate total storage
 	totalStorageGB := b.actualHostProfile.GetTotalStorageGB()
 	if int(totalStorageGB) < b.minimalRequirements.MinStorageGB {
-		return fmt.Errorf("storage does not meet %s requirements (minimum %d GB, found %d GB)",
+		return errorx.IllegalState.New("storage does not meet %s requirements (minimum %d GB, found %d GB)",
 			b.nodeType, b.minimalRequirements.MinStorageGB, totalStorageGB)
 	}
 	return nil
@@ -111,7 +113,7 @@ func (b *baseNode) validateSplitStorage() error {
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("storage does not meet %s requirements: %s", b.nodeType, strings.Join(errs, "; "))
+		return errorx.IllegalState.New("storage does not meet %s requirements: %s", b.nodeType, strings.Join(errs, "; "))
 	}
 	return nil
 }

--- a/pkg/hardware/node_spec.go
+++ b/pkg/hardware/node_spec.go
@@ -5,6 +5,7 @@ package hardware
 import (
 	"fmt"
 
+	"github.com/joomcode/errorx"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -25,7 +26,7 @@ var _ Spec = (*nodeSpec)(nil)
 func NewNodeSpec(nodeType, profile string, hostProfile HostProfile) (Spec, error) {
 	requirements, found := GetRequirements(nodeType, profile)
 	if !found {
-		return nil, fmt.Errorf("no requirements defined for node type %q with profile %q", nodeType, profile)
+		return nil, errorx.IllegalArgument.New("no requirements defined for node type %q with profile %q", nodeType, profile)
 	}
 
 	return &nodeSpec{

--- a/pkg/helm/manager.go
+++ b/pkg/helm/manager.go
@@ -5,7 +5,6 @@ package helm
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -225,7 +224,7 @@ func (h *helmManager) InstallChart(ctx context.Context, releaseName, chartRef, c
 	// Check chart dependencies to make sure all are present in /charts
 	if chartDependencies := chartRequested.Metadata.Dependencies; chartDependencies != nil {
 		if err := action.CheckDependencies(chartRequested, chartDependencies); err != nil {
-			err = fmt.Errorf("failed to check chart dependencies: %w", err)
+			err = errorx.ExternalError.Wrap(err, "failed to check chart dependencies")
 			if !installClient.DependencyUpdate {
 				return nil, err
 			}
@@ -246,7 +245,7 @@ func (h *helmManager) InstallChart(ctx context.Context, releaseName, chartRef, c
 			}
 			// Reload the chart with the updated Chart.lock file.
 			if chartRequested, err = loader.Load(chartPath); err != nil {
-				return nil, fmt.Errorf("failed to reload chart after repo update: %w", err)
+				return nil, errorx.ExternalError.Wrap(err, "failed to reload chart after repo update")
 			}
 		}
 	}
@@ -366,7 +365,7 @@ func (h *helmManager) UpgradeChart(ctx context.Context, releaseName, chartRef, c
 
 	if req := chart.Metadata.Dependencies; req != nil {
 		if err := action.CheckDependencies(chart, req); err != nil {
-			err = fmt.Errorf("failed to check chart dependencies: %w", err)
+			err = errorx.ExternalError.Wrap(err, "failed to check chart dependencies")
 			if !upgradeClient.DependencyUpdate {
 				return nil, ErrChartDependencyMissing.Wrap(err, "chart dependency check failed")
 			}

--- a/pkg/security/principal/provider_utils_unix.go
+++ b/pkg/security/principal/provider_utils_unix.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/joomcode/errorx"
 )
 
 type lineReader[E unixUser | unixGroup] func(index int, line string) (*E, error)
@@ -57,12 +59,12 @@ func readEntityFile[E unixUser | unixGroup](file string, fn lineReader[E]) ([]*E
 
 func parseUnixUser(index int, line string) (*unixUser, error) {
 	if !strings.Contains(line, ":") {
-		return nil, fmt.Errorf("invalid user entry at line %d, no colons were present", index)
+		return nil, errorx.IllegalFormat.New("invalid user entry at line %d, no colons were present", index)
 	}
 
 	parts := strings.Split(line, ":")
 	if len(parts) != 7 {
-		return nil, fmt.Errorf("invalid user entry at line %d, not enough fields", index)
+		return nil, errorx.IllegalFormat.New("invalid user entry at line %d, not enough fields", index)
 	}
 
 	// The unix passwd file has the following colon delimited fields:
@@ -77,17 +79,17 @@ func parseUnixUser(index int, line string) (*unixUser, error) {
 
 	username := strings.TrimSpace(parts[0])
 	if len(username) == 0 {
-		return nil, fmt.Errorf("invalid user entry at line %d, empty username field", index)
+		return nil, errorx.IllegalFormat.New("invalid user entry at line %d, empty username field", index)
 	}
 
 	uid, err := strconv.Atoi(parts[2])
 	if err != nil {
-		return nil, fmt.Errorf("invalid user entry at line %d, invalid uid field", index)
+		return nil, errorx.IllegalFormat.Wrap(err, "invalid user entry at line %d, invalid uid field", index)
 	}
 
 	gid, err := strconv.Atoi(parts[3])
 	if err != nil {
-		return nil, fmt.Errorf("invalid user entry at line %d, invalid gid field", index)
+		return nil, errorx.IllegalFormat.Wrap(err, "invalid user entry at line %d, invalid gid field", index)
 	}
 
 	displayName := displayNameFromGecos(parts[4])
@@ -114,22 +116,22 @@ func parseUnixGroup(index int, line string) (*unixGroup, error) {
 	// parts[3] = members
 
 	if !strings.Contains(line, ":") {
-		return nil, fmt.Errorf("invalid group entry at line %d, no colons were present", index)
+		return nil, errorx.IllegalFormat.New("invalid group entry at line %d, no colons were present", index)
 	}
 
 	parts := strings.Split(line, ":")
 	if len(parts) < 3 || len(parts) > 4 {
-		return nil, fmt.Errorf("invalid group entry at line %d, not enough fields", index)
+		return nil, errorx.IllegalFormat.New("invalid group entry at line %d, not enough fields", index)
 	}
 
 	groupname := strings.TrimSpace(parts[0])
 	if len(groupname) == 0 {
-		return nil, fmt.Errorf("invalid group entry at line %d, empty groupname field", index)
+		return nil, errorx.IllegalFormat.New("invalid group entry at line %d, empty groupname field", index)
 	}
 
 	gid, err := strconv.Atoi(parts[2])
 	if err != nil {
-		return nil, fmt.Errorf("invalid group entry at line %d, invalid gid field", index)
+		return nil, errorx.IllegalFormat.Wrap(err, "invalid group entry at line %d, invalid gid field", index)
 	}
 
 	var members []string

--- a/pkg/security/sudoers/sudoers.go
+++ b/pkg/security/sudoers/sudoers.go
@@ -3,8 +3,9 @@
 package sudoers
 
 import (
-	"fmt"
 	"strings"
+
+	"github.com/joomcode/errorx"
 
 	"github.com/hashgraph/solo-weaver/pkg/fsx"
 )
@@ -40,11 +41,11 @@ func ValidateContent(content []byte) error {
 			continue
 		}
 		if !strings.Contains(line, "=") {
-			return fmt.Errorf("sudoers line missing '=' separator: %q", line)
+			return errorx.IllegalFormat.New("sudoers line missing '=' separator: %q", line)
 		}
 		idx := strings.LastIndex(line, ":")
 		if idx < 0 {
-			return fmt.Errorf("sudoers line missing command tag (e.g. NOPASSWD:): %q", line)
+			return errorx.IllegalFormat.New("sudoers line missing command tag (e.g. NOPASSWD:): %q", line)
 		}
 		for _, cmd := range strings.Split(line[idx+1:], ",") {
 			cmd = strings.TrimSpace(cmd)
@@ -52,7 +53,7 @@ func ValidateContent(content []byte) error {
 				continue
 			}
 			if cmd != "ALL" && !strings.HasPrefix(cmd, "/") {
-				return fmt.Errorf("sudoers command must be an absolute path or ALL, got: %q", cmd)
+				return errorx.IllegalFormat.New("sudoers command must be an absolute path or ALL, got: %q", cmd)
 			}
 		}
 	}
@@ -63,10 +64,10 @@ func ValidateContent(content []byte) error {
 // Delegates to fsx.AtomicWriteFile so partial writes are never visible to sudo.
 func WriteEntry(dst string, content []byte) error {
 	if err := ValidateContent(content); err != nil {
-		return fmt.Errorf("sudoers content failed validation: %w", err)
+		return errorx.IllegalFormat.Wrap(err, "sudoers content failed validation")
 	}
 	if err := fsx.AtomicWriteFile(dst, content, 0o440); err != nil {
-		return fmt.Errorf("failed to write sudoers entry at %s: %w", dst, err)
+		return errorx.ExternalError.Wrap(err, "failed to write sudoers entry at %s", dst)
 	}
 	return nil
 }

--- a/pkg/software/config.go
+++ b/pkg/software/config.go
@@ -11,8 +11,10 @@ import (
 	"sync"
 	"text/template"
 
-	"github.com/hashgraph/solo-weaver/pkg/semver"
+	"github.com/joomcode/errorx"
 	"gopkg.in/yaml.v3"
+
+	"github.com/hashgraph/solo-weaver/pkg/semver"
 )
 
 //go:embed infrastructure-catalog.yaml
@@ -211,7 +213,7 @@ func (v VersionDetails) GetArchiveByName(archiveName string) (*ArchiveDetail, er
 			return &v.Archives[i], nil
 		}
 	}
-	return nil, fmt.Errorf("archive file '%s' not found", archiveName)
+	return nil, errorx.IllegalArgument.New("archive file '%s' not found", archiveName)
 }
 
 // GetBinaryByName retrieves a specific binary file by name
@@ -221,7 +223,7 @@ func (v VersionDetails) GetBinaryByName(binaryName string) (*BinaryDetail, error
 			return &v.Binaries[i], nil
 		}
 	}
-	return nil, fmt.Errorf("binary file '%s' not found", binaryName)
+	return nil, errorx.IllegalArgument.New("binary file '%s' not found", binaryName)
 }
 
 // GetConfigByName retrieves a specific configuration file by name
@@ -231,7 +233,7 @@ func (v VersionDetails) GetConfigByName(configName string) (*ConfigDetail, error
 			return &v.Configs[i], nil
 		}
 	}
-	return nil, fmt.Errorf("configuration file '%s' not found", configName)
+	return nil, errorx.IllegalArgument.New("configuration file '%s' not found", configName)
 }
 
 type ArchiveDetail struct {
@@ -391,13 +393,13 @@ func (c *InfrastructureCatalog) validate() error {
 	for i := range c.Host {
 		host := &c.Host[i]
 		if _, err := host.GetDefaultVersion(); err != nil {
-			return fmt.Errorf("host[%s]: %w", host.Name, err)
+			return errorx.IllegalFormat.Wrap(err, "host[%s]", host.Name)
 		}
 	}
 	for i := range c.Cluster {
 		chart := &c.Cluster[i]
 		if err := chart.validate(); err != nil {
-			return fmt.Errorf("cluster[%s]: %w", chart.Name, err)
+			return errorx.IllegalFormat.Wrap(err, "cluster[%s]", chart.Name)
 		}
 	}
 	return nil
@@ -416,28 +418,28 @@ func (cm *ChartMetadata) validate() error {
 	switch cm.Type {
 	case ChartTypeClassic:
 		if cm.Repo == "" {
-			return fmt.Errorf("classic chart must declare a repo")
+			return errorx.IllegalFormat.New("classic chart must declare a repo")
 		}
 	case ChartTypeOCI:
 		if cm.Repo != "" {
-			return fmt.Errorf("oci chart must not declare a repo (repo is encoded in the chart reference)")
+			return errorx.IllegalFormat.New("oci chart must not declare a repo (repo is encoded in the chart reference)")
 		}
 	case "":
-		return fmt.Errorf("missing type (must be %q or %q)", ChartTypeClassic, ChartTypeOCI)
+		return errorx.IllegalFormat.New("missing type (must be %q or %q)", ChartTypeClassic, ChartTypeOCI)
 	default:
-		return fmt.Errorf("unknown type %q (must be %q or %q)", cm.Type, ChartTypeClassic, ChartTypeOCI)
+		return errorx.IllegalFormat.New("unknown type %q (must be %q or %q)", cm.Type, ChartTypeClassic, ChartTypeOCI)
 	}
 	if cm.Chart == "" {
-		return fmt.Errorf("missing chart reference")
+		return errorx.IllegalFormat.New("missing chart reference")
 	}
 	if cm.Namespace == "" {
-		return fmt.Errorf("missing namespace")
+		return errorx.IllegalFormat.New("missing namespace")
 	}
 	if cm.Release == "" {
-		return fmt.Errorf("missing release")
+		return errorx.IllegalFormat.New("missing release")
 	}
 	if len(cm.Versions) == 0 {
-		return fmt.Errorf("no versions declared")
+		return errorx.IllegalFormat.New("no versions declared")
 	}
 	// Iterate over versions in a stable, alphabetical order so that when
 	// more than one version is malformed the error message always names
@@ -451,10 +453,10 @@ func (cm *ChartMetadata) validate() error {
 	for _, version := range versions {
 		details := cm.Versions[version]
 		if details.Algorithm == "" {
-			return fmt.Errorf("version %s: empty algorithm", version)
+			return errorx.IllegalFormat.New("version %s: empty algorithm", version)
 		}
 		if details.Value == "" {
-			return fmt.Errorf("version %s: empty checksum", version)
+			return errorx.IllegalFormat.New("version %s: empty checksum", version)
 		}
 	}
 	if _, err := cm.GetDefaultVersion(); err != nil {
@@ -469,7 +471,7 @@ func (cm *ChartMetadata) validate() error {
 // `default:` is unset or names an unknown version.
 func (cm *ChartMetadata) GetDefaultVersion() (string, error) {
 	if cm.Default == "" {
-		return "", fmt.Errorf("chart %s has no default version declared", cm.Name)
+		return "", errorx.IllegalFormat.New("chart %s has no default version declared", cm.Name)
 	}
 	if _, ok := cm.Versions[cm.Default]; !ok {
 		return "", NewVersionNotFoundError(cm.Name, string(cm.Default))
@@ -498,7 +500,7 @@ func executeTemplate(templateStr string, data TemplateData) (string, error) {
 // error when `default:` is unset or names an unknown version.
 func (si *ArtifactMetadata) GetDefaultVersion() (string, error) {
 	if si.Default == "" {
-		return "", fmt.Errorf("artifact %s has no default version declared", si.Name)
+		return "", errorx.IllegalFormat.New("artifact %s has no default version declared", si.Name)
 	}
 	if _, ok := si.Versions[si.Default]; !ok {
 		return "", NewVersionNotFoundError(si.Name, string(si.Default))

--- a/pkg/software/downloader.go
+++ b/pkg/software/downloader.go
@@ -7,7 +7,6 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -15,8 +14,9 @@ import (
 	"time"
 
 	"github.com/automa-saga/logx"
-	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
 
+	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/hashgraph/solo-weaver/pkg/sanity"
 )
 
@@ -77,12 +77,12 @@ func WithInsecureTLS(insecure bool) DownloaderOption {
 func (fd *Downloader) validateRedirect(req *http.Request, via []*http.Request) error {
 	// Limit the number of redirects to prevent redirect loops
 	if len(via) >= 10 {
-		return fmt.Errorf("stopped after 10 redirects")
+		return errorx.RejectedOperation.New("stopped after 10 redirects")
 	}
 
 	// Validate the redirect URL against the allowlist
 	if err := sanity.ValidateURL(req.URL.String(), &sanity.ValidateURLOptions{AllowedDomains: fd.allowedDomains}); err != nil {
-		return fmt.Errorf("redirect to untrusted domain: %w", err)
+		return errorx.RejectedOperation.Wrap(err, "redirect to untrusted domain")
 	}
 
 	return nil
@@ -216,7 +216,7 @@ func (fd *Downloader) Extract(compressedFilePath string, destDir string) error {
 
 			// Validate that the target path is within the extraction directory
 			if _, err := sanity.ValidatePathWithinBase(cleanDestDir, targetPath); err != nil {
-				return NewExtractionError(fmt.Errorf("path traversal attempt in hdr.ServerName: %s", hdr.Name), cleanCompressedPath, cleanDestDir)
+				return NewExtractionError(errorx.IllegalState.New("path traversal attempt in hdr.ServerName: %s", hdr.Name), cleanCompressedPath, cleanDestDir)
 			}
 
 			switch hdr.Typeflag {
@@ -250,7 +250,7 @@ func (fd *Downloader) Extract(compressedFilePath string, destDir string) error {
 				// Validate symlink target to prevent path traversal attacks
 				// Reject absolute paths in symlink targets
 				if filepath.IsAbs(hdr.Linkname) {
-					return NewExtractionError(fmt.Errorf("absolute symlink target not allowed: %s -> %s", hdr.Name, hdr.Linkname), cleanCompressedPath, cleanDestDir)
+					return NewExtractionError(errorx.IllegalState.New("absolute symlink target not allowed: %s -> %s", hdr.Name, hdr.Linkname), cleanCompressedPath, cleanDestDir)
 				}
 
 				// Resolve the symlink target relative to the symlink's parent directory
@@ -258,7 +258,7 @@ func (fd *Downloader) Extract(compressedFilePath string, destDir string) error {
 				symlinkDir := filepath.Dir(targetPath)
 				resolvedTarget := filepath.Join(symlinkDir, hdr.Linkname)
 				if _, err := sanity.ValidatePathWithinBase(cleanDestDir, resolvedTarget); err != nil {
-					return NewExtractionError(fmt.Errorf("symlink target escapes extraction directory: %s -> %s", hdr.Name, hdr.Linkname), cleanCompressedPath, cleanDestDir)
+					return NewExtractionError(errorx.IllegalState.New("symlink target escapes extraction directory: %s -> %s", hdr.Name, hdr.Linkname), cleanCompressedPath, cleanDestDir)
 				}
 
 				// Ensure parent directory exists
@@ -281,13 +281,13 @@ func (fd *Downloader) Extract(compressedFilePath string, destDir string) error {
 				// Validate hardlink target to prevent path traversal attacks
 				// Reject absolute paths in hardlink targets
 				if filepath.IsAbs(hdr.Linkname) {
-					return NewExtractionError(fmt.Errorf("absolute hardlink target not allowed: %s -> %s", hdr.Name, hdr.Linkname), cleanCompressedPath, cleanDestDir)
+					return NewExtractionError(errorx.IllegalState.New("absolute hardlink target not allowed: %s -> %s", hdr.Name, hdr.Linkname), cleanCompressedPath, cleanDestDir)
 				}
 
 				// Hard links - hdr.Linkname contains the target path (relative to archive root)
 				linkTarget := filepath.Join(cleanDestDir, hdr.Linkname)
 				if _, err := sanity.ValidatePathWithinBase(cleanDestDir, linkTarget); err != nil {
-					return NewExtractionError(fmt.Errorf("hardlink target escapes extraction directory: %s -> %s", hdr.Name, hdr.Linkname), cleanCompressedPath, cleanDestDir)
+					return NewExtractionError(errorx.IllegalState.New("hardlink target escapes extraction directory: %s -> %s", hdr.Name, hdr.Linkname), cleanCompressedPath, cleanDestDir)
 				}
 
 				// Ensure parent directory exists

--- a/pkg/software/kubeadm_installer.go
+++ b/pkg/software/kubeadm_installer.go
@@ -198,7 +198,7 @@ var GenerateKubeadmToken = func() (string, error) {
 		for i := range b {
 			nBig, err := rand.Int(rand.Reader, big.NewInt(int64(len(allowedChars))))
 			if err != nil {
-				return "", fmt.Errorf("failed to generate random int for kubeadm token: %w", err)
+				return "", errorx.ExternalError.Wrap(err, "failed to generate random int for kubeadm token")
 			}
 			b[i] = allowedChars[nBig.Int64()]
 		}


### PR DESCRIPTION
## Description

`github.com/joomcode/errorx` was adopted as the standard error library by PR #15 in July 2025, but without a CI gate the codebase drifted — 105 `fmt.Errorf` + 1 `errors.New` re-accumulated across 24 production files. This PR delivers all three parts of the chewie rollout (mirroring swirldslabs/chewie#232 + #233) in a single branch:

1. **Lint gate** (commit 1). `.golangci.yml` v2 with `forbidigo` rejecting `errors.New` and `fmt.Errorf` in non-test, non-generated Go files, scoped to lines new vs `origin/main`. Wired into `task lint` and `task lint:check` via a new `lint:errorx` task, with `setup:golangci-lint` pinning v2.12.2. CI checkout uses `fetch-depth: 0` so `new-from-rev: origin/main` resolves.
2. **Mass migration** (commit 2). All 106 production call sites converted to the appropriate `errorx.<Type>` namespace per the documented mapping. The lone `errors.New` sentinel `prompt.ErrAborted` becomes `errorx.RejectedOperation.New("aborted by user")` — identity-based `errors.Is(err, ErrAborted)` semantics are preserved.
3. **Claude skill** (commit 3). New `.claude/skills/errorx-conventions/SKILL.md` captures the rule, namespace-mapping table, the `errors.Join(sentinel, cause)` pattern for sentinel errors, and the migration traps (custom inner constructors, grandfathered custom namespaces, `fmt` import retention).

The migration commit is mechanical and intentionally isolated so reviewers can sample-check a handful of files rather than reading all 24. Suggested files for sampling: `pkg/helm/manager.go` (external/helm), `pkg/software/config.go` (schema validation), `internal/workflows/steps/step_alloy.go` (mixed external/state shapes), `cmd/cli/commands/common/flags.go` (programmer-error type-switch defaults → `AssertionFailed`), `internal/ui/prompt/prompt.go` (sentinel conversion).

### Namespace mapping at a glance

| Shape | Namespace |
|---|---|
| File I/O, exec/shell, helm, kubectl, k8s API, network, crypto/rand | `errorx.ExternalError.Wrap` |
| Template render, internal computation failure | `errorx.InternalError.Wrap` |
| YAML/JSON unmarshal, malformed payload, schema validation | `errorx.IllegalFormat.Wrap` / `.New` |
| Invariant breach ("should never happen") | `errorx.AssertionFailed.New` |
| User CLI flag or config value rejected | `errorx.IllegalArgument.New` / `.Wrap` |
| User cancelled / permission refused / policy reject | `errorx.RejectedOperation.New` |
| Inconsistent runtime state, environment doesn't meet requirements | `errorx.IllegalState.New` |

### Review guide

A detailed reviewer checklist and the per-file change table live at [`docs/claude/reviews/00628-enforce-errorx.md`](https://github.com/hashgraph/solo-weaver/blob/00628-enforce-errorx/docs/claude/reviews/00628-enforce-errorx.md). The plan capturing scope decisions is at [`docs/claude/plans/00628-enforce-errorx.md`](https://github.com/hashgraph/solo-weaver/blob/00628-enforce-errorx/docs/claude/plans/00628-enforce-errorx.md).

### Verification

- `task lint:check` is clean. Negative test confirmed: injecting `_ = errors.New("test")` into any production file makes `task lint:check` fail with the configured `forbidigo` message.
- `grep -rE 'errors\.New\(|fmt\.Errorf\(' --include='*.go' cmd internal pkg | grep -v _test.go` returns 0 matches.
- Per-package unit tests pass for the touched packages on macOS. The wider `task test:unit` failure on macOS is pre-existing (`internal/mount` is Linux-only; `pkg/software/base_installer_test.go` permission-denied on `mkdir /opt/solo` — both predate this PR and are gated by the UTM VM workflow).

### Related Issues

* Closes #628
