### PR TITLE
feat(manifests): add consensus-node-components.yaml parser

### DIFF
--- a/docs/claude/reviews/00531-consensus-node-components-parser.md
+++ b/docs/claude/reviews/00531-consensus-node-components-parser.md
@@ -1,0 +1,69 @@
+# #531 — Review guide: consensus-node-components.yaml parser
+
+> **Issue:** https://github.com/hashgraph/solo-weaver/issues/531
+> **Epic:** https://github.com/hashgraph/solo-weaver/issues/501
+> **Branch:** `00531-consensus-node-components-parser`
+> **Base:** `00535-manifest-schema-version-validation` (stacked; auto-retargets to `00501-manifest-parsing` after #535 merges)
+
+## Problem and solution
+
+`consensus-node-components.yaml` ships inside every CN deployment package and declares the container images (consensus node plus five named sidecars: `recordStreamUploader`, `eventStreamUploader`, `blockStreamUploader`, `backupUploader`, `uc`) along with the layer-hash integrity records used to verify those images before they run. This story is the first concrete parser story under epic #501 and the first consumer of `ValidateSchemaVersion` from PR #634.
+
+The parser strict-decodes the YAML into `ConsensusNodeComponents`, then runs semantic validation that goes beyond what struct shape alone can enforce — most importantly the *placement* rule for `layerHashes`: deterministic builds carry one shared set at the component level and no per-registry overrides; non-deterministic builds invert that. Getting this wrong silently would mean a missing or duplicated integrity record at apply time, so the validator rejects every misplacement explicitly.
+
+### Spec note
+
+The story body lists the five sidecar names above; the older HIP draft (`hip-xxxx0`) shows a single bundled `cheetah` sidecar. Stories supersede the HIP draft (same convention as the `provisioner.cli`/`provisioner.daemon` split flagged in #535's plan). Strict decoding therefore rejects `cheetah` (or any other unknown component name) — `TestParseConsensusNodeComponents_RejectsUnknownComponentName` pins that.
+
+### "Absent = no change"
+
+Per the manifest contract, every entry under `images:` is optional. A nil pointer (Go-side) corresponds to "section absent from the YAML" and signals "no change to that component". A separate `enabled *bool` field per entry encodes the operator's intent to turn a component on or off; nil there means "no change to the current enabled state" — distinct from `enabled: false` which is an explicit disable.
+
+## Changed files
+
+| File | What changed |
+|---|---|
+| `pkg/manifests/consensus_node_components.go` (new) | Types (`ConsensusNodeComponents`, `Images`, `Image`, `Deterministic`, `Registry`, `LayerHashes`), `SupportedImagePlatforms`, `ParseConsensusNodeComponents`, internal validators |
+| `pkg/manifests/consensus_node_components_test.go` (new) | Happy paths (full, partial, empty `images:`), strict-decode rejections, schemaVersion gate, table-driven semantic-validation failures, multi-document rejection |
+| `pkg/manifests/decode.go` (new) | Shared `decodeStrictSingleYAMLDoc(kind, data, out)` helper used by every concrete parser: enables `KnownFields(true)` and rejects multi-document inputs |
+| `pkg/manifests/errors.go` | Added `ValidationError` type and `NewValidationError(kind, field, reason)` constructor; added `fieldProperty` printable property |
+| `docs/claude/reviews/00531-consensus-node-components-parser.md` (new) | This guide |
+
+## Code review checklist
+
+- [ ] **`Image` field types model the "absent = no change" contract.** `Enabled *bool` distinguishes nil (no change), `true` (enable), and `false` (disable). Compare against `Deterministic *Deterministic` and the per-component `*Image` fields under `Images` — the pointer convention is consistent throughout.
+- [ ] **`ParseConsensusNodeComponents` runs `ValidateSchemaVersion` first.** A future-versioned manifest is rejected before any current-shape decode can yield misleading errors. `TestParseConsensusNodeComponents_RejectsUnsupportedSchemaVersion` pins it.
+- [ ] **Strict decode is enabled at this layer** (via the new `decodeStrictSingleYAMLDoc` helper in `pkg/manifests/decode.go`, which sets `dec.KnownFields(true)` and rejects multi-document inputs). Unknown top-level fields and unknown component names under `images:` both fail with `ParseError`. Multi-document YAML streams fail with `ValidationError` — see `TestParseConsensusNodeComponents_RejectsMultipleYAMLDocuments`. The `KnownFields(true)` strictness at parser level is intentional contrast with the schemaVersion validator from #535, which tolerates unknown fields by design (`TestValidateSchemaVersion_ToleratesUnknownFields` in PR #634).
+- [ ] **Deterministic vs non-deterministic placement is enforced both ways.** Six dedicated test cases cover all four combinations (`deterministic.supported` × `layerHashes` present at component-level vs registry-level). The validation error messages explain which direction to move the data.
+- [ ] **Platform identifiers are validated against `SupportedImagePlatforms`** (`linux/amd64`, `linux/arm64`). Unknown platform keys produce an error naming the offending value; empty hash lists per platform are rejected (a platform key with `[]` is meaningless).
+- [ ] **Field paths in `ValidationError` messages are dotted Go paths** (e.g. `images.backupUploader.registries[0].layerHashes`). The format makes errors greppable against the YAML source and makes review failures easy to locate.
+- [ ] **No production caller yet.** This PR ships the parser; #531 says nothing about wiring it into a workflow. That's deferred — the parser is exercised exclusively by its unit tests until a daemon/operator integration story picks it up.
+
+## Test commands
+
+```bash
+# Unit tests for the parser (and the existing schemaVersion validator)
+go test -race -cover -tags='!integration' ./pkg/manifests/...
+
+# Lint pipeline (errorx gate, gofmt)
+task lint:check
+```
+
+Expected:
+
+```
+ok      github.com/hashgraph/solo-weaver/pkg/manifests    coverage: 97.7% of statements
+```
+
+## Manual UAT
+
+No CLI surface, no daemon hook, no production caller yet. Reviewers can spot-check the parser shape against the spec by running this REPL-style snippet in the repo root:
+
+```bash
+cat <<'EOF' | go run -trimpath -ldflags='-s -w' ./pkg/manifests/... 2>/dev/null || true
+# (no main package — read the fixture instead)
+EOF
+cat pkg/manifests/consensus_node_components_test.go | sed -n '/fullDeterministicManifest = /,/^$/p' | head
+```
+
+The intended user-facing experience surfaces once a follow-on story (outside epic #501) wires this parser into the daemon's package-extraction flow.

--- a/pkg/manifests/consensus_node_components.go
+++ b/pkg/manifests/consensus_node_components.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package manifests
+
+import (
+	"fmt"
+	"sort"
+)
+
+// ConsensusNodeComponents is the parsed root of a consensus-node-components.yaml
+// manifest. It declares the container images for the consensus node and its
+// named sidecars, plus the layer-hash integrity records used to verify those
+// images before they run.
+//
+// Per the manifest contract ("absent = no change"), every entry under Images is
+// optional. A nil entry signals "the deployment package does not change this
+// component", not "disable this component" — that decision is encoded in the
+// Image.Enabled pointer field instead.
+type ConsensusNodeComponents struct {
+	Header `yaml:",inline"`
+	Images Images `yaml:"images"`
+}
+
+// Images groups the consensus node and its five named sidecars. Each field is
+// a pointer so a parser can distinguish absent from explicitly-zero. Unknown
+// component names in the YAML are rejected by strict decoding; if the set of
+// supported sidecars grows, this struct grows with it.
+type Images struct {
+	ConsensusNode        *Image `yaml:"consensusNode,omitempty"`
+	RecordStreamUploader *Image `yaml:"recordStreamUploader,omitempty"`
+	EventStreamUploader  *Image `yaml:"eventStreamUploader,omitempty"`
+	BlockStreamUploader  *Image `yaml:"blockStreamUploader,omitempty"`
+	BackupUploader       *Image `yaml:"backupUploader,omitempty"`
+	UC                   *Image `yaml:"uc,omitempty"`
+}
+
+// Image is the per-component spec. Enabled is a tri-state pointer so the
+// manifest can carry an explicit on/off intent (true / false) distinct from
+// "no opinion" (nil). Note that when an Image entry is present at all, the
+// other required fields (Version, Registries) must still be set — validation
+// enforces this. A nil entry under Images is the "absent = no change"
+// signal at the section level.
+type Image struct {
+	Enabled       *bool          `yaml:"enabled,omitempty"`
+	Version       string         `yaml:"version"`
+	Deterministic *Deterministic `yaml:"deterministic,omitempty"`
+	Registries    []Registry     `yaml:"registries"`
+}
+
+// Deterministic describes whether a component's container images produce
+// identical layer hashes across all registries for the same version. When
+// Supported is true, LayerHashes is the single shared record used to verify
+// every registry; when false, each Registry carries its own layerHashes
+// override and LayerHashes here must be empty.
+type Deterministic struct {
+	Supported   bool        `yaml:"supported"`
+	LayerHashes LayerHashes `yaml:"layerHashes,omitempty"`
+}
+
+// Registry is one publication site for a component image. For non-deterministic
+// components, LayerHashes is a per-registry override (because the same logical
+// image produces different layer digests at each registry).
+type Registry struct {
+	Image       string      `yaml:"image"`
+	LayerHashes LayerHashes `yaml:"layerHashes,omitempty"`
+}
+
+// LayerHashes maps a container platform identifier (e.g. "linux/arm64") to an
+// ordered list of layer digests for that platform.
+type LayerHashes map[string][]string
+
+// SupportedImagePlatforms is the set of platform identifiers accepted in any
+// layerHashes map. The slice is kept sorted so it can appear directly in
+// error messages without surprising readers.
+var SupportedImagePlatforms = []string{"linux/amd64", "linux/arm64"}
+
+// ParseConsensusNodeComponents parses raw YAML bytes of a
+// consensus-node-components.yaml manifest. It runs the cross-cutting
+// schemaVersion check first (so a future-versioned manifest is rejected before
+// any current-shape decode), then strict-decodes the (single) YAML document
+// into ConsensusNodeComponents (unknown top-level fields or unknown component
+// names under images: are errors; multi-document inputs are rejected), then
+// runs semantic validation on every present component entry.
+func ParseConsensusNodeComponents(data []byte) (*ConsensusNodeComponents, error) {
+	if _, err := ValidateSchemaVersion(KindConsensusNodeComponents, data); err != nil {
+		return nil, err
+	}
+
+	var doc ConsensusNodeComponents
+	if err := decodeStrictSingleYAMLDoc(KindConsensusNodeComponents, data, &doc); err != nil {
+		return nil, err
+	}
+
+	if err := doc.validate(); err != nil {
+		return nil, err
+	}
+	return &doc, nil
+}
+
+// validate enforces the semantic invariants of a parsed manifest. It runs on
+// every non-nil entry under Images and fails fast on the first violation,
+// reporting the dotted field path so the user can find the offending entry.
+func (c *ConsensusNodeComponents) validate() error {
+	for _, e := range c.Images.entries() {
+		if e.image == nil {
+			continue
+		}
+		if err := e.image.validate(e.name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type namedImage struct {
+	name  string
+	image *Image
+}
+
+// entries returns the named image fields in a deterministic order so that
+// validation errors are reproducible.
+func (i Images) entries() []namedImage {
+	return []namedImage{
+		{name: "consensusNode", image: i.ConsensusNode},
+		{name: "recordStreamUploader", image: i.RecordStreamUploader},
+		{name: "eventStreamUploader", image: i.EventStreamUploader},
+		{name: "blockStreamUploader", image: i.BlockStreamUploader},
+		{name: "backupUploader", image: i.BackupUploader},
+		{name: "uc", image: i.UC},
+	}
+}
+
+func (img *Image) validate(componentName string) error {
+	prefix := "images." + componentName
+
+	if img.Version == "" {
+		return NewValidationError(KindConsensusNodeComponents, prefix+".version", "must not be empty")
+	}
+	if len(img.Registries) == 0 {
+		return NewValidationError(KindConsensusNodeComponents, prefix+".registries", "must declare at least one registry")
+	}
+
+	deterministicSupported := img.Deterministic != nil && img.Deterministic.Supported
+
+	if deterministicSupported {
+		if len(img.Deterministic.LayerHashes) == 0 {
+			return NewValidationError(KindConsensusNodeComponents, prefix+".deterministic.layerHashes",
+				"must be declared when deterministic.supported is true")
+		}
+		if err := validateLayerHashesPlatforms(prefix+".deterministic.layerHashes", img.Deterministic.LayerHashes); err != nil {
+			return err
+		}
+	} else if img.Deterministic != nil && len(img.Deterministic.LayerHashes) > 0 {
+		return NewValidationError(KindConsensusNodeComponents, prefix+".deterministic.layerHashes",
+			"must not be set when deterministic.supported is false (use per-registry overrides)")
+	}
+
+	for idx, reg := range img.Registries {
+		regPrefix := fmt.Sprintf("%s.registries[%d]", prefix, idx)
+		if reg.Image == "" {
+			return NewValidationError(KindConsensusNodeComponents, regPrefix+".image", "must not be empty")
+		}
+		if deterministicSupported {
+			if len(reg.LayerHashes) > 0 {
+				return NewValidationError(KindConsensusNodeComponents, regPrefix+".layerHashes",
+					"must not be set when deterministic.supported is true (use the shared deterministic.layerHashes)")
+			}
+		} else {
+			if len(reg.LayerHashes) == 0 {
+				return NewValidationError(KindConsensusNodeComponents, regPrefix+".layerHashes",
+					"must be declared for non-deterministic components")
+			}
+			if err := validateLayerHashesPlatforms(regPrefix+".layerHashes", reg.LayerHashes); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateLayerHashesPlatforms(fieldPath string, hashes LayerHashes) error {
+	allowed := make(map[string]struct{}, len(SupportedImagePlatforms))
+	for _, p := range SupportedImagePlatforms {
+		allowed[p] = struct{}{}
+	}
+	platforms := make([]string, 0, len(hashes))
+	for p := range hashes {
+		platforms = append(platforms, p)
+	}
+	sort.Strings(platforms)
+	for _, p := range platforms {
+		if _, ok := allowed[p]; !ok {
+			return NewValidationError(KindConsensusNodeComponents, fieldPath,
+				fmt.Sprintf("unsupported platform %q (supported: %v)", p, SupportedImagePlatforms))
+		}
+		if len(hashes[p]) == 0 {
+			return NewValidationError(KindConsensusNodeComponents, fieldPath+"."+p,
+				"must declare at least one layer hash")
+		}
+	}
+	return nil
+}

--- a/pkg/manifests/consensus_node_components_test.go
+++ b/pkg/manifests/consensus_node_components_test.go
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package manifests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/require"
+)
+
+// fullDeterministicManifest is the happy-path fixture: every component
+// present and every layerHashes map populated for both linux/amd64 and
+// linux/arm64. The five sidecar uploaders use the deterministic path
+// (component-level layerHashes); backupUploader exercises the
+// non-deterministic path (per-registry layerHashes, deterministic.supported
+// explicitly false) so both code paths see coverage from a single fixture.
+const fullDeterministicManifest = `
+schemaVersion: v1
+images:
+  consensusNode:
+    enabled: true
+    version: "0.75.0"
+    deterministic:
+      supported: true
+      layerHashes:
+        linux/arm64:
+          - "sha256:cn-arm64-1"
+        linux/amd64:
+          - "sha256:cn-amd64-1"
+    registries:
+      - image: "ghcr.io/hashgraph/hedera-services/consensus-node:0.75.0"
+      - image: "ghcr.io/other-org/hedera-services/consensus-node:0.75.0"
+  recordStreamUploader:
+    version: "0.43.0"
+    deterministic:
+      supported: true
+      layerHashes:
+        linux/arm64: ["sha256:rsu-arm64"]
+        linux/amd64: ["sha256:rsu-amd64"]
+    registries:
+      - image: "ghcr.io/hashgraph/solo-record-stream:0.43.0"
+  eventStreamUploader:
+    version: "0.43.0"
+    deterministic:
+      supported: true
+      layerHashes:
+        linux/arm64: ["sha256:esu-arm64"]
+        linux/amd64: ["sha256:esu-amd64"]
+    registries:
+      - image: "ghcr.io/hashgraph/solo-event-stream:0.43.0"
+  blockStreamUploader:
+    version: "0.43.0"
+    deterministic:
+      supported: true
+      layerHashes:
+        linux/arm64: ["sha256:bsu-arm64"]
+        linux/amd64: ["sha256:bsu-amd64"]
+    registries:
+      - image: "ghcr.io/hashgraph/solo-block-stream:0.43.0"
+  uc:
+    version: "1.5.0"
+    deterministic:
+      supported: true
+      layerHashes:
+        linux/arm64: ["sha256:uc-arm64"]
+        linux/amd64: ["sha256:uc-amd64"]
+    registries:
+      - image: "ghcr.io/hashgraph/solo-uc:1.5.0"
+  backupUploader:
+    enabled: false
+    version: "0.33.0"
+    deterministic:
+      supported: false
+    registries:
+      - image: "ghcr.io/hashgraph/hedera-services/backup-uploader:0.33.0"
+        layerHashes:
+          linux/arm64: ["sha256:bu-ghcr-arm64"]
+          linux/amd64: ["sha256:bu-ghcr-amd64"]
+      - image: "ghcr.io/other-org/hedera-services/backup-uploader:0.33.0"
+        layerHashes:
+          linux/arm64: ["sha256:bu-other-arm64"]
+          linux/amd64: ["sha256:bu-other-amd64"]
+`
+
+func TestParseConsensusNodeComponents_FullHappyPath(t *testing.T) {
+	doc, err := ParseConsensusNodeComponents([]byte(fullDeterministicManifest))
+	require.NoError(t, err)
+	require.Equal(t, SchemaV1, doc.SchemaVersion)
+
+	require.NotNil(t, doc.Images.ConsensusNode)
+	require.Equal(t, "0.75.0", doc.Images.ConsensusNode.Version)
+	require.NotNil(t, doc.Images.ConsensusNode.Enabled)
+	require.True(t, *doc.Images.ConsensusNode.Enabled)
+	require.Len(t, doc.Images.ConsensusNode.Registries, 2)
+
+	require.NotNil(t, doc.Images.BackupUploader)
+	require.NotNil(t, doc.Images.BackupUploader.Enabled)
+	require.False(t, *doc.Images.BackupUploader.Enabled)
+	require.False(t, doc.Images.BackupUploader.Deterministic.Supported)
+	require.Empty(t, doc.Images.BackupUploader.Deterministic.LayerHashes)
+	require.Len(t, doc.Images.BackupUploader.Registries[0].LayerHashes, 2)
+}
+
+func TestParseConsensusNodeComponents_AbsentSectionsTolerated(t *testing.T) {
+	// "Absent = no change" — only consensusNode declared; the other five
+	// components are simply not in the manifest, which is valid.
+	data := []byte(`
+schemaVersion: v1
+images:
+  consensusNode:
+    version: "0.75.0"
+    deterministic:
+      supported: true
+      layerHashes:
+        linux/arm64: ["sha256:a"]
+        linux/amd64: ["sha256:b"]
+    registries:
+      - image: "ghcr.io/x:0.75.0"
+`)
+	doc, err := ParseConsensusNodeComponents(data)
+	require.NoError(t, err)
+	require.NotNil(t, doc.Images.ConsensusNode)
+	require.Nil(t, doc.Images.RecordStreamUploader)
+	require.Nil(t, doc.Images.UC)
+	require.Nil(t, doc.Images.ConsensusNode.Enabled, "absent enabled field stays nil")
+}
+
+func TestParseConsensusNodeComponents_EmptyImagesTolerated(t *testing.T) {
+	// images: {} (or images: ) — the manifest changes nothing. Permitted.
+	doc, err := ParseConsensusNodeComponents([]byte("schemaVersion: v1\nimages: {}\n"))
+	require.NoError(t, err)
+	require.Nil(t, doc.Images.ConsensusNode)
+}
+
+func TestParseConsensusNodeComponents_RejectsUnknownTopLevelField(t *testing.T) {
+	data := []byte(`
+schemaVersion: v1
+mysteryField: 42
+images: {}
+`)
+	_, err := ParseConsensusNodeComponents(data)
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ParseError), "expected ParseError, got %v", err)
+}
+
+func TestParseConsensusNodeComponents_RejectsUnknownComponentName(t *testing.T) {
+	// "cheetah" was the bundled-sidecar name in the HIP draft but the story
+	// for #531 split it into five named uploaders. Unknown component names
+	// must surface as a parse error rather than be silently dropped.
+	data := []byte(`
+schemaVersion: v1
+images:
+  cheetah:
+    version: "0.43.0"
+    deterministic: {supported: true, layerHashes: {linux/amd64: ["sha256:x"], linux/arm64: ["sha256:y"]}}
+    registries: [{image: "ghcr.io/x:0.43.0"}]
+`)
+	_, err := ParseConsensusNodeComponents(data)
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ParseError), "expected ParseError, got %v", err)
+}
+
+func TestParseConsensusNodeComponents_RejectsUnsupportedSchemaVersion(t *testing.T) {
+	// The schemaVersion gate fires before any consensus-node-specific decode.
+	_, err := ParseConsensusNodeComponents([]byte("schemaVersion: v2\nimages: {}\n"))
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, UnsupportedSchemaVersionError),
+		"expected UnsupportedSchemaVersionError, got %v", err)
+}
+
+func TestParseConsensusNodeComponents_ValidationFailures(t *testing.T) {
+	tests := []struct {
+		name          string
+		yaml          string
+		expectField   string
+		expectMessage string
+	}{
+		{
+			name: "missing version",
+			yaml: `
+schemaVersion: v1
+images:
+  consensusNode:
+    deterministic: {supported: true, layerHashes: {linux/amd64: ["x"], linux/arm64: ["y"]}}
+    registries: [{image: "ghcr.io/x:0.75.0"}]
+`,
+			expectField:   "images.consensusNode.version",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "empty registries",
+			yaml: `
+schemaVersion: v1
+images:
+  consensusNode:
+    version: "0.75.0"
+    deterministic: {supported: true, layerHashes: {linux/amd64: ["x"], linux/arm64: ["y"]}}
+    registries: []
+`,
+			expectField:   "images.consensusNode.registries",
+			expectMessage: "must declare at least one registry",
+		},
+		{
+			name: "registry missing image",
+			yaml: `
+schemaVersion: v1
+images:
+  consensusNode:
+    version: "0.75.0"
+    deterministic: {supported: true, layerHashes: {linux/amd64: ["x"], linux/arm64: ["y"]}}
+    registries:
+      - image: ""
+`,
+			expectField:   "images.consensusNode.registries[0].image",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "deterministic supported but no layerHashes",
+			yaml: `
+schemaVersion: v1
+images:
+  consensusNode:
+    version: "0.75.0"
+    deterministic: {supported: true}
+    registries: [{image: "ghcr.io/x:0.75.0"}]
+`,
+			expectField:   "images.consensusNode.deterministic.layerHashes",
+			expectMessage: "must be declared when deterministic.supported is true",
+		},
+		{
+			name: "deterministic supported but registry has override",
+			yaml: `
+schemaVersion: v1
+images:
+  consensusNode:
+    version: "0.75.0"
+    deterministic: {supported: true, layerHashes: {linux/amd64: ["x"], linux/arm64: ["y"]}}
+    registries:
+      - image: "ghcr.io/x:0.75.0"
+        layerHashes:
+          linux/amd64: ["sha256:rogue"]
+`,
+			expectField:   "images.consensusNode.registries[0].layerHashes",
+			expectMessage: "must not be set when deterministic.supported is true",
+		},
+		{
+			name: "deterministic unsupported but layerHashes set at deterministic level",
+			yaml: `
+schemaVersion: v1
+images:
+  backupUploader:
+    version: "0.33.0"
+    deterministic:
+      supported: false
+      layerHashes: {linux/amd64: ["x"]}
+    registries:
+      - image: "ghcr.io/x:0.33.0"
+        layerHashes: {linux/amd64: ["y"], linux/arm64: ["z"]}
+`,
+			expectField:   "images.backupUploader.deterministic.layerHashes",
+			expectMessage: "must not be set when deterministic.supported is false",
+		},
+		{
+			name: "deterministic absent — registry must carry layerHashes",
+			yaml: `
+schemaVersion: v1
+images:
+  backupUploader:
+    version: "0.33.0"
+    registries:
+      - image: "ghcr.io/x:0.33.0"
+`,
+			expectField:   "images.backupUploader.registries[0].layerHashes",
+			expectMessage: "must be declared for non-deterministic components",
+		},
+		{
+			name: "unsupported platform key",
+			yaml: `
+schemaVersion: v1
+images:
+  consensusNode:
+    version: "0.75.0"
+    deterministic:
+      supported: true
+      layerHashes:
+        linux/amd64: ["x"]
+        linux/arm64: ["y"]
+        windows/arm64: ["z"]
+    registries:
+      - image: "ghcr.io/x:0.75.0"
+`,
+			expectField:   "images.consensusNode.deterministic.layerHashes",
+			expectMessage: `unsupported platform "windows/arm64"`,
+		},
+		{
+			name: "empty layer hash list for a platform",
+			yaml: `
+schemaVersion: v1
+images:
+  consensusNode:
+    version: "0.75.0"
+    deterministic:
+      supported: true
+      layerHashes:
+        linux/amd64: ["x"]
+        linux/arm64: []
+    registries:
+      - image: "ghcr.io/x:0.75.0"
+`,
+			expectField:   "images.consensusNode.deterministic.layerHashes.linux/arm64",
+			expectMessage: "must declare at least one layer hash",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseConsensusNodeComponents([]byte(tt.yaml))
+			require.Error(t, err)
+			require.True(t, errorx.IsOfType(err, ValidationError),
+				"expected ValidationError, got %v", err)
+			msg := err.Error()
+			require.Contains(t, msg, tt.expectField, "error should reference field path")
+			require.True(t, strings.Contains(msg, tt.expectMessage),
+				"expected message to contain %q, got %q", tt.expectMessage, msg)
+		})
+	}
+}
+
+func TestParseConsensusNodeComponents_MalformedYAML(t *testing.T) {
+	_, err := ParseConsensusNodeComponents([]byte("schemaVersion: v1\nimages: [not, a, map]\n"))
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ParseError), "expected ParseError, got %v", err)
+}
+
+// Pins the contract that the parser refuses inputs containing more than one
+// YAML document. Without this check yaml.Decoder.Decode would consume only
+// the first document and silently drop the rest — a failure mode that's
+// easy to ship and hard to detect for a council-signed manifest.
+func TestParseConsensusNodeComponents_RejectsMultipleYAMLDocuments(t *testing.T) {
+	data := []byte(`---
+schemaVersion: v1
+images:
+  consensusNode:
+    version: "0.75.0"
+    deterministic:
+      supported: true
+      layerHashes:
+        linux/amd64: ["sha256:a"]
+        linux/arm64: ["sha256:b"]
+    registries:
+      - image: "ghcr.io/x:0.75.0"
+---
+schemaVersion: v1
+images: {}
+`)
+	_, err := ParseConsensusNodeComponents(data)
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ValidationError),
+		"expected ValidationError (extra YAML document), got %v", err)
+	require.Contains(t, err.Error(), "exactly one YAML document")
+}

--- a/pkg/manifests/decode.go
+++ b/pkg/manifests/decode.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package manifests
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// decodeStrictSingleYAMLDoc decodes data into out using strict YAML semantics
+// (yaml.v3 KnownFields(true), so unknown fields are an error) and rejects
+// inputs containing more than one YAML document. Multi-document streams would
+// otherwise yield the first document silently while dropping the rest — a
+// failure mode that's easy to ship and hard to detect, especially for a
+// council-signed manifest where exactly-one document is the contract.
+//
+// Returns a typed *errorx.Error: ParseError on decode failure, ValidationError
+// when a trailing document is found.
+func decodeStrictSingleYAMLDoc(kind Kind, data []byte, out interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(out); err != nil {
+		return NewParseError(err, kind)
+	}
+	var discard interface{}
+	err := dec.Decode(&discard)
+	switch {
+	case err == nil:
+		return NewValidationError(kind, "<document>",
+			"manifest must contain exactly one YAML document; additional documents are not permitted")
+	case errors.Is(err, io.EOF):
+		// Single document — the expected case.
+		return nil
+	default:
+		// Trailing bytes that look like a malformed second document.
+		return NewParseError(err, kind)
+	}
+}

--- a/pkg/manifests/errors.go
+++ b/pkg/manifests/errors.go
@@ -13,10 +13,12 @@ var (
 	MissingSchemaVersionError     = ErrorsNamespace.NewType("missing_schema_version")
 	UnsupportedSchemaVersionError = ErrorsNamespace.NewType("unsupported_schema_version")
 	UnknownKindError              = ErrorsNamespace.NewType("unknown_kind")
+	ValidationError               = ErrorsNamespace.NewType("validation_error")
 
 	kindProperty              = errorx.RegisterPrintableProperty("kind")
 	schemaVersionProperty     = errorx.RegisterPrintableProperty("schema_version")
 	supportedVersionsProperty = errorx.RegisterPrintableProperty("supported_versions")
+	fieldProperty             = errorx.RegisterPrintableProperty("field")
 )
 
 const (
@@ -24,6 +26,7 @@ const (
 	missingSchemaVersionErrorMsg     = "manifest %q is missing required field \"schemaVersion\""
 	unsupportedSchemaVersionErrorMsg = "manifest %q declares schemaVersion %q (supported: %v)"
 	unknownKindErrorMsg              = "unknown manifest kind %q"
+	validationErrorMsg               = "manifest %q: invalid %s: %s"
 )
 
 func NewParseError(cause error, kind Kind) *errorx.Error {
@@ -54,4 +57,15 @@ func NewUnsupportedSchemaVersionError(kind Kind, declared SchemaVersion, support
 func NewUnknownKindError(kind Kind) *errorx.Error {
 	return UnknownKindError.New(unknownKindErrorMsg, string(kind)).
 		WithProperty(kindProperty, string(kind))
+}
+
+// NewValidationError flags a semantic-validation failure on a parsed manifest:
+// a field is present and structurally valid, but its value violates a rule
+// that yaml.Unmarshal alone cannot enforce (e.g. layerHashes appearing in the
+// wrong place for a deterministic build). The field path is the dotted Go
+// field name, e.g. `images.backupUploader.registries[0].layerHashes`.
+func NewValidationError(kind Kind, field string, reason string) *errorx.Error {
+	return ValidationError.New(validationErrorMsg, string(kind), field, reason).
+		WithProperty(kindProperty, string(kind)).
+		WithProperty(fieldProperty, field)
 }


### PR DESCRIPTION
## Summary

- First concrete parser under epic #501; first consumer of `ValidateSchemaVersion` from #634.
- Strict-decodes a manifest's `images:` section into typed `Image` entries for the consensus node and the five named sidecars (`recordStreamUploader`, `eventStreamUploader`, `blockStreamUploader`, `backupUploader`, `uc`). Unknown component names (e.g. the HIP draft's bundled `cheetah`) fail parsing.
- Enforces the **layerHashes placement contract** in both directions: deterministic builds carry one shared record at the component level *and* no per-registry overrides; non-deterministic builds invert that. Misplacement is the kind of error that would silently break image integrity verification at apply time, so it's rejected explicitly.
- Validates platform identifiers against `{linux/amd64, linux/arm64}`; rejects empty per-platform hash lists.
- **"Absent = no change"** is the contract: every entry under `images:`, and the `enabled` field per entry, are pointer-typed so callers can distinguish nil (no change) from an explicit value.
- Adds `ValidationError` errorx type for semantic failures `yaml.Unmarshal` alone cannot catch; messages carry dotted field paths (e.g. `images.backupUploader.registries[0].layerHashes`).

**Stacked on #634** so the parser can reach `ValidateSchemaVersion`. Once #634 merges into `00501-manifest-parsing`, GitHub auto-retargets this PR.

Closes #531. Refs #501.

## Test plan

- [x] `go test -race -cover -tags='!integration' ./pkg/manifests/...` → all green, **97.7%** statement coverage (up from 96.7% in #634)
- [x] `task lint` — clean
- [ ] CI passes on this PR
- [ ] Reviewer reads `pkg/manifests/consensus_node_components.go` against [the review guide](docs/claude/reviews/00531-consensus-node-components-parser.md), paying particular attention to the deterministic vs non-deterministic placement matrix

## Spec note

The story body names five sidecar uploaders (`recordStreamUploader`, `eventStreamUploader`, `blockStreamUploader`, `backupUploader`, `uc`). The older HIP draft (`hip-xxxx0`) shows a single bundled `cheetah` sidecar instead. The story supersedes the HIP draft (same convention as the `provisioner.cli`/`provisioner.daemon` split flagged in #634); strict decoding therefore rejects `cheetah` and any other unknown component name. `TestParseConsensusNodeComponents_RejectsUnknownComponentName` pins that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)