### PR TITLE
chore: no need to use ProxyCommand for local UTM based tests

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -24,7 +24,8 @@ vars:
   # external SSH agents (e.g. 1Password) from intercepting key auth.
   # ProxyCommand routes through nc with --apple-no-connectx to avoid macOS
   # connectx(2) failures on bridged UTM networks behind captive WiFi or VPNs.
-  SSH_OPTS: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentityAgent=none -o ProxyCommand="nc --apple-no-connectx %h %p"'
+  #SSH_OPTS: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentityAgent=none -o ProxyCommand="nc --apple-no-connectx %h %p"'
+  SSH_OPTS: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentityAgent=none'
   UTM_VMS_DIR: "{{.HOME}}/Library/Containers/com.utmapp.UTM/Data/Documents"
   GET_VM_IP: |
     get_vm_ip() {


### PR DESCRIPTION
## Description

This pull request makes a minor change to the `Taskfile.yaml` configuration by updating the default SSH options. The `ProxyCommand` for using `nc --apple-no-connectx` has been commented out, so SSH connections will no longer use this proxy by default.

- Configuration update:
  * [`Taskfile.yaml`](diffhunk://#diff-1552e0a6f970b2191f0e8ef34ac62e41815fc6cdbc213921e915a042e500f03aL27-R28): Commented out the `ProxyCommand` option in `SSH_OPTS`, so SSH connections will not use `nc --apple-no-connectx` by default.

### Related Issues

* Closes #
