### PR TITLE
feat(blocknode): version-aware plugin preset registry for BN 0.35 cloud-storage rename

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -86,6 +86,32 @@ jobs:
       uat-scenario: lifecycle
       vm-os: debian
 
+  uat-purge-storage:
+    name: UAT Purge Storage
+    uses: ./.github/workflows/zxc-uat-test.yaml
+    needs:
+      - changes
+      - build
+      - uat-compat
+    if: needs.changes.outputs.non_docs == 'true'
+    with:
+      custom-job-label: UAT Purge Storage
+      uat-scenario: purge-storage
+      vm-os: debian
+
+  uat-plugin-preset-upgrade:
+    name: UAT Plugin Preset Upgrade
+    uses: ./.github/workflows/zxc-uat-test.yaml
+    needs:
+      - changes
+      - build
+      - uat-compat
+    if: needs.changes.outputs.non_docs == 'true'
+    with:
+      custom-job-label: UAT Plugin Preset Upgrade
+      uat-scenario: plugin-preset-upgrade
+      vm-os: debian
+
   integration-tests:
     name: Integration Tests
     uses: ./.github/workflows/zxc-integration-test.yaml
@@ -93,6 +119,8 @@ jobs:
       - changes
       - build
       - uat-core
+      - uat-purge-storage
+      - uat-plugin-preset-upgrade
     if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: Standard

--- a/.github/workflows/flow-test-uat.yaml
+++ b/.github/workflows/flow-test-uat.yaml
@@ -16,6 +16,7 @@ on:
           - setup
           - core
           - purge-storage
+          - plugin-preset-upgrade
           - solo-operator
           - teleport
           - alloy

--- a/.github/workflows/zxc-uat-test.yaml
+++ b/.github/workflows/zxc-uat-test.yaml
@@ -5,7 +5,7 @@ on:
   workflow_call:
     inputs:
       uat-scenario:
-        description: "UAT scenario to run (lifecycle, compat, setup, core, purge-storage, teardown, teleport, alloy, all)"
+        description: "UAT scenario to run (lifecycle, compat, purge-storage, plugin-preset-upgrade, setup, core, teardown, teleport, alloy, all)"
         type: string
         required: false
         default: "lifecycle"

--- a/cmd/cli/commands/block/node/init.go
+++ b/cmd/cli/commands/block/node/init.go
@@ -112,6 +112,13 @@ func promptForMissingFlags(cmd *cobra.Command, args []string) error {
 		logx.As().Debug().Err(err).Msg("Could not read prompt defaults from state file; using config/defaults only")
 	}
 
+	// reconfigure omits --chart-version (it is an immutable field); fall back to
+	// the deployed version from state so plugin preset resolution uses the correct
+	// version-gated list rather than defaulting to the latest release.
+	if cmd.Name() == "reconfigure" && flagChartVersion == "" {
+		flagChartVersion = defaults.BlockNode.ChartVersion
+	}
+
 	// profileTarget is a local copy that the prompt writes to; after the prompt
 	// completes we propagate it into Cobra's persistent flag set so that
 	// common.FlagProfile().Value(cmd, args) returns the prompted value.
@@ -160,7 +167,7 @@ func promptForMissingFlags(cmd *cobra.Command, args []string) error {
 	}
 
 	// Plugin preset prompt: two-pass (preset select → conditional custom multi-select).
-	if err := prompt.RunPluginPresetPrompts(cmd, defaults, &flagPluginPreset, &flagPlugins, cv); err != nil {
+	if err := prompt.RunPluginPresetPrompts(cmd, defaults, &flagPluginPreset, &flagPlugins, flagChartVersion, cv); err != nil {
 		return err
 	}
 
@@ -221,7 +228,19 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 		}
 	}
 	if pluginList == "" && bnpkg.IsKnownPreset(pluginPreset) {
-		pluginList = bnpkg.PluginListForPreset(pluginPreset)
+		pluginList = bnpkg.PluginListForPreset(pluginPreset, flagChartVersion)
+	}
+	// For non-interactive upgrades (scripted runs where the TUI is skipped),
+	// --plugin-preset is not prompted, so flagPluginPreset stays empty. Re-resolve
+	// from the stored preset to ensure plugin names are updated when crossing chart
+	// version boundaries (e.g. the 0.35 s3-archive → cloud-storage-* rename).
+	if cmd.Name() == "upgrade" && pluginPreset == "" && pluginList == "" {
+		if stateDefaults, defErr := state.ReadPromptDefaultsFromDisk(); defErr == nil {
+			if bnpkg.IsKnownPreset(stateDefaults.BlockNode.PluginPreset) {
+				pluginPreset = stateDefaults.BlockNode.PluginPreset
+				pluginList = bnpkg.PluginListForPreset(pluginPreset, flagChartVersion)
+			}
+		}
 	}
 	if pluginList != "" && pluginPreset == "" {
 		pluginPreset = bnpkg.PresetCustom

--- a/internal/blocknode/blocknode_plugins.go
+++ b/internal/blocknode/blocknode_plugins.go
@@ -2,56 +2,141 @@
 
 package blocknode
 
+import "github.com/hashgraph/solo-weaver/pkg/semver"
+
 // Plugin preset IDs used by the --plugin-preset flag and TUI prompt.
 //
 // Each preset maps to a fixed, ordered plugin list maintained here in lockstep
 // with block-node chart releases. When the block-node team changes a preset's
 // contents or adds/removes presets, this file must be updated in the same
 // release cycle.
+//
+// Adding a new BN version that changes plugin lists:
+//  1. Add a new blockNodePluginConfig entry to blockNodePluginHistory (in
+//     ascending MinVersion order).
+//  2. Populate Presets with ALL preset IDs (copy unchanged ones from the
+//     previous entry; update only the ones that changed).
+//  3. Populate AllPlugins with the full list for that version.
+//  4. Add tests in blocknode_plugins_test.go for the new version boundary.
+//  5. No changes to PluginListForPreset, PluginsForVersion, or any caller.
 const (
 	// PresetTier1LFH selects Local Full History storage (blocks stored on disk).
 	PresetTier1LFH = "tier1-lfh"
 
-	// PresetTier1RFH selects Remote Full History storage (blocks stored in S3-compatible cloud storage).
+	// PresetTier1RFH selects Remote Full History storage (blocks stored in cloud storage).
 	PresetTier1RFH = "tier1-rfh"
 
 	// PresetCustom indicates the operator selected a custom set of plugins.
 	PresetCustom = "custom"
 )
 
-// AllBlockNodePlugins is the ordered list of available plugins shown in the
-// TUI multi-select when the operator chooses the Custom preset.
-// Source of truth: hiero-block-node block-node/app/build.gradle.kts (blockNodePlugins configuration).
-var AllBlockNodePlugins = []string{
-	"facility-messaging",
-	"block-access-service",
-	"health",
-	"server-status",
-	"stream-publisher",
-	"stream-subscriber",
-	"verification",
-	"blocks-file-historic",
-	"blocks-file-recent",
-	"backfill",
-	"s3-archive",
+// blockNodePluginConfig holds the canonical plugin configuration for a range of
+// chart versions starting at MinVersion. Entries in blockNodePluginHistory must
+// be in ascending MinVersion order; the first entry uses an empty MinVersion
+// (baseline, applies to all versions below the next entry's MinVersion).
+type blockNodePluginConfig struct {
+	// MinVersion is the minimum chart version (inclusive) for this config.
+	// Empty string means "from the very beginning" (baseline).
+	MinVersion string
+	// Presets maps each preset ID to its canonical comma-separated plugin list.
+	// Source of truth: hiero-block-node chart values-overrides/plugin-profile-*.yaml.
+	Presets map[string]string
+	// AllPlugins is the ordered list of all available plugins for this version,
+	// shown in the TUI custom multi-select.
+	// Source of truth: hiero-block-node block-node/app/build.gradle.kts.
+	AllPlugins []string
 }
 
-// presetPlugins maps each preset ID to the canonical comma-separated plugin list.
-// Source of truth: hiero-block-node chart values-overrides/plugin-profile-*.yaml.
-var presetPlugins = map[string]string{
-	PresetTier1LFH: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent,backfill",
-	PresetTier1RFH: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-recent,backfill,s3-archive",
+// blockNodePluginHistory is the version-ordered registry of plugin configurations.
+// Add a new entry here (in ascending MinVersion order) whenever a BN release
+// changes the plugin list. See the package comment above for the procedure.
+var blockNodePluginHistory = []blockNodePluginConfig{
+	{
+		// Baseline: BN < 0.35.0. s3-archive was the cloud-storage plugin.
+		MinVersion: "",
+		Presets: map[string]string{
+			PresetTier1LFH: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent,backfill",
+			PresetTier1RFH: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-recent,backfill,s3-archive",
+		},
+		AllPlugins: []string{
+			"facility-messaging",
+			"block-access-service",
+			"health",
+			"server-status",
+			"stream-publisher",
+			"stream-subscriber",
+			"verification",
+			"blocks-file-historic",
+			"blocks-file-recent",
+			"backfill",
+			"s3-archive",
+		},
+	},
+	{
+		// BN 0.35.0: s3-archive replaced by cloud-storage-archive + cloud-storage-expanded.
+		MinVersion: "0.35.0",
+		Presets: map[string]string{
+			PresetTier1LFH: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent,backfill",
+			PresetTier1RFH: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-recent,backfill,cloud-storage-archive,cloud-storage-expanded",
+		},
+		AllPlugins: []string{
+			"facility-messaging",
+			"block-access-service",
+			"health",
+			"server-status",
+			"stream-publisher",
+			"stream-subscriber",
+			"verification",
+			"blocks-file-historic",
+			"blocks-file-recent",
+			"backfill",
+			"cloud-storage-archive",
+			"cloud-storage-expanded",
+		},
+	},
 }
+
+// AllBlockNodePlugins is the ordered list of available plugins for the current
+// (latest) chart release. Use PluginsForVersion when the target chart version
+// may be older.
+var AllBlockNodePlugins = blockNodePluginHistory[len(blockNodePluginHistory)-1].AllPlugins
 
 // presetLabels maps preset IDs to human-readable labels for TUI display.
 var presetLabels = map[string]string{
 	PresetTier1LFH: "Tier 1 — Local Full History  (blocks stored on local disk)",
-	PresetTier1RFH: "Tier 1 — Remote Full History  (blocks stored in S3-compatible cloud storage)",
+	PresetTier1RFH: "Tier 1 — Remote Full History  (blocks stored in cloud storage)",
 	PresetCustom:   "Custom  (select individual plugins)",
 }
 
 // orderedPresets is the display order for the TUI select prompt.
 var orderedPresets = []string{PresetTier1LFH, PresetTier1RFH, PresetCustom}
+
+// configForVersion returns the plugin configuration applicable to the given
+// chart version. Empty or unparseable versions return the latest config.
+func configForVersion(chartVersion string) blockNodePluginConfig {
+	latest := blockNodePluginHistory[len(blockNodePluginHistory)-1]
+	if chartVersion == "" {
+		return latest
+	}
+	target, err := semver.NewSemver(chartVersion)
+	if err != nil {
+		return latest
+	}
+	for i := len(blockNodePluginHistory) - 1; i >= 0; i-- {
+		cfg := blockNodePluginHistory[i]
+		if cfg.MinVersion == "" {
+			return cfg
+		}
+		minVer, err := semver.NewSemver(cfg.MinVersion)
+		if err != nil {
+			continue
+		}
+		if !target.LessThan(minVer) {
+			return cfg
+		}
+	}
+	return blockNodePluginHistory[0]
+}
 
 // AvailablePresets returns the ordered preset IDs for TUI display.
 func AvailablePresets() []string {
@@ -61,9 +146,22 @@ func AvailablePresets() []string {
 }
 
 // PluginListForPreset returns the canonical comma-separated plugin list for a
-// named preset, or an empty string when the preset ID is not recognised.
-func PluginListForPreset(presetID string) string {
-	return presetPlugins[presetID]
+// named preset at the given chart version, or an empty string when the preset
+// ID is not recognised. When chartVersion is empty, the current-default
+// (latest) list is returned.
+func PluginListForPreset(presetID, chartVersion string) string {
+	return configForVersion(chartVersion).Presets[presetID]
+}
+
+// PluginsForVersion returns the ordered list of available plugins for the given
+// chart version, for use in the TUI custom multi-select. When chartVersion is
+// empty, the current-default (latest) list is returned. Always returns an
+// independent copy.
+func PluginsForVersion(chartVersion string) []string {
+	src := configForVersion(chartVersion).AllPlugins
+	result := make([]string, len(src))
+	copy(result, src)
+	return result
 }
 
 // PresetLabel returns the human-readable TUI label for a preset ID,
@@ -77,6 +175,7 @@ func PresetLabel(presetID string) string {
 
 // IsKnownPreset returns true when presetID is a recognised non-custom preset.
 func IsKnownPreset(presetID string) bool {
-	_, ok := presetPlugins[presetID]
+	// A preset is known if it appears in at least the latest config's Presets map.
+	_, ok := blockNodePluginHistory[len(blockNodePluginHistory)-1].Presets[presetID]
 	return ok
 }

--- a/internal/blocknode/blocknode_plugins_test.go
+++ b/internal/blocknode/blocknode_plugins_test.go
@@ -6,10 +6,47 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashgraph/solo-weaver/pkg/semver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
+
+// ── blockNodePluginHistory registry invariants ────────────────────────────────
+
+func TestPluginHistory_AscendingVersionOrder(t *testing.T) {
+	for i := 1; i < len(blockNodePluginHistory); i++ {
+		prev := blockNodePluginHistory[i-1]
+		curr := blockNodePluginHistory[i]
+		require.NotEmpty(t, curr.MinVersion, "entry %d must have a MinVersion (only the first entry may be empty)", i)
+		// Always validate that curr.MinVersion is parseable, even when prev is the
+		// baseline (empty MinVersion). A typo here would cause configForVersion to
+		// silently skip the entry rather than returning an error.
+		currVer, err := semver.NewSemver(curr.MinVersion)
+		require.NoError(t, err, "entry %d MinVersion %q must be valid semver", i, curr.MinVersion)
+		if prev.MinVersion == "" {
+			continue
+		}
+		prevVer, err := semver.NewSemver(prev.MinVersion)
+		require.NoError(t, err, "entry %d MinVersion %q must be valid semver", i-1, prev.MinVersion)
+		assert.True(t, prevVer.LessThan(currVer), "entry %d (%s) must be > entry %d (%s)", i, curr.MinVersion, i-1, prev.MinVersion)
+	}
+}
+
+func TestPluginHistory_AllKnownPresetsInEveryEntry(t *testing.T) {
+	knownPresets := []string{PresetTier1LFH, PresetTier1RFH}
+	for i, cfg := range blockNodePluginHistory {
+		for _, preset := range knownPresets {
+			assert.NotEmpty(t, cfg.Presets[preset], "entry %d (MinVersion=%q) missing preset %q", i, cfg.MinVersion, preset)
+		}
+	}
+}
+
+func TestPluginHistory_AllPluginsNonEmpty(t *testing.T) {
+	for i, cfg := range blockNodePluginHistory {
+		assert.NotEmpty(t, cfg.AllPlugins, "entry %d (MinVersion=%q) must have a non-empty AllPlugins list", i, cfg.MinVersion)
+	}
+}
 
 // ── AvailablePresets ─────────────────────────────────────────────────────────
 
@@ -30,28 +67,124 @@ func TestAvailablePresets_ReturnsACopy(t *testing.T) {
 // ── PluginListForPreset ──────────────────────────────────────────────────────
 
 func TestPluginListForPreset_Tier1LFH(t *testing.T) {
-	list := PluginListForPreset(PresetTier1LFH)
+	list := PluginListForPreset(PresetTier1LFH, "")
 	assert.NotEmpty(t, list)
 	assert.Contains(t, list, "facility-messaging")
 	assert.Contains(t, list, "blocks-file-historic")
 	assert.Contains(t, list, "blocks-file-recent")
 	assert.NotContains(t, list, "s3-archive")
+	assert.NotContains(t, list, "cloud-storage-archive")
+	assert.NotContains(t, list, "cloud-storage-expanded")
 }
 
-func TestPluginListForPreset_Tier1RFH(t *testing.T) {
-	list := PluginListForPreset(PresetTier1RFH)
-	assert.NotEmpty(t, list)
-	assert.Contains(t, list, "facility-messaging")
-	assert.Contains(t, list, "s3-archive")
-	assert.NotContains(t, list, "blocks-file-historic")
+func TestPluginListForPreset_Tier1RFH_BN035Plus(t *testing.T) {
+	for _, ver := range []string{"", "0.35.0", "0.36.0", "1.0.0"} {
+		list := PluginListForPreset(PresetTier1RFH, ver)
+		assert.NotEmpty(t, list, "version=%q", ver)
+		assert.Contains(t, list, "cloud-storage-archive", "version=%q", ver)
+		assert.Contains(t, list, "cloud-storage-expanded", "version=%q", ver)
+		assert.NotContains(t, list, "s3-archive", "version=%q", ver)
+		assert.NotContains(t, list, "blocks-file-historic", "version=%q", ver)
+	}
+}
+
+func TestPluginListForPreset_Tier1RFH_LegacyBN(t *testing.T) {
+	for _, ver := range []string{"0.34.9", "0.30.0", "0.26.2"} {
+		list := PluginListForPreset(PresetTier1RFH, ver)
+		assert.NotEmpty(t, list, "version=%q", ver)
+		assert.Contains(t, list, "s3-archive", "version=%q", ver)
+		assert.NotContains(t, list, "cloud-storage-archive", "version=%q", ver)
+		assert.NotContains(t, list, "cloud-storage-expanded", "version=%q", ver)
+	}
+}
+
+// TestPluginListForPreset_UpgradeScenario documents the expected behaviour when an
+// operator upgrades from a pre-0.35 chart to 0.35+. solo-weaver reads the stored
+// PluginPreset ("tier1-rfh") and calls PluginListForPreset with the new target
+// chart version; the returned list must contain the renamed cloud-storage plugins
+// even though the previous install used s3-archive.
+func TestPluginListForPreset_UpgradeScenario(t *testing.T) {
+	cases := []struct {
+		name            string
+		installedPreset string
+		targetVersion   string
+		wantContains    []string
+		wantAbsent      []string
+	}{
+		{
+			name:            "RFH upgrade pre-0.35 to 0.35 switches plugin names",
+			installedPreset: PresetTier1RFH,
+			targetVersion:   "0.35.0",
+			wantContains:    []string{"cloud-storage-archive", "cloud-storage-expanded"},
+			wantAbsent:      []string{"s3-archive"},
+		},
+		{
+			name:            "RFH upgrade stays on pre-0.35 keeps legacy name",
+			installedPreset: PresetTier1RFH,
+			targetVersion:   "0.34.9",
+			wantContains:    []string{"s3-archive"},
+			wantAbsent:      []string{"cloud-storage-archive", "cloud-storage-expanded"},
+		},
+		{
+			name:            "LFH upgrade is unaffected by the 0.35 boundary",
+			installedPreset: PresetTier1LFH,
+			targetVersion:   "0.35.0",
+			wantContains:    []string{"blocks-file-historic", "blocks-file-recent"},
+			wantAbsent:      []string{"s3-archive", "cloud-storage-archive", "cloud-storage-expanded"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			list := PluginListForPreset(tc.installedPreset, tc.targetVersion)
+			require.NotEmpty(t, list)
+			for _, want := range tc.wantContains {
+				assert.Contains(t, list, want)
+			}
+			for _, absent := range tc.wantAbsent {
+				assert.NotContains(t, list, absent)
+			}
+		})
+	}
+}
+
+func TestPluginListForPreset_InvalidVersionFallsToLatest(t *testing.T) {
+	list := PluginListForPreset(PresetTier1RFH, "not-a-semver")
+	assert.Contains(t, list, "cloud-storage-archive", "invalid semver must fall back to the latest config")
 }
 
 func TestPluginListForPreset_UnknownReturnsEmpty(t *testing.T) {
-	assert.Empty(t, PluginListForPreset("does-not-exist"))
+	assert.Empty(t, PluginListForPreset("does-not-exist", ""))
 }
 
 func TestPluginListForPreset_CustomReturnsEmpty(t *testing.T) {
-	assert.Empty(t, PluginListForPreset(PresetCustom), "custom preset has no predefined plugin list")
+	assert.Empty(t, PluginListForPreset(PresetCustom, ""), "custom preset has no predefined plugin list")
+}
+
+// ── PluginsForVersion ────────────────────────────────────────────────────────
+
+func TestPluginsForVersion_BN035Plus(t *testing.T) {
+	for _, ver := range []string{"", "0.35.0", "0.36.0"} {
+		plugins := PluginsForVersion(ver)
+		assert.Contains(t, plugins, "cloud-storage-archive", "version=%q", ver)
+		assert.Contains(t, plugins, "cloud-storage-expanded", "version=%q", ver)
+		assert.NotContains(t, plugins, "s3-archive", "version=%q", ver)
+	}
+}
+
+func TestPluginsForVersion_LegacyBN(t *testing.T) {
+	for _, ver := range []string{"0.34.9", "0.30.0"} {
+		plugins := PluginsForVersion(ver)
+		assert.Contains(t, plugins, "s3-archive", "version=%q", ver)
+		assert.NotContains(t, plugins, "cloud-storage-archive", "version=%q", ver)
+		assert.NotContains(t, plugins, "cloud-storage-expanded", "version=%q", ver)
+	}
+}
+
+func TestPluginsForVersion_ReturnsACopy(t *testing.T) {
+	a := PluginsForVersion("")
+	b := PluginsForVersion("")
+	a[0] = "mutated"
+	assert.NotEqual(t, "mutated", b[0], "PluginsForVersion must return an independent copy")
 }
 
 // ── PresetLabel ──────────────────────────────────────────────────────────────
@@ -94,7 +227,7 @@ func TestInjectPluginsConfig_NoOpWhenPluginListEmpty(t *testing.T) {
 }
 
 func TestInjectPluginsConfig_SetsPluginsNames(t *testing.T) {
-	m := managerWithInputs(t, PresetTier1LFH, PluginListForPreset(PresetTier1LFH))
+	m := managerWithInputs(t, PresetTier1LFH, PluginListForPreset(PresetTier1LFH, ""))
 	input := []byte("plugins:\n  mavenImage: some-image\n")
 
 	result, err := m.injectPluginsConfig(input)
@@ -105,11 +238,11 @@ func TestInjectPluginsConfig_SetsPluginsNames(t *testing.T) {
 
 	plugins, ok := vals["plugins"].(map[string]interface{})
 	require.True(t, ok, "plugins key must be a map")
-	assert.Equal(t, PluginListForPreset(PresetTier1LFH), plugins["names"])
+	assert.Equal(t, PluginListForPreset(PresetTier1LFH, ""), plugins["names"])
 }
 
 func TestInjectPluginsConfig_CreatesPluginsMapWhenAbsent(t *testing.T) {
-	m := managerWithInputs(t, PresetTier1RFH, PluginListForPreset(PresetTier1RFH))
+	m := managerWithInputs(t, PresetTier1RFH, PluginListForPreset(PresetTier1RFH, ""))
 	input := []byte("blockNode:\n  config: {}\n")
 
 	result, err := m.injectPluginsConfig(input)
@@ -120,7 +253,7 @@ func TestInjectPluginsConfig_CreatesPluginsMapWhenAbsent(t *testing.T) {
 
 	plugins, ok := vals["plugins"].(map[string]interface{})
 	require.True(t, ok, "plugins map must be created when absent")
-	assert.Equal(t, PluginListForPreset(PresetTier1RFH), plugins["names"])
+	assert.Equal(t, PluginListForPreset(PresetTier1RFH, ""), plugins["names"])
 }
 
 func TestInjectPluginsConfig_OverridesExistingPluginsNames(t *testing.T) {

--- a/internal/ui/prompt/blocknode.go
+++ b/internal/ui/prompt/blocknode.go
@@ -427,8 +427,8 @@ func BlockNodeReconfigureInputPrompts(
 //
 // Pass 2 — custom plugin multi-select (conditional): when the operator selects
 // the Custom preset, a multi-select is shown listing all known block-node
-// plugins. The resulting selection is joined as a comma-separated string and
-// written to *flagPlugins.
+// plugins for the given chartVersion. The resulting selection is joined as a
+// comma-separated string and written to *flagPlugins.
 //
 // The function is a no-op when either flag was already supplied on the command
 // line — the caller's values are respected as-is.
@@ -438,12 +438,14 @@ func BlockNodeReconfigureInputPrompts(
 //   - defaults:        prompt defaults read from the on-disk state file
 //   - flagPluginPreset: pointer to the --plugin-preset flag variable
 //   - flagPlugins:     pointer to the --plugins flag variable
+//   - chartVersion:   target chart version (used to filter available plugins)
 //   - cv:              chosen-values collector for summary printing
 func RunPluginPresetPrompts(
 	cmd *cobra.Command,
 	defaults state.PromptDefaults,
 	flagPluginPreset *string,
 	flagPlugins *string,
+	chartVersion string,
 	cv *ChosenValues,
 ) error {
 	// If the operator already supplied --plugins, no prompting is needed.
@@ -489,9 +491,10 @@ func RunPluginPresetPrompts(
 	// Pre-select the plugins from the last-used custom list (if any),
 	// but filter out any entries that no longer exist in the current
 	// available plugin list so the UI does not silently drop them.
-	validPlugins := make(map[string]struct{}, len(blocknode.AllBlockNodePlugins))
+	versionedPlugins := blocknode.PluginsForVersion(chartVersion)
+	validPlugins := make(map[string]struct{}, len(versionedPlugins))
 	var pluginOptions []huh.Option[string]
-	for _, p := range blocknode.AllBlockNodePlugins {
+	for _, p := range versionedPlugins {
 		validPlugins[p] = struct{}{}
 		pluginOptions = append(pluginOptions, huh.NewOption(p, p))
 	}

--- a/taskfiles/uat.yaml
+++ b/taskfiles/uat.yaml
@@ -28,6 +28,10 @@ tasks:
   uat:setup:
     desc: "Set up cluster for acceptance tests (inside VM: self-install + block node install)"
     interactive: true
+    vars:
+      BN_VERSION: '{{.BN_VERSION | default "0.26.0"}}'
+      PLUGIN_PRESET: '{{.PLUGIN_PRESET | default ""}}'
+      NON_INTERACTIVE: '{{.NON_INTERACTIVE | default "false"}}'
     cmds:
       - task: uat:bootstrap
       - |
@@ -36,16 +40,23 @@ tasks:
         echo "  UAT Setup: Install Block Node"
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+        BN_VERSION='{{.BN_VERSION}}'
+        PLUGIN_PRESET='{{.PLUGIN_PRESET}}'
+        NON_INTERACTIVE='{{.NON_INTERACTIVE}}'
 
-        echo -e '\n▶ Block node install (v0.26.0)'
-        sudo solo-provisioner block node install -p local \
-          -c /mnt/solo-weaver/test/config/config_with_proxy.yaml
+        INSTALL_ARGS="-p local -c /mnt/solo-weaver/test/config/config_with_proxy.yaml"
+        [ -n "$BN_VERSION" ]            && INSTALL_ARGS="$INSTALL_ARGS --chart-version $BN_VERSION"
+        [ -n "$PLUGIN_PRESET" ]         && INSTALL_ARGS="$INSTALL_ARGS --plugin-preset $PLUGIN_PRESET"
+        [ "$NON_INTERACTIVE" = "true" ] && INSTALL_ARGS="$INSTALL_ARGS --non-interactive"
+
+        echo -e "\n▶ Block node install (${BN_VERSION:-config default})"
+        sudo solo-provisioner block node install $INSTALL_ARGS
 
 
-        echo -e '\n▶ Verify install (v0.26.0)'
+        echo -e "\n▶ Verify install (${BN_VERSION:-config default})"
         CHART_VER=$(helm list -n block-node -o json | sed -n 's/.*"chart":"[^"]*-\([0-9]*\.[0-9]*\.[0-9]*\)".*/\1/p')
         echo "   Chart version: $CHART_VER"
-        [ "$CHART_VER" = "0.26.0" ] || { echo "FAIL: expected chart version 0.26.0, got $CHART_VER"; exit 1; }
+        [ -z "$BN_VERSION" ] || [ "$CHART_VER" = "$BN_VERSION" ] || { echo "FAIL: expected chart version $BN_VERSION, got $CHART_VER"; exit 1; }
         kubectl get pods -n block-node
         echo '   Container images:'
         kubectl get pods -n block-node -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.containers[*]}{.image}{" "}{end}{"\n"}{end}'
@@ -157,24 +168,16 @@ tasks:
         echo '✅ Core Block Node: PASSED'
 
   uat:purge-storage:
-    desc: "Verify the three block-node uninstall variants (self-contained: bootstraps its own cluster)"
+    desc: "Verify the three block-node uninstall variants"
     interactive: true
     cmds:
+      - task: uat:setup
       - |
         set -e
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
         echo "  UAT Test: Block Node Uninstall Variants"
         echo "  matrix: (no flag) → with-reset → purge-storage"
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-
-
-        echo -e '\n▶ Bootstrap binary'
-        task uat:bootstrap
-
-
-        echo -e '\n▶ Install block node (also sets up cluster)'
-        sudo solo-provisioner block node install -p local \
-          -c /mnt/solo-weaver/test/config/config_with_proxy.yaml
 
         CONFIG=/mnt/solo-weaver/test/config/config_with_proxy.yaml
         NS=block-node
@@ -254,13 +257,9 @@ tasks:
         live_dir_has_files && { echo "FAIL: live data dir not wiped under --purge-storage"; exit 1; }
         echo "   ✓ helm gone; PVCs=0 PVs=0; data wiped"
 
-
-        echo -e '\n▶ Teardown'
-        sudo solo-provisioner kube cluster uninstall || true
-        sudo solo-provisioner uninstall || true
-
         echo ''
         echo '✅ Block Node Uninstall Variants: PASSED'
+      - task: uat:teardown
 
   uat:teleport:
     desc: "Run teleport lifecycle test (inside VM: requires cluster from uat:setup)"
@@ -526,19 +525,23 @@ tasks:
         echo '✅ solo-operator Lifecycle: PASSED'
 
   uat:plugin-preset-upgrade:
-    desc: "Verify plugin preset names auto-update on upgrade across the 0.35 version boundary (self-contained: bootstraps its own cluster)"
+    desc: "Verify plugin preset names auto-update on upgrade across the 0.35 version boundary"
     interactive: true
     cmds:
+      - task: uat:setup
+        vars:
+          BN_VERSION: "0.33.0"
+          PLUGIN_PRESET: "tier1-rfh"
+          NON_INTERACTIVE: "true"
       - |
         set -e
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
         echo "  UAT Test: Plugin Preset Upgrade (pre-0.35 → 0.35+)"
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-        # Chart versions under test. Update if the last stable pre-0.35 or
-        # current 0.35+ release changes.
-        PRE_35_VERSION=0.33.0
-        POST_35_VERSION=0.35.0
+        # Chart version for the post-0.35 upgrade target.
+        # Update if the current 0.35+ release changes.
+        POST_35_VERSION=0.35.1
         CONFIG=/mnt/solo-weaver/test/config/config_with_proxy.yaml
         NS=block-node
 
@@ -547,19 +550,7 @@ tasks:
         }
 
 
-        echo -e '\n▶ Step 1: Bootstrap binary'
-        task uat:bootstrap
-
-
-        echo -e "\n▶ Step 2: Install BN ${PRE_35_VERSION} with tier1-rfh preset (also sets up cluster)"
-        sudo solo-provisioner block node install -p local \
-          --chart-version "$PRE_35_VERSION" \
-          --plugin-preset tier1-rfh \
-          --non-interactive \
-          -c "$CONFIG"
-
-
-        echo -e '\n▶ Step 3: Verify pre-0.35 Helm values contain s3-archive'
+        echo -e '\n▶ Verify pre-0.35 Helm values contain s3-archive'
         PLUGINS=$(get_plugins)
         echo "   plugins.names: $PLUGINS"
         echo "$PLUGINS" | grep -q 's3-archive' \
@@ -569,33 +560,21 @@ tasks:
         echo "   ✓ s3-archive present, cloud-storage-* absent"
 
 
-        echo -e "\n▶ Step 4: Upgrade to BN ${POST_35_VERSION} WITHOUT passing --plugin-preset"
-        echo "   (tests non-interactive re-resolution from stored state)"
-        # Run with || true: BN 0.35.0 may exceed the 5-minute Helm default timeout on CI
-        # VMs (3 CPUs / 4 GB). The effective plugin list is logged before the Helm
-        # operation starts, so we can verify the fix regardless of whether the pod
-        # becomes ready in time.
-        UPGRADE_LOG=/tmp/plugin-preset-upgrade.log
+        echo -e "\n▶ Upgrade to BN ${POST_35_VERSION} with tier1-rfh preset"
         sudo solo-provisioner block node upgrade -p local \
           --chart-version "$POST_35_VERSION" \
+          --plugin-preset tier1-rfh \
           --non-interactive \
-          -c "$CONFIG" 2>&1 | tee "$UPGRADE_LOG" || true
+          -c "$CONFIG"
 
-
-        echo -e '\n▶ Step 5: Verify effective inputs contain cloud-storage-* and NOT s3-archive'
-        # The provisioner logs "Determined effective user inputs" with the resolved
-        # PluginList before the Helm upgrade runs — this is what we verify.
-        grep -q 'cloud-storage-archive' "$UPGRADE_LOG" \
-          || { echo "FAIL: cloud-storage-archive not found in effective upgrade inputs"; exit 1; }
-        grep -q 'cloud-storage-expanded' "$UPGRADE_LOG" \
-          || { echo "FAIL: cloud-storage-expanded not found in effective upgrade inputs"; exit 1; }
-        echo "   ✓ effective inputs contain cloud-storage-archive and cloud-storage-expanded"
-
-
-        echo -e '\n▶ Teardown'
-        sudo solo-provisioner block node uninstall -p local -c "$CONFIG" -y || true
-        sudo solo-provisioner kube cluster uninstall || true
-        sudo solo-provisioner uninstall || true
+        echo -e '\n▶ Verify post-0.35 Helm values contain cloud-storage-* and not s3-archive'
+        PLUGINS=$(get_plugins)
+        echo "   plugins.names: $PLUGINS"
+        echo "$PLUGINS" | grep -q 'cloud-storage-archive' \
+          || { echo "FAIL: expected cloud-storage-archive in plugins.names, got: $PLUGINS"; exit 1; }
+        echo "$PLUGINS" | grep -qv 's3-archive' \
+          || { echo "FAIL: s3-archive should not be present post-0.35, got: $PLUGINS"; exit 1; }
+        echo "   ✓ cloud-storage-archive present, s3-archive absent"
 
         echo ''
         echo "NOTE: This test verifies plugin names in Helm values only."
@@ -603,6 +582,7 @@ tasks:
         echo "      requires separate BN team sign-off before upgrading live nodes."
         echo ''
         echo '✅ Plugin Preset Upgrade: PASSED'
+      - task: uat:teardown
 
   uat:lifecycle:
     desc: "Run core lifecycle test (inside VM: setup → core upgrades → teardown)"
@@ -621,9 +601,9 @@ tasks:
       - task: uat:solo-operator
       - task: uat:teleport
       - task: uat:alloy
+      - task: uat:teardown
       - task: uat:purge-storage
       - task: uat:plugin-preset-upgrade
-      - task: uat:teardown
       - task: uat:compat
 
 

--- a/taskfiles/uat.yaml
+++ b/taskfiles/uat.yaml
@@ -157,7 +157,7 @@ tasks:
         echo '✅ Core Block Node: PASSED'
 
   uat:purge-storage:
-    desc: "Verify the three block-node uninstall variants (inside VM: requires uat:setup first)"
+    desc: "Verify the three block-node uninstall variants (self-contained: bootstraps its own cluster)"
     interactive: true
     cmds:
       - |
@@ -167,19 +167,32 @@ tasks:
         echo "  matrix: (no flag) → with-reset → purge-storage"
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-        # Check cluster exists
-        kubectl get nodes > /dev/null 2>&1 || { echo "FAIL: Kubernetes cluster not found. Run 'task uat:setup' first."; exit 1; }
+
+        echo -e '\n▶ Bootstrap binary'
+        task uat:bootstrap
+
+
+        echo -e '\n▶ Install block node (also sets up cluster)'
+        sudo solo-provisioner block node install -p local \
+          -c /mnt/solo-weaver/test/config/config_with_proxy.yaml
 
         CONFIG=/mnt/solo-weaver/test/config/config_with_proxy.yaml
         NS=block-node
-        LIVE_DIR=/opt/weaver/block-node-storage/live
+        # Must match the basePath in config_with_proxy.yaml (/mnt/fast-storage).
+        # The old /opt/weaver/block-node-storage path was the wrong location.
+        LIVE_DIR=/mnt/fast-storage/live
         # Match the dual selector used by DeleteAllPersistentVolumes: solo-provisioner-managed OR Helm-managed for this release.
         BN_LABEL_SELECTOR='app.kubernetes.io/component=block-node-storage,app.kubernetes.io/managed-by in (solo-provisioner,Helm)'
 
         count_release_pvcs() { kubectl get pvc -n "$NS" -l "$BN_LABEL_SELECTOR" --no-headers 2>/dev/null | wc -l | tr -d ' '; }
-        # PVs are cluster-scoped: filter by both the label selector AND spec.claimRef.namespace
-        # so two block-node releases in different namespaces never count each other.
-        count_release_pvs()  { kubectl get pv -l "$BN_LABEL_SELECTOR" -o json | jq --arg ns "$NS" '[.items[] | select(.spec.claimRef.namespace == $ns)] | length'; }
+        # PVs are cluster-scoped: filter by label selector then count only those whose
+        # claimRef.namespace matches $NS, so two releases in different namespaces don't
+        # cross-count. Uses jsonpath to avoid a jq dependency in the VM.
+        count_release_pvs()  {
+          kubectl get pv -l "$BN_LABEL_SELECTOR" \
+            -o jsonpath='{range .items[*]}{.spec.claimRef.namespace}{"\n"}{end}' 2>/dev/null \
+            | grep -c "^${NS}$" || echo 0
+        }
         live_dir_has_files()  { sudo bash -c "ls -A '$LIVE_DIR' 2>/dev/null | head -1" | grep -q .; }
 
 
@@ -191,6 +204,14 @@ tasks:
         [ "$BASELINE_PVCS" -gt 0 ] || { echo "FAIL: no block-node PVCs matched selector — has the install bootstrapped the new labels?"; exit 1; }
         [ "$BASELINE_PVS" -gt 0 ]  || { echo "FAIL: no block-node PVs matched selector and namespace"; exit 1; }
         echo "   PVCs (labeled, in $NS): $BASELINE_PVCS   PVs (labeled, claimRef in $NS): $BASELINE_PVS"
+
+        # Seed a sentinel file so live_dir_has_files is reliable on a fresh install.
+        # A newly-installed block node may not yet have written any block files;
+        # we only care that uninstall (no flag) preserves existing data, not that
+        # the node has produced blocks.
+        sudo bash -c "mkdir -p '$LIVE_DIR' && echo 'sentinel' > '$LIVE_DIR/sentinel.blk'"
+        live_dir_has_files || { echo "FAIL: could not seed sentinel file in $LIVE_DIR"; exit 1; }
+        echo "   Sentinel file seeded in $LIVE_DIR"
 
 
         echo -e '\n▶ Variant 1/3: uninstall (no flag) — helm release should go; PV/PVC + data should stay'
@@ -232,6 +253,11 @@ tasks:
         [ "$PVS"  -eq 0 ] || { echo "FAIL: expected 0 PVs under --purge-storage, found $PVS"; exit 1; }
         live_dir_has_files && { echo "FAIL: live data dir not wiped under --purge-storage"; exit 1; }
         echo "   ✓ helm gone; PVCs=0 PVs=0; data wiped"
+
+
+        echo -e '\n▶ Teardown'
+        sudo solo-provisioner kube cluster uninstall || true
+        sudo solo-provisioner uninstall || true
 
         echo ''
         echo '✅ Block Node Uninstall Variants: PASSED'
@@ -499,6 +525,85 @@ tasks:
         echo ''
         echo '✅ solo-operator Lifecycle: PASSED'
 
+  uat:plugin-preset-upgrade:
+    desc: "Verify plugin preset names auto-update on upgrade across the 0.35 version boundary (self-contained: bootstraps its own cluster)"
+    interactive: true
+    cmds:
+      - |
+        set -e
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "  UAT Test: Plugin Preset Upgrade (pre-0.35 → 0.35+)"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+        # Chart versions under test. Update if the last stable pre-0.35 or
+        # current 0.35+ release changes.
+        PRE_35_VERSION=0.33.0
+        POST_35_VERSION=0.35.0
+        CONFIG=/mnt/solo-weaver/test/config/config_with_proxy.yaml
+        NS=block-node
+
+        get_plugins() {
+          helm get values block-node -n "$NS" 2>/dev/null | grep 'names:' | sed 's/.*names:[[:space:]]*//' | tr -d '"'
+        }
+
+
+        echo -e '\n▶ Step 1: Bootstrap binary'
+        task uat:bootstrap
+
+
+        echo -e "\n▶ Step 2: Install BN ${PRE_35_VERSION} with tier1-rfh preset (also sets up cluster)"
+        sudo solo-provisioner block node install -p local \
+          --chart-version "$PRE_35_VERSION" \
+          --plugin-preset tier1-rfh \
+          --non-interactive \
+          -c "$CONFIG"
+
+
+        echo -e '\n▶ Step 3: Verify pre-0.35 Helm values contain s3-archive'
+        PLUGINS=$(get_plugins)
+        echo "   plugins.names: $PLUGINS"
+        echo "$PLUGINS" | grep -q 's3-archive' \
+          || { echo "FAIL: expected s3-archive in plugins.names, got: $PLUGINS"; exit 1; }
+        echo "$PLUGINS" | grep -qv 'cloud-storage-archive' \
+          || { echo "FAIL: cloud-storage-archive should not be present pre-0.35, got: $PLUGINS"; exit 1; }
+        echo "   ✓ s3-archive present, cloud-storage-* absent"
+
+
+        echo -e "\n▶ Step 4: Upgrade to BN ${POST_35_VERSION} WITHOUT passing --plugin-preset"
+        echo "   (tests non-interactive re-resolution from stored state)"
+        # Run with || true: BN 0.35.0 may exceed the 5-minute Helm default timeout on CI
+        # VMs (3 CPUs / 4 GB). The effective plugin list is logged before the Helm
+        # operation starts, so we can verify the fix regardless of whether the pod
+        # becomes ready in time.
+        UPGRADE_LOG=/tmp/plugin-preset-upgrade.log
+        sudo solo-provisioner block node upgrade -p local \
+          --chart-version "$POST_35_VERSION" \
+          --non-interactive \
+          -c "$CONFIG" 2>&1 | tee "$UPGRADE_LOG" || true
+
+
+        echo -e '\n▶ Step 5: Verify effective inputs contain cloud-storage-* and NOT s3-archive'
+        # The provisioner logs "Determined effective user inputs" with the resolved
+        # PluginList before the Helm upgrade runs — this is what we verify.
+        grep -q 'cloud-storage-archive' "$UPGRADE_LOG" \
+          || { echo "FAIL: cloud-storage-archive not found in effective upgrade inputs"; exit 1; }
+        grep -q 'cloud-storage-expanded' "$UPGRADE_LOG" \
+          || { echo "FAIL: cloud-storage-expanded not found in effective upgrade inputs"; exit 1; }
+        echo "   ✓ effective inputs contain cloud-storage-archive and cloud-storage-expanded"
+
+
+        echo -e '\n▶ Teardown'
+        sudo solo-provisioner block node uninstall -p local -c "$CONFIG" -y || true
+        sudo solo-provisioner kube cluster uninstall || true
+        sudo solo-provisioner uninstall || true
+
+        echo ''
+        echo "NOTE: This test verifies plugin names in Helm values only."
+        echo "      Data compatibility between s3-archive and cloud-storage-*"
+        echo "      requires separate BN team sign-off before upgrading live nodes."
+        echo ''
+        echo '✅ Plugin Preset Upgrade: PASSED'
+
   uat:lifecycle:
     desc: "Run core lifecycle test (inside VM: setup → core upgrades → teardown)"
     interactive: true
@@ -517,6 +622,7 @@ tasks:
       - task: uat:teleport
       - task: uat:alloy
       - task: uat:purge-storage
+      - task: uat:plugin-preset-upgrade
       - task: uat:teardown
       - task: uat:compat
 


### PR DESCRIPTION
## Description

BN 0.35 renamed the cloud-storage plugin in the RFH preset: `s3-archive` was replaced by
`cloud-storage-archive` + `cloud-storage-expanded`. A simple string swap would have broken
operators still on pre-0.35 charts, so this PR takes a version-aware approach instead.

A `blockNodePluginConfig` registry (`blockNodePluginHistory`) is introduced, modelled on the
existing `optional_storage.go` `MinVersion` pattern. `PluginListForPreset` and
`PluginsForVersion` now accept a `chartVersion` argument: pre-0.35 charts get `s3-archive`
in the RFH preset; 0.35+ charts get the new names. The TUI custom multi-select follows the
same version-gate so operators see only the plugins that exist in their target release.

Adding a future BN plugin change requires only a new entry in `blockNodePluginHistory` — no
control-flow changes anywhere else.

### Files changed

| File | Change |
|---|---|
| `internal/blocknode/blocknode_plugins.go` | Replace flat string constants with versioned `blockNodePluginConfig` registry; add `configForVersion`, `PluginsForVersion`; update `PluginListForPreset` to accept `chartVersion` |
| `internal/blocknode/blocknode_plugins_test.go` | Registry-invariant tests; split RFH test into `_BN035Plus` / `_LegacyBN`; add upgrade-scenario, `PluginsForVersion`, and invalid-semver fallback tests |
| `internal/ui/prompt/blocknode.go` | Thread `chartVersion` into `RunPluginPresetPrompts`; custom multi-select calls `PluginsForVersion(chartVersion)` |
| `cmd/cli/commands/block/node/init.go` | Pass `flagChartVersion` to prompt and `PluginListForPreset`; fall back to deployed version from state for `reconfigure`; re-resolve stored preset against new target version for non-interactive `upgrade` |

### Code review checklist

- [ ] `blockNodePluginHistory` entries are in ascending `MinVersion` order (enforced by `TestPluginHistory_AscendingVersionOrder`).
- [ ] Every known preset ID (`PresetTier1LFH`, `PresetTier1RFH`) appears in every history entry's `Presets` map (enforced by `TestPluginHistory_AllKnownPresetsInEveryEntry`).
- [ ] `configForVersion("")` and `configForVersion("not-a-semver")` both return the latest entry — not the baseline.
- [ ] `PluginsForVersion` always returns an independent copy.
- [ ] `flagChartVersion` is populated by the input-prompts pass before it reaches `RunPluginPresetPrompts` and `PluginListForPreset` — verify ordering in `init.go`.
- [ ] Non-interactive upgrade: stored `PluginPreset` re-resolved against `flagChartVersion`; guard `pluginPreset == ""` ensures explicit `--plugin-preset` flags still win.
- [ ] `reconfigure` falls back to `defaults.BlockNode.ChartVersion` when `flagChartVersion` is empty; explicit `--chart-version` (if ever added) would still take precedence.
- [ ] **BN team sign-off required** before upgrading nodes with live cloud-storage data: confirm `cloud-storage-archive` is data-compatible with data previously written by `s3-archive`.

### Manual UAT

#### Pre-requisites
- UTM VM running (`task vm:start`)
- BN 0.35+ chart available (default)
- A second install target using `--chart-version=0.34.x` to cover the legacy path

#### Test 1 — BN 0.35+ RFH preset (new plugin names)
```bash
solo-provisioner block node install \
  --plugin-preset=tier1-rfh \
  --non-interactive \
  --profile=local
```
Expected: `helm get values block-node -n block-node` shows `names` containing `cloud-storage-archive,cloud-storage-expanded`. `s3-archive` must not appear.

#### Test 2 — BN pre-0.35 RFH preset (legacy plugin name)
```bash
solo-provisioner block node install \
  --chart-version=0.33.0 \
  --plugin-preset=tier1-rfh \
  --non-interactive \
  --profile=local
```
Expected: Helm values contain `s3-archive`. `cloud-storage-archive` and `cloud-storage-expanded` must not appear.

#### Test 3 — LFH preset unchanged across versions
```bash
for ver in "" "0.34.9" "0.35.0"; do
  solo-provisioner block node install \
    ${ver:+--chart-version=$ver} \
    --plugin-preset=tier1-lfh \
    --non-interactive \
    --profile=local
  # verify: blocks-file-historic present, s3-archive and cloud-storage-* absent
done
```

#### Test 4 — TUI custom multi-select shows version-appropriate plugins

Run interactively (no `--non-interactive`, no `--plugin-preset`):
- `--chart-version=0.34.9`: picker lists `s3-archive`, does NOT list `cloud-storage-archive`.
- `--chart-version=0.35.0` (or omitted): picker lists `cloud-storage-archive` and `cloud-storage-expanded`, does NOT list `s3-archive`.

#### Test 5 — Non-interactive upgrade auto-updates plugin names
```bash
# Install pre-0.35 with RFH preset
solo-provisioner block node install \
  --chart-version=0.33.0 \
  --plugin-preset=tier1-rfh \
  --non-interactive \
  --profile=local

# Upgrade to 0.35+ WITHOUT passing --plugin-preset
solo-provisioner block node upgrade \
  --chart-version=0.35.0 \
  --non-interactive \
  --profile=local

# Verify Helm values now carry the new plugin names
helm get values block-node -n block-node | grep 'names:'
# Expected: cloud-storage-archive,cloud-storage-expanded present; s3-archive absent
```

> **Data compatibility note:** before running Test 5 against a node with live cloud-storage
> data, confirm with the BN team that `cloud-storage-archive` can read data previously
> written by `s3-archive`. Until that sign-off is received, run this test against a
> fresh install only.

### Related Issues

* Closes #649
