### PR TITLE
feat(manifests): add schemaVersion validator for CN deployment-package manifests

### DIFF
--- a/docs/claude/reviews/00535-manifest-schema-version-validation.md
+++ b/docs/claude/reviews/00535-manifest-schema-version-validation.md
@@ -1,0 +1,53 @@
+# #535 — Review guide: schemaVersion validation across all manifests
+
+> **Issue:** https://github.com/hashgraph/solo-weaver/issues/535
+> **Epic:** https://github.com/hashgraph/solo-weaver/issues/501
+> **Branch:** `00535-manifest-schema-version-validation`
+> **Base:** `00501-manifest-parsing`
+
+## Problem and solution
+
+Epic #501 introduces parsers for the four YAML files under `manifests/` in the CN deployment package. Every one of those files declares a `schemaVersion`, and the epic spec requires that an unknown value is rejected with a clear error *before* any further parsing. Story #535 is the cross-cutting prerequisite: do this once in a shared package so the four parser stories (#531/#532/#533/#534) all plug into a single validator instead of each rolling their own.
+
+This PR lays down a new `pkg/manifests/` package whose only consumer-facing entry point is the schemaVersion validator `ValidateSchemaVersion(kind, data)`; supporting types (`Kind`, `SchemaVersion`, `Header`, `SchemaV1`), error classifications, and the `SupportedVersions` helper round out the surface area but exist solely to serve that one validator. There is no production caller yet — concrete parsers come in #531–#534, each as its own PR targeting `00501-manifest-parsing`. The epic branch is merged to `main` only after all six stories land.
+
+The validator inspects only the `schemaVersion` field (other fields are tolerated at this stage so a future parser can use strict-decode on the *typed* root struct without surprise). The set of accepted versions is a per-kind map seeded with `{v1}` for all four kinds; widening to `v2` later is a one-line change.
+
+## Changed files
+
+| File | What changed |
+|---|---|
+| `pkg/manifests/manifests.go` (new) | `Kind`, `SchemaVersion`, `Header`, `supportedVersions` registry, `ValidateSchemaVersion`, `SupportedVersions` |
+| `pkg/manifests/errors.go` (new) | `errorx` namespace + four error types (`ParseError`, `MissingSchemaVersionError`, `UnsupportedSchemaVersionError`, `UnknownKindError`) and their constructors |
+| `pkg/manifests/manifests_test.go` (new) | Table-driven unit tests; 96.7% coverage |
+| `docs/claude/reviews/00535-manifest-schema-version-validation.md` (new) | This guide |
+
+## Code review checklist
+
+- [ ] **Errors are classifiable by `errorx.IsOfType`.** Every constructor returns a typed `*errorx.Error` so downstream code (and tests) can branch on classification, mirroring the pattern used by `pkg/software/errors.go` and `pkg/security/principal/errors.go`.
+- [ ] **No strict-decode at this layer.** `TestValidateSchemaVersion_ToleratesUnknownFields` pins the contract: extra top-level fields do *not* trigger an error here. This is deliberate — per-kind parsers in #531–#534 will apply strict decoding against their typed root struct, where field-level errors are useful rather than misleading.
+- [ ] **Empty `schemaVersion:` is treated as missing.** YAML `schemaVersion:` (no value) decodes to the empty string and is rejected with `MissingSchemaVersionError`, not silently accepted.
+- [ ] **Unsupported value error message includes the supported set.** `unsupported_schema_version: manifest "external-files" declares schemaVersion "v2" (supported: [v1])` — both the offending value and the accepted list are in the message, and stored as printable error properties for structured logging.
+- [ ] **`Kind` defensive check.** `UnknownKindError` covers the programmer-mistake path where a caller passes an unregistered `Kind`. Not a user-input error, but worth surfacing explicitly so future parser PRs catch it during development.
+- [ ] **`sortedSupported` deterministic ordering.** Map iteration order is randomised in Go; the helper sorts before returning so error messages and `SupportedVersions(kind)` are reproducible. (Coverage on the comparator is 83.3% only because we ship a single version today — the comparator branch will be exercised once a second version lands.)
+- [ ] **Plan note on the field name.** The HIP draft (`hip-xxxx0`) uses `version:` for `external-files.yaml` and `state-sources.yaml` but `schemaVersion:` for the other two. The story bodies for #535/#533/#534 uniformly say `schemaVersion`. This PR follows the story bodies (newer than the HIP draft); if #533 or #534 confirms the on-disk field is actually `version`, the validator gains a per-kind YAML tag override at that time.
+
+## Test commands
+
+```bash
+# Unit tests (the new package has no platform-specific code)
+go test -race -cover -tags='!integration' ./pkg/manifests/...
+
+# Lint pipeline (errorx gate, gofmt)
+task lint:check
+```
+
+Expected:
+
+```
+ok      github.com/hashgraph/solo-weaver/pkg/manifests    coverage: 96.7% of statements
+```
+
+## Manual UAT
+
+This PR introduces no CLI surface and no production caller, so there is no end-user UAT. The validator is exercised exclusively by its unit tests until a parser story (first one being #531) wires it in. Reviewers can inspect the API shape by reading `pkg/manifests/manifests.go` top-to-bottom — the package comment names the four manifest kinds and the deferred-to-follow-on stories.

--- a/pkg/manifests/errors.go
+++ b/pkg/manifests/errors.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package manifests
+
+import (
+	"github.com/joomcode/errorx"
+)
+
+var (
+	ErrorsNamespace = errorx.NewNamespace("manifests")
+
+	ParseError                    = ErrorsNamespace.NewType("parse_error")
+	MissingSchemaVersionError     = ErrorsNamespace.NewType("missing_schema_version")
+	UnsupportedSchemaVersionError = ErrorsNamespace.NewType("unsupported_schema_version")
+	UnknownKindError              = ErrorsNamespace.NewType("unknown_kind")
+
+	kindProperty              = errorx.RegisterPrintableProperty("kind")
+	schemaVersionProperty     = errorx.RegisterPrintableProperty("schema_version")
+	supportedVersionsProperty = errorx.RegisterPrintableProperty("supported_versions")
+)
+
+const (
+	parseErrorMsg                    = "failed to parse manifest %q"
+	missingSchemaVersionErrorMsg     = "manifest %q is missing required field \"schemaVersion\""
+	unsupportedSchemaVersionErrorMsg = "manifest %q declares schemaVersion %q (supported: %v)"
+	unknownKindErrorMsg              = "unknown manifest kind %q"
+)
+
+func NewParseError(cause error, kind Kind) *errorx.Error {
+	err := ParseError.New(parseErrorMsg, string(kind)).
+		WithProperty(kindProperty, string(kind))
+	if cause != nil {
+		err = err.WithUnderlyingErrors(cause)
+	}
+	return err
+}
+
+func NewMissingSchemaVersionError(kind Kind) *errorx.Error {
+	return MissingSchemaVersionError.New(missingSchemaVersionErrorMsg, string(kind)).
+		WithProperty(kindProperty, string(kind))
+}
+
+func NewUnsupportedSchemaVersionError(kind Kind, declared SchemaVersion, supported []SchemaVersion) *errorx.Error {
+	supportedStrs := make([]string, len(supported))
+	for i, v := range supported {
+		supportedStrs[i] = string(v)
+	}
+	return UnsupportedSchemaVersionError.New(unsupportedSchemaVersionErrorMsg, string(kind), string(declared), supportedStrs).
+		WithProperty(kindProperty, string(kind)).
+		WithProperty(schemaVersionProperty, string(declared)).
+		WithProperty(supportedVersionsProperty, supportedStrs)
+}
+
+func NewUnknownKindError(kind Kind) *errorx.Error {
+	return UnknownKindError.New(unknownKindErrorMsg, string(kind)).
+		WithProperty(kindProperty, string(kind))
+}

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package manifests parses and validates the YAML manifest files shipped under
+// manifests/ inside a consensus-node deployment package
+// (consensus-node-components.yaml, infrastructure-versions.yaml,
+// external-files.yaml, state-sources.yaml).
+//
+// This initial revision exposes the cross-cutting schemaVersion validator
+// (ValidateSchemaVersion plus its supporting Kind, SchemaVersion, Header
+// types and typed errorx error classifications) used by every per-manifest
+// parser as its first step. Concrete parsers and root structs for the four
+// manifest kinds are added in follow-on stories (see issues #531–#534).
+package manifests
+
+import (
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SchemaVersion is the value of the schemaVersion field on a manifest.
+type SchemaVersion string
+
+// SchemaV1 is the only schemaVersion currently accepted on any manifest.
+const SchemaV1 SchemaVersion = "v1"
+
+// Kind identifies which of the four manifest files is being parsed. Its string
+// value matches the basename (without ".yaml") of the file inside the
+// deployment package's manifests/ directory.
+type Kind string
+
+const (
+	KindConsensusNodeComponents Kind = "consensus-node-components"
+	KindInfrastructureVersions  Kind = "infrastructure-versions"
+	KindExternalFiles           Kind = "external-files"
+	KindStateSources            Kind = "state-sources"
+)
+
+// supportedVersions records the schemaVersion values this build accepts for
+// each manifest kind. Bumping a manifest to v2 requires adding that version
+// here and shipping a corresponding parser that knows how to read it.
+var supportedVersions = map[Kind]map[SchemaVersion]struct{}{
+	KindConsensusNodeComponents: {SchemaV1: {}},
+	KindInfrastructureVersions:  {SchemaV1: {}},
+	KindExternalFiles:           {SchemaV1: {}},
+	KindStateSources:            {SchemaV1: {}},
+}
+
+// Header captures the common schemaVersion field present on every manifest.
+// Concrete parsers in #531–#534 embed it in their root struct so a single
+// strict-decode pass yields both the version and the rest of the document.
+type Header struct {
+	SchemaVersion SchemaVersion `yaml:"schemaVersion"`
+}
+
+// ValidateSchemaVersion decodes only the schemaVersion field from data and
+// confirms the value is in the supported set for kind. It returns the parsed
+// Header. Callers run this before full unmarshalling so that a manifest
+// declaring an unsupported (e.g. future) schemaVersion is rejected with a
+// clear error instead of producing surprising decode failures against the
+// current shape.
+//
+// Unknown fields in data are tolerated at this stage — the function inspects
+// only schemaVersion. Per-kind parsers may apply stricter checks downstream.
+func ValidateSchemaVersion(kind Kind, data []byte) (Header, error) {
+	supported, ok := supportedVersions[kind]
+	if !ok {
+		return Header{}, NewUnknownKindError(kind)
+	}
+
+	var h Header
+	if err := yaml.Unmarshal(data, &h); err != nil {
+		return Header{}, NewParseError(err, kind)
+	}
+
+	if h.SchemaVersion == "" {
+		return Header{}, NewMissingSchemaVersionError(kind)
+	}
+
+	if _, ok := supported[h.SchemaVersion]; !ok {
+		return Header{}, NewUnsupportedSchemaVersionError(kind, h.SchemaVersion, sortedSupported(kind))
+	}
+
+	return h, nil
+}
+
+// SupportedVersions returns the sorted list of schemaVersion values this build
+// accepts for kind, or nil if kind is not a recognised manifest. It exists for
+// callers that need to render help text or diagnostics.
+func SupportedVersions(kind Kind) []SchemaVersion {
+	if _, ok := supportedVersions[kind]; !ok {
+		return nil
+	}
+	return sortedSupported(kind)
+}
+
+func sortedSupported(kind Kind) []SchemaVersion {
+	versions := make([]SchemaVersion, 0, len(supportedVersions[kind]))
+	for v := range supportedVersions[kind] {
+		versions = append(versions, v)
+	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
+	return versions
+}

--- a/pkg/manifests/manifests_test.go
+++ b/pkg/manifests/manifests_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package manifests
+
+import (
+	"testing"
+
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSchemaVersion_AcceptsV1ForEveryKnownKind(t *testing.T) {
+	for _, kind := range []Kind{
+		KindConsensusNodeComponents,
+		KindInfrastructureVersions,
+		KindExternalFiles,
+		KindStateSources,
+	} {
+		t.Run(string(kind), func(t *testing.T) {
+			header, err := ValidateSchemaVersion(kind, []byte("schemaVersion: v1\n"))
+			require.NoError(t, err)
+			require.Equal(t, SchemaV1, header.SchemaVersion)
+		})
+	}
+}
+
+func TestValidateSchemaVersion_MissingField(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty document", data: []byte("")},
+		{name: "only other fields", data: []byte("foo: bar\nbaz: 42\n")},
+		{name: "explicit empty value", data: []byte("schemaVersion:\n")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ValidateSchemaVersion(KindExternalFiles, tt.data)
+			require.Error(t, err)
+			require.True(t, errorx.IsOfType(err, MissingSchemaVersionError),
+				"expected MissingSchemaVersionError, got %v", err)
+			require.Contains(t, err.Error(), string(KindExternalFiles))
+		})
+	}
+}
+
+func TestValidateSchemaVersion_UnsupportedValue(t *testing.T) {
+	data := []byte("schemaVersion: v2\n")
+	_, err := ValidateSchemaVersion(KindConsensusNodeComponents, data)
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, UnsupportedSchemaVersionError),
+		"expected UnsupportedSchemaVersionError, got %v", err)
+	require.Contains(t, err.Error(), string(KindConsensusNodeComponents))
+	require.Contains(t, err.Error(), "v2")
+	require.Contains(t, err.Error(), "v1")
+}
+
+func TestValidateSchemaVersion_MalformedYAML(t *testing.T) {
+	// Unterminated mapping key — yaml.v3 rejects this at parse time.
+	data := []byte("schemaVersion: [v1\n")
+	_, err := ValidateSchemaVersion(KindStateSources, data)
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ParseError),
+		"expected ParseError, got %v", err)
+	require.Contains(t, err.Error(), string(KindStateSources))
+}
+
+func TestValidateSchemaVersion_UnknownKind(t *testing.T) {
+	_, err := ValidateSchemaVersion(Kind("not-a-real-manifest"), []byte("schemaVersion: v1\n"))
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, UnknownKindError),
+		"expected UnknownKindError, got %v", err)
+	require.Contains(t, err.Error(), "not-a-real-manifest")
+}
+
+// Pins the contract that unknown top-level fields are tolerated at the
+// schemaVersion-validation stage. Per-kind parsers added in #531–#534 must not
+// assume this validator has already rejected unknown fields.
+func TestValidateSchemaVersion_ToleratesUnknownFields(t *testing.T) {
+	data := []byte("schemaVersion: v1\nrogueField: ignore-me\nnested:\n  also: tolerated\n")
+	header, err := ValidateSchemaVersion(KindInfrastructureVersions, data)
+	require.NoError(t, err)
+	require.Equal(t, SchemaV1, header.SchemaVersion)
+}
+
+func TestSupportedVersions(t *testing.T) {
+	t.Run("returns v1 for every known kind", func(t *testing.T) {
+		for _, kind := range []Kind{
+			KindConsensusNodeComponents,
+			KindInfrastructureVersions,
+			KindExternalFiles,
+			KindStateSources,
+		} {
+			got := SupportedVersions(kind)
+			require.Equal(t, []SchemaVersion{SchemaV1}, got, "kind=%s", kind)
+		}
+	})
+
+	t.Run("returns nil for unknown kind", func(t *testing.T) {
+		require.Nil(t, SupportedVersions(Kind("nope")))
+	})
+}


### PR DESCRIPTION
## Summary

- Lays down `pkg/manifests/`, a new package that the four follow-on parser stories (#531–#534) will plug into as their first step.
- This initial revision exposes only `ValidateSchemaVersion(kind, data)` — it inspects the `schemaVersion` field on raw YAML bytes and rejects anything other than `v1` for the four known manifest kinds (`consensus-node-components`, `infrastructure-versions`, `external-files`, `state-sources`) with a typed `errorx` classification.
- Unknown top-level fields are *tolerated* at this layer so per-kind parsers can apply strict decoding against their typed root struct, where field-level errors are useful rather than misleading. A test pins this contract.
- No production caller yet; this is the cross-cutting prerequisite for epic #501.

Targets the epic feature branch `00501-manifest-parsing`, not `main` — see [feature-branch-per-epic convention]. The epic branch will merge to `main` once all six story PRs (#531–#536) land.

Closes #535. Refs #501.

## Test plan

- [x] `go test -race -cover -tags='!integration' ./pkg/manifests/...` → all green, **96.7%** statement coverage
- [x] `task lint` — passes for the new files (the pre-existing 18 license-check failures elsewhere are unrelated)
- [ ] CI on the PR passes
- [ ] Reviewer sanity-checks the API shape in `pkg/manifests/manifests.go` and the error classification pattern in `pkg/manifests/errors.go` against the [review guide](docs/claude/reviews/00535-manifest-schema-version-validation.md)

## Open follow-up — defer to #533/#534

The HIP draft (`hip-xxxx0`) uses `version: v1` for `external-files.yaml` and `state-sources.yaml` but `schemaVersion: v1` for the other two. The story bodies for #535/#533/#534 uniformly say `schemaVersion`. This PR follows the story bodies (newer than the HIP draft); if #533 or #534 confirms the on-disk field is actually `version`, the validator gains a per-kind YAML tag override at that time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)