### PR TITLE
feat(blocknode): bump default block node chart version to v0.35.1

### DIFF
--- a/cmd/cli/commands/block/node/reconfigure_it_test.go
+++ b/cmd/cli/commands/block/node/reconfigure_it_test.go
@@ -21,7 +21,7 @@ blockNode:
   namespace: "test-ns"
   release: "test-release"
   chart: "oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server"
-  version: "0.30.2"
+  version: "0.35.1"
   storage:
     basePath: "/mnt/storage"
 `

--- a/docs/dev/acceptance-tests.md
+++ b/docs/dev/acceptance-tests.md
@@ -83,9 +83,10 @@ kubectl get pods -n block-node -o jsonpath='{range .items[*]}{.metadata.name}{"\
 ```
 
 ```bash
-# 4. Upgrade to latest (v0.30.2 — version from config file, no CLI flag)
+# 4. Upgrade to intermediate version (v0.30.2 — explicit flag)
 sudo solo-provisioner block node upgrade -p local \
-  -c /mnt/solo-weaver/test/config/config_with_proxy_latest.yaml
+  --chart-version 0.30.2 \
+  -c /mnt/solo-weaver/test/config/config_with_proxy.yaml
 ```
 
 **Verify:**
@@ -95,7 +96,19 @@ kubectl get pods -n block-node -o jsonpath='{range .items[*]}{.metadata.name}{"\
 ```
 
 ```bash
-# 5. Reset block node (clears storage, keeps cluster)
+# 5. Upgrade to latest (v0.35.1 — version from config file, no CLI flag)
+sudo solo-provisioner block node upgrade -p local \
+  -c /mnt/solo-weaver/test/config/config_with_proxy_latest.yaml
+```
+
+**Verify:**
+```bash
+helm list -n block-node                 # Chart version is 0.35.1
+kubectl get pods -n block-node -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.containers[*]}{.image}{end}{"\n"}{end}'  # Image shows 0.35.1
+```
+
+```bash
+# 6. Reset block node (clears storage, keeps cluster)
 sudo solo-provisioner block node reset -p local \
   -c /mnt/solo-weaver/test/config/config_with_proxy.yaml
 ```
@@ -106,7 +119,7 @@ kubectl get pods -n block-node          # Pods running (recreated)
 ```
 
 ```bash
-# 6. Block node uninstall
+# 7. Block node uninstall
 sudo solo-provisioner block node uninstall -p local \
   -c /mnt/solo-weaver/test/config/config_with_proxy.yaml
 ```

--- a/internal/ui/prompt/prompt_test.go
+++ b/internal/ui/prompt/prompt_test.go
@@ -377,7 +377,7 @@ func TestRunInputPrompts_SkipsUnregisteredFlag(t *testing.T) {
 		{
 			FlagName:       "chart-version",
 			Title:          "Chart Version",
-			EffectiveValue: "0.30.2",
+			EffectiveValue: "0.35.1",
 			Target:         &target,
 		},
 	}

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -11,6 +11,6 @@ const (
 	BLOCK_NODE_NAMESPACE         = "block-node"
 	BLOCK_NODE_RELEASE           = "block-node"
 	BLOCK_NODE_CHART             = "oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server"
-	BLOCK_NODE_VERSION           = "0.30.2"
+	BLOCK_NODE_VERSION           = "0.35.1"
 	BLOCK_NODE_STORAGE_BASE_PATH = "/mnt/fast-storage"
 )

--- a/taskfiles/uat.yaml
+++ b/taskfiles/uat.yaml
@@ -112,12 +112,13 @@ tasks:
         echo "   metallb.io/address-pool: $ANNOTATION ✓"
 
 
-        echo -e '\n▶ Upgrade to latest (v0.30.2) using updated chartVersion in config'
+        echo -e '\n▶ Upgrade to v0.30.2 using --chart-version flag'
         sudo solo-provisioner block node upgrade -p local \
-          -c /mnt/solo-weaver/test/config/config_with_proxy_latest.yaml
+          --chart-version 0.30.2 \
+          -c /mnt/solo-weaver/test/config/config_with_proxy.yaml
 
 
-        echo -e '\n▶ Verify upgrade to latest (v0.30.2)'
+        echo -e '\n▶ Verify upgrade to v0.30.2 using --chart-version flag'
         CHART_VER=$(helm list -n block-node -o json | sed -n 's/.*"chart":"[^"]*-\([0-9]*\.[0-9]*\.[0-9]*\)".*/\1/p')
         echo "   Chart version: $CHART_VER"
         [ "$CHART_VER" = "0.30.2" ] || { echo "FAIL: expected chart version 0.30.2, got $CHART_VER"; exit 1; }
@@ -127,6 +128,24 @@ tasks:
         echo -e '\n▶ Verify MetalLB annotation present after upgrade to v0.30.2'
         ANNOTATION=$(kubectl get svc block-node-block-node-server -n block-node -o jsonpath='{.metadata.annotations.metallb\.io/address-pool}')
         [ "$ANNOTATION" = "public-address-pool" ] || { echo "FAIL: metallb annotation missing after v0.30.2 upgrade, got: '$ANNOTATION'"; exit 1; }
+        echo "   metallb.io/address-pool: $ANNOTATION ✓"
+
+
+        echo -e '\n▶ Upgrade to latest (v0.35.1) using updated chartVersion in config'
+        sudo solo-provisioner block node upgrade -p local \
+          -c /mnt/solo-weaver/test/config/config_with_proxy_latest.yaml
+
+
+        echo -e '\n▶ Verify upgrade to latest (v0.35.1)'
+        CHART_VER=$(helm list -n block-node -o json | sed -n 's/.*"chart":"[^"]*-\([0-9]*\.[0-9]*\.[0-9]*\)".*/\1/p')
+        echo "   Chart version: $CHART_VER"
+        [ "$CHART_VER" = "0.35.1" ] || { echo "FAIL: expected chart version 0.35.1, got $CHART_VER"; exit 1; }
+        echo '   Container images:'
+        kubectl get pods -n block-node -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.containers[*]}{.image}{" "}{end}{"\n"}{end}'
+
+        echo -e '\n▶ Verify MetalLB annotation present after upgrade to v0.35.1'
+        ANNOTATION=$(kubectl get svc block-node-block-node-server -n block-node -o jsonpath='{.metadata.annotations.metallb\.io/address-pool}')
+        [ "$ANNOTATION" = "public-address-pool" ] || { echo "FAIL: metallb annotation missing after v0.35.1 upgrade, got: '$ANNOTATION'"; exit 1; }
         echo "   metallb.io/address-pool: $ANNOTATION ✓"
 
 

--- a/test/config/config_with_proxy_latest.yaml
+++ b/test/config/config_with_proxy_latest.yaml
@@ -6,7 +6,7 @@ blockNode:
   namespace: "block-node"
   release: "block-node"
   chart: "oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server"
-  version: "0.30.2"
+  version: "0.35.1"
   storage:
     basePath: "/mnt/fast-storage"
 proxy:


### PR DESCRIPTION
## Description

The hardcoded default block-node Helm chart version in solo-provisioner was `0.30.2`,
five minor versions behind the current hiero-block-node GA release (`0.35.1`). Operators
running `sudo solo-provisioner block node install -p local` silently received an outdated
chart with no indication a newer version was available — surfaced during an independent
node operator evaluation in June 2026.

This PR bumps `BLOCK_NODE_VERSION` in `pkg/deps/deps.go` (the single source of truth
that flows into all install/upgrade defaults via `pkg/config/global.go`) to `0.35.1`.
The `--chart-version` flag is unchanged, so operators who need to pin an older version
can still do so explicitly.

`uat:core` is extended to cover a full upgrade chain:
`v0.26.0 → v0.29.0 (flag) → v0.30.2 (flag) → v0.35.1 (config)`. The old
"upgrade to latest via config" step at `0.30.2` is demoted to an explicit
`--chart-version` hop so the intermediate version remains tested, and a new step
exercises the new default end-to-end.

### Review guide

# Review Guide — #650: Bump block node Helm chart version to v0.35.1

## Summary

The hardcoded default block-node Helm chart version was `0.30.2`, five minor versions
behind the current GA release. This PR bumps the single source-of-truth constant
(`pkg/deps/deps.go`) to `0.35.1` and extends `uat:core` to validate a full
v0.26.0 → v0.29.0 → v0.30.2 → v0.35.1 upgrade chain.

## Changed files

| File | Change |
|---|---|
| `pkg/deps/deps.go` | `BLOCK_NODE_VERSION` bumped from `0.30.2` to `0.35.1` (single source of truth) |
| `test/config/config_with_proxy_latest.yaml` | `version` field updated to `0.35.1` — drives the "latest" upgrade step in `uat:core` |
| `taskfiles/uat.yaml` | Demoted old v0.30.2 "latest" step to explicit `--chart-version 0.30.2` hop; added new v0.35.1 step via config file |
| `internal/ui/prompt/prompt_test.go` | `EffectiveValue` for chart-version prompt updated to `0.35.1` |
| `cmd/cli/commands/block/node/reconfigure_it_test.go` | Embedded config fixture version updated to `0.35.1` |

## Code review checklist

- [ ] `pkg/deps/deps.go` is the only place the version constant is defined — confirm no other hardcoded `0.30.2` remains in non-UAT source (`grep -rn '0\.30\.2' --include='*.go'` returns 0 hits)
- [ ] UAT upgrade chain in `taskfiles/uat.yaml`: install v0.26.0 → upgrade v0.29.0 (flag) → upgrade v0.30.2 (flag) → upgrade v0.35.1 (config) → reset
- [ ] `config_with_proxy_latest.yaml` version matches `BLOCK_NODE_VERSION` in `deps.go`
- [ ] No other test fixtures embed `0.30.2` as an expected default (`prompt_test.go` and `reconfigure_it_test.go` both updated)
- [ ] `--chart-version` flag still overrides the default (acceptance criterion from issue)

## Test commands

```bash
# Unit tests (run inside UTM VM)
task vm:test:unit

# Targeted: prompt unit tests
task vm:test:unit TEST_PATHS=./internal/ui/prompt/...

# Integration: reconfigure tests
task vm:test:integration TEST_NAME='^Test.*Reconfigure'
```

## Manual UAT (run inside UTM VM — requires `task uat:setup` first)

```bash
task uat:core
```

Expected output (final upgrade step):

```
▶ Upgrade to latest (v0.35.1) using updated chartVersion in config
▶ Verify upgrade to latest (v0.35.1)
   Chart version: 0.35.1
   Container images: ...
▶ Verify MetalLB annotation present after upgrade to v0.35.1
   metallb.io/address-pool: public-address-pool ✓
✅ Core Block Node: PASSED
```

Also verify the flag-override path still works:

```bash
sudo solo-provisioner block node install -p local --chart-version 0.29.0
helm list -n block-node -o json | grep chart
# expect: chart version 0.29.0
```

### Related Issues

* Closes #650
