### PR TITLE
fix(cilium): disable XDP load-balancer acceleration to prevent NIC carrier flaps

### DIFF
--- a/docs/claude/reviews/00669-disable-xdp-acceleration.md
+++ b/docs/claude/reviews/00669-disable-xdp-acceleration.md
@@ -1,0 +1,94 @@
+# 00669 — Disable Cilium XDP load-balancer acceleration
+
+## Problem
+
+`kube cluster install` rendered the embedded Cilium values
+(`internal/templates/files/cilium/cilium-config.yaml`) with
+`loadBalancer.acceleration: "best-effort"` and `routingMode: native` with no
+explicit `devices:` list. With `best-effort`, Cilium auto-detects native
+datapath devices — including the host's public/default-route NIC — and attaches
+an **XDP** program to each.
+
+On `ixgbe` NICs (e.g. Intel X550) the driver performs a PHY/link reset whenever
+an XDP program is attached or the agent reconciles. This flapped the public NIC's
+carrier continuously (Gained → Lost every ~10s). Two consequences observed on a
+block-node host:
+
+1. `systemd-networkd` never finished configuring the link, so the node's static
+   public IP was never installed — the host lost public connectivity.
+2. Sustained flapping tripped the **upstream switch's link-flap err-disable**,
+   which shut the port. That state lives on the switch and **survives a host
+   reboot**, so the host stayed offline until the provider re-enabled the port.
+
+Because the reconcile daemon re-applies the embedded config, there was no durable
+operator workaround — the fix has to be in the shipped template.
+
+## Solution
+
+Set `loadBalancer.acceleration: "disabled"` so Cilium uses **tc-eBPF** instead of
+XDP. tc-eBPF performs the same DSR/maglev load balancing without attaching an XDP
+program to any NIC, so the `ixgbe` PHY is never reset and the public NIC cannot
+flap. A comment documents the rationale and references this issue.
+
+This is a safe default across mixed hardware: it removes the XDP hardware-offload
+fast path (a throughput optimization) but preserves full kube-proxy-replacement /
+NodePort / LB functionality.
+
+## Changed files
+
+| File | Change |
+| --- | --- |
+| `internal/templates/files/cilium/cilium-config.yaml` | `loadBalancer.acceleration` changed `"best-effort"` → `"disabled"`; added a comment explaining the XDP/ixgbe PHY-reset + switch err-disable rationale (refs #669). |
+| `docs/claude/reviews/00669-disable-xdp-acceleration.md` | This review guide. |
+
+## Review checklist
+
+- [ ] `acceleration` is exactly `"disabled"` (not removed, not `"native"`).
+- [ ] No other Cilium values changed (mode `dsr`, dsrDispatch `opt`, algorithm
+      `maglev`, l7 backend `disabled`, kubeProxyReplacement, etc. all unchanged).
+- [ ] No Go code or tests reference the old `best-effort` value
+      (`grep -rn "best-effort\|bpf-lb-acceleration" --include='*.go'`).
+- [ ] Template still renders (the `{{.MachineIP}}` / `{{.SandboxDir}}` /
+      `{{.SandboxLocalBinDir}}` substitutions are untouched).
+
+## Tests
+
+```bash
+# Confirm no code/tests assert the removed value:
+grep -rniE "best-effort|bpf-lb-acceleration" --include="*.go" --include="*.yaml" . | grep -v vendor/
+
+# Cilium installer unit/integration tests (render + configure):
+go test ./pkg/software/... -run Cilium -count=1
+go test ./internal/workflows/steps/... -run Cilium -count=1
+```
+
+## Manual UAT
+
+On a node with an `ixgbe` public NIC (or any kubeadm node):
+
+```bash
+# 1. Install a cluster with this build.
+sudo solo-provisioner kube cluster install --profile <profile> --node-type <type> \
+  --config <sandbox>/etc/weaver/solo-provisioner.yaml --non-interactive
+
+# 2. The rendered values must show acceleration disabled.
+grep -A1 acceleration <sandbox>/etc/weaver/cilium-config.yaml
+#   acceleration: "disabled"
+
+# 3. The live Cilium config must agree.
+KUBECONFIG=/etc/kubernetes/admin.conf kubectl -n kube-system \
+  get cm cilium-config -o jsonpath='{.data.bpf-lb-acceleration}'; echo
+#   disabled
+
+# 4. No XDP program is attached to any host NIC.
+for n in $(ls /sys/class/net | grep -E '^eno|^enp|^eth'); do
+  echo -n "$n: "; ip -d link show "$n" | grep -qi xdp && echo "XDP ATTACHED (bad)" || echo "no xdp (good)"
+done
+
+# 5. The public NIC keeps carrier — no flapping.
+journalctl -u systemd-networkd -b | grep -iE 'eno[0-9].*(Gained|Lost) carrier' | tail
+#   expect: NOT a repeating Gained/Lost loop on the public NIC
+```
+
+Expected: cluster comes up healthy (`cilium status` OK, nodes Ready), the public
+NIC stays up with its address, and no NIC carries an XDP program.

--- a/docs/claude/reviews/00669-disable-xdp-acceleration.md
+++ b/docs/claude/reviews/00669-disable-xdp-acceleration.md
@@ -1,4 +1,4 @@
-# 00669 — Use generic (testing-only) Cilium XDP to avoid ixgbe PHY reset
+# 00669 — Disable Cilium XDP load-balancer acceleration
 
 ## Problem
 
@@ -7,12 +7,12 @@
 `loadBalancer.acceleration: "best-effort"` and `routingMode: native` with no
 explicit `devices:` list. With `best-effort`, Cilium auto-detects native
 datapath devices — including the host's public/default-route NIC — and attaches
-a **native (driver-mode) XDP** program to each.
+an **XDP** program to each.
 
 On `ixgbe` NICs (e.g. Intel X550) the driver performs a PHY/link reset whenever
-a native XDP program is attached or the agent reconciles. This flapped the public
-NIC's carrier continuously (Gained → Lost every ~10s). Two consequences observed
-on a block-node host:
+an XDP program is attached or the agent reconciles. This flapped the public NIC's
+carrier continuously (Gained → Lost every ~10s). Two consequences observed on a
+block-node host:
 
 1. `systemd-networkd` never finished configuring the link, so the node's static
    public IP was never installed — the host lost public connectivity.
@@ -25,40 +25,31 @@ operator workaround — the fix has to be in the shipped template.
 
 ## Solution
 
-Set `loadBalancer.acceleration: "testing-only"` so Cilium attaches XDP in
-**generic (SKB) mode** rather than native driver mode. Generic XDP runs the
-program in the kernel network stack instead of the NIC driver's receive path, so
-the `ixgbe` PHY is never reset and the public NIC cannot flap — while still
-keeping an XDP-based load-balancer datapath (DSR/maglev unchanged).
+Set `loadBalancer.acceleration: "disabled"` so Cilium uses **tc-eBPF** instead of
+XDP. tc-eBPF performs the same DSR/maglev load balancing without attaching an XDP
+program to any NIC, so the `ixgbe` PHY is never reset and the public NIC cannot
+flap. A comment documents the rationale and references this issue.
 
-`"testing-only"` is Cilium's own value for generic XDP (`XDPModeGeneric` in
-`pkg/option`). The Cilium v1.18 Helm chart passes `loadBalancer.acceleration`
-verbatim into the `bpf-lb-acceleration` ConfigMap key and its `values.schema.json`
-types the field as a plain string (no enum), so the value installs cleanly.
-
-Trade-off: generic XDP is Cilium's CI/testing path — it does not bypass GRO and
-cannot linearize every skb, so it forgoes the native-XDP hardware-offload
-throughput gain. It is chosen here deliberately for `ixgbe` link stability over
-raw XDP offload performance. (If offload is not needed at all,
-`acceleration: "disabled"` / tc-eBPF is the alternative — see history of #669.)
+This is a safe default across mixed hardware: it removes the XDP hardware-offload
+fast path (a throughput optimization) but preserves full kube-proxy-replacement /
+NodePort / LB functionality.
 
 ## Changed files
 
 | File | Change |
 | --- | --- |
-| `internal/templates/files/cilium/cilium-config.yaml` | `loadBalancer.acceleration` changed `"best-effort"` → `"testing-only"` (generic/SKB XDP); comment rewritten to explain the native-XDP/ixgbe PHY-reset + switch err-disable rationale and the generic-XDP mitigation (refs #669). |
+| `internal/templates/files/cilium/cilium-config.yaml` | `loadBalancer.acceleration` changed `"best-effort"` → `"disabled"`; added a comment explaining the XDP/ixgbe PHY-reset + switch err-disable rationale (refs #669). |
 | `docs/claude/reviews/00669-disable-xdp-acceleration.md` | This review guide. |
 
 ## Review checklist
 
-- [ ] `acceleration` is exactly `"testing-only"` (not `"native"`, `"best-effort"`,
-      or removed).
+- [ ] `acceleration` is exactly `"disabled"` (not removed, not `"native"`).
 - [ ] No other Cilium values changed (mode `dsr`, dsrDispatch `opt`, algorithm
       `maglev`, l7 backend `disabled`, kubeProxyReplacement, etc. all unchanged).
-- [ ] No Go code or tests assert the old `best-effort` value
+- [ ] No Go code or tests reference the old `best-effort` value
       (`grep -rn "best-effort\|bpf-lb-acceleration" --include='*.go'`).
-- [ ] Template still renders (the `{{.MachineIP}}` / `{{.SandboxDir}}`
-      substitutions are untouched).
+- [ ] Template still renders (the `{{.MachineIP}}` / `{{.SandboxDir}}` /
+      `{{.SandboxLocalBinDir}}` substitutions are untouched).
 
 ## Tests
 
@@ -80,20 +71,19 @@ On a node with an `ixgbe` public NIC (or any kubeadm node):
 sudo solo-provisioner kube cluster install --profile <profile> --node-type <type> \
   --config <sandbox>/etc/weaver/solo-provisioner.yaml --non-interactive
 
-# 2. The rendered values must show acceleration testing-only.
+# 2. The rendered values must show acceleration disabled.
 grep -A1 acceleration <sandbox>/etc/weaver/cilium-config.yaml
-#   acceleration: "testing-only"
+#   acceleration: "disabled"
 
-# 3. The live Cilium config must agree (helm accepted the value — no schema reject).
+# 3. The live Cilium config must agree.
 KUBECONFIG=/etc/kubernetes/admin.conf kubectl -n kube-system \
   get cm cilium-config -o jsonpath='{.data.bpf-lb-acceleration}'; echo
-#   testing-only
+#   disabled
 
-# 4. XDP is attached in GENERIC/SKB mode (not native driver mode).
+# 4. No XDP program is attached to any host NIC.
 for n in $(ls /sys/class/net | grep -E '^eno|^enp|^eth'); do
-  echo -n "$n: "; ip -d link show "$n" | grep -oiE 'xdp(generic|drv|offload)?' | head -1 || echo "no xdp"
+  echo -n "$n: "; ip -d link show "$n" | grep -qi xdp && echo "XDP ATTACHED (bad)" || echo "no xdp (good)"
 done
-#   expect: xdpgeneric on the LB devices, NOT xdpdrv (native)
 
 # 5. The public NIC keeps carrier — no flapping.
 journalctl -u systemd-networkd -b | grep -iE 'eno[0-9].*(Gained|Lost) carrier' | tail
@@ -101,5 +91,4 @@ journalctl -u systemd-networkd -b | grep -iE 'eno[0-9].*(Gained|Lost) carrier' |
 ```
 
 Expected: cluster comes up healthy (`cilium status` OK, nodes Ready), the public
-NIC stays up with its address, and XDP runs in generic mode (no native-driver
-attach, so no PHY reset).
+NIC stays up with its address, and no NIC carries an XDP program.

--- a/docs/claude/reviews/00669-disable-xdp-acceleration.md
+++ b/docs/claude/reviews/00669-disable-xdp-acceleration.md
@@ -1,4 +1,4 @@
-# 00669 — Disable Cilium XDP load-balancer acceleration
+# 00669 — Use generic (testing-only) Cilium XDP to avoid ixgbe PHY reset
 
 ## Problem
 
@@ -7,12 +7,12 @@
 `loadBalancer.acceleration: "best-effort"` and `routingMode: native` with no
 explicit `devices:` list. With `best-effort`, Cilium auto-detects native
 datapath devices — including the host's public/default-route NIC — and attaches
-an **XDP** program to each.
+a **native (driver-mode) XDP** program to each.
 
 On `ixgbe` NICs (e.g. Intel X550) the driver performs a PHY/link reset whenever
-an XDP program is attached or the agent reconciles. This flapped the public NIC's
-carrier continuously (Gained → Lost every ~10s). Two consequences observed on a
-block-node host:
+a native XDP program is attached or the agent reconciles. This flapped the public
+NIC's carrier continuously (Gained → Lost every ~10s). Two consequences observed
+on a block-node host:
 
 1. `systemd-networkd` never finished configuring the link, so the node's static
    public IP was never installed — the host lost public connectivity.
@@ -25,31 +25,40 @@ operator workaround — the fix has to be in the shipped template.
 
 ## Solution
 
-Set `loadBalancer.acceleration: "disabled"` so Cilium uses **tc-eBPF** instead of
-XDP. tc-eBPF performs the same DSR/maglev load balancing without attaching an XDP
-program to any NIC, so the `ixgbe` PHY is never reset and the public NIC cannot
-flap. A comment documents the rationale and references this issue.
+Set `loadBalancer.acceleration: "testing-only"` so Cilium attaches XDP in
+**generic (SKB) mode** rather than native driver mode. Generic XDP runs the
+program in the kernel network stack instead of the NIC driver's receive path, so
+the `ixgbe` PHY is never reset and the public NIC cannot flap — while still
+keeping an XDP-based load-balancer datapath (DSR/maglev unchanged).
 
-This is a safe default across mixed hardware: it removes the XDP hardware-offload
-fast path (a throughput optimization) but preserves full kube-proxy-replacement /
-NodePort / LB functionality.
+`"testing-only"` is Cilium's own value for generic XDP (`XDPModeGeneric` in
+`pkg/option`). The Cilium v1.18 Helm chart passes `loadBalancer.acceleration`
+verbatim into the `bpf-lb-acceleration` ConfigMap key and its `values.schema.json`
+types the field as a plain string (no enum), so the value installs cleanly.
+
+Trade-off: generic XDP is Cilium's CI/testing path — it does not bypass GRO and
+cannot linearize every skb, so it forgoes the native-XDP hardware-offload
+throughput gain. It is chosen here deliberately for `ixgbe` link stability over
+raw XDP offload performance. (If offload is not needed at all,
+`acceleration: "disabled"` / tc-eBPF is the alternative — see history of #669.)
 
 ## Changed files
 
 | File | Change |
 | --- | --- |
-| `internal/templates/files/cilium/cilium-config.yaml` | `loadBalancer.acceleration` changed `"best-effort"` → `"disabled"`; added a comment explaining the XDP/ixgbe PHY-reset + switch err-disable rationale (refs #669). |
+| `internal/templates/files/cilium/cilium-config.yaml` | `loadBalancer.acceleration` changed `"best-effort"` → `"testing-only"` (generic/SKB XDP); comment rewritten to explain the native-XDP/ixgbe PHY-reset + switch err-disable rationale and the generic-XDP mitigation (refs #669). |
 | `docs/claude/reviews/00669-disable-xdp-acceleration.md` | This review guide. |
 
 ## Review checklist
 
-- [ ] `acceleration` is exactly `"disabled"` (not removed, not `"native"`).
+- [ ] `acceleration` is exactly `"testing-only"` (not `"native"`, `"best-effort"`,
+      or removed).
 - [ ] No other Cilium values changed (mode `dsr`, dsrDispatch `opt`, algorithm
       `maglev`, l7 backend `disabled`, kubeProxyReplacement, etc. all unchanged).
-- [ ] No Go code or tests reference the old `best-effort` value
+- [ ] No Go code or tests assert the old `best-effort` value
       (`grep -rn "best-effort\|bpf-lb-acceleration" --include='*.go'`).
-- [ ] Template still renders (the `{{.MachineIP}}` / `{{.SandboxDir}}` /
-      `{{.SandboxLocalBinDir}}` substitutions are untouched).
+- [ ] Template still renders (the `{{.MachineIP}}` / `{{.SandboxDir}}`
+      substitutions are untouched).
 
 ## Tests
 
@@ -71,19 +80,20 @@ On a node with an `ixgbe` public NIC (or any kubeadm node):
 sudo solo-provisioner kube cluster install --profile <profile> --node-type <type> \
   --config <sandbox>/etc/weaver/solo-provisioner.yaml --non-interactive
 
-# 2. The rendered values must show acceleration disabled.
+# 2. The rendered values must show acceleration testing-only.
 grep -A1 acceleration <sandbox>/etc/weaver/cilium-config.yaml
-#   acceleration: "disabled"
+#   acceleration: "testing-only"
 
-# 3. The live Cilium config must agree.
+# 3. The live Cilium config must agree (helm accepted the value — no schema reject).
 KUBECONFIG=/etc/kubernetes/admin.conf kubectl -n kube-system \
   get cm cilium-config -o jsonpath='{.data.bpf-lb-acceleration}'; echo
-#   disabled
+#   testing-only
 
-# 4. No XDP program is attached to any host NIC.
+# 4. XDP is attached in GENERIC/SKB mode (not native driver mode).
 for n in $(ls /sys/class/net | grep -E '^eno|^enp|^eth'); do
-  echo -n "$n: "; ip -d link show "$n" | grep -qi xdp && echo "XDP ATTACHED (bad)" || echo "no xdp (good)"
+  echo -n "$n: "; ip -d link show "$n" | grep -oiE 'xdp(generic|drv|offload)?' | head -1 || echo "no xdp"
 done
+#   expect: xdpgeneric on the LB devices, NOT xdpdrv (native)
 
 # 5. The public NIC keeps carrier — no flapping.
 journalctl -u systemd-networkd -b | grep -iE 'eno[0-9].*(Gained|Lost) carrier' | tail
@@ -91,4 +101,5 @@ journalctl -u systemd-networkd -b | grep -iE 'eno[0-9].*(Gained|Lost) carrier' |
 ```
 
 Expected: cluster comes up healthy (`cilium status` OK, nodes Ready), the public
-NIC stays up with its address, and no NIC carries an XDP program.
+NIC stays up with its address, and XDP runs in generic mode (no native-driver
+attach, so no PHY reset).

--- a/internal/templates/files/cilium/cilium-config.yaml
+++ b/internal/templates/files/cilium/cilium-config.yaml
@@ -31,18 +31,21 @@ autoDirectNodeRoutes: true
 #ipv4NativeRoutingCIDR: 10.128.0.0/20
 
 # Load Balancer Configuration
-# acceleration is intentionally "disabled" (tc-eBPF), NOT "best-effort". With
-# best-effort, Cilium attaches an XDP program to every auto-detected native
-# device, including the host's public/default-route NIC. On ixgbe NICs (e.g.
-# Intel X550) the driver resets the PHY on XDP attach/reconcile, which flaps the
-# link; sustained flapping can get the upstream switch port err-disabled, taking
-# the host offline until the provider re-enables the port (survives reboot).
-# tc-eBPF performs the same load balancing without touching the PHY. See #669.
+# acceleration uses generic (SKB) XDP via Cilium's "testing-only" value, NOT
+# "native"/"best-effort". With native XDP, Cilium attaches the XDP program in the
+# driver's early receive path on every auto-detected native device, including the
+# host's public/default-route NIC. On ixgbe NICs (e.g. Intel X550) the driver
+# resets the PHY on XDP attach/reconcile, which flaps the link; sustained flapping
+# can get the upstream switch port err-disabled, taking the host offline until the
+# provider re-enables it (survives reboot). Generic XDP runs the program in the
+# network stack (SKB) instead of the driver, so the PHY is never reset, while
+# keeping an XDP-based LB datapath. Cilium names this value "testing-only"
+# (XDPModeGeneric in pkg/option). See #669.
 loadBalancer:
   mode: dsr
   dsrDispatch: opt
   algorithm: maglev
-  acceleration: "disabled"
+  acceleration: "testing-only"
   l7:
     backend: disabled
 

--- a/internal/templates/files/cilium/cilium-config.yaml
+++ b/internal/templates/files/cilium/cilium-config.yaml
@@ -31,21 +31,18 @@ autoDirectNodeRoutes: true
 #ipv4NativeRoutingCIDR: 10.128.0.0/20
 
 # Load Balancer Configuration
-# acceleration uses generic (SKB) XDP via Cilium's "testing-only" value, NOT
-# "native"/"best-effort". With native XDP, Cilium attaches the XDP program in the
-# driver's early receive path on every auto-detected native device, including the
-# host's public/default-route NIC. On ixgbe NICs (e.g. Intel X550) the driver
-# resets the PHY on XDP attach/reconcile, which flaps the link; sustained flapping
-# can get the upstream switch port err-disabled, taking the host offline until the
-# provider re-enables it (survives reboot). Generic XDP runs the program in the
-# network stack (SKB) instead of the driver, so the PHY is never reset, while
-# keeping an XDP-based LB datapath. Cilium names this value "testing-only"
-# (XDPModeGeneric in pkg/option). See #669.
+# acceleration is intentionally "disabled" (tc-eBPF), NOT "best-effort". With
+# best-effort, Cilium attaches an XDP program to every auto-detected native
+# device, including the host's public/default-route NIC. On ixgbe NICs (e.g.
+# Intel X550) the driver resets the PHY on XDP attach/reconcile, which flaps the
+# link; sustained flapping can get the upstream switch port err-disabled, taking
+# the host offline until the provider re-enables the port (survives reboot).
+# tc-eBPF performs the same load balancing without touching the PHY. See #669.
 loadBalancer:
   mode: dsr
   dsrDispatch: opt
   algorithm: maglev
-  acceleration: "testing-only"
+  acceleration: "disabled"
   l7:
     backend: disabled
 

--- a/internal/templates/files/cilium/cilium-config.yaml
+++ b/internal/templates/files/cilium/cilium-config.yaml
@@ -31,11 +31,18 @@ autoDirectNodeRoutes: true
 #ipv4NativeRoutingCIDR: 10.128.0.0/20
 
 # Load Balancer Configuration
+# acceleration is intentionally "disabled" (tc-eBPF), NOT "best-effort". With
+# best-effort, Cilium attaches an XDP program to every auto-detected native
+# device, including the host's public/default-route NIC. On ixgbe NICs (e.g.
+# Intel X550) the driver resets the PHY on XDP attach/reconcile, which flaps the
+# link; sustained flapping can get the upstream switch port err-disabled, taking
+# the host offline until the provider re-enables the port (survives reboot).
+# tc-eBPF performs the same load balancing without touching the PHY. See #669.
 loadBalancer:
   mode: dsr
   dsrDispatch: opt
   algorithm: maglev
-  acceleration: "best-effort"
+  acceleration: "disabled"
   l7:
     backend: disabled
 


### PR DESCRIPTION
## Problem

`kube cluster install` renders the embedded Cilium values with
`loadBalancer.acceleration: "best-effort"` and `routingMode: native` (no explicit
`devices:`). With `best-effort`, Cilium auto-detects native datapath devices —
including the host's **public/default-route NIC** — and attaches an **XDP**
program to each.

On `ixgbe` NICs (Intel X550) the driver resets the PHY whenever an XDP program is
attached or the agent reconciles. On a block-node host this flapped the public
NIC's carrier continuously (Gained → Lost every ~10s), with two consequences:

1. `systemd-networkd` never finished configuring the link, so the node's static
   public IP was never installed — the host lost public connectivity.
2. Sustained flapping tripped the **upstream switch's link-flap err-disable**,
   which shut the port. That state lives on the switch and **survived a host
   reboot**, so the host stayed offline until the provider re-enabled the port.

Because the reconcile daemon re-applies the embedded config, there is no durable
operator workaround — killing/reconfiguring Cilium by hand is reverted. The fix
has to be in the shipped template.

Full root-cause write-up and evidence: #669.

## Fix

Set `loadBalancer.acceleration: "disabled"` so Cilium uses **tc-eBPF** instead of
XDP. tc-eBPF performs the same DSR / maglev load balancing without attaching an
XDP program to any NIC, so the `ixgbe` PHY is never reset and the public NIC
cannot flap.

## Trade-off

Removes the XDP hardware-offload fast path (a throughput optimization). Preserves
full kube-proxy-replacement / NodePort / LoadBalancer behavior. Safe default
across mixed hardware.

## Follow-ups (not in this PR)

- Expose/scope an explicit `devices:` list so the datapath never binds the public
  NIC at all.
- The template sets `k8sServiceHost: {{.MachineIP}}`, and `GetMachineIP()` returns
  the first UP IPv4 (often the public NIC); device-scoping interacts with this, so
  a node-IP knob may be warranted.

## Test

```bash
grep -A1 acceleration <sandbox>/etc/weaver/cilium-config.yaml      # acceleration: "disabled"
KUBECONFIG=/etc/kubernetes/admin.conf kubectl -n kube-system \
  get cm cilium-config -o jsonpath='{.data.bpf-lb-acceleration}'   # disabled
# no XDP attached to any host NIC; public NIC keeps carrier (no Gained/Lost loop)
```

See `docs/claude/reviews/00669-disable-xdp-acceleration.md` for the full review guide and UAT.
