### PR TITLE
feat(manifests): add state-sources.yaml parser

### DIFF
--- a/docs/claude/reviews/00534-state-sources-parser.md
+++ b/docs/claude/reviews/00534-state-sources-parser.md
@@ -1,0 +1,56 @@
+# #534 — Review guide: state-sources.yaml parser
+
+> **Issue:** https://github.com/hashgraph/solo-weaver/issues/534
+> **Epic:** https://github.com/hashgraph/solo-weaver/issues/501
+> **Branch:** `00534-state-sources-parser`
+> **Base:** `00533-external-files-parser` (stacked; auto-retargets up the chain as upstream PRs merge)
+
+## Problem and solution
+
+`state-sources.yaml` declares the cloud storage locations from which a new or rejoining consensus node can fast-sync the latest saved-state snapshot — avoiding a full replay of the event stream from genesis. Multiple buckets across GCS, S3, and different regions are listed for redundancy and geographic locality. For each bucket, two parallel maps keyed by node ID locate the per-node index file (which names the latest available round) and the per-node base path (under which the round's state files live).
+
+The parser strict-decodes the YAML and validates per source: `bucket` non-empty; `type ∈ {gcs, s3}`; `location` non-empty; `index` and `paths` both non-empty maps; *and* their key sets must match exactly (an index pointing at a node with no path is unfollowable; a path with no index has no latest-round pointer). Bucket URLs are unique across sources — two entries pointing at the same bucket would be ambiguous.
+
+### Stacked-PR layout
+
+At the top of the four-parser stack: `00501-…` ← #634 (#535) ← #636 (#531) ← #638 (#532) ← #639 (#533) ← **this PR**. All five target the epic branch via the chain; GitHub auto-retargets each downstream PR as upstreams merge.
+
+This PR is the first concrete consumer of the `decodeStrictSingleYAMLDoc` helper introduced in #636's amend pass — written from the start to use it (the three earlier parsers were retrofitted via the cascade).
+
+## Changed files
+
+| File | What changed |
+|---|---|
+| `pkg/manifests/state_sources.go` (new) | Types (`StateSources`, `StateSource`, `BucketType`), `ParseStateSources`, per-source validation including index/paths key-set consistency and cross-source bucket uniqueness |
+| `pkg/manifests/state_sources_test.go` (new) | Happy path, empty-stateSources no-op, schemaVersion gate (including the HIP-shape `version:` rejection), strict-decode + multi-doc rejection, 10 table-driven validation-failure cases, same-node-across-buckets-allowed pin |
+| `docs/claude/reviews/00534-state-sources-parser.md` (new) | This guide |
+
+## Code review checklist
+
+- [ ] **`BucketType` is a typed constant.** Validation switches on `BucketTypeGCS` / `BucketTypeS3`; an unknown value yields a clear error naming both the offending value and the supported set.
+- [ ] **`Sources` is the Go field name; YAML key is `stateSources`.** Avoids the package-level naming collision with the `StateSources` struct itself while preserving the on-disk schema.
+- [ ] **`validateNodeKeysMatch` enforces set equality between `index` and `paths`.** Sorted alphabetically before reporting, so the same node name appears in the error on every run. Two dedicated test cases pin both directions (missing from paths; missing from index).
+- [ ] **Cross-source bucket uniqueness.** Duplicate buckets across `stateSources[]` are rejected with a message naming the previous index, mirroring the duplicate-destination pattern in #533.
+- [ ] **Same node ID across multiple buckets is allowed.** That's the whole point of multi-bucket redundancy. `TestParseStateSources_SameNodeAcrossBucketsAllowed` pins it.
+- [ ] **Empty `stateSources:` is valid.** Some networks may not use fast-sync; the parser must not require at least one source. `TestParseStateSources_EmptyStateSourcesTolerated` pins it.
+- [ ] **HIP `version: v1` rejection is via the schemaVersion validator**, not via strict-decode. `version:` is silently ignored at the schemaVersion stage (the validator inspects only `schemaVersion`), so the manifest surfaces as `MissingSchemaVersionError`. The test names this contract explicitly.
+
+## Test commands
+
+```bash
+# Unit tests (this PR brings the package to 97.8% coverage with the parser + 30 tests)
+go test -race -cover -tags='!integration' ./pkg/manifests/...
+
+# Lint pipeline (errorx gate, gofmt)
+task lint:check
+```
+
+Expected:
+
+```
+ok      github.com/hashgraph/solo-weaver/pkg/manifests    coverage: 97.8% of statements
+```
+
+## Manual UAT
+
+No CLI surface, no daemon hook. The fixture at the top of `pkg/manifests/state_sources_test.go` (`fullStateSourcesManifest`) is the canonical reference shape, mirroring the example in the HIP for `state-sources.yaml`. The intended user-facing behaviour surfaces once a follow-on story wires this parser into the daemon's fast-sync bootstrap flow.

--- a/pkg/manifests/state_sources.go
+++ b/pkg/manifests/state_sources.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package manifests
+
+import (
+	"fmt"
+	"sort"
+)
+
+// StateSources is the parsed root of a state-sources.yaml manifest. It
+// declares one or more cloud storage buckets from which a new or rejoining
+// consensus node can fast-sync the latest saved-state snapshot rather than
+// replaying the entire event stream from genesis. Multiple buckets are
+// listed for redundancy and geographic locality.
+type StateSources struct {
+	Header  `yaml:",inline"`
+	Sources []StateSource `yaml:"stateSources,omitempty"`
+}
+
+// StateSource is one cloud-storage entry. Each source declares its location
+// (region), the bucket URL, and two parallel maps keyed by node ID: Index
+// names the per-node index file containing the latest available round, and
+// Paths names the per-node base directory where that round's state files
+// live.
+type StateSource struct {
+	Bucket   string            `yaml:"bucket"`
+	Type     BucketType        `yaml:"type"`
+	Location string            `yaml:"location"`
+	Index    map[string]string `yaml:"index"`
+	Paths    map[string]string `yaml:"paths"`
+}
+
+// BucketType enumerates the cloud-storage backends recognised today.
+// Extending this set requires adding the case here and (separately) wiring
+// the downloader to authenticate against the new backend.
+type BucketType string
+
+const (
+	BucketTypeGCS BucketType = "gcs"
+	BucketTypeS3  BucketType = "s3"
+)
+
+// ParseStateSources parses raw YAML bytes of a state-sources.yaml manifest.
+// It runs the cross-cutting schemaVersion check first, then strict-decodes
+// the single YAML document (unknown top-level fields fail; multi-document
+// inputs are rejected), then runs per-source semantic validation.
+func ParseStateSources(data []byte) (*StateSources, error) {
+	if _, err := ValidateSchemaVersion(KindStateSources, data); err != nil {
+		return nil, err
+	}
+
+	var doc StateSources
+	if err := decodeStrictSingleYAMLDoc(KindStateSources, data, &doc); err != nil {
+		return nil, err
+	}
+
+	if err := doc.validate(); err != nil {
+		return nil, err
+	}
+	return &doc, nil
+}
+
+// validate enforces per-source invariants and the cross-source uniqueness
+// rule on bucket URLs (two stateSources[] entries pointing at the same
+// bucket would be ambiguous and almost certainly a manifest authoring
+// mistake).
+func (ss *StateSources) validate() error {
+	seenBuckets := make(map[string]int, len(ss.Sources))
+	for i := range ss.Sources {
+		if err := ss.Sources[i].validate(i); err != nil {
+			return err
+		}
+		bucket := ss.Sources[i].Bucket
+		if prevIdx, dup := seenBuckets[bucket]; dup {
+			return NewValidationError(KindStateSources,
+				fmt.Sprintf("stateSources[%d].bucket", i),
+				fmt.Sprintf("duplicate bucket %q (also declared by stateSources[%d])", bucket, prevIdx))
+		}
+		seenBuckets[bucket] = i
+	}
+	return nil
+}
+
+func (s *StateSource) validate(idx int) error {
+	prefix := fmt.Sprintf("stateSources[%d]", idx)
+
+	if s.Bucket == "" {
+		return NewValidationError(KindStateSources, prefix+".bucket", "must not be empty")
+	}
+	switch s.Type {
+	case BucketTypeGCS, BucketTypeS3:
+	case "":
+		return NewValidationError(KindStateSources, prefix+".type", "must not be empty")
+	default:
+		return NewValidationError(KindStateSources, prefix+".type",
+			fmt.Sprintf("invalid value %q (must be %q or %q)", s.Type, BucketTypeGCS, BucketTypeS3))
+	}
+	if s.Location == "" {
+		return NewValidationError(KindStateSources, prefix+".location", "must not be empty")
+	}
+
+	if len(s.Index) == 0 {
+		return NewValidationError(KindStateSources, prefix+".index", "must declare at least one node")
+	}
+	if len(s.Paths) == 0 {
+		return NewValidationError(KindStateSources, prefix+".paths", "must declare at least one node")
+	}
+
+	// Every node must appear in both index and paths — an index pointing at a
+	// node with no path is unfollowable, and a path with no index has no
+	// "latest round" pointer.
+	if err := validateNodeKeysMatch(prefix, s.Index, s.Paths); err != nil {
+		return err
+	}
+	if err := validateMapEntriesNonEmpty(prefix+".index", s.Index); err != nil {
+		return err
+	}
+	if err := validateMapEntriesNonEmpty(prefix+".paths", s.Paths); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateNodeKeysMatch enforces that index and paths declare exactly the
+// same set of node IDs. Mismatches are surfaced with the offending node ID
+// named explicitly so the manifest author knows which row to fix.
+func validateNodeKeysMatch(prefix string, index, paths map[string]string) error {
+	missingFromPaths := sortedMissingKeys(index, paths)
+	for _, node := range missingFromPaths {
+		return NewValidationError(KindStateSources, prefix+".paths",
+			fmt.Sprintf("node %q is listed in index but missing from paths", node))
+	}
+	missingFromIndex := sortedMissingKeys(paths, index)
+	for _, node := range missingFromIndex {
+		return NewValidationError(KindStateSources, prefix+".index",
+			fmt.Sprintf("node %q is listed in paths but missing from index", node))
+	}
+	return nil
+}
+
+// sortedMissingKeys returns the keys present in have but absent from want,
+// sorted alphabetically so error messages name the same node on repeat runs.
+func sortedMissingKeys(have, want map[string]string) []string {
+	missing := make([]string, 0)
+	for k := range have {
+		if _, ok := want[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+func validateMapEntriesNonEmpty(fieldPath string, m map[string]string) error {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if k == "" {
+			return NewValidationError(KindStateSources, fieldPath, "node ID key must not be empty")
+		}
+		if m[k] == "" {
+			return NewValidationError(KindStateSources, fieldPath+"."+k, "must not be empty")
+		}
+	}
+	return nil
+}

--- a/pkg/manifests/state_sources_test.go
+++ b/pkg/manifests/state_sources_test.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package manifests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/require"
+)
+
+const fullStateSourcesManifest = `
+schemaVersion: v1
+stateSources:
+  - bucket: "https://storage.googleapis.com/mainnet-state-backups"
+    type: gcs
+    location: "us-central-1"
+    index:
+      "council-node-1": "/current-node/council-node-1.txt"
+      "council-node-2": "/current-node/council-node-2.txt"
+      "council-node-3": "/current-node/council-node-3.txt"
+    paths:
+      "council-node-1": "/council-node-1"
+      "council-node-2": "/council-node-2"
+      "council-node-3": "/council-node-3"
+  - bucket: "https://s3.cloud.com/mainnet"
+    type: s3
+    location: "ap-southeast-1"
+    index:
+      "council-node-11": "/current-node/council-node-11.txt"
+      "council-node-12": "/current-node/council-node-12.txt"
+    paths:
+      "council-node-11": "/council-node-11"
+      "council-node-12": "/council-node-12"
+`
+
+func TestParseStateSources_FullHappyPath(t *testing.T) {
+	doc, err := ParseStateSources([]byte(fullStateSourcesManifest))
+	require.NoError(t, err)
+	require.Equal(t, SchemaV1, doc.SchemaVersion)
+	require.Len(t, doc.Sources, 2)
+
+	require.Equal(t, BucketTypeGCS, doc.Sources[0].Type)
+	require.Equal(t, "us-central-1", doc.Sources[0].Location)
+	require.Len(t, doc.Sources[0].Index, 3)
+	require.Equal(t, "/current-node/council-node-1.txt", doc.Sources[0].Index["council-node-1"])
+	require.Equal(t, "/council-node-1", doc.Sources[0].Paths["council-node-1"])
+
+	require.Equal(t, BucketTypeS3, doc.Sources[1].Type)
+	require.Len(t, doc.Sources[1].Index, 2)
+}
+
+func TestParseStateSources_EmptyStateSourcesTolerated(t *testing.T) {
+	// A manifest with no stateSources is a structurally valid no-op — e.g.
+	// some networks may not use fast-sync.
+	doc, err := ParseStateSources([]byte("schemaVersion: v1\n"))
+	require.NoError(t, err)
+	require.Empty(t, doc.Sources)
+}
+
+func TestParseStateSources_RejectsUnknownTopLevelField(t *testing.T) {
+	_, err := ParseStateSources([]byte("schemaVersion: v1\nmysteryField: 1\n"))
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ParseError), "expected ParseError, got %v", err)
+}
+
+func TestParseStateSources_RejectsHIPVersionField(t *testing.T) {
+	// The HIP draft used `version: v1` at the top level for this manifest;
+	// the unified convention across all four manifests is schemaVersion.
+	data := []byte(`
+version: v1
+stateSources: []
+`)
+	_, err := ParseStateSources(data)
+	require.Error(t, err)
+	// Missing schemaVersion is caught by the cross-cutting validator (not
+	// by strict-decode), so this surfaces as MissingSchemaVersionError —
+	// "version: v1" is silently ignored at the schemaVersion stage and the
+	// schemaVersion field itself is absent.
+	require.True(t, errorx.IsOfType(err, MissingSchemaVersionError),
+		"expected MissingSchemaVersionError, got %v", err)
+}
+
+func TestParseStateSources_RejectsUnsupportedSchemaVersion(t *testing.T) {
+	_, err := ParseStateSources([]byte("schemaVersion: v2\n"))
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, UnsupportedSchemaVersionError),
+		"expected UnsupportedSchemaVersionError, got %v", err)
+}
+
+func TestParseStateSources_RejectsMultipleYAMLDocuments(t *testing.T) {
+	data := []byte(`---
+schemaVersion: v1
+stateSources: []
+---
+schemaVersion: v1
+`)
+	_, err := ParseStateSources(data)
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, ValidationError),
+		"expected ValidationError (extra YAML document), got %v", err)
+	require.Contains(t, err.Error(), "exactly one YAML document")
+}
+
+func TestParseStateSources_ValidationFailures(t *testing.T) {
+	tests := []struct {
+		name          string
+		yaml          string
+		expectField   string
+		expectMessage string
+	}{
+		{
+			name: "missing bucket",
+			yaml: `
+schemaVersion: v1
+stateSources:
+  - type: gcs
+    location: "us-central-1"
+    index: {n1: "/i.txt"}
+    paths: {n1: "/p"}
+`,
+			expectField:   "stateSources[0].bucket",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "missing type",
+			yaml: `
+schemaVersion: v1
+stateSources:
+  - bucket: "gs://x"
+    location: "us-central-1"
+    index: {n1: "/i.txt"}
+    paths: {n1: "/p"}
+`,
+			expectField:   "stateSources[0].type",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "invalid type",
+			yaml: `
+schemaVersion: v1
+stateSources:
+  - bucket: "gs://x"
+    type: azure
+    location: "us-central-1"
+    index: {n1: "/i.txt"}
+    paths: {n1: "/p"}
+`,
+			expectField:   "stateSources[0].type",
+			expectMessage: `invalid value "azure"`,
+		},
+		{
+			name: "missing location",
+			yaml: `
+schemaVersion: v1
+stateSources:
+  - bucket: "gs://x"
+    type: gcs
+    index: {n1: "/i.txt"}
+    paths: {n1: "/p"}
+`,
+			expectField:   "stateSources[0].location",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "empty index",
+			yaml: `
+schemaVersion: v1
+stateSources:
+  - bucket: "gs://x"
+    type: gcs
+    location: "us-central-1"
+    index: {}
+    paths: {n1: "/p"}
+`,
+			expectField:   "stateSources[0].index",
+			expectMessage: "must declare at least one node",
+		},
+		{
+			name: "empty paths",
+			yaml: `
+schemaVersion: v1
+stateSources:
+  - bucket: "gs://x"
+    type: gcs
+    location: "us-central-1"
+    index: {n1: "/i.txt"}
+    paths: {}
+`,
+			expectField:   "stateSources[0].paths",
+			expectMessage: "must declare at least one node",
+		},
+		{
+			name: "node listed in index but missing from paths",
+			yaml: `
+schemaVersion: v1
+stateSources:
+  - bucket: "gs://x"
+    type: gcs
+    location: "us-central-1"
+    index: {n1: "/i1", n2: "/i2"}
+    paths: {n1: "/p1"}
+`,
+			expectField:   "stateSources[0].paths",
+			expectMessage: `node "n2" is listed in index but missing from paths`,
+		},
+		{
+			name: "node listed in paths but missing from index",
+			yaml: `
+schemaVersion: v1
+stateSources:
+  - bucket: "gs://x"
+    type: gcs
+    location: "us-central-1"
+    index: {n1: "/i1"}
+    paths: {n1: "/p1", n2: "/p2"}
+`,
+			expectField:   "stateSources[0].index",
+			expectMessage: `node "n2" is listed in paths but missing from index`,
+		},
+		{
+			name: "empty value in index",
+			yaml: `
+schemaVersion: v1
+stateSources:
+  - bucket: "gs://x"
+    type: gcs
+    location: "us-central-1"
+    index: {n1: ""}
+    paths: {n1: "/p1"}
+`,
+			expectField:   "stateSources[0].index.n1",
+			expectMessage: "must not be empty",
+		},
+		{
+			name: "duplicate bucket across sources",
+			yaml: `
+schemaVersion: v1
+stateSources:
+  - bucket: "gs://x"
+    type: gcs
+    location: "us-central-1"
+    index: {n1: "/i"}
+    paths: {n1: "/p"}
+  - bucket: "gs://x"
+    type: gcs
+    location: "us-east-1"
+    index: {n2: "/i"}
+    paths: {n2: "/p"}
+`,
+			expectField:   "stateSources[1].bucket",
+			expectMessage: `duplicate bucket "gs://x"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseStateSources([]byte(tt.yaml))
+			require.Error(t, err)
+			require.True(t, errorx.IsOfType(err, ValidationError),
+				"expected ValidationError, got %v", err)
+			msg := err.Error()
+			require.Contains(t, msg, tt.expectField, "error should reference field path")
+			require.True(t, strings.Contains(msg, tt.expectMessage),
+				"expected message to contain %q, got %q", tt.expectMessage, msg)
+		})
+	}
+}
+
+// The same node ID can legitimately appear in multiple buckets — that's the
+// whole point of multi-bucket redundancy. Pin that behaviour.
+func TestParseStateSources_SameNodeAcrossBucketsAllowed(t *testing.T) {
+	data := []byte(`
+schemaVersion: v1
+stateSources:
+  - bucket: "gs://primary"
+    type: gcs
+    location: "us-central-1"
+    index: {n1: "/i", n2: "/i"}
+    paths: {n1: "/p", n2: "/p"}
+  - bucket: "s3://mirror"
+    type: s3
+    location: "ap-southeast-1"
+    index: {n1: "/i", n2: "/i"}
+    paths: {n1: "/p", n2: "/p"}
+`)
+	_, err := ParseStateSources(data)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Fourth and final concrete parser under epic #501. Strict-decodes `state-sources.yaml`, which declares the cloud-storage buckets a new or rejoining CN can fast-sync the latest saved-state snapshot from.
- Per-source validation: non-empty `bucket`; `type ∈ {gcs, s3}`; non-empty `location`; non-empty `index` and `paths` maps.
- **Index/paths key-set equality**: every node ID in `index` must also appear in `paths` and vice-versa. An index entry with no paths counterpart is unfollowable; a paths entry with no index counterpart has no "latest round" pointer. Both directions are pinned by dedicated tests.
- **Cross-source bucket uniqueness**: two `stateSources[]` entries pointing at the same bucket are rejected (the second one would be ambiguous). The same *node ID* across different buckets is allowed — that's the whole point of multi-bucket redundancy.
- First concrete consumer of the `decodeStrictSingleYAMLDoc` helper from #636's amend pass (the three earlier parsers were retrofitted via the cascade rebase).

### Stacked PR

Top of the four-parser stack: `00501-…` ← #634 ← #636 ← #638 ← #639 ← **this PR**. All five target the epic branch via the chain; GitHub auto-retargets each downstream PR as upstreams merge.

Closes #534. Refs #501.

## Test plan

- [x] `go test -race -cover -tags='!integration' ./pkg/manifests/...` → all green, **97.8%** statement coverage
- [x] `task lint` — clean
- [ ] CI passes on this PR
- [ ] Reviewer reads `pkg/manifests/state_sources.go` against [the review guide](docs/claude/reviews/00534-state-sources-parser.md). Particular attention to: index/paths set-equality enforcement, cross-source bucket-uniqueness check, and the same-node-across-buckets pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)