### PR TITLE
fix(cli): detect missing sudo early to prevent zerolog noise on startup

### DIFF
--- a/cmd/cli/commands/root.go
+++ b/cmd/cli/commands/root.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/alloy"
@@ -134,6 +135,15 @@ func Execute(ctx context.Context) error {
 		return errorx.IllegalArgument.New("context is required")
 	}
 
+	// Guard before any file I/O: lumberjack and the state-file reader both
+	// require root. Exit early with a clear message so no log-rotation noise
+	// appears on screen for non-exempt invocations.
+	if os.Getuid() != 0 && !isPrivilegeExemptInvocation(os.Args[1:]) {
+		return errorx.RejectedOperation.New("solo-provisioner must be run with superuser privileges").
+			WithProperty(doctor.ErrPropertyResolution,
+				fmt.Sprintf("Run: sudo %s", strings.Join(os.Args, " ")))
+	}
+
 	cobra.OnInitialize(func() {
 		initConfig(ctx)
 		fmt.Print(ui.RenderVersionHeader())
@@ -234,6 +244,24 @@ func initConfig(ctx context.Context) {
 	// Activate proxy after logging is initialized so the activation log
 	// respects TUI suppression and goes to the log file instead of stdout.
 	activateProxy(ctx)
+}
+
+// isPrivilegeExemptInvocation reports whether args represents an invocation
+// that does not require superuser privileges (version output, help text).
+func isPrivilegeExemptInvocation(args []string) bool {
+	if len(args) == 0 {
+		return true
+	}
+	for _, arg := range args {
+		switch arg {
+		case "--version", "-v", "--help", "-h":
+			return true
+		}
+	}
+	// Only the leading subcommand word can be exempt; flag values and nested
+	// subcommands after it are not checked because they may follow a
+	// flag=value pair whose value looks like a word (e.g. --log-level debug).
+	return args[0] == "version" || args[0] == "help"
 }
 
 func activateProxy(ctx context.Context) {

--- a/cmd/cli/commands/root_test.go
+++ b/cmd/cli/commands/root_test.go
@@ -10,6 +10,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsPrivilegeExemptInvocation(t *testing.T) {
+	exempt := [][]string{
+		{},
+		{"--version"},
+		{"-v"},
+		{"--help"},
+		{"-h"},
+		{"version"},
+		{"help"},
+		{"help", "block"},
+		{"--non-interactive", "--help"},
+		{"--log-level", "debug", "-h"},
+	}
+	for _, args := range exempt {
+		require.True(t, isPrivilegeExemptInvocation(args), "expected exempt: %v", args)
+	}
+
+	notExempt := [][]string{
+		{"block", "node", "install"},
+		{"install"},
+		{"uninstall"},
+		{"kube", "cluster", "install"},
+		{"block", "node", "upgrade", "--profile=mainnet"},
+		{"teleport", "node", "install"},
+		{"alloy", "cluster", "install"},
+	}
+	for _, args := range notExempt {
+		require.False(t, isPrivilegeExemptInvocation(args), "expected not exempt: %v", args)
+	}
+}
+
 func TestNoShortNameCollisionsInRealCommandTree(t *testing.T) {
 	require.False(t, common.DetectShortNameCollisions(rootCmd),
 		"short name collisions detected in command tree")


### PR DESCRIPTION
## Description

When `solo-provisioner` is run without root privileges, lumberjack tries to rotate the
root-owned log file before any real work begins, flooding the terminal with `zerolog`
rename errors. The state-file reader then hits a `permission denied` — the real cause
(missing sudo) is never mentioned.

```
zerolog: could not write event: can't rename log file: rename /opt/solo/weaver/logs/solo-provisioner.log /opt/solo/weaver/logs/solo-provisioner-2026-06-04T09-33-57.539.log: permission denied
...
Error: common.internal_error: failed to read state file at /opt/solo/weaver/state/state.yaml, cause: open /opt/solo/weaver/state/state.yaml: permission denied
```

The existing `CheckPrivilegesStep` inside the preflight workflow fires too late — after
`RunPersistentPreRun` has already failed on the state file. The fix adds a single guard
in `Execute()`, _before_ `cobra.OnInitialize`, so no log setup or state I/O runs for
non-root non-exempt invocations. The error is returned as `errorx.RejectedOperation`
with a resolution step, which `doctor.CheckErr` renders as the standard clean panel:

```
  ✗ Error: solo-provisioner must be run with superuser privileges.

  Resolution:
    1. Run: sudo solo-provisioner block node install
```

Commands that genuinely don't require root (`version`, `help`, `-v`/`--version`,
`-h`/`--help`, bare invocation) are exempted via `isPrivilegeExemptInvocation`.

### Review guide

# Review Guide: #651 — Improve `solo-provisioner` error UX when run without sudo

## Summary

Without root privileges, `solo-provisioner` was flooding the terminal with lumberjack
log-rotation errors and then a cryptic `permission denied` on the state file — instead
of a single actionable message. The fix adds a privilege guard at the very start of
`Execute()`, before `cobra.OnInitialize` touches any file, so no log setup runs and
`doctor.CheckErr` surfaces the clean error panel.

## Changed files

| File | Change |
|---|---|
| `cmd/cli/commands/root.go` | Add `isPrivilegeExemptInvocation(args []string) bool` helper and early privilege guard in `Execute()` |
| `cmd/cli/commands/root_test.go` | Add `TestIsPrivilegeExemptInvocation` table-driven unit test |

## Code review checklist

- [ ] `Execute()` returns before `cobra.OnInitialize` when non-root + non-exempt — confirm
  no file I/O (lumberjack, state file) is reachable from the returned error path
- [ ] `isPrivilegeExemptInvocation` is a pure function (no I/O, no global state) — safe
  to unit-test on any platform
- [ ] Exempt list is conservative: only `version`, `help`, `--version`/`-v`,
  `--help`/`-h`, and bare invocation (help)
- [ ] `errorx.RejectedOperation` + `ErrPropertyResolution` matches the pattern used by
  the existing `CheckPrivilegesStep` in `internal/workflows/preflight.go:80`
- [ ] `strings.Join(os.Args, " ")` in the resolution message reproduces the full original
  invocation (including the binary name) for copy-paste
- [ ] Existing `CheckPrivilegesStep` is untouched — still guards the weaver-UID case
  inside actual workflows

## Unit tests

Run in the UTM VM (Linux required due to `internal/mount` transitive dep):

```bash
task vm:test:unit
# or to run just this test:
# go test -v -run TestIsPrivilegeExemptInvocation -tags='!integration' ./cmd/cli/commands/
```

On macOS the whole `./cmd/...` tree fails to compile (Linux-only `mount` dep), so
`isPrivilegeExemptInvocation` tests must be verified in the VM.

## Manual UAT (UTM VM, as non-root user)

```bash
# 1. Should show the clean error panel — NO zerolog rotation lines
solo-provisioner block node install
# Expected:
#   ✗ Error: solo-provisioner must be run with superuser privileges.
#
#   Resolution:
#     1. Run: sudo solo-provisioner block node install

# 2. Should print version without error
solo-provisioner -v
solo-provisioner version

# 3. Should print help without error
solo-provisioner help
solo-provisioner
solo-provisioner --help
```

<img width="807" height="475" alt="image" src="https://github.com/user-attachments/assets/e37b49c0-7c5c-4ae0-aa3d-16a19d6a8d2e" />


### Related Issues

* Closes #651
