### PR TITLE
fix(vm): replace 9p shared mount with rsync sync to /mnt/solo-weaver

### DIFF
--- a/docs/claude/plans/00616-replace-9p-with-rsync-sync.md
+++ b/docs/claude/plans/00616-replace-9p-with-rsync-sync.md
@@ -1,0 +1,103 @@
+# #616 — Replace VM 9p shared mount with rsync-based sync for `/mnt/solo-weaver`
+
+> **Issue:** https://github.com/hashgraph/solo-weaver/issues/616
+> **Story branch:** `00616-replace-9p-with-rsync-sync`
+> **PR base:** `main` (branched from `origin/main` @ `f07505c`)
+> **PR closes:** #616
+
+## Summary
+
+The UTM VM currently sees the host source tree via virtio-9p at `/mnt/solo-weaver`, configured via an `/etc/fstab` entry in `vm:configure:ssh`. virtio-9p on macOS+UTM is flaky (stalls, permission glitches) and — more importantly — it silently keeps pointing at the worktree path that was active the first time the VM was provisioned. Switching to a sibling worktree under `solo-weaver-wt/` leaves the VM looking at the old tree, so newly added files are invisible despite a successful host build.
+
+This PR replaces the 9p mount with a one-way rsync from host → VM, keeping `/mnt/solo-weaver` as the in-VM path so the ~52 references in tasks, UAT scripts, docs, and `scripts/debug-vm-run.sh` stay untouched. A new `task vm:sync` wraps the rsync; it is wired as a dep on the host-side tasks that expect fresh code in the VM (`vm:test:unit`, `vm:test:integration`, `vm:alloy:start`, `vm:teleport:start`, `vm:configure:tools`, `vm:debug:test`, `vm:debug:app`). CI is unaffected — `.github/workflows/zxc-uat-test.yaml` already rsyncs to `/home/provisioner/solo-weaver/` and symlinks `/mnt/solo-weaver`, so local now converges on the same shape.
+
+## Problem
+
+Current state in `taskfiles/vm.yaml:437-446` (inside `vm:configure:ssh`):
+
+```bash
+echo 'Mounting shared directory...'
+sudo mkdir -p /mnt/solo-weaver
+if ! grep -q '/mnt/solo-weaver' /etc/fstab; then
+  echo 'share   /mnt/solo-weaver   9p  trans=virtio,version=9p2000.L,rw,nofail 0   0' \
+    | sudo tee -a /etc/fstab >/dev/null
+fi
+sudo mount -a || true
+```
+
+Failure modes from the issue:
+
+1. **Worktree switching is invisible to the VM.** The `share` tag in the 9p mount is bound to whichever host directory UTM had registered when the VM was first provisioned. Switching to another `solo-weaver-wt/<branch>/` worktree on the host does not retarget the mount, so the VM keeps building against the original tree.
+2. **virtio-9p is intermittently flaky on macOS+UTM** — stalls and permission glitches, especially on restricted networks.
+
+CI already avoids 9p (`.github/workflows/zxc-uat-test.yaml:380-405` rsyncs to `/home/provisioner/solo-weaver/` and symlinks `/mnt/solo-weaver`), so this PR closes the local↔CI divergence too.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Keep the in-VM path as `/mnt/solo-weaver`? | **Yes.** Issue explicitly says minimize churn across ~52 references. A pure plumbing change. |
+| One-way or two-way sync? | **One-way (host → VM).** Source of truth is the host worktree. Two-way needs conflict resolution that's not needed here. |
+| `rsync --delete`? | **Yes.** Without it, files removed on a branch switch linger in the VM and confuse builds. Build artifacts that live outside `/mnt/solo-weaver` (system Go, `/tmp/*`) are unaffected. |
+| Should `vm:sync` run automatically on `vm:start`? | **No.** Make it explicit. The user invokes `task vm:sync` after worktree switches; task-level deps cover the hot-path test/UAT tasks. Auto-syncing on every `vm:start` would surprise users who just want to SSH into a running VM. |
+| Clean up existing 9p fstab entries on already-provisioned VMs? | **Yes.** `vm:configure:ssh` now removes any `^.*\s/mnt/solo-weaver\s.*9p` line from `/etc/fstab` and unmounts the path if currently a 9p mountpoint, then chowns it to `provisioner`. Safe to re-run. |
+| Same rsync excludes as CI? | **Mostly different.** CI excludes `vendor/` and `bin/` because it rebuilds inside the VM; locally the dev typically builds on the host (`task build:cli GOOS=linux GOARCH=arm64`) and expects `bin/solo-provisioner-linux-arm64` to be visible in the VM. Local excludes: `.git`, `.ssh`, `*.iso`, `*.img`, `*.qcow2`, `*.log`, `.DS_Store`. Keep `vendor/` and `bin/`. |
+| Use `{{.VM_USER}}` (provisioner) as the rsync target? | **Yes.** Existing tasks SSH as `provisioner` with `{{.SSH_PRIVATE_KEY}}`/`{{.SSH_OPTS}}`. `vm:configure:ssh` chowns `/mnt/solo-weaver` to `provisioner:provisioner` so plain rsync writes without sudo. |
+
+## Scope
+
+### `taskfiles/vm.yaml`
+
+- [ ] In `vm:configure:ssh` (the inner SSH heredoc at lines ~437-446): replace the 9p block with: remove any `9p` line for `/mnt/solo-weaver` from `/etc/fstab`, unmount the path if currently a 9p mountpoint, ensure `/mnt/solo-weaver` exists as a plain directory, `chown -R provisioner:provisioner /mnt/solo-weaver`.
+- [ ] Add new task `vm:sync` (deps `[vm:start]`) that runs `rsync -az --delete` from `./` (host cwd) → `provisioner@<vm-ip>:/mnt/solo-weaver/` with the excludes listed above, using `{{.SSH_PRIVATE_KEY}}` / `{{.SSH_OPTS}}` for the SSH transport, and the existing `{{.GET_VM_IP}}` helper for IP resolution.
+- [ ] Add `vm:sync` as a dep to `vm:configure:tools` (so its `cd /mnt/solo-weaver && task install:go` finds the tree on first-time setup).
+- [ ] Add `vm:sync` as a dep to `vm:debug:test` and `vm:debug:app` (they SSH in and run dlv against `/mnt/solo-weaver`).
+
+### `taskfiles/tests.yaml`
+
+- [ ] Add `vm:sync` to the `deps` of `vm:test:unit`.
+- [ ] Add `vm:sync` to the `deps` of `vm:test:integration`.
+
+### `taskfiles/alloy.yaml`
+
+- [ ] Add `vm:sync` to the `deps` of `vm:alloy:start` (and optionally `vm:alloy:stop` / `vm:alloy:clean` — both ssh in and `cd /mnt/solo-weaver`).
+
+### `taskfiles/teleport.yaml`
+
+- [ ] Add `vm:sync` to the `deps` of `vm:teleport:start` (and optionally `vm:teleport:stop` / `vm:teleport:clean`).
+
+### `docs/dev/quickstart.md`
+
+- [ ] Add `rsync` to the requirements list (it's already listed — keep). Add a "Syncing host changes into the VM" subsection explaining that `task vm:sync` is required after host edits or worktree switches.
+- [ ] Update the "Setup VM" section to remove the wording about the UTM shared folder restart prompt that's currently in `vm:download:golden` ("👉 Please restart UTM to reload VMs and set up the shared solo-weaver directory"). That message in `taskfiles/vm.yaml:124` and `:190` becomes misleading once 9p is gone; rewrite to point at `task vm:sync`. *(Note: this is a `vm.yaml` change too, not just docs — moving the bullet here for visibility.)*
+
+### `docs/dev/acceptance-tests.md`
+
+- [ ] Add `task vm:sync` to the prerequisites block (line 28-32) after `task vm:start` / `task proxy:start` / `task build:cli`.
+
+## Out of scope
+
+- Removing or renaming `/mnt/solo-weaver` as the in-VM path. Issue explicitly preserves it.
+- Changes to `.github/workflows/zxc-uat-test.yaml` or `.github/workflows/zxc-integration-test.yaml` — they already use rsync; the virtio references there are for the disk/NIC, not 9p.
+- File-watcher / continuous sync (e.g. `fswatch` + auto-rsync). Manual `task vm:sync` is the agreed UX. Easy to add later if needed.
+- Two-way sync or in-VM editing workflow.
+- Pruning the existing `bin/` from sync (CI does, local doesn't) — see decision above.
+
+## Test plan
+
+- [ ] Unit: no code under `internal/` / `pkg/` / `cmd/` changes, so no Go unit tests are affected. `task lint` runs as the formatting gate (project rule).
+- [ ] Manual UAT (UTM VM):
+  - [ ] `task vm:reset` against a fresh golden image → succeeds with no 9p in `/etc/fstab` and `/mnt/solo-weaver` is a plain directory owned by `provisioner`.
+  - [ ] `task vm:test:unit` → triggers `vm:sync`, then unit tests pass inside the VM.
+  - [ ] Worktree switch test: edit a file (`echo "// scratch" >> internal/state/some_file.go`) in this worktree → switch to a different worktree directory on the host that does NOT have that change → from there run `task vm:sync` → SSH in and confirm `/mnt/solo-weaver/internal/state/some_file.go` matches the new worktree's content (no leftover `// scratch`). This is the worktree-switching scenario from the issue.
+  - [ ] `task vm:ssh:proxy` → inside VM: `task uat:lifecycle`. Should pass.
+  - [ ] `grep -q /mnt/solo-weaver /etc/fstab` inside the VM after `vm:reset` → returns nothing.
+- [ ] CI: unchanged workflows — confirm the existing `zxc-uat-test.yaml` and `zxc-integration-test.yaml` runs stay green.
+
+## Risks / rollbacks
+
+- **Initial sync slow vs 9p.** First `task vm:sync` rsyncs the whole tree (~100 MB minus excludes). Subsequent syncs are incremental and fast. Acceptable trade.
+- **Disk usage doubles.** Files now exist on host AND in VM (vs 9p where the VM read host files directly). ~100 MB extra in the VM disk — negligible vs the multi-GB VM image.
+- **Forgetting `task vm:sync` after edits.** Mitigated by wiring deps on the hot-path test/UAT tasks. The escape hatch is `task vm:ssh` → which won't auto-sync. Documented in quickstart.
+- **Pre-existing 9p mount on a dev's VM.** `vm:configure:ssh` cleans up fstab + unmounts. If a dev does not re-run `vm:reset`, their VM keeps the old 9p mount until they do — `task vm:sync` itself would just rsync over the 9p mount, which... actually works, but defeats the purpose. Mitigation: call out in the PR description that existing devs should run `task vm:reset` once.
+- **Rollback:** revert the PR; the 9p fstab entry comes back; `vm:reset` re-mounts as before. No data loss.

--- a/docs/claude/reviews/00616-replace-9p-with-rsync-sync.md
+++ b/docs/claude/reviews/00616-replace-9p-with-rsync-sync.md
@@ -1,0 +1,148 @@
+# #616 — Replace VM 9p shared mount with rsync-based sync
+
+## Summary
+
+**Problem.** The UTM VM mounted the host source tree via virtio-9p at `/mnt/solo-weaver`, configured in
+`vm:configure:ssh`. The 9p mount is bound to whichever host directory UTM had registered the first time the VM was
+provisioned, so switching git worktrees on the host left the VM looking at the original tree — newly added files were
+invisible despite a successful host build. virtio-9p on macOS+UTM was also intermittently flaky.
+
+**Solution.** Drop the 9p `/etc/fstab` entry; instead, populate `/mnt/solo-weaver` via a new `task vm:sync` that
+`rsync -az --delete`s the host worktree into the VM. The in-VM path stays `/mnt/solo-weaver`, so ~52 references in
+tasks, UAT scripts, docs, and `scripts/debug-vm-run.sh` are unchanged. `vm:sync` is wired as a dep on the host-side
+tasks that need fresh code in the VM. CI is unaffected — `.github/workflows/zxc-uat-test.yaml` already rsyncs +
+symlinks `/mnt/solo-weaver`, so local now matches CI.
+
+**Upgrade path for existing dev VMs:** `task vm:reset` once. Clones from the golden image, so the legacy 9p fstab
+entry is left behind on the old working VM (which gets destroyed by `vm:reset`).
+
+## Changed files
+
+| File | Change |
+|---|---|
+| `taskfiles/vm.yaml` | `vm:configure:ssh`: drop 9p fstab block, `chown /mnt/solo-weaver` to `provisioner`. Add new `vm:sync` task. Add `vm:sync` dep to `vm:debug:test`, `vm:debug:app`, `vm:configure:tools`. Rewrite "restart UTM" banner in `vm:download:golden` to drop the obsolete "set up shared folder" wording. |
+| `taskfiles/tests.yaml` | Add `vm:sync` to deps of `vm:test:unit` and `vm:test:integration`. |
+| `taskfiles/alloy.yaml` | Add `vm:sync` to deps of `vm:alloy:start`, `vm:alloy:stop`, `vm:alloy:clean`. |
+| `taskfiles/teleport.yaml` | Add `vm:sync` to deps of `vm:teleport:start`, `vm:teleport:stop`, `vm:teleport:clean`. |
+| `docs/dev/quickstart.md` | Drop obsolete "set up shared folder" wording. Add new section "Syncing host changes into the VM" explaining `task vm:sync`. Renumber section 2 → 3. |
+| `docs/dev/acceptance-tests.md` | Add `task vm:sync` to the prerequisites bullet list. |
+| `docs/claude/plans/00616-replace-9p-with-rsync-sync.md` | Implementation plan (drafted before code changes per project convention). |
+| `docs/claude/reviews/00616-replace-9p-with-rsync-sync.md` | This file. |
+
+## Code review checklist
+
+- [ ] `vm:configure:ssh` no longer writes a 9p line to `/etc/fstab`; `/mnt/solo-weaver` is just `mkdir -p` + `chown -R provisioner:provisioner`.
+- [ ] `vm:sync` declares `deps: [vm:start]`, uses `{{.GET_VM_IP}}`, `{{.SSH_PRIVATE_KEY}}`, `{{.SSH_OPTS}}`, `{{.VM_USER}}` — same conventions as the surrounding tasks.
+- [ ] `vm:sync`'s exclude list omits `bin/` and `vendor/` on purpose (local builds happen on the host; CI excludes them because it rebuilds in-VM).
+- [ ] `--delete` is on in `vm:sync` — confirm no in-VM build artifacts under `/mnt/solo-weaver` would be wiped by it. (Builds put output in `bin/` which IS synced from host, so `--delete` only nukes stale files from prior host states.)
+- [ ] Every host-side task that does work expecting fresh code in `/mnt/solo-weaver` declares `vm:sync` as a dep: `vm:test:unit`, `vm:test:integration`, `vm:alloy:{start,stop,clean}`, `vm:teleport:{start,stop,clean}`, `vm:debug:{test,app}`, `vm:configure:tools`.
+- [ ] `task vm:ssh` and `task vm:ssh:proxy` intentionally do NOT depend on `vm:sync` — they're meant for interactive use, and users may want to SSH in without forcing a sync.
+- [ ] No reference to `9p`, `virtio-9p`, or the "shared folder" UTM wording remains in `taskfiles/` or `docs/dev/`.
+- [ ] In-VM `/mnt/solo-weaver` paths in `taskfiles/uat.yaml`, `taskfiles/alloy.yaml`, `taskfiles/teleport.yaml`, `scripts/debug-vm-run.sh`, `docs/dev/acceptance-tests.md`, `docs/dev/quickstart.md` are unchanged — the in-VM path is identical pre- and post-PR.
+
+## Sanity check (host)
+
+```bash
+# 1. Surface any lingering 9p references
+rg -n '9p|virtio-9p|shared folder' taskfiles/ docs/dev/
+# Expected: no hits (the only `virtio` hits should be in .github/workflows/* for the QEMU NIC/disk).
+
+# 2. Confirm every host-side vm:* task that runs against /mnt/solo-weaver declares vm:sync
+rg -n 'vm:sync' taskfiles/
+# Expected: vm.yaml (definition + deps), tests.yaml, alloy.yaml, teleport.yaml — at least 10 hits.
+```
+
+## Manual UAT (UTM VM)
+
+1. **Fresh VM bring-up — no 9p anywhere.**
+
+   ```bash
+   task vm:reset
+   task vm:ssh
+   # inside the VM:
+   grep -E '/mnt/solo-weaver' /etc/fstab
+   # Expected: no output (or non-zero exit), the legacy 9p line is gone.
+   mountpoint /mnt/solo-weaver
+   # Expected: "/mnt/solo-weaver is not a mountpoint" — it's a plain directory now.
+   ls -ld /mnt/solo-weaver
+   # Expected: owned by provisioner:provisioner.
+   ls /mnt/solo-weaver
+   # Expected: empty until first `task vm:sync` from the host.
+   exit
+   ```
+
+2. **`task vm:sync` populates the tree.**
+
+   ```bash
+   task vm:sync
+   # Expected output (abridged):
+   #   📤 Syncing /Users/.../solo-weaver-wt/00616-... → provisioner@<vm-ip>:/mnt/solo-weaver/ ...
+   #   sending incremental file list
+   #   ... (rsync progress) ...
+   #   ✓ Sync complete
+   task vm:ssh
+   # inside the VM:
+   ls /mnt/solo-weaver/Taskfile.yaml /mnt/solo-weaver/cmd /mnt/solo-weaver/bin
+   # Expected: all present.
+   exit
+   ```
+
+3. **Worktree switch is visible after `task vm:sync`.** This is the core regression scenario from issue #616.
+
+   ```bash
+   # In worktree A:
+   echo "// scratch-A" >> internal/state/state.go
+   task vm:sync
+   task vm:ssh
+   # inside the VM:
+   tail -1 /mnt/solo-weaver/internal/state/state.go
+   # Expected: "// scratch-A"
+   exit
+
+   # Now switch to a different worktree directory (e.g. cd into another solo-weaver-wt/<branch>/):
+   cd /path/to/other/worktree
+   task vm:sync
+   task vm:ssh
+   # inside the VM:
+   tail -1 /mnt/solo-weaver/internal/state/state.go
+   # Expected: the OTHER worktree's last line — the "// scratch-A" appended in worktree A is GONE.
+   # This is what was broken before — 9p kept pointing at worktree A regardless of where the host was.
+   exit
+   ```
+
+4. **`task vm:test:unit` auto-syncs and passes.**
+
+   ```bash
+   echo "// scratch-2" >> internal/state/state.go
+   task vm:test:unit
+   # Expected: rsync runs as a dep, then unit tests execute inside the VM and pass.
+   ```
+
+5. **UAT lifecycle still passes inside the VM.**
+
+   ```bash
+   task build:cli GOOS=linux GOARCH=arm64
+   task vm:sync
+   task vm:ssh:proxy
+   # inside the VM:
+   task uat:lifecycle
+   # Expected: setup → core upgrades → teardown all green, identical to pre-PR behavior.
+   ```
+
+## CI verification
+
+No workflow changes. The existing rsync-based step in `.github/workflows/zxc-uat-test.yaml` (lines 380-405) and the
+`ln -sfn /home/provisioner/solo-weaver /mnt/solo-weaver` symlink (line 472-473) keep working as-is. Confirm the
+`uat-lifecycle` workflow stays green on this PR.
+
+## Risks & rollback
+
+- **Forgetting `task vm:sync` after host edits.** Mitigated by `vm:sync` deps on the hot-path tasks. Plain `task vm:ssh`
+  is the escape hatch where the user must remember.
+- **Initial sync slower than 9p (which was zero-copy).** First sync rsyncs ~100 MB minus excludes; subsequent syncs are
+  incremental. Acceptable trade for the correctness + reliability win.
+- **Existing dev VMs with a stale 9p fstab line.** Resolved by `task vm:reset` (which clones from the golden image, so
+  the working VM is destroyed). Devs who don't reset will see weirdness — `task vm:sync` would write into a 9p-mounted
+  directory, which actually works but defeats the purpose. Call this out in the PR body.
+- **Rollback:** revert this PR. The 9p fstab block returns on next `vm:reset`. No data loss; the VM's own disk is
+  unaffected because `/mnt/solo-weaver` is just a mount point / sync target.

--- a/docs/dev/acceptance-tests.md
+++ b/docs/dev/acceptance-tests.md
@@ -29,6 +29,9 @@ These tasks are designed to run inside any Linux VM — both the local UTM VM
 - UTM VM set up (`task vm:start`)
 - Cache proxy running (`task proxy:start`)
 - Binary built (`task build:cli GOOS=linux GOARCH=arm64`)
+- Host tree synced into the VM (`task vm:sync`) — required after editing files on the host or switching worktrees;
+  the `vm:test:*`, `vm:alloy:*`, `vm:teleport:*`, and debug tasks invoke this automatically, but the in-VM UAT runs
+  driven from `task vm:ssh:proxy` rely on the most recent manual `task vm:sync`.
 
 ## A. Core Block Node Lifecycle
 

--- a/docs/dev/quickstart.md
+++ b/docs/dev/quickstart.md
@@ -9,7 +9,7 @@ development, testing, and debugging using UTM VMs.
 - Task (https://taskfile.dev/#/installation)
 - Git
 - UTM (for local development and debugging)
-- rsync (for file synchronization with UTM VMs)
+- rsync (auto-installed via `task vm:install`; on macOS, Homebrew rsync is used because the system `/usr/bin/rsync` is Apple's openrsync and is incompatible with the VM's Samba rsync)
 - (Optional) IntelliJ IDEA or GoLand for debugging
 
 ## Project Setup 
@@ -66,23 +66,38 @@ This is handled automatically when you run:
 task vm:start
 ```
 
-**NOTE:** If no VM image exists yet, it will download **golden Debian image**, and you will need to restart UTM to load
-the new image and set up shared folder (e.g. `solo-weaver`).
-Remember you only need to set up the shared folder once. You will see instructions as below:
+**NOTE:** If no VM image exists yet, it will download the **golden Debian image** and prompt you to restart UTM so it
+picks up the new VM:
 
-``` 
-👉 Please restart UTM to reload VMs and set up the shared solo-weaver directory (`open -a UTM`).
+```
+👉 Please restart UTM to reload VMs ('open -a UTM'), then run 'task vm:start'.
 ```
 
-Once you restart UTM and set the shared-folder `solo-weaver`, run the following command again to start the VM:
-
-```sh
-task vm:start
-```
+After restarting UTM, run `task vm:start` again to finish provisioning.
 
 ---
 
-#### 2. Day-to-Day Debugging & Testing
+#### 2. Syncing host changes into the VM
+
+The host source tree is **not** auto-mounted in the VM. Instead, the VM gets a one-way rsync copy at
+`/mnt/solo-weaver`. Run `task vm:sync` after editing files on the host, after switching git worktrees, or any time you
+want the VM to reflect the current host state:
+
+```sh
+task vm:sync
+```
+
+`task vm:test:unit`, `task vm:test:integration`, `task vm:alloy:start`, `task vm:teleport:start`, and the debug-server
+tasks already declare `vm:sync` as a dependency, so the most common workflows stay one-command. Plain `task vm:ssh`
+does **not** auto-sync — call `task vm:sync` first if you need fresh code inside the SSH session.
+
+`task vm:sync` uses `rsync -az --delete`, so files removed on the host are also removed in the VM. The `bin/` and
+`vendor/` directories are included (local builds happen on the host); `.git`, `.ssh`, and VM disk artifacts
+(`*.iso`, `*.img`, `*.qcow2`) are excluded.
+
+---
+
+#### 3. Day-to-Day Debugging & Testing
 
 Once you have started the vm, you can follow the instructions below to run and debug your application or tests inside
 the VM directly from IntelliJ IDEA or other IDEs.

--- a/taskfiles/alloy.yaml
+++ b/taskfiles/alloy.yaml
@@ -327,7 +327,7 @@ tasks:
 
   vm:alloy:start:
     desc: "Set up Alloy stack in the VM"
-    deps: [vm:install-docker]
+    deps: [vm:install-docker, vm:sync]
     cmds:
       - |
         echo "🚀 Setting up Alloy stack in VM..."
@@ -361,6 +361,7 @@ tasks:
 
   vm:alloy:stop:
     desc: "Stop Alloy stack in the VM"
+    deps: [vm:sync]
     cmds:
       - |
         echo "🛑 Stopping Alloy stack in VM..."
@@ -378,6 +379,7 @@ tasks:
 
   vm:alloy:clean:
     desc: "Stop and remove all Alloy data in the VM"
+    deps: [vm:sync]
     cmds:
       - |
         echo "🧹 Cleaning Alloy stack in VM..."

--- a/taskfiles/teleport.yaml
+++ b/taskfiles/teleport.yaml
@@ -243,7 +243,7 @@ tasks:
 
   vm:teleport:start:
     desc: "Start Teleport server in the VM"
-    deps: [vm:install-docker]
+    deps: [vm:install-docker, vm:sync]
     cmds:
       - |
         echo "🚀 Starting Teleport server in VM..."
@@ -276,6 +276,7 @@ tasks:
 
   vm:teleport:stop:
     desc: "Stop Teleport server in the VM"
+    deps: [vm:sync]
     cmds:
       - |
         echo "🛑 Stopping Teleport server in VM..."
@@ -293,6 +294,7 @@ tasks:
 
   vm:teleport:clean:
     desc: "Stop and remove all Teleport data in the VM"
+    deps: [vm:sync]
     cmds:
       - |
         echo "🧹 Cleaning Teleport server in VM..."

--- a/taskfiles/tests.yaml
+++ b/taskfiles/tests.yaml
@@ -110,6 +110,7 @@ tasks:
     desc: "Run all unit tests in a UTM VM (useful for testing system-level functionality)"
     deps:
       - "vm:start"
+      - "vm:sync"
     cmds:
       - cmd: |
           VM_IP=$({{.GET_VM_IP}} get_vm_ip)
@@ -132,6 +133,7 @@ tasks:
     desc: "Run all integration tests in a UTM VM with cache proxies (useful for testing system-level functionality). Use TEST_NAME to run a specific test, e.g., task vm:test:integration TEST_NAME='^Test_InitializeCluster_Fresh_Integration$'"
     deps:
       - vm:start
+      - vm:sync
     cmds:
       - cmd: |
           VM_IP=$({{.GET_VM_IP}} get_vm_ip)

--- a/taskfiles/vm.yaml
+++ b/taskfiles/vm.yaml
@@ -19,14 +19,16 @@ tasks:
     dir: scripts
     deps:
       - "vm:start"
+      - "vm:sync"
     cmds:
       - "./debug-vm-run.sh test {{.CLI_ARGS}}"
-  
+
   vm:debug:app:
     desc: "Start remote application debug server on the VM (pass args with -- after command)"
     dir: scripts
     deps:
       - "vm:start"
+      - "vm:sync"
     cmds:
       - "./debug-vm-run.sh app {{.CLI_ARGS}}"
   
@@ -85,6 +87,12 @@ tasks:
         if ! command -v rsync >/dev/null 2>&1; then
           echo "Installing rsync via Homebrew..."
           brew install rsync
+        elif rsync --version 2>&1 | head -1 | grep -qi openrsync; then
+          # macOS ships Apple's openrsync at /usr/bin/rsync, which injects
+          # flags (e.g. --apple-no-connectx) that Samba rsync in the VM rejects.
+          # Force-install the full Samba rsync via Homebrew.
+          echo "Detected Apple's openrsync (incompatible with VM's Samba rsync); installing Homebrew rsync..."
+          brew install rsync
         else
           echo "rsync is already installed"
         fi
@@ -121,7 +129,7 @@ tasks:
           echo "Checking UTM VMs directory for existing golden VM...: {{.UTM_VMS_DIR}}/{{.VM_GOLDEN_NAME}}.utm"
           if [ -d "{{.UTM_VMS_DIR}}/{{.VM_GOLDEN_NAME}}.utm" ] || [ -f "{{.UTM_VMS_DIR}}/{{.VM_GOLDEN_NAME}}.utm" ]; then
             echo "✓ Golden VM already exists in UTM directory: {{.UTM_VMS_DIR}}/{{.VM_GOLDEN_NAME}}.utm"
-            echo "👉 Please restart UTM to reload VMs and set up the shared solo-weaver directory ('open -a UTM')."
+            echo "👉 Please restart UTM to reload VMs ('open -a UTM'), then run 'task vm:start'."
             exit 1 # non zero would stop further steps
           else
             echo "✓ No existing golden VM found, proceeding to download."
@@ -187,7 +195,7 @@ tasks:
         cp -r "$TEMP_DIR/golden-image.utm" "{{.UTM_VMS_DIR}}/{{.VM_GOLDEN_NAME}}.utm"
         
         echo "✓ Golden VM downloaded successfully and placed in UTM directory: {{.UTM_VMS_DIR}}/{{.VM_GOLDEN_NAME}}.utm"
-        echo "👉 Please restart UTM to reload VMs and set up the shared solo-weaver directory ('open -a UTM')."
+        echo "👉 Please restart UTM to reload VMs ('open -a UTM'), then run 'task vm:start'."
         exit 1 # non zero would stop further steps
   
   vm:reset:
@@ -322,7 +330,53 @@ tasks:
           -o ConnectTimeout=10 -o ServerAliveInterval=3 -o ServerAliveCountMax=2 \
           -o LogLevel=ERROR -fN -L 2222:127.0.0.1:22 {{.VM_USER}}@$VM_IP || true
         echo "✓ SSH port forwarding established on localhost:2222 for debugging purposes"
-  
+
+  vm:sync:
+    desc: "Sync the host source tree to the VM's /mnt/solo-weaver via rsync (one-way, host → VM). Run after switching worktrees or editing files on the host."
+    deps:
+      - vm:install
+      - vm:start
+    cmds:
+      - |
+        VM_IP=$({{.GET_VM_IP}} get_vm_ip)
+        if [ -z "$VM_IP" ]; then
+          echo "❌ Could not determine VM IP. Is the VM running?"
+          exit 1
+        fi
+        # Preflight: rsync must be installed in the VM and /mnt/solo-weaver
+        # must be writable by {{.VM_USER}}. A configured/golden-image VM
+        # satisfies both; older or hand-rolled VMs may not.
+        if ! ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} {{.VM_USER}}@$VM_IP \
+          'command -v rsync >/dev/null 2>&1 && [ -w /mnt/solo-weaver ]'; then
+          echo "❌ VM preflight failed: 'rsync' missing or /mnt/solo-weaver not writable by {{.VM_USER}}."
+          echo "👉 Run 'task vm:reset' to re-clone the VM from the golden image."
+          exit 1
+        fi
+        # rsync's -e arg gets re-parsed by the shell, which mangles SSH_OPTS
+        # values that contain nested quotes (e.g. ProxyCommand="nc ..."),
+        # leaking inner tokens into rsync's argv. Write ssh + opts to a
+        # wrapper script and pass that as -e so the option string survives.
+        SSH_WRAPPER=$(mktemp -t solo-vm-ssh.XXXXXX)
+        trap 'rm -f "$SSH_WRAPPER"' EXIT
+        cat > "$SSH_WRAPPER" <<'EOF'
+        #!/bin/sh
+        exec ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} "$@"
+        EOF
+        chmod +x "$SSH_WRAPPER"
+        echo "📤 Syncing $(pwd) → {{.VM_USER}}@$VM_IP:/mnt/solo-weaver/ ..."
+        rsync -az --delete \
+          --exclude='.git' \
+          --exclude='.ssh' \
+          --exclude='*.iso' \
+          --exclude='*.img' \
+          --exclude='*.qcow2' \
+          --exclude='*.log' \
+          --exclude='.DS_Store' \
+          -e "$SSH_WRAPPER" \
+          ./ \
+          {{.VM_USER}}@$VM_IP:/mnt/solo-weaver/
+        echo "✓ Sync complete"
+
   vm:configure:
     internal: true
     desc: "Configure the VM with SSH, sudo, and mounts (full configuration)"
@@ -434,21 +488,16 @@ tasks:
           sudo systemctl restart sshd || sudo systemctl restart ssh
           echo '✓ SSH daemon configured for root login with keys'
         
-          echo 'Mounting shared directory...'
           sudo mkdir -p /mnt/solo-weaver
-          if ! grep -q '/mnt/solo-weaver' /etc/fstab; then
-            echo 'share   /mnt/solo-weaver   9p  trans=virtio,version=9p2000.L,rw,nofail 0   0' | sudo tee -a /etc/fstab >/dev/null
-          fi
-          sudo mount -a || true
-        
-          # Try to set ownership and permissions to the VM user (best effort)
-        
-          echo "✓ Shared directory mounted at /mnt/solo-weaver"
+          sudo chown -R {{.VM_USER}}:{{.VM_USER}} /mnt/solo-weaver
+          echo '✓ /mnt/solo-weaver ready for rsync (run task vm:sync from the host)'
         "
   
   vm:configure:tools:
     internal: true
     desc: "Install development tools (Git, Task, Go, Delve) - runs after proxy tunnels are set up"
+    deps:
+      - vm:sync
     cmds:
       - |
         VM_IP=$({{.GET_VM_IP}} get_vm_ip)


### PR DESCRIPTION
## Description

The UTM VM mounted the host source tree via virtio-9p at `/mnt/solo-weaver`, configured in `vm:configure:ssh`. The 9p mount was bound to whichever host directory UTM had registered the first time the VM was provisioned, so switching git worktrees on the host left the VM looking at the original tree — newly added files were invisible despite a successful host build. virtio-9p on macOS+UTM was also intermittently flaky.

This drops the 9p `/etc/fstab` entry and populates `/mnt/solo-weaver` via a new `task vm:sync` that runs `rsync -az --delete` from the host worktree into the VM. The in-VM path stays `/mnt/solo-weaver`, so the ~52 references in tasks, UAT scripts, docs, and `scripts/debug-vm-run.sh` are unchanged. `vm:sync` is wired as a dep on the host-side tasks that need fresh code in the VM (`vm:test:unit`, `vm:test:integration`, `vm:alloy:*`, `vm:teleport:*`, `vm:debug:*`, `vm:configure:tools`). CI is unaffected — `zxc-uat-test.yaml` already rsyncs + symlinks `/mnt/solo-weaver`.

### Upgrade note

Existing dev VMs: run `task vm:reset` once to drop the legacy 9p fstab entry (the working VM is destroyed and re-cloned from the golden image).

### Review guide

See [`docs/claude/reviews/00616-replace-9p-with-rsync-sync.md`](docs/claude/reviews/00616-replace-9p-with-rsync-sync.md).

### Related Issues

* Closes #616
