### PR TITLE
feat(manifests): add infrastructure-versions.yaml parser

### DIFF
--- a/docs/claude/reviews/00532-infrastructure-versions-parser.md
+++ b/docs/claude/reviews/00532-infrastructure-versions-parser.md
@@ -1,0 +1,63 @@
+# #532 — Review guide: infrastructure-versions.yaml parser
+
+> **Issue:** https://github.com/hashgraph/solo-weaver/issues/532
+> **Epic:** https://github.com/hashgraph/solo-weaver/issues/501
+> **Branch:** `00532-infrastructure-versions-parser`
+> **Base:** `00531-consensus-node-components-parser` (stacked; auto-retargets up the chain as upstream PRs merge)
+
+## Problem and solution
+
+`infrastructure-versions.yaml` ships inside every CN deployment package and pins two things the provisioner needs at apply time:
+
+1. **The exact `solo-provisioner` versions** to install — split into `provisioner.cli` (CLI binary) and `provisioner.daemon` (daemon binary), each with `version` + `algorithm` + `checksum`. The split reflects the existing two-binary release layout from epic #498 (CLI tags `vX.Y.Z`; daemon tags `daemon-vX.Y.Z` — independently released).
+2. **An audit record** of every host-level binary (`cri-o`, `kubelet`, `kubeadm`, etc.) and Helm chart (`alloy`, `metallb`, `metrics-server`, etc.) whose installed version the provisioner will reconcile against its embedded catalog at runtime. These are deliberately **audit-only** records — they do not select versions; `provisioner.<cli|daemon>.version` does.
+
+The parser strict-decodes the YAML, then validates: provisioner sub-sections have all three integrity fields when present, host[] and cluster[] entries have non-empty name + version, and names are unique within each section (duplicate names would produce ambiguous audit records).
+
+### Spec note — supersedes the HIP draft
+
+The HIP draft (`hip-xxxx0`) shows a single `provisioner.version` field. The story body for #532 supersedes that with the `cli`/`daemon` split — same convention as the `cheetah` → 5-sidecar split flagged in #531. Strict decoding therefore rejects a manifest with `provisioner.version` at the top level of `provisioner:` — `TestParseInfrastructureVersions_RejectsHIPSingleProvisionerVersion` pins this contract.
+
+### Stacked-PR layout
+
+This branch is stacked on `00531-consensus-node-components-parser` (PR #636), which is itself stacked on `00535-manifest-schema-version-validation` (PR #634). The reason is the shared `ValidationError` errorx type and `NewValidationError` constructor that #531 added to `pkg/manifests/errors.go` — both #532 and #531 use it. Stacking avoids a merge conflict on `errors.go` and keeps the typed-error surface defined exactly once.
+
+As the upstream PRs merge into the epic branch, GitHub will auto-retarget this PR down the chain (PR #636 first, then this one), arriving at `00501-manifest-parsing` cleanly.
+
+## Changed files
+
+| File | What changed |
+|---|---|
+| `pkg/manifests/infrastructure_versions.go` (new) | Types (`InfrastructureVersions`, `Provisioner`, `Binary`, `HostComponent`, `ClusterChart`), `ParseInfrastructureVersions`, internal validators |
+| `pkg/manifests/infrastructure_versions_test.go` (new) | Happy paths (full + partial), schemaVersion gate, strict-decode rejections (incl. the HIP-shape rejection), table-driven validation failures including duplicate-name cases |
+| `docs/claude/reviews/00532-infrastructure-versions-parser.md` (new) | This guide |
+
+## Code review checklist
+
+- [ ] **`Provisioner`, `Provisioner.CLI`, `Provisioner.Daemon` are pointer-typed.** A manifest with only `provisioner.cli` present (or with no `provisioner:` block at all) is valid under "absent = no change" — verified by `TestParseInfrastructureVersions_OnlyCLIPresent` and `TestParseInfrastructureVersions_AllSectionsAbsent`.
+- [ ] **Strict decode at this layer.** Unknown top-level fields and unknown sub-keys under `provisioner:` (most importantly the old HIP-shape `provisioner.version`) fail with `ParseError`. Two dedicated test cases pin this.
+- [ ] **All three integrity fields required when a `Binary` is present.** `Binary.validate` checks `version`, `algorithm`, and `checksum` individually so a missing one produces a precise field-path error.
+- [ ] **Host and cluster name uniqueness is per-section.** Same name in both `host[]` and `cluster[]` is allowed (`TestParseInfrastructureVersions_NamesShareableAcrossSections`) — but duplicates *within* a section are rejected.
+- [ ] **Algorithm is not enum-restricted.** The Binary struct accepts any non-empty algorithm string, matching the convention in `pkg/software/config.go::Checksum`. A future "must be sha256" enforcement can be added centrally there once the catalog standardises on it.
+- [ ] **Validator does not depend on host[]/cluster[] catalog membership.** The provisioner catalog membership check (whether the named host or cluster component is actually recognised by the embedded `pkg/software/infrastructure-catalog.yaml`) is intentionally a runtime concern, not a manifest-parse concern — keeping this PR focused on syntax + per-entry semantics.
+- [ ] **No production caller yet.** Like #531, this story ships the parser only. Wiring into the daemon/UC apply flow is a follow-on outside epic #501.
+
+## Test commands
+
+```bash
+# Unit tests (this PR brings the package to 98.5% coverage)
+go test -race -cover -tags='!integration' ./pkg/manifests/...
+
+# Lint pipeline (errorx gate, gofmt)
+task lint:check
+```
+
+Expected:
+
+```
+ok      github.com/hashgraph/solo-weaver/pkg/manifests    coverage: 98.5% of statements
+```
+
+## Manual UAT
+
+No CLI surface, no daemon hook. Reviewers can spot-check the parser shape by reading the fixture at the top of `pkg/manifests/infrastructure_versions_test.go` (`fullInfrastructureVersionsManifest`) against `pkg/manifests/infrastructure_versions.go::InfrastructureVersions`. The intended user-facing behaviour surfaces once a follow-on story wires this parser into the daemon's package-extraction flow.

--- a/pkg/manifests/infrastructure_versions.go
+++ b/pkg/manifests/infrastructure_versions.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package manifests
+
+import (
+	"fmt"
+)
+
+// InfrastructureVersions is the parsed root of an infrastructure-versions.yaml
+// manifest. It declares the solo-provisioner binary versions (CLI + daemon)
+// that must be installed at apply time, plus an audit record of every host-
+// level binary and Helm chart whose version the provisioner will reconcile.
+//
+// Per the manifest contract ("absent = no change"), every section is optional.
+// Provisioner is a pointer so a partial manifest can omit the section
+// entirely. Host and Cluster are slices: a missing section and an empty
+// section both decode to len==0 — callers that need to differentiate them
+// must inspect the raw YAML, not the slice length, but the parser treats
+// both identically since they're equivalent under the "absent = no change"
+// contract.
+type InfrastructureVersions struct {
+	Header      `yaml:",inline"`
+	Provisioner *Provisioner    `yaml:"provisioner,omitempty"`
+	Host        []HostComponent `yaml:"host,omitempty"`
+	Cluster     []ClusterChart  `yaml:"cluster,omitempty"`
+}
+
+// Provisioner holds the integrity records for the two solo-provisioner
+// binaries. The split reflects the existing two-binary layout in this repo
+// (CLI: solo-provisioner; daemon: solo-provisioner-daemon — independently
+// released and tagged). Both sub-sections are pointer-typed for the same
+// "absent = no change" reason as Image.Enabled in #531.
+type Provisioner struct {
+	CLI    *Binary `yaml:"cli,omitempty"`
+	Daemon *Binary `yaml:"daemon,omitempty"`
+}
+
+// Binary is one solo-provisioner binary's release spec — the exact version to
+// install and the checksum used to verify the downloaded artifact.
+type Binary struct {
+	Version   string `yaml:"version"`
+	Algorithm string `yaml:"algorithm"`
+	Checksum  string `yaml:"checksum"`
+}
+
+// HostComponent is one audit-record entry under host: — a host-level binary
+// (e.g. cri-o, kubelet, kubeadm, kubectl, helm, cilium) whose installed
+// version the provisioner reconciles against its embedded catalog.
+type HostComponent struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+// ClusterChart is one audit-record entry under cluster: — a Helm chart
+// installed into the Kubernetes cluster (e.g. alloy, metallb, metrics-server)
+// whose installed version the provisioner reconciles against its embedded
+// catalog.
+type ClusterChart struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+// ParseInfrastructureVersions parses raw YAML bytes of an
+// infrastructure-versions.yaml manifest. It runs the cross-cutting
+// schemaVersion check first, then strict-decodes the single YAML document
+// (unknown top-level fields fail; multi-document inputs are rejected), then
+// runs semantic validation.
+func ParseInfrastructureVersions(data []byte) (*InfrastructureVersions, error) {
+	if _, err := ValidateSchemaVersion(KindInfrastructureVersions, data); err != nil {
+		return nil, err
+	}
+
+	var doc InfrastructureVersions
+	if err := decodeStrictSingleYAMLDoc(KindInfrastructureVersions, data, &doc); err != nil {
+		return nil, err
+	}
+
+	if err := doc.validate(); err != nil {
+		return nil, err
+	}
+	return &doc, nil
+}
+
+func (iv *InfrastructureVersions) validate() error {
+	if iv.Provisioner != nil {
+		if err := iv.Provisioner.CLI.validate("provisioner.cli"); err != nil {
+			return err
+		}
+		if err := iv.Provisioner.Daemon.validate("provisioner.daemon"); err != nil {
+			return err
+		}
+	}
+	if err := validateAuditEntries("host", entriesFromHost(iv.Host)); err != nil {
+		return err
+	}
+	if err := validateAuditEntries("cluster", entriesFromCluster(iv.Cluster)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validate checks an individual Binary section. A nil receiver is allowed —
+// callers use it to express "this binary's section was absent from the
+// manifest", which is valid under the "absent = no change" contract.
+func (b *Binary) validate(fieldPath string) error {
+	if b == nil {
+		return nil
+	}
+	if b.Version == "" {
+		return NewValidationError(KindInfrastructureVersions, fieldPath+".version", "must not be empty")
+	}
+	if b.Algorithm == "" {
+		return NewValidationError(KindInfrastructureVersions, fieldPath+".algorithm", "must not be empty")
+	}
+	if b.Checksum == "" {
+		return NewValidationError(KindInfrastructureVersions, fieldPath+".checksum", "must not be empty")
+	}
+	return nil
+}
+
+type auditEntry struct {
+	name    string
+	version string
+}
+
+func entriesFromHost(in []HostComponent) []auditEntry {
+	out := make([]auditEntry, len(in))
+	for i, c := range in {
+		out[i] = auditEntry{name: c.Name, version: c.Version}
+	}
+	return out
+}
+
+func entriesFromCluster(in []ClusterChart) []auditEntry {
+	out := make([]auditEntry, len(in))
+	for i, c := range in {
+		out[i] = auditEntry{name: c.Name, version: c.Version}
+	}
+	return out
+}
+
+// validateAuditEntries enforces the contract on host[] / cluster[]: every
+// entry must declare both name and version, and names must be unique within
+// a section. Duplicate names would produce ambiguous audit records.
+func validateAuditEntries(section string, entries []auditEntry) error {
+	seen := make(map[string]struct{}, len(entries))
+	for i, e := range entries {
+		prefix := fmt.Sprintf("%s[%d]", section, i)
+		if e.name == "" {
+			return NewValidationError(KindInfrastructureVersions, prefix+".name", "must not be empty")
+		}
+		if e.version == "" {
+			return NewValidationError(KindInfrastructureVersions, prefix+".version", "must not be empty")
+		}
+		if _, dup := seen[e.name]; dup {
+			return NewValidationError(KindInfrastructureVersions, prefix+".name",
+				fmt.Sprintf("duplicate entry %q in %s[] (each name must be unique)", e.name, section))
+		}
+		seen[e.name] = struct{}{}
+	}
+	return nil
+}

--- a/pkg/manifests/infrastructure_versions_test.go
+++ b/pkg/manifests/infrastructure_versions_test.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package manifests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/require"
+)
+
+// fullInfrastructureVersionsManifest is the happy-path fixture: both
+// provisioner binaries with full integrity records, plus a representative
+// host[] and cluster[] audit list.
+const fullInfrastructureVersionsManifest = `
+schemaVersion: v1
+provisioner:
+  cli:
+    version: "0.42.0"
+    algorithm: sha256
+    checksum: "abc123"
+  daemon:
+    version: "0.42.0"
+    algorithm: sha256
+    checksum: "def456"
+host:
+  - name: cri-o
+    version: "1.33.4"
+  - name: kubelet
+    version: "1.33.4"
+  - name: kubeadm
+    version: "1.33.4"
+  - name: kubectl
+    version: "1.33.4"
+  - name: helm
+    version: "3.18.6"
+  - name: cilium
+    version: "0.18.7"
+cluster:
+  - name: alloy
+    version: "1.4.0"
+  - name: metallb
+    version: "0.15.2"
+  - name: metrics-server
+    version: "3.13.0"
+`
+
+func TestParseInfrastructureVersions_FullHappyPath(t *testing.T) {
+	doc, err := ParseInfrastructureVersions([]byte(fullInfrastructureVersionsManifest))
+	require.NoError(t, err)
+	require.Equal(t, SchemaV1, doc.SchemaVersion)
+
+	require.NotNil(t, doc.Provisioner)
+	require.NotNil(t, doc.Provisioner.CLI)
+	require.Equal(t, "0.42.0", doc.Provisioner.CLI.Version)
+	require.Equal(t, "sha256", doc.Provisioner.CLI.Algorithm)
+	require.Equal(t, "abc123", doc.Provisioner.CLI.Checksum)
+	require.NotNil(t, doc.Provisioner.Daemon)
+	require.Equal(t, "def456", doc.Provisioner.Daemon.Checksum)
+
+	require.Len(t, doc.Host, 6)
+	require.Equal(t, "cri-o", doc.Host[0].Name)
+	require.Equal(t, "1.33.4", doc.Host[0].Version)
+
+	require.Len(t, doc.Cluster, 3)
+	require.Equal(t, "alloy", doc.Cluster[0].Name)
+}
+
+func TestParseInfrastructureVersions_AllSectionsAbsent(t *testing.T) {
+	// Per "absent = no change", a manifest with only schemaVersion is a no-op
+	// but is structurally valid.
+	doc, err := ParseInfrastructureVersions([]byte("schemaVersion: v1\n"))
+	require.NoError(t, err)
+	require.Nil(t, doc.Provisioner)
+	require.Empty(t, doc.Host)
+	require.Empty(t, doc.Cluster)
+}
+
+func TestParseInfrastructureVersions_OnlyCLIPresent(t *testing.T) {
+	// "Absent = no change" applies inside provisioner too: declaring only the
+	// CLI's record (e.g. a CLI-only release) is valid.
+	data := []byte(`
+schemaVersion: v1
+provisioner:
+  cli:
+    version: "0.42.0"
+    algorithm: sha256
+    checksum: "abc"
+`)
+	doc, err := ParseInfrastructureVersions(data)
+	require.NoError(t, err)
+	require.NotNil(t, doc.Provisioner)
+	require.NotNil(t, doc.Provisioner.CLI)
+	require.Nil(t, doc.Provisioner.Daemon)
+}
+
+func TestParseInfrastructureVersions_RejectsUnknownTopLevelField(t *testing.T) {
+	_, err := ParseInfrastructureVersions([]byte("schemaVersion: v1\nmysteryField: 42\n"))
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ParseError), "expected ParseError, got %v", err)
+}
+
+func TestParseInfrastructureVersions_RejectsHIPSingleProvisionerVersion(t *testing.T) {
+	// The HIP draft used `provisioner.version`; the story body for #532
+	// supersedes it with the cli/daemon split. A manifest written against
+	// the old shape must surface as a parse error rather than be silently
+	// accepted with both cli and daemon nil.
+	data := []byte(`
+schemaVersion: v1
+provisioner:
+  version: "0.42.0"
+`)
+	_, err := ParseInfrastructureVersions(data)
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ParseError), "expected ParseError, got %v", err)
+}
+
+func TestParseInfrastructureVersions_RejectsUnsupportedSchemaVersion(t *testing.T) {
+	_, err := ParseInfrastructureVersions([]byte("schemaVersion: v2\n"))
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, UnsupportedSchemaVersionError),
+		"expected UnsupportedSchemaVersionError, got %v", err)
+}
+
+func TestParseInfrastructureVersions_ValidationFailures(t *testing.T) {
+	tests := []struct {
+		name          string
+		yaml          string
+		expectField   string
+		expectMessage string
+	}{
+		{
+			name: "cli missing version",
+			yaml: `
+schemaVersion: v1
+provisioner:
+  cli:
+    algorithm: sha256
+    checksum: "abc"
+`,
+			expectField:   "provisioner.cli.version",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "cli missing algorithm",
+			yaml: `
+schemaVersion: v1
+provisioner:
+  cli:
+    version: "0.42.0"
+    checksum: "abc"
+`,
+			expectField:   "provisioner.cli.algorithm",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "daemon missing checksum",
+			yaml: `
+schemaVersion: v1
+provisioner:
+  daemon:
+    version: "0.42.0"
+    algorithm: sha256
+`,
+			expectField:   "provisioner.daemon.checksum",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "host entry missing name",
+			yaml: `
+schemaVersion: v1
+host:
+  - name: cri-o
+    version: "1.33.4"
+  - version: "1.33.4"
+`,
+			expectField:   "host[1].name",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "host entry missing version",
+			yaml: `
+schemaVersion: v1
+host:
+  - name: cri-o
+`,
+			expectField:   "host[0].version",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "duplicate host names",
+			yaml: `
+schemaVersion: v1
+host:
+  - name: cri-o
+    version: "1.33.4"
+  - name: cri-o
+    version: "1.33.5"
+`,
+			expectField:   "host[1].name",
+			expectMessage: `duplicate entry "cri-o"`,
+		},
+		{
+			name: "cluster entry missing version",
+			yaml: `
+schemaVersion: v1
+cluster:
+  - name: alloy
+`,
+			expectField:   "cluster[0].version",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "duplicate cluster names",
+			yaml: `
+schemaVersion: v1
+cluster:
+  - name: alloy
+    version: "1.4.0"
+  - name: alloy
+    version: "1.4.1"
+`,
+			expectField:   "cluster[1].name",
+			expectMessage: `duplicate entry "alloy"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseInfrastructureVersions([]byte(tt.yaml))
+			require.Error(t, err)
+			require.True(t, errorx.IsOfType(err, ValidationError),
+				"expected ValidationError, got %v", err)
+			msg := err.Error()
+			require.Contains(t, msg, tt.expectField, "error should reference field path")
+			require.True(t, strings.Contains(msg, tt.expectMessage),
+				"expected message to contain %q, got %q", tt.expectMessage, msg)
+		})
+	}
+}
+
+func TestParseInfrastructureVersions_RejectsMultipleYAMLDocuments(t *testing.T) {
+	data := []byte(`---
+schemaVersion: v1
+host:
+  - name: cri-o
+    version: "1.33.4"
+---
+schemaVersion: v1
+`)
+	_, err := ParseInfrastructureVersions(data)
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ValidationError),
+		"expected ValidationError (extra YAML document), got %v", err)
+	require.Contains(t, err.Error(), "exactly one YAML document")
+}
+
+// Host and cluster names are independent namespaces — the same name appearing
+// in both sections (e.g. some-tool packaged both ways) is allowed.
+func TestParseInfrastructureVersions_NamesShareableAcrossSections(t *testing.T) {
+	data := []byte(`
+schemaVersion: v1
+host:
+  - name: helm
+    version: "3.18.6"
+cluster:
+  - name: helm
+    version: "0.0.0"
+`)
+	_, err := ParseInfrastructureVersions(data)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Second parser under epic #501. Strict-decodes `infrastructure-versions.yaml` into:
  - `provisioner.cli` and `provisioner.daemon`, each with `version` + `algorithm` + `checksum`. The split matches the existing two-binary release layout from epic #498 (CLI tags `vX.Y.Z`; daemon tags `daemon-vX.Y.Z` — independently released). **Supersedes the older single `provisioner.version` field in the HIP draft** — a manifest using that shape now fails parsing (test: `RejectsHIPSingleProvisionerVersion`).
  - `host[]` audit record (cri-o, kubelet, kubeadm, kubectl, helm, cilium, etc.)
  - `cluster[]` audit record (alloy, metallb, metrics-server, etc.)
- Per the "absent = no change" contract, every section is optional. `Provisioner`, `Provisioner.CLI`, and `Provisioner.Daemon` are pointer-typed so a partial manifest remains valid.
- `host[]`/`cluster[]` entries must declare both `name` and `version`, and names must be unique **within** each section. Names are independent across sections — the same name in both `host[]` and `cluster[]` is allowed (test pins this).

### Stacked PR

This PR is stacked on **#636** (#531 — consensus-node-components parser), which is itself stacked on **#634** (#535 — schemaVersion validator). The reason is the shared `ValidationError` errorx type and `NewValidationError` constructor that #636 added to `pkg/manifests/errors.go` — both parsers use it. Stacking avoids a merge conflict on `errors.go` and keeps the typed-error surface defined exactly once. As upstream PRs merge, GitHub will auto-retarget down the chain (#634 → epic, then #636 retargets to epic, then this PR retargets to epic).

Closes #532. Refs #501.

## Test plan

- [x] `go test -race -cover -tags='!integration' ./pkg/manifests/...` → all green, **98.5%** statement coverage (up from 97.7% in #636)
- [x] `task lint` — clean
- [ ] CI passes on this PR
- [ ] Reviewer reads `pkg/manifests/infrastructure_versions.go` against [the review guide](docs/claude/reviews/00532-infrastructure-versions-parser.md). Particular attention to: pointer-typed `Provisioner` shape, the HIP-shape rejection test, host/cluster duplicate-name semantics.

## Spec note

The story body for #532 explicitly splits `provisioner` into `cli` and `daemon` subsections (each with `version`+`algorithm`+`checksum`). The HIP draft (`hip-xxxx0`) still shows a single `provisioner.version` field. Stories supersede the HIP draft (same convention as the `cheetah` → 5-sidecar split flagged in #636). Strict decoding therefore rejects the old shape outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)