### PR TITLE
fix(cli): allow --version and version on uninstalled hosts

### DIFF
--- a/cmd/cli/commands/common/run.go
+++ b/cmd/cli/commands/common/run.go
@@ -192,6 +192,20 @@ func RunPersistentPreRun(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// `--version` on the root command must work on an uninstalled host: the
+	// root's RunE prints the version and returns, so running the installation
+	// check first would defeat the flag's purpose. Limit the bypass to the
+	// root (Parent == nil) so an inherited --version on a subcommand — which
+	// has no print path — still goes through the normal checks. Query
+	// PersistentFlags directly: it's where the flag is declared, and unlike
+	// Flags() it doesn't depend on cobra's pre-Execute merge step (which
+	// matters in unit tests that invoke this PreRun without Execute).
+	if cmd.Parent() == nil {
+		if v, _ := cmd.PersistentFlags().GetBool(FlagVersion().Name); v {
+			return nil
+		}
+	}
+
 	if !RequireGlobalChecks(cmd) {
 		return nil
 	}

--- a/cmd/cli/commands/common/run_test.go
+++ b/cmd/cli/commands/common/run_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/hashgraph/solo-weaver/internal/doctor"
 	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -106,6 +107,21 @@ func TestDeepestFailureError_PicksFirstFailureNotSecond(t *testing.T) {
 
 	got := deepestFailureError(r)
 	require.ErrorIs(t, got, first)
+}
+
+// TestRunPersistentPreRun_VersionFlagShortCircuits guards the bypass for
+// `./solo-provisioner --version`: on a freshly built binary the installation
+// workflow would fail, so the root's PreRun must return nil before it runs
+// when --version is set on the root command. If this returned an error or
+// reached the workflow build, the test would fail or panic — neither happens
+// because the short-circuit fires first.
+func TestRunPersistentPreRun_VersionFlagShortCircuits(t *testing.T) {
+	root := &cobra.Command{Use: "solo-provisioner"}
+	flagName := FlagVersion().Name
+	root.PersistentFlags().BoolP(flagName, FlagVersion().ShortName, false, "show version")
+	require.NoError(t, root.PersistentFlags().Set(flagName, "true"))
+
+	require.NoError(t, RunPersistentPreRun(root, nil))
 }
 
 // TestDeepestFailureError_SkipsSkippedAndSuccessSiblings verifies that

--- a/cmd/cli/commands/root.go
+++ b/cmd/cli/commands/root.go
@@ -86,6 +86,11 @@ func init() {
 	// disable global checks for install command since we need to install it first without any checks
 	common.SkipGlobalChecks(selfInstallCmd)
 
+	// `version` must be invokable on an uninstalled host (it's the no-install
+	// sanity check reviewers run), so it opts out of the global checks too.
+	versionCmd := version.Cmd()
+	common.SkipGlobalChecks(versionCmd)
+
 	// add subcommands
 	rootCmd.AddCommand(selfInstallCmd)
 	rootCmd.AddCommand(selfUninstallCmd)
@@ -93,7 +98,7 @@ func init() {
 	rootCmd.AddCommand(block.GetCmd())
 	rootCmd.AddCommand(teleport.GetCmd())
 	rootCmd.AddCommand(alloy.GetCmd())
-	rootCmd.AddCommand(version.Cmd())
+	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(tuiDemoCmd)
 
 	if common.DetectShortNameCollisions(rootCmd) {

--- a/cmd/cli/commands/root_test.go
+++ b/cmd/cli/commands/root_test.go
@@ -6,10 +6,28 @@ import (
 	"testing"
 
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNoShortNameCollisionsInRealCommandTree(t *testing.T) {
 	require.False(t, common.DetectShortNameCollisions(rootCmd),
 		"short name collisions detected in command tree")
+}
+
+// TestVersionSubcommandSkipsGlobalChecks asserts that the registered
+// `version` subcommand is annotated to bypass the global pre-run checks.
+// Without this annotation the subcommand fails on freshly built binaries
+// because the installation check runs first (see #615).
+func TestVersionSubcommandSkipsGlobalChecks(t *testing.T) {
+	var versionCmd *cobra.Command
+	for _, sub := range rootCmd.Commands() {
+		if sub.Use == "version" {
+			versionCmd = sub
+			break
+		}
+	}
+	require.NotNil(t, versionCmd, "version subcommand not registered on rootCmd")
+	require.False(t, common.RequireGlobalChecks(versionCmd),
+		"version subcommand must opt out of global pre-run checks")
 }

--- a/docs/claude/plans/00615-fix-version-skip-global-checks.md
+++ b/docs/claude/plans/00615-fix-version-skip-global-checks.md
@@ -1,0 +1,70 @@
+# #615 — `--version` and `version` subcommand require install
+
+> **Issue:** https://github.com/hashgraph/solo-weaver/issues/615
+> **Story branch:** `00615-fix-version-skip-global-checks`
+> **PR base:** `main` (branched from `origin/main` @ `f07505c`)
+> **PR closes:** #615
+
+## Summary
+
+The CLI's `--version` flag and `version` subcommand both fail on a freshly built binary because the root command's `PersistentPreRunE` (`common.RunPersistentPreRun`) always runs `CheckWeaverInstallationWorkflow` and any pending startup migrations before the version is printed. The fix opts the `version` subcommand out via the existing `SkipGlobalChecks` annotation, and short-circuits `RunPersistentPreRun` when the root command was invoked with `--version`.
+
+## Problem
+
+- `cmd/cli/commands/root.go:52-54` wires `PersistentPreRunE → common.RunPersistentPreRun`.
+- `cmd/cli/commands/common/run.go:190-217` `RunPersistentPreRun` runs `CheckWeaverInstallationWorkflow` + `RunStartupMigrations` unless the command has `Annotations["requireGlobalChecks"] == "false"` (set via `common.SkipGlobalChecks`).
+- Only `selfInstallCmd` (`cmd/cli/commands/root.go:87`) and `tuiDemoCmd` (`cmd/cli/commands/demo.go:34`) opt out today.
+- `version.Cmd()` (`cmd/cli/commands/root.go:96`, returning a fresh `*cobra.Command` from `pkg/version/cli/releases.go:50`) is not opted out, so `./solo-provisioner version` fails on an uninstalled host.
+- The `--version` flag is bound to the root command's `RunE` (`cmd/cli/commands/root.go:55-61`); cobra runs `PersistentPreRunE` first, so even `./solo-provisioner --version` fails before the print path is reached.
+- Surfaced in the UAT for #516/#517 (PR #605) where reviewers are instructed to run `./bin/solo-provisioner-linux-amd64 --version` as a no-install sanity check.
+
+The daemon binary (`cmd/daemon/main.go`) defines no `PersistentPreRunE`, so this is CLI-only — no daemon-side change.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| How to opt the `version` subcommand out? | Capture the command returned by `version.Cmd()` into a local var, call `common.SkipGlobalChecks(versionCmd)`, then `rootCmd.AddCommand(versionCmd)` — mirroring the `selfInstallCmd` pattern. |
+| How to opt the `--version` flag out? | Short-circuit `RunPersistentPreRun` at the top: when `cmd.Parent() == nil` (i.e. the root command itself is running) and the persistent `version` flag is set, return `nil` before any check or migration runs. |
+| Why not also annotate the root? | `SkipGlobalChecks` is per-command; we cannot conditionally toggle it based on a flag value. The flag-check short-circuit is the minimal targeted bypass and keeps every non-`--version` invocation of the root command unchanged. |
+| Should `block check --version` etc. also bypass? | No. `--version` only triggers the version-print path on the root's `RunE`; on subcommands the flag is inherited but inert. Preserving the install/migration checks for those invocations matches current behavior. |
+| Scope of unit tests? | (1) a `common` package test that `RunPersistentPreRun` returns nil with no side effects when `--version` is set on a root-like command; (2) a `commands` package test that the registered `version` subcommand has `RequireGlobalChecks == false`. |
+
+## Scope
+
+### `cmd/cli/commands/common/run.go`
+- [ ] In `RunPersistentPreRun`, after the `cmd == nil` guard, add a short-circuit: if `cmd.Parent() == nil` and `cmd.Flags().GetBool("version")` is true, return `nil`.
+
+### `cmd/cli/commands/root.go`
+- [ ] In `init()`, capture `version.Cmd()` into a local variable, call `common.SkipGlobalChecks(versionCmd)`, and use that variable in `rootCmd.AddCommand(versionCmd)`.
+
+### `cmd/cli/commands/common/run_test.go`
+- [ ] Add `TestRunPersistentPreRun_VersionFlagShortCircuit`: build a minimal cobra command with a `version` bool persistent flag, set it, call `RunPersistentPreRun`, expect `nil` and no panic (workflow not constructed).
+
+### `cmd/cli/commands/root_test.go`
+- [ ] Add `TestVersionSubcommandSkipsGlobalChecks`: walk `rootCmd`'s subcommands to find the one with `Use == "version"` and assert `common.RequireGlobalChecks(versionCmd) == false`.
+
+## Out of scope
+
+- `selfUninstallCmd` is not in the `SkipGlobalChecks` list either (`cmd/cli/commands/root.go:91` adds it without the annotation). That's a separate question — not raised in #615 and not changed here.
+- Migrating `--version` handling away from `PersistentPreRunE`-then-`RunE` to cobra's built-in `Version` field (which would obviate the short-circuit entirely). Bigger surface change; defer.
+- Any docs update under `docs/quickstart.md` — this PR neither adds nor removes a CLI flag/subcommand; semantics of `version` are unchanged (it just becomes invokable pre-install).
+
+## Test plan
+
+- [ ] Unit:
+  - `go test -race ./cmd/cli/commands/common/...` — passes new short-circuit test.
+  - `go test -race ./cmd/cli/commands/...` — passes new subcommand-annotation test.
+- [ ] Manual UAT on a freshly built binary (no install):
+  - `./bin/solo-provisioner-linux-<arch> --version` → prints version JSON (or `-o text` etc.), exit 0.
+  - `./bin/solo-provisioner-linux-<arch> version` → same.
+  - `./bin/solo-provisioner-linux-<arch> version -o json` → JSON output.
+  - `./bin/solo-provisioner-linux-<arch> block node check --profile=local` → still triggers the installation check (current failure mode preserved on uninstalled hosts).
+- [ ] `task lint` clean.
+- [ ] `task license:check` clean.
+
+## Risks / rollbacks
+
+- **Risk:** the short-circuit accidentally bypasses checks for some other invocation path. Mitigation: condition is narrow (`cmd.Parent() == nil` AND `--version` flag set) — only matches `./solo-provisioner --version` (or `-v`), which is exactly the targeted case.
+- **Risk:** `cmd.Flags().GetBool("version")` errors if the flag isn't defined on some test cmd. Mitigation: the function already ignores the error; lookup against the persistent flag (registered at init time) so production cmd always has it.
+- **Rollback:** revert the two-file change; behavior returns to pre-fix. No state, schema, or wire-format changes.

--- a/docs/claude/reviews/00615-fix-version-skip-global-checks.md
+++ b/docs/claude/reviews/00615-fix-version-skip-global-checks.md
@@ -1,0 +1,218 @@
+# PR Review Guide — fix(cli): make `--version` and `version` work on uninstalled hosts
+
+**Issue:** [#615](https://github.com/hashgraph/solo-weaver/issues/615)
+**Branch:** `00615-fix-version-skip-global-checks`
+
+---
+
+## What Was Done
+
+### Problem
+
+The CLI's `--version` flag and `version` subcommand both fail on a freshly built binary because the
+root command's `PersistentPreRunE` (`common.RunPersistentPreRun`) always runs the
+`CheckWeaverInstallationWorkflow` and any pending startup migrations before the version is printed.
+
+- `version.Cmd()` is a normal subcommand and was not opted out via `common.SkipGlobalChecks`, so
+  `./solo-provisioner version` fails on an uninstalled host.
+- `--version` is bound to the root's `RunE`, but cobra runs `PersistentPreRunE` first, so
+  `./solo-provisioner --version` fails before the print path is ever reached.
+
+This was surfaced in the UAT for #516/#517 (PR #605), where reviewers are instructed to run
+`./bin/solo-provisioner-linux-<arch> --version` as a no-install sanity check.
+
+### Solution
+
+Two narrowly scoped bypasses:
+
+1. **`version` subcommand:** capture the command returned by `version.Cmd()` into a local variable
+   and call `common.SkipGlobalChecks(versionCmd)` before adding it to `rootCmd`, mirroring the
+   existing pattern for `selfInstallCmd`.
+2. **`--version` flag:** short-circuit `RunPersistentPreRun` at the top when the running command is
+   the root (`cmd.Parent() == nil`) **and** the persistent `version` flag is set. The check uses
+   `cmd.PersistentFlags().GetBool("version")` so the same code path is exercisable in unit tests
+   that invoke the PreRun directly without going through `cobra.Command.Execute()`.
+
+The daemon binary (`cmd/daemon/main.go`) defines no `PersistentPreRunE`, so no daemon-side change is
+needed.
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `cmd/cli/commands/common/run.go` | Short-circuit `RunPersistentPreRun` when `cmd.Parent() == nil` **and** the `version` persistent flag is set; returns `nil` before the installation check or migrations run. Queries `PersistentFlags()` (not `Flags()`) so the path is testable without cobra's pre-Execute flag merge. |
+| `cmd/cli/commands/root.go` | Capture `version.Cmd()` into a local variable, annotate it with `common.SkipGlobalChecks`, then `AddCommand(versionCmd)` — same pattern used for `selfInstallCmd`. |
+| `cmd/cli/commands/common/run_test.go` | New `TestRunPersistentPreRun_VersionFlagShortCircuits` builds a minimal root-like cobra command with a `version` persistent flag, sets it, and asserts `RunPersistentPreRun` returns `nil` without reaching the workflow build (which would panic on test harness). |
+| `cmd/cli/commands/root_test.go` | New `TestVersionSubcommandSkipsGlobalChecks` walks `rootCmd.Commands()` for `Use == "version"` and asserts `common.RequireGlobalChecks(versionCmd) == false`. |
+
+---
+
+## Code Review Checklist
+
+### `cmd/cli/commands/common/run.go`
+
+- [x] Short-circuit is placed **after** the `cmd == nil` guard and **before** `RequireGlobalChecks`,
+      so a non-root caller (e.g. `block node check`) never enters the bypass.
+- [x] Guard is `cmd.Parent() == nil` — the short-circuit only fires on the root command, not on any
+      subcommand that inherits the persistent `--version` flag.
+- [x] Flag is read via `cmd.PersistentFlags().GetBool(FlagVersion().Name)` rather than the literal
+      `"version"`, so a future rename via the shared flag descriptor can't silently break the
+      bypass. Uses `PersistentFlags()` (not `Flags()`) so the path is reachable in unit tests that
+      bypass cobra's `Execute()` flag-merge step.
+- [x] Error returned by `GetBool` is intentionally discarded (`_`) — if the flag isn't registered,
+      `v` is the zero value (`false`) and the bypass simply doesn't fire, falling through to the
+      normal checks. This matches the safety profile of the existing flag lookups in this file.
+
+### `cmd/cli/commands/root.go`
+
+- [x] `versionCmd := version.Cmd()` is captured once; the same `*cobra.Command` is passed to both
+      `common.SkipGlobalChecks(versionCmd)` and `rootCmd.AddCommand(versionCmd)` — no double-call to
+      `version.Cmd()`.
+- [x] Annotation happens **before** `AddCommand` so the command tree never observes an unannotated
+      `version` subcommand.
+
+### `cmd/cli/commands/common/run_test.go`
+
+- [x] Test creates a minimal `*cobra.Command` with no `Run`/`RunE` — the PreRun must return cleanly
+      without trying to build a workflow. If the short-circuit regressed, the test would hit the
+      workflow-build path and panic.
+- [x] Flag is registered on `PersistentFlags()` (matching production) and set via
+      `PersistentFlags().Set`, which exercises the same lookup path the production code uses.
+
+### `cmd/cli/commands/root_test.go`
+
+- [x] Test walks the real `rootCmd.Commands()` registered by `init()`, not a mock — proves the
+      annotation reaches the registered subcommand, not just an in-memory copy.
+- [x] Fails loudly with a clear message if the `version` subcommand is removed or renamed
+      (`require.NotNil` with explanatory message before the annotation assertion).
+
+### Scope
+
+- [x] `selfUninstallCmd` is **not** in the `SkipGlobalChecks` list either (`root.go:91`). That is
+      intentionally out of scope for this PR — not raised in #615.
+- [x] `block node check --version`, `block node install --version`, etc. still go through the
+      installation check. The flag is inherited but inert on subcommands (only the root has a
+      print path bound to `RunE`), so preserving the check matches current behavior.
+
+---
+
+## Running the Tests
+
+### Unit tests for the changed packages
+
+The `cmd/cli/commands/common` package transitively imports `internal/mount`, which is Linux-only.
+On macOS the package will not compile; run the tests inside the UTM VM:
+
+```bash
+task vm:test:unit
+```
+
+Or, scoped to the two packages exercised by this PR:
+
+```bash
+go test -race -tags='!integration' \
+  ./cmd/cli/commands/common/... \
+  ./cmd/cli/commands/...
+```
+
+Expected new lines in the output:
+
+```
+=== RUN   TestRunPersistentPreRun_VersionFlagShortCircuits
+--- PASS: TestRunPersistentPreRun_VersionFlagShortCircuits
+
+=== RUN   TestVersionSubcommandSkipsGlobalChecks
+--- PASS: TestVersionSubcommandSkipsGlobalChecks
+```
+
+### Integration tests
+
+No integration test was added — the bypass is fully exercised at the unit level and via manual UAT.
+Existing integration tests are unaffected (this PR does not change any workflow step or check
+behavior for installed hosts).
+
+---
+
+## Manual UAT Steps
+
+UAT must be done with a **freshly built binary on a host without `solo-provisioner` installed**, so
+that the installation check would fail if the bypass were missing. The easiest such host is the
+UTM VM with no prior `task vm:install` or `sudo .../solo-provisioner install` run.
+
+```bash
+task build:cli GOOS=linux GOARCH=arm64    # or GOARCH=amd64
+scp -i .ssh/id_rsa_vm bin/solo-provisioner-linux-arm64 provisioner@<vm-ip>:/tmp/solo-provisioner-test
+ssh -i .ssh/id_rsa_vm provisioner@<vm-ip>
+chmod +x /tmp/solo-provisioner-test
+```
+
+Then on the VM:
+
+```bash
+# 1) --version flag on the root command
+/tmp/solo-provisioner-test --version
+```
+
+Expected output (single line, exit 0):
+
+```
+{"version":"0.0.0","commit":"<short-sha>","goversion":"go1.26.0"}
+```
+
+```bash
+# 2) Short form of the flag
+/tmp/solo-provisioner-test -v
+```
+
+Same JSON output, exit 0.
+
+```bash
+# 3) version subcommand (default output)
+/tmp/solo-provisioner-test version
+```
+
+Same JSON output, exit 0.
+
+```bash
+# 4) version subcommand with explicit JSON output
+/tmp/solo-provisioner-test version -o json
+```
+
+Same JSON output, exit 0.
+
+```bash
+# 5) Negative case — subcommand that should still trigger the installation check
+/tmp/solo-provisioner-test block node check --profile=local
+```
+
+Expected output (exit 1):
+
+```
+Solo Provisioner installation check failed: current executable is not in the expected bin directory
+  expectedPath=/opt/solo/weaver/bin/solo-provisioner
+
+✗ Error: solo-provisioner installation or re-installation required
+
+Resolution:
+  install or re-install solo-provisioner binary; run
+  `sudo /tmp/solo-provisioner-test install` to install and then run
+  `solo-provisioner block node check --profile=local`.
+```
+
+This last case proves the bypass is narrowly scoped — only `--version` and `version` skip the
+installation check; every other path on an uninstalled host still fails loudly.
+
+---
+
+## Risks / Rollback
+
+- **Risk:** the short-circuit accidentally bypasses checks for some other invocation path.
+  Mitigation: the condition is `cmd.Parent() == nil` **AND** `--version` flag set — only matches
+  `./solo-provisioner --version` (or `-v`), which is exactly the targeted case. The UAT step 5
+  above verifies this.
+- **Risk:** `cmd.PersistentFlags().GetBool(FlagVersion().Name)` errors if the flag isn't defined
+  on some caller. Mitigation: the function ignores the error; on the production root command the
+  flag always exists (registered in `init()` at `cmd/cli/commands/root.go` via the same
+  `FlagVersion()` descriptor).
+- **Rollback:** revert the two-file change in `cmd/cli/commands/`. Behavior returns to pre-fix.
+  No state, schema, or wire-format changes.


### PR DESCRIPTION
## Description

Both `./solo-provisioner --version` and `./solo-provisioner version` failed on a freshly built binary because the root command's `PersistentPreRunE` (`common.RunPersistentPreRun`) unconditionally ran the `CheckWeaverInstallationWorkflow` (and any pending startup migrations) before the version print path could execute. This was surfaced by the no-install UAT step from PR #605, which instructs reviewers to run `./bin/solo-provisioner-linux-<arch> --version` as a sanity check.

The fix is two narrowly scoped bypasses, mirroring the existing `selfInstallCmd` pattern:

- **`version` subcommand:** capture the command returned by `version.Cmd()`, call `common.SkipGlobalChecks(versionCmd)`, and pass that variable to `rootCmd.AddCommand` — the same pattern already used for `selfInstallCmd`.
- **`--version` flag:** short-circuit `RunPersistentPreRun` at the top when `cmd.Parent() == nil` (root command is running) **and** the persistent `version` flag is set. Queries `cmd.PersistentFlags().GetBool("version")` directly so the path is reachable in unit tests that bypass cobra's `Execute()`-time flag merge.

Inherited `--version` on subcommands (e.g. `block node check --version`) is intentionally not bypassed: the flag is inert there because only the root has a print path bound to `RunE`, and preserving the installation check for those invocations matches current behavior.

The daemon binary defines no `PersistentPreRunE`, so no daemon-side change is needed.

### Files changed

| File | Change |
|------|--------|
| `cmd/cli/commands/common/run.go` | Short-circuit `RunPersistentPreRun` when the root is running with the `version` persistent flag set. |
| `cmd/cli/commands/root.go` | Annotate the `version` subcommand with `common.SkipGlobalChecks` before adding it to `rootCmd`. |
| `cmd/cli/commands/common/run_test.go` | `TestRunPersistentPreRun_VersionFlagShortCircuits` — exercises the new bypass directly. |
| `cmd/cli/commands/root_test.go` | `TestVersionSubcommandSkipsGlobalChecks` — walks the registered command tree and asserts the annotation. |

### Review guide

[`docs/claude/reviews/00615-fix-version-skip-global-checks.md`](docs/claude/reviews/00615-fix-version-skip-global-checks.md) — code-review checklist and step-by-step manual UAT instructions, including the negative case that proves the bypass is correctly scoped.

### Related Issues

* Closes #615
