### PR TITLE
feat(manifests): add external-files.yaml parser

### DIFF
--- a/docs/claude/reviews/00533-external-files-parser.md
+++ b/docs/claude/reviews/00533-external-files-parser.md
@@ -1,0 +1,61 @@
+# #533 — Review guide: external-files.yaml parser
+
+> **Issue:** https://github.com/hashgraph/solo-weaver/issues/533
+> **Epic:** https://github.com/hashgraph/solo-weaver/issues/501
+> **Branch:** `00533-external-files-parser`
+> **Base:** `00532-infrastructure-versions-parser` (stacked; auto-retargets up the chain as upstream PRs merge)
+
+## Problem and solution
+
+`external-files.yaml` declares large remote files (over the ~1 MB ConfigurationFile-CR limit) that the upgrade-controller sidecar or the `solo-provisioner-upgrade` daemon must download and stage on the host before the consensus node restarts. Each entry specifies where to fetch the file from, how to verify its integrity (`algorithm` + `checksum`), where to put it (`destination`), whether a download failure is fatal (`optional`), and the timing of both download and install (`phase`).
+
+The parser strict-decodes the YAML and validates: every entry has a non-empty `url`/`algorithm`/`checksum`/`destination`; `phase.download` is one of `{prepare, freeze}`; `phase.install` is `freeze` (the only legal value today). Destination uniqueness across the file list is enforced — two entries can't install to the same path, since they would silently overwrite each other.
+
+### Spec note — supersedes the HIP draft
+
+The HIP draft (`hip-xxxx0`) shows a single `hash: "sha256:..."` field; the story body for #533 supersedes that with separate `algorithm` + `checksum` fields (matching the convention already used in `pkg/software/config.go::Checksum` and now in `infrastructure-versions.yaml`'s `Binary` from #638). A manifest using the old shape fails parsing — `TestParseExternalFiles_RejectsHIPHashFieldShape` pins this.
+
+### Scope boundary with #536
+
+Story #533 implements the parser *infrastructure* for `destination`, validating that the field is non-empty. Story **#536** layers on the strict allowlist of marker prefixes (`HAPIAPP_DIR`, `SOLO_PROVISIONER_DIR`) — that's intentionally a separate PR so the policy is easy to audit and revisit independently of the parser. The test `TestParseExternalFiles_DestinationPrefixNotYetEnforced` pins this scope split: an arbitrary absolute path passes here, and #536 will be the PR that flips that.
+
+### Stacked-PR layout
+
+This branch is stacked on `00532-infrastructure-versions-parser` (PR #638), which is stacked on `00531-…` (PR #636), which is stacked on `00535-…` (PR #634). All four PRs target the epic branch `00501-manifest-parsing`. As upstream PRs merge, GitHub will auto-retarget each downstream PR down the chain.
+
+## Changed files
+
+| File | What changed |
+|---|---|
+| `pkg/manifests/external_files.go` (new) | Types (`ExternalFiles`, `ExternalFile`, `Phase`, `DownloadPhase`, `InstallPhase`), `ParseExternalFiles`, per-entry validation |
+| `pkg/manifests/external_files_test.go` (new) | Happy path, empty-files no-op, `optional`-defaults-false pin, strict-decode rejections (incl. HIP-shape), table-driven validation failures including duplicate-destination, `phase.download`/`phase.install` enum cases, and the destination-prefix-deferred-to-#536 pin |
+| `docs/claude/reviews/00533-external-files-parser.md` (new) | This guide |
+
+## Code review checklist
+
+- [ ] **`DownloadPhase` and `InstallPhase` are typed constants.** Validation switches over the typed constants so misspellings in production callers (e.g. `manifests.DownloadPhasePrepar`) fail to compile rather than fail at runtime.
+- [ ] **`Optional` is a bool (not a pointer).** The story specifies a default of `false`; `yaml.v3` zeroes the field when absent, which is the same as the documented default. Pinned by `TestParseExternalFiles_OptionalDefaultsFalse`. Future enhancement (distinguishing nil from explicit-false) would need a pointer, but that's not in scope here.
+- [ ] **Strict decode at this layer.** Unknown top-level fields and unknown per-entry fields (most importantly the HIP-shape `hash:`) fail with `ParseError`. Two dedicated test cases pin this.
+- [ ] **Duplicate-destination check uses a map keyed by destination string.** The previous index is included in the error message so the operator knows both lines to look at.
+- [ ] **Empty files list is valid.** `TestParseExternalFiles_EmptyFilesList` pins that a manifest with only `schemaVersion: v1` is a structurally valid no-op — useful in environments where no external files exist for a given release.
+- [ ] **Scope boundary with #536.** `TestParseExternalFiles_DestinationPrefixNotYetEnforced` is the *contract* boundary: this PR validates destination is non-empty, #536 will add the strict allowlist. The test will be replaced (not deleted) in #536 with assertions that the strict allowlist now applies — clean, audit-able transition.
+
+## Test commands
+
+```bash
+# Unit tests (this PR brings the package to 98.8% coverage)
+go test -race -cover -tags='!integration' ./pkg/manifests/...
+
+# Lint pipeline (errorx gate, gofmt)
+task lint:check
+```
+
+Expected:
+
+```
+ok      github.com/hashgraph/solo-weaver/pkg/manifests    coverage: 98.8% of statements
+```
+
+## Manual UAT
+
+No CLI surface, no daemon hook. The fixture at the top of `pkg/manifests/external_files_test.go` (`fullExternalFilesManifest`) is the canonical reference shape — reviewers can read it alongside the type definitions in `pkg/manifests/external_files.go`. The intended user-facing behaviour surfaces once a follow-on story wires this parser into the daemon/UC apply flow.

--- a/pkg/manifests/external_files.go
+++ b/pkg/manifests/external_files.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package manifests
+
+import (
+	"fmt"
+)
+
+// ExternalFiles is the parsed root of an external-files.yaml manifest. It
+// declares large remote files (over the ~1 MB ConfigurationFile-CR limit)
+// that the upgrade-controller sidecar or the solo-provisioner-upgrade daemon
+// must download and stage on the host before the consensus node restarts.
+type ExternalFiles struct {
+	Header `yaml:",inline"`
+	Files  []ExternalFile `yaml:"files,omitempty"`
+}
+
+// ExternalFile is one entry under files:. The destination is expressed using
+// a directory-marker prefix (e.g. HAPIAPP_DIR/...) that the downloader
+// resolves to a real filesystem path at apply time. This parser validates
+// that destination is non-empty but does not enforce the specific allowed
+// marker prefixes — that's #536's responsibility.
+type ExternalFile struct {
+	URL         string `yaml:"url"`
+	Algorithm   string `yaml:"algorithm"`
+	Checksum    string `yaml:"checksum"`
+	ContentType string `yaml:"contentType,omitempty"`
+	Destination string `yaml:"destination"`
+	// Optional defaults to false. When true, a download failure for this entry
+	// is logged but does not abort the wider apply. yaml.v3 zeroes the field
+	// when absent from the YAML, which is the same as the documented default.
+	Optional bool  `yaml:"optional,omitempty"`
+	Phase    Phase `yaml:"phase"`
+}
+
+// Phase tells the downloader when each file is fetched and when it is moved
+// into place. Download can happen either before the freeze window starts
+// (prepare — concurrent with normal traffic) or during the freeze itself.
+// Install always happens during the freeze, when the CN is stopped and the
+// staged files can be moved into place atomically.
+type Phase struct {
+	Download DownloadPhase `yaml:"download"`
+	Install  InstallPhase  `yaml:"install"`
+}
+
+// DownloadPhase enumerates the legal values for phase.download. "prepare"
+// downloads before the freeze window begins (low-risk, can spread network
+// I/O over a long lead time); "freeze" delays the download until the freeze
+// window itself (used for large state-bearing files that must reflect the
+// exact freeze-time bytes).
+type DownloadPhase string
+
+const (
+	DownloadPhasePrepare DownloadPhase = "prepare"
+	DownloadPhaseFreeze  DownloadPhase = "freeze"
+)
+
+// InstallPhase enumerates the legal values for phase.install. Today only
+// "freeze" is permitted — installing a large file outside the freeze window
+// would require the CN to be live during a non-atomic move and is rejected
+// by design.
+type InstallPhase string
+
+const (
+	InstallPhaseFreeze InstallPhase = "freeze"
+)
+
+// ParseExternalFiles parses raw YAML bytes of an external-files.yaml
+// manifest. It runs the cross-cutting schemaVersion check first, then
+// strict-decodes the single YAML document (unknown top-level fields fail;
+// multi-document inputs are rejected), then runs per-entry semantic
+// validation.
+func ParseExternalFiles(data []byte) (*ExternalFiles, error) {
+	if _, err := ValidateSchemaVersion(KindExternalFiles, data); err != nil {
+		return nil, err
+	}
+
+	var doc ExternalFiles
+	if err := decodeStrictSingleYAMLDoc(KindExternalFiles, data, &doc); err != nil {
+		return nil, err
+	}
+
+	if err := doc.validate(); err != nil {
+		return nil, err
+	}
+	return &doc, nil
+}
+
+// validate enforces semantic invariants on every files[] entry. Two files
+// declaring the same destination would silently overwrite each other at
+// install time, so destination uniqueness is enforced here.
+func (ef *ExternalFiles) validate() error {
+	seenDestinations := make(map[string]int, len(ef.Files))
+	for i := range ef.Files {
+		if err := ef.Files[i].validate(i); err != nil {
+			return err
+		}
+		dest := ef.Files[i].Destination
+		if prevIdx, dup := seenDestinations[dest]; dup {
+			return NewValidationError(KindExternalFiles,
+				fmt.Sprintf("files[%d].destination", i),
+				fmt.Sprintf("duplicate destination %q (also declared by files[%d]); two entries cannot install to the same path", dest, prevIdx))
+		}
+		seenDestinations[dest] = i
+	}
+	return nil
+}
+
+func (f *ExternalFile) validate(idx int) error {
+	prefix := fmt.Sprintf("files[%d]", idx)
+
+	if f.URL == "" {
+		return NewValidationError(KindExternalFiles, prefix+".url", "must not be empty")
+	}
+	if f.Algorithm == "" {
+		return NewValidationError(KindExternalFiles, prefix+".algorithm", "must not be empty")
+	}
+	if f.Checksum == "" {
+		return NewValidationError(KindExternalFiles, prefix+".checksum", "must not be empty")
+	}
+	if f.Destination == "" {
+		return NewValidationError(KindExternalFiles, prefix+".destination", "must not be empty")
+	}
+
+	switch f.Phase.Download {
+	case DownloadPhasePrepare, DownloadPhaseFreeze:
+	case "":
+		return NewValidationError(KindExternalFiles, prefix+".phase.download", "must not be empty")
+	default:
+		return NewValidationError(KindExternalFiles, prefix+".phase.download",
+			fmt.Sprintf("invalid value %q (must be %q or %q)", f.Phase.Download, DownloadPhasePrepare, DownloadPhaseFreeze))
+	}
+
+	switch f.Phase.Install {
+	case InstallPhaseFreeze:
+	case "":
+		return NewValidationError(KindExternalFiles, prefix+".phase.install", "must not be empty")
+	default:
+		return NewValidationError(KindExternalFiles, prefix+".phase.install",
+			fmt.Sprintf("invalid value %q (must be %q)", f.Phase.Install, InstallPhaseFreeze))
+	}
+
+	return nil
+}

--- a/pkg/manifests/external_files_test.go
+++ b/pkg/manifests/external_files_test.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package manifests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/require"
+)
+
+const fullExternalFilesManifest = `
+schemaVersion: v1
+files:
+  - url: "s3://hedera-artifacts/keys/genesis-key.bin"
+    algorithm: sha256
+    checksum: "abc123"
+    contentType: "application/octet-stream"
+    destination: "HAPIAPP_DIR/data/keys/genesis-key.bin"
+    phase:
+      download: prepare
+      install: freeze
+  - url: "https://example.org/cert.pem"
+    algorithm: sha256
+    checksum: "def456"
+    destination: "SOLO_PROVISIONER_DIR/certs/cert.pem"
+    optional: true
+    phase:
+      download: freeze
+      install: freeze
+`
+
+func TestParseExternalFiles_FullHappyPath(t *testing.T) {
+	doc, err := ParseExternalFiles([]byte(fullExternalFilesManifest))
+	require.NoError(t, err)
+	require.Equal(t, SchemaV1, doc.SchemaVersion)
+	require.Len(t, doc.Files, 2)
+
+	require.Equal(t, "s3://hedera-artifacts/keys/genesis-key.bin", doc.Files[0].URL)
+	require.Equal(t, "sha256", doc.Files[0].Algorithm)
+	require.Equal(t, "application/octet-stream", doc.Files[0].ContentType)
+	require.False(t, doc.Files[0].Optional, "optional defaults to false when absent")
+	require.Equal(t, DownloadPhasePrepare, doc.Files[0].Phase.Download)
+	require.Equal(t, InstallPhaseFreeze, doc.Files[0].Phase.Install)
+
+	require.True(t, doc.Files[1].Optional)
+	require.Equal(t, DownloadPhaseFreeze, doc.Files[1].Phase.Download)
+}
+
+func TestParseExternalFiles_EmptyFilesList(t *testing.T) {
+	// A manifest with no files declared is a structurally valid no-op.
+	doc, err := ParseExternalFiles([]byte("schemaVersion: v1\n"))
+	require.NoError(t, err)
+	require.Empty(t, doc.Files)
+}
+
+func TestParseExternalFiles_OptionalDefaultsFalse(t *testing.T) {
+	// The story specifies optional defaults to false. Verify yaml.v3 produces
+	// that result for an entry that omits optional entirely.
+	data := []byte(`
+schemaVersion: v1
+files:
+  - url: "s3://x/y"
+    algorithm: sha256
+    checksum: "z"
+    destination: "HAPIAPP_DIR/y"
+    phase:
+      download: prepare
+      install: freeze
+`)
+	doc, err := ParseExternalFiles(data)
+	require.NoError(t, err)
+	require.False(t, doc.Files[0].Optional)
+}
+
+func TestParseExternalFiles_RejectsUnknownTopLevelField(t *testing.T) {
+	_, err := ParseExternalFiles([]byte("schemaVersion: v1\nmysteryField: 1\n"))
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ParseError), "expected ParseError, got %v", err)
+}
+
+func TestParseExternalFiles_RejectsHIPHashFieldShape(t *testing.T) {
+	// The HIP draft used a single hash: "sha256:..." field; the story body
+	// for #533 supersedes that with separate algorithm + checksum fields.
+	// A manifest using the old shape must surface as a parse error.
+	data := []byte(`
+schemaVersion: v1
+files:
+  - url: "s3://x/y"
+    hash: "sha256:abc"
+    destination: "HAPIAPP_DIR/y"
+    phase: {download: prepare, install: freeze}
+`)
+	_, err := ParseExternalFiles(data)
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ParseError), "expected ParseError, got %v", err)
+}
+
+func TestParseExternalFiles_RejectsUnsupportedSchemaVersion(t *testing.T) {
+	_, err := ParseExternalFiles([]byte("schemaVersion: v2\n"))
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, UnsupportedSchemaVersionError),
+		"expected UnsupportedSchemaVersionError, got %v", err)
+}
+
+func TestParseExternalFiles_ValidationFailures(t *testing.T) {
+	base := func(over string) string {
+		// Build a minimal valid entry and overlay the specific failure shape.
+		return "schemaVersion: v1\nfiles:\n  - " + strings.TrimPrefix(over, "- ")
+	}
+
+	tests := []struct {
+		name          string
+		yaml          string
+		expectField   string
+		expectMessage string
+	}{
+		{
+			name: "missing url",
+			yaml: base(`- algorithm: sha256
+    checksum: "z"
+    destination: "HAPIAPP_DIR/y"
+    phase: {download: prepare, install: freeze}`),
+			expectField:   "files[0].url",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "missing algorithm",
+			yaml: base(`- url: "s3://x/y"
+    checksum: "z"
+    destination: "HAPIAPP_DIR/y"
+    phase: {download: prepare, install: freeze}`),
+			expectField:   "files[0].algorithm",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "missing checksum",
+			yaml: base(`- url: "s3://x/y"
+    algorithm: sha256
+    destination: "HAPIAPP_DIR/y"
+    phase: {download: prepare, install: freeze}`),
+			expectField:   "files[0].checksum",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "missing destination",
+			yaml: base(`- url: "s3://x/y"
+    algorithm: sha256
+    checksum: "z"
+    phase: {download: prepare, install: freeze}`),
+			expectField:   "files[0].destination",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "phase.download missing",
+			yaml: base(`- url: "s3://x/y"
+    algorithm: sha256
+    checksum: "z"
+    destination: "HAPIAPP_DIR/y"
+    phase: {install: freeze}`),
+			expectField:   "files[0].phase.download",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "phase.download invalid value",
+			yaml: base(`- url: "s3://x/y"
+    algorithm: sha256
+    checksum: "z"
+    destination: "HAPIAPP_DIR/y"
+    phase: {download: install, install: freeze}`),
+			expectField:   "files[0].phase.download",
+			expectMessage: `invalid value "install"`,
+		},
+		{
+			name: "phase.install missing",
+			yaml: base(`- url: "s3://x/y"
+    algorithm: sha256
+    checksum: "z"
+    destination: "HAPIAPP_DIR/y"
+    phase: {download: prepare}`),
+			expectField:   "files[0].phase.install",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "phase.install non-freeze value",
+			yaml: base(`- url: "s3://x/y"
+    algorithm: sha256
+    checksum: "z"
+    destination: "HAPIAPP_DIR/y"
+    phase: {download: prepare, install: prepare}`),
+			expectField:   "files[0].phase.install",
+			expectMessage: `invalid value "prepare"`,
+		},
+		{
+			name: "duplicate destinations",
+			yaml: `
+schemaVersion: v1
+files:
+  - url: "s3://x/a"
+    algorithm: sha256
+    checksum: "1"
+    destination: "HAPIAPP_DIR/a"
+    phase: {download: prepare, install: freeze}
+  - url: "s3://y/a"
+    algorithm: sha256
+    checksum: "2"
+    destination: "HAPIAPP_DIR/a"
+    phase: {download: prepare, install: freeze}
+`,
+			expectField:   "files[1].destination",
+			expectMessage: `duplicate destination "HAPIAPP_DIR/a"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseExternalFiles([]byte(tt.yaml))
+			require.Error(t, err)
+			require.True(t, errorx.IsOfType(err, ValidationError),
+				"expected ValidationError, got %v", err)
+			msg := err.Error()
+			require.Contains(t, msg, tt.expectField, "error should reference field path")
+			require.True(t, strings.Contains(msg, tt.expectMessage),
+				"expected message to contain %q, got %q", tt.expectMessage, msg)
+		})
+	}
+}
+
+func TestParseExternalFiles_RejectsMultipleYAMLDocuments(t *testing.T) {
+	data := []byte(`---
+schemaVersion: v1
+files:
+  - url: "s3://x/y"
+    algorithm: sha256
+    checksum: "z"
+    destination: "HAPIAPP_DIR/y"
+    phase: {download: prepare, install: freeze}
+---
+schemaVersion: v1
+files: []
+`)
+	_, err := ParseExternalFiles(data)
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ValidationError),
+		"expected ValidationError (extra YAML document), got %v", err)
+	require.Contains(t, err.Error(), "exactly one YAML document")
+}
+
+// Pins the contract that this parser does NOT enforce the specific allowed
+// destination marker prefixes (HAPIAPP_DIR, SOLO_PROVISIONER_DIR). That
+// strict-allowlist enforcement is the subject of #536, which is the
+// follow-on PR in this epic. Until then, any non-empty destination passes.
+func TestParseExternalFiles_DestinationPrefixNotYetEnforced(t *testing.T) {
+	data := []byte(`
+schemaVersion: v1
+files:
+  - url: "s3://x/y"
+    algorithm: sha256
+    checksum: "z"
+    destination: "/absolute/path/elsewhere.bin"
+    phase: {download: prepare, install: freeze}
+`)
+	_, err := ParseExternalFiles(data)
+	require.NoError(t, err, "destination allowlist enforcement is deferred to #536")
+}


### PR DESCRIPTION
## Summary

- Third parser under epic #501. Strict-decodes `external-files.yaml` — the manifest declaring large remote files (over the ~1 MB ConfigurationFile-CR limit) that the upgrade-controller sidecar or `solo-provisioner-upgrade` daemon downloads and stages before a CN restart.
- Each entry validates: non-empty `url` + `algorithm` + `checksum` + `destination`; `phase.download ∈ {prepare, freeze}`; `phase.install = freeze` (the only legal value today); `optional` defaults to `false`.
- **Duplicate destinations across `files[]` are rejected** — two entries cannot install to the same path. The error message names both indices so the operator knows which two lines to look at.
- **Supersedes HIP draft `hash:` field** with separate `algorithm` + `checksum` (matching `pkg/software/config.go::Checksum` and #638's `Binary`). HIP-shape `hash:` now fails parsing.

### Scope boundary with #536

This PR validates `destination` is non-empty. Story **#536** adds the strict allowlist of marker prefixes (`HAPIAPP_DIR`, `SOLO_PROVISIONER_DIR`) on top. `TestParseExternalFiles_DestinationPrefixNotYetEnforced` pins the boundary — that test will be replaced (not deleted) in #536 with assertions of the strict allowlist, making the policy transition auditable in the diff.

### Stacked PR

This PR sits at the top of the stack: `00501-…` ← #634 ← #636 ← #638 ← **this PR**. All four target the epic branch via the chain; GitHub auto-retargets each downstream PR as upstreams merge.

Closes #533. Refs #501.

## Test plan

- [x] `go test -race -cover -tags='!integration' ./pkg/manifests/...` → all green, **98.8%** statement coverage (up from 98.5% in #638)
- [x] `task lint` — clean
- [ ] CI passes on this PR
- [ ] Reviewer reads `pkg/manifests/external_files.go` against [the review guide](docs/claude/reviews/00533-external-files-parser.md). Particular attention to: the typed `DownloadPhase`/`InstallPhase` enums, duplicate-destination check, and the scope boundary with #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)