### PR TITLE
fix(log): make provisioner log files world-readable and omit missing daemon log from summary

### DIFF
--- a/cmd/cli/commands/common/run.go
+++ b/cmd/cli/commands/common/run.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"path"
 	"time"
 
@@ -145,7 +146,10 @@ func finalizeWorkflowReport(report *automa.Report) error {
 
 	totalDuration := report.EndTime.Sub(report.StartTime)
 	logPath := path.Join(logCfg.Directory, logCfg.Filename)
-	daemonLogPath := path.Join(logCfg.Directory, "solo-provisioner-daemon.log")
+	daemonLogPath := ""
+	if p := path.Join(logCfg.Directory, "solo-provisioner-daemon.log"); fileExists(p) {
+		daemonLogPath = p
+	}
 	fmt.Print(ui.RenderSummaryTable(report, totalDuration, reportPath, logPath, daemonLogPath))
 
 	logx.As().Info().
@@ -157,6 +161,11 @@ func finalizeWorkflowReport(report *automa.Report) error {
 		return err
 	}
 	return report.Error
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
 }
 
 // deepestFailureError descends through nested StepReports to return the

--- a/cmd/cli/commands/root.go
+++ b/cmd/cli/commands/root.go
@@ -189,7 +189,7 @@ func initConfig(ctx context.Context) {
 		_ = os.Chmod(logConfig.Directory, models.DefaultStorageDirPerm)
 	}
 
-	// Pre-create the log file with group-readable mode (0640) before lumberjack claims it.
+	// Pre-create the log file with world-readable mode (0644) before lumberjack claims it.
 	// Lumberjack hardcodes 0600 on first creation; opening an existing file uses O_APPEND
 	// which preserves the existing mode. Because the directory now has setgid, the newly
 	// created file inherits the weaver group automatically.
@@ -197,12 +197,13 @@ func initConfig(ctx context.Context) {
 	// fix their group and mode explicitly.
 	logFilePath := path.Join(logConfig.Directory, logConfig.Filename)
 	if _, statErr := os.Stat(logFilePath); os.IsNotExist(statErr) {
-		if f, createErr := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY, 0o640); createErr == nil {
+		if f, createErr := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY, models.DefaultFilePerm); createErr == nil {
 			_ = f.Close()
+			_ = os.Chmod(logFilePath, models.DefaultFilePerm)
 		}
 	} else if statErr == nil && gidErr == nil {
 		_ = os.Chown(logFilePath, 0, svcGID)
-		_ = os.Chmod(logFilePath, 0o640)
+		_ = os.Chmod(logFilePath, models.DefaultFilePerm)
 	}
 	if logConfig.MaxSize == 0 {
 		logConfig.MaxSize = 50 // 50 MB

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -94,16 +94,17 @@ func initConfig(ctx context.Context) {
 		_ = os.Chmod(logConfig.Directory, models.DefaultStorageDirPerm)
 	}
 
-	// Pre-create the log file with group-readable mode (0640) before lumberjack
+	// Pre-create the log file with world-readable mode (0644) before lumberjack
 	// claims it. For files created with wrong ownership in prior runs, fix them.
 	logFilePath := path.Join(logConfig.Directory, logConfig.Filename)
 	if _, statErr := os.Stat(logFilePath); os.IsNotExist(statErr) {
-		if f, createErr := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY, 0o640); createErr == nil {
+		if f, createErr := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY, models.DefaultFilePerm); createErr == nil {
 			_ = f.Close()
+			_ = os.Chmod(logFilePath, models.DefaultFilePerm)
 		}
 	} else if statErr == nil && gidErr == nil {
 		_ = os.Chown(logFilePath, 0, svcGID)
-		_ = os.Chmod(logFilePath, 0o640)
+		_ = os.Chmod(logFilePath, models.DefaultFilePerm)
 	}
 	if logConfig.MaxSize == 0 {
 		logConfig.MaxSize = 50

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/automa-saga/automa"
+	"github.com/stretchr/testify/assert"
+)
+
+func newReport() *automa.Report {
+	now := time.Now()
+	return &automa.Report{StartTime: now, EndTime: now.Add(time.Second)}
+}
+
+func TestRenderSummaryTable_IncludesDaemonLogWhenNonEmpty(t *testing.T) {
+	out := RenderSummaryTable(newReport(), time.Second, "/logs/report.yaml", "/logs/solo-provisioner.log", "/logs/solo-provisioner-daemon.log")
+	assert.Contains(t, out, "Daemon log:")
+	assert.Contains(t, out, "/logs/solo-provisioner-daemon.log")
+}
+
+func TestRenderSummaryTable_OmitsDaemonLogWhenEmpty(t *testing.T) {
+	out := RenderSummaryTable(newReport(), time.Second, "/logs/report.yaml", "/logs/solo-provisioner.log", "")
+	assert.False(t, strings.Contains(out, "Daemon log:"), "daemon log line should be absent when daemonLogPath is empty")
+}


### PR DESCRIPTION
## Description

After `solo-provisioner block node install`, the completion summary prints three log paths. Two were broken for non-root operators:

- **`solo-provisioner.log`** was created with `0640` (group-readable only). Operators not in the `weaver` group hit `Permission denied` trying to read it — despite `setup_report_*.yaml` being world-readable (`0644`) right next to it.
- **`solo-provisioner-daemon.log`** was always included in the summary regardless of whether the file existed. The daemon binary (a separate systemd service) creates that file only on first start, so the path printed as `No such file or directory` on every fresh install.

Both log files — CLI (`root.go`) and daemon (`cmd/daemon/main.go`) — now pre-create with `models.DefaultFilePerm` (`0644`) instead of `0640`. The `Daemon log:` line in the summary is omitted until `os.Stat` confirms the file is actually present.

### Review guide

# Review Guide — #652: Make provisioner log files consistently accessible

## Summary

After `solo-provisioner block node install`, the completion summary listed three log paths.
Two were broken: `solo-provisioner.log` was created `0640` (group-readable only), requiring
sudo for operators not in the `weaver` group; and `solo-provisioner-daemon.log` was always
printed even when the daemon binary hadn't created the file yet.

Fix: log files now use `models.DefaultFilePerm` (`0644`, world-readable) and the Daemon log
line in the summary is only emitted when the file actually exists on disk.

## Changed files

| File | Change |
|---|---|
| `cmd/cli/commands/root.go` | `OpenFile`/`Chmod` mode `0o640` → `models.DefaultFilePerm` for CLI log pre-creation |
| `cmd/daemon/main.go` | Same permission fix for daemon log pre-creation |
| `cmd/cli/commands/common/run.go` | `daemonLogPath` set only when `os.Stat` confirms the file exists; `fileExists` helper added |
| `internal/ui/view_test.go` | New: two unit tests for `RenderSummaryTable` covering present/absent daemon log line |
| `docs/claude/plans/00652-make-solo-provisioner-log-files-consistently.md` | Plan file |

## Code review checklist

- [ ] `models.DefaultFilePerm` is `0o644` — confirm no other callers in `root.go` or `cmd/daemon/main.go` still use raw `0o640`
- [ ] `fileExists` uses `os.Stat`; a symlink to a missing target returns `false` (correct — we only want to show the path when the file is genuinely readable)
- [ ] `RenderSummaryTable` in `view.go:314` already guards `daemonLogPath != ""` — the fix is purely in the caller (`run.go`), not the renderer
- [ ] The `else if statErr == nil && gidErr == nil` branch in both `root.go` and `daemon/main.go` also uses `models.DefaultFilePerm` — verify both `Chmod` call sites were updated
- [ ] No new import added to `root.go` or `daemon/main.go` — `models` was already imported

## Unit tests

```bash
# Run on macOS (no Linux-only deps)
go test -race -cover -tags='!integration' ./internal/ui/...
```

Expected: `ok github.com/hashgraph/solo-weaver/internal/ui` with both new cases passing.

Full suite (requires UTM VM):

```bash
task vm:test:unit
```

## Manual UAT (UTM VM, post block node install)

1. Run `sudo solo-provisioner block node install`.
2. **Check summary output**: `Log:` line present; **no** `Daemon log:` line (daemon service not yet started).
3. Verify CLI log permissions:
   ```bash
   stat /opt/solo/weaver/logs/solo-provisioner.log
   # expect: Access: (0644/-rw-r--r--)
   ```
4. Read log as non-root:
   ```bash
   sudo -u <non-root-user> head /opt/solo/weaver/logs/solo-provisioner.log
   # expect: output without Permission denied
   ```
5. Start daemon service:
   ```bash
   sudo systemctl start solo-provisioner-daemon
   ```
6. Run any CLI workflow again (e.g. `solo-provisioner block node check`).
7. **Check summary output**: `Daemon log:` line now present.
8. Verify daemon log permissions:
   ```bash
   stat /opt/solo/weaver/logs/solo-provisioner-daemon.log
   # expect: Access: (0644/-rw-r--r--)
   ```
9. Read daemon log as non-root:
   ```bash
   sudo -u <non-root-user> head /opt/solo/weaver/logs/solo-provisioner-daemon.log
   # expect: output without Permission denied
   ```
10. Confirm `setup_report_*.yaml` is also `0644` (pre-existing behavior, no regression).

### Related Issues

* Closes #652
