### PR TITLE
fix(cilium): migrate existing clusters off best-effort XDP acceleration

### DIFF
--- a/cmd/cli/commands/root.go
+++ b/cmd/cli/commands/root.go
@@ -123,6 +123,7 @@ func RegisterMigrations() {
 	migration.Register(migration.ScopeStartup, state.NewUnifiedStateMigration())
 	migration.Register(migration.ScopeStartup, state.NewHelmReleaseSchemaV2Migration())
 	migration.Register(migration.ScopeStartup, workflows.NewLegacyBinaryMigration())
+	migration.Register(migration.ScopeStartup, workflows.NewCiliumAccelerationMigration())
 
 	// ── Block-node upgrade migrations (run during block node upgrade workflow) ─
 	migration.Register(migration.ScopeBlockNode, blocknode.NewVerificationStorageMigration())

--- a/docs/claude/reviews/00669-cilium-acceleration-migration.md
+++ b/docs/claude/reviews/00669-cilium-acceleration-migration.md
@@ -23,14 +23,23 @@ exposed to the flap until manually fixed.
 Add a startup-scoped `CLIVersionMigration` (`CiliumAccelerationMigration`,
 `internal/workflows/migration_cilium_acceleration.go`) that runs on the first
 provisioner invocation after upgrading across the version boundary and brings
-existing clusters onto the new template:
+existing clusters onto the new template. The provisioner can run before anything
+is deployed, so it checks both install preconditions before touching Cilium:
 
-1. Read `bpf-lb-acceleration` from the live `cilium-config` ConfigMap.
-2. No-op if it can't be read (node has no cluster) or is already `disabled`
-   (migration already ran) — this makes it safely idempotent/one-shot regardless
-   of when the on-disk provisioner version advances past the boundary.
-3. Otherwise re-render `cilium-config.yaml` (`software.ReconfigureCiliumConfig`)
+1. **Kubernetes installed?** — the kubeadm admin kubeconfig
+   (`/etc/kubernetes/admin.conf`) exists. If not, skip.
+2. **Cilium installed?** — the `cilium-config` ConfigMap exists (read via the
+   provisioner's own `kube.Client`). If the API is unreachable or the ConfigMap is
+   absent, skip.
+3. **Already done?** — if `bpf-lb-acceleration` is already `disabled`, skip. This
+   makes the migration idempotent/one-shot regardless of when the on-disk
+   provisioner version advances past the boundary.
+4. Otherwise re-render `cilium-config.yaml` (`software.ReconfigureCiliumConfig`)
    and apply it with `cilium upgrade --values <config> --wait`.
+
+The live-state reads use the provisioner's `internal/kube` client
+(`kube.NewClient` + `ResourceExists` / `GetResourceNestedString`), not a `kubectl`
+shell-out.
 
 `Applies()` is inherited from `CLIVersionMigration` and gates purely on the CLI
 version boundary (`minVersion = 0.19.1`, the release shipping #674 + this
@@ -57,8 +66,10 @@ config to its canonical sandbox path; the existing install path
       only `fix:`/`ci:` commits present). If a `feat:` lands first, bump to the
       resulting minor.
 - [ ] Migration is registered under `ScopeStartup` after `LegacyBinaryMigration`.
-- [ ] `Execute` no-ops when the ConfigMap read errors or returns `disabled`
-      (idempotent / one-shot; safe across repeated invocations in the window).
+- [ ] `Execute` no-ops when Kubernetes is not installed (no admin.conf), when
+      Cilium is not installed (no `cilium-config`), when the API is unreachable,
+      or when acceleration is already `disabled` (idempotent / one-shot; safe
+      across repeated invocations in the window and on undeployed hosts).
 - [ ] `cilium upgrade` uses `--values <rendered config>` and `--wait`.
 - [ ] No change to install-time behaviour (`createCiliumConfigFile` still renders
       via the shared helper and writes through the fileManager).

--- a/docs/claude/reviews/00669-cilium-acceleration-migration.md
+++ b/docs/claude/reviews/00669-cilium-acceleration-migration.md
@@ -1,0 +1,96 @@
+# 00669 — Startup migration: re-apply disabled Cilium acceleration to existing clusters
+
+## Problem
+
+PR #674 changed the embedded Cilium template
+(`internal/templates/files/cilium/cilium-config.yaml`) to
+`loadBalancer.acceleration: "disabled"` (tc-eBPF) so Cilium no longer attaches a
+native XDP program to the host's public NIC — native XDP attach/reconcile resets
+the ixgbe (Intel X550) PHY and flaps the link, dropping the node's public IP
+(#669).
+
+The template change only helps **new** clusters. On an already-provisioned node
+the Cilium setup steps are guarded and never re-apply it:
+
+- `configureCilium` skips when the installer's persisted `IsConfigured` flag is set.
+- `installCiliumCNI` skips when `cilium status` succeeds (cluster already running).
+
+So existing clusters keep `bpf-lb-acceleration: best-effort` (native XDP) and stay
+exposed to the flap until manually fixed.
+
+## Solution
+
+Add a startup-scoped `CLIVersionMigration` (`CiliumAccelerationMigration`,
+`internal/workflows/migration_cilium_acceleration.go`) that runs on the first
+provisioner invocation after upgrading across the version boundary and brings
+existing clusters onto the new template:
+
+1. Read `bpf-lb-acceleration` from the live `cilium-config` ConfigMap.
+2. No-op if it can't be read (node has no cluster) or is already `disabled`
+   (migration already ran) — this makes it safely idempotent/one-shot regardless
+   of when the on-disk provisioner version advances past the boundary.
+3. Otherwise re-render `cilium-config.yaml` (`software.ReconfigureCiliumConfig`)
+   and apply it with `cilium upgrade --values <config> --wait`.
+
+`Applies()` is inherited from `CLIVersionMigration` and gates purely on the CLI
+version boundary (`minVersion = 0.19.1`, the release shipping #674 + this
+migration); all live-state checks live in `Execute` with safe no-op fallbacks.
+
+`software.ReconfigureCiliumConfig` is a new exported helper that re-renders the
+config to its canonical sandbox path; the existing install path
+(`createCiliumConfigFile`) and it now share a `renderCiliumConfig` helper.
+
+## Changed files
+
+| File | Change |
+| --- | --- |
+| `internal/workflows/migration_cilium_acceleration.go` | New `CiliumAccelerationMigration` (startup `CLIVersionMigration`). |
+| `internal/workflows/migration_cilium_acceleration_test.go` | Tests for `Applies` (version boundary) and `Execute` (already-disabled / no-cluster / best-effort). |
+| `pkg/software/cilium_installer.go` | Extract `renderCiliumConfig`; add exported `ReconfigureCiliumConfig` + `CiliumConfigPath`. |
+| `cmd/cli/commands/root.go` | Register the migration under `migration.ScopeStartup`. |
+| `docs/claude/reviews/00669-cilium-acceleration-migration.md` | This review guide. |
+
+## Review checklist
+
+- [ ] `minVersion` (`ciliumAccelerationMinVersion`) equals the release that ships
+      #674 + this migration (semantic-release bump since v0.19.0 → **0.19.1**;
+      only `fix:`/`ci:` commits present). If a `feat:` lands first, bump to the
+      resulting minor.
+- [ ] Migration is registered under `ScopeStartup` after `LegacyBinaryMigration`.
+- [ ] `Execute` no-ops when the ConfigMap read errors or returns `disabled`
+      (idempotent / one-shot; safe across repeated invocations in the window).
+- [ ] `cilium upgrade` uses `--values <rendered config>` and `--wait`.
+- [ ] No change to install-time behaviour (`createCiliumConfigFile` still renders
+      via the shared helper and writes through the fileManager).
+
+## Tests
+
+```bash
+go test ./internal/workflows/... -run CiliumAcceleration -count=1
+go test ./pkg/software/... -run Cilium -count=1
+```
+
+## Manual UAT
+
+On an existing block-node host currently at `best-effort` (e.g. the testnet `blk`
+nodes), after upgrading the provisioner binary to the release carrying this change:
+
+```bash
+# Before: live config still best-effort, native XDP attached to the public NIC.
+KUBECONFIG=/etc/kubernetes/admin.conf kubectl -n kube-system \
+  get cm cilium-config -o jsonpath='{.data.bpf-lb-acceleration}'; echo   # best-effort
+
+# Run any provisioner command (the startup migration fires in PersistentPreRun):
+sudo solo-provisioner version
+
+# After: live config flipped to disabled, no XDP on the public NIC, no carrier flap.
+KUBECONFIG=/etc/kubernetes/admin.conf kubectl -n kube-system \
+  get cm cilium-config -o jsonpath='{.data.bpf-lb-acceleration}'; echo   # disabled
+for n in $(ls /sys/class/net | grep -E '^eno|^enp|^eth'); do
+  echo -n "$n: "; ip -d link show "$n" | grep -qi xdp && echo "XDP ATTACHED (bad)" || echo "no xdp (good)"
+done
+journalctl -u systemd-networkd -b | grep -iE 'eno[0-9].*(Gained|Lost) carrier' | tail
+```
+
+Re-running a provisioner command must NOT re-trigger `cilium upgrade` (Execute
+sees `disabled` and no-ops).

--- a/internal/workflows/migration_cilium_acceleration.go
+++ b/internal/workflows/migration_cilium_acceleration.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// migration_cilium_acceleration.go re-applies the Cilium load-balancer
+// acceleration setting to already-provisioned clusters.
+//
+// PR #674 changed the embedded cilium-config template to
+// loadBalancer.acceleration: "disabled" (tc-eBPF) so Cilium no longer attaches a
+// native XDP program to the host's public NIC. On ixgbe NICs (e.g. Intel X550)
+// native XDP attach/reconcile resets the PHY and flaps the link, dropping the
+// node's public IP (#669).
+//
+// The Cilium setup steps are guarded — configureCilium skips on the persisted
+// IsConfigured flag, and installCiliumCNI skips when `cilium status` succeeds —
+// so an already-provisioned cluster never re-renders or re-applies the template
+// and keeps best-effort native XDP. This startup migration closes that gap: on
+// the first provisioner run after upgrading across the version boundary it
+// re-renders cilium-config.yaml and runs `cilium upgrade` so the live cluster
+// adopts the disabled acceleration.
+//
+// Registered in cmd/cli/commands/root.go RegisterMigrations() under
+// migration.ScopeStartup.
+
+package workflows
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/automa-saga/automa/automa_steps"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/migration"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/hashgraph/solo-weaver/pkg/software"
+	"github.com/joomcode/errorx"
+)
+
+// ciliumAccelerationMinVersion is the CLI release that ships the disabled-acceleration
+// template (#674) together with this migration. The migration applies when
+// upgrading from a version below this boundary to this version or later.
+const ciliumAccelerationMinVersion = "0.19.1"
+
+// adminKubeconfigPath is the kubeadm-written admin kubeconfig used to read the
+// live cilium-config ConfigMap.
+const adminKubeconfigPath = "/etc/kubernetes/admin.conf"
+
+// disabledAcceleration is the target bpf-lb-acceleration value (tc-eBPF, no XDP).
+const disabledAcceleration = "disabled"
+
+// runShell and reconfigureCiliumConfig are seams so tests can stub shell
+// execution and the on-disk config re-render.
+var (
+	runShell                = automa_steps.RunBashScript
+	reconfigureCiliumConfig = software.ReconfigureCiliumConfig
+)
+
+// CiliumAccelerationMigration re-renders cilium-config.yaml and runs `cilium upgrade`
+// so already-provisioned clusters adopt loadBalancer.acceleration=disabled (#669/#674).
+type CiliumAccelerationMigration struct {
+	migration.CLIVersionMigration
+}
+
+// NewCiliumAccelerationMigration constructs the migration.
+func NewCiliumAccelerationMigration() *CiliumAccelerationMigration {
+	return &CiliumAccelerationMigration{
+		CLIVersionMigration: migration.NewCLIVersionMigration(
+			"cilium-disable-xdp-acceleration-v"+ciliumAccelerationMinVersion,
+			"Re-render cilium-config and run 'cilium upgrade' so existing clusters adopt "+
+				"loadBalancer.acceleration=disabled (tc-eBPF) instead of best-effort native XDP (#669)",
+			ciliumAccelerationMinVersion,
+		),
+	}
+}
+
+// Execute re-renders cilium-config.yaml from the updated template and applies it
+// with `cilium upgrade --values <config> --wait`.
+//
+// It is self-guarding and idempotent: it no-ops when no live cilium-config is
+// reachable (the node has no cluster) or when acceleration is already "disabled"
+// (the migration already ran). Applies() only gates on the CLI version boundary,
+// so these checks make repeated invocations within the upgrade window harmless.
+func (m *CiliumAccelerationMigration) Execute(ctx context.Context, mctx *migration.Context) error {
+	acc, err := liveCiliumAcceleration()
+	if err != nil {
+		logx.As().Debug().Err(err).
+			Msg("cilium acceleration migration: no reachable cilium-config (no cluster on this node?); skipping")
+		return nil
+	}
+	if acc == disabledAcceleration {
+		logx.As().Info().Msg("cilium acceleration migration: bpf-lb-acceleration already 'disabled'; nothing to do")
+		return nil
+	}
+
+	configPath, err := reconfigureCiliumConfig()
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to re-render cilium-config.yaml")
+	}
+
+	logx.As().Info().
+		Str("config", configPath).
+		Str("from", acc).
+		Str("to", disabledAcceleration).
+		Msg("Applying cilium-config (loadBalancer.acceleration=disabled) to existing cluster via 'cilium upgrade'")
+
+	upgrade := []string{
+		fmt.Sprintf("/usr/bin/sudo %s/cilium upgrade --values %s --wait",
+			models.Paths().SandboxBinDir, configPath),
+	}
+	if _, err := runShell(upgrade, ""); err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to run 'cilium upgrade' to apply disabled LB acceleration")
+	}
+
+	return nil
+}
+
+// Rollback is a no-op: re-running a known-good provisioner version re-applies the
+// desired template. We intentionally do not restore best-effort acceleration —
+// that is the NIC-flapping behaviour the migration exists to remove.
+func (m *CiliumAccelerationMigration) Rollback(ctx context.Context, mctx *migration.Context) error {
+	logx.As().Warn().Msg("Rollback for cilium acceleration migration is not supported (would re-introduce the NIC-flapping XDP acceleration)")
+	return nil
+}
+
+// liveCiliumAcceleration reads bpf-lb-acceleration from the live cilium-config
+// ConfigMap. Returns an error when the ConfigMap cannot be read (e.g. no cluster).
+func liveCiliumAcceleration() (string, error) {
+	cmd := []string{
+		fmt.Sprintf("/usr/bin/sudo env KUBECONFIG=%s /usr/local/bin/kubectl -n kube-system get configmap cilium-config -o jsonpath='{.data.bpf-lb-acceleration}'",
+			adminKubeconfigPath),
+	}
+	out, err := runShell(cmd, "")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}

--- a/internal/workflows/migration_cilium_acceleration.go
+++ b/internal/workflows/migration_cilium_acceleration.go
@@ -25,6 +25,7 @@ package workflows
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/automa-saga/automa/automa_steps"
 	"github.com/automa-saga/logx"
@@ -43,12 +44,17 @@ const ciliumAccelerationMinVersion = "0.19.1"
 // disabledAcceleration is the target bpf-lb-acceleration value (tc-eBPF, no XDP).
 const disabledAcceleration = "disabled"
 
-// Seams so tests can stub the live-config read, the on-disk re-render, and shell
-// execution without touching a cluster or the filesystem.
+// adminKubeconfigPath is the kubeadm-written admin kubeconfig; its presence is the
+// marker that Kubernetes has been provisioned on this host.
+const adminKubeconfigPath = "/etc/kubernetes/admin.conf"
+
+// Seams so tests can stub the install preconditions, the on-disk re-render, and
+// shell execution without touching a cluster or the filesystem.
 var (
 	runShell                = automa_steps.RunBashScript
 	reconfigureCiliumConfig = software.ReconfigureCiliumConfig
-	readCiliumAcceleration  = liveCiliumAcceleration
+	kubernetesInstalled     = defaultKubernetesInstalled
+	readCiliumState         = defaultReadCiliumState
 )
 
 // CiliumAccelerationMigration re-renders cilium-config.yaml and runs `cilium upgrade`
@@ -77,15 +83,26 @@ func NewCiliumAccelerationMigration() *CiliumAccelerationMigration {
 // (the migration already ran). Applies() only gates on the CLI version boundary,
 // so these checks make repeated invocations within the upgrade window harmless.
 func (m *CiliumAccelerationMigration) Execute(ctx context.Context, mctx *migration.Context) error {
-	acc, err := readCiliumAcceleration(ctx)
-	if err != nil {
-		logx.As().Debug().Err(err).
-			Msg("cilium acceleration migration: cilium-config not reachable (no cluster on this node?); skipping")
+	// The provisioner can run before anything is deployed, so reconfigure only
+	// when both Kubernetes and Cilium are actually installed on this host.
+	if !kubernetesInstalled() {
+		logx.As().Debug().Msg("cilium acceleration migration: Kubernetes not installed on this host; skipping")
 		return nil
 	}
-	if acc == "" || acc == disabledAcceleration {
+
+	installed, acc, err := readCiliumState(ctx)
+	if err != nil {
+		logx.As().Debug().Err(err).
+			Msg("cilium acceleration migration: Kubernetes API not reachable; skipping")
+		return nil
+	}
+	if !installed {
+		logx.As().Debug().Msg("cilium acceleration migration: Cilium not installed (no cilium-config); skipping")
+		return nil
+	}
+	if acc == disabledAcceleration || acc == "" {
 		logx.As().Info().Str("acceleration", acc).
-			Msg("cilium acceleration migration: nothing to do (no cilium-config or already disabled)")
+			Msg("cilium acceleration migration: nothing to do (already disabled)")
 		return nil
 	}
 
@@ -119,14 +136,34 @@ func (m *CiliumAccelerationMigration) Rollback(ctx context.Context, mctx *migrat
 	return nil
 }
 
-// liveCiliumAcceleration reads bpf-lb-acceleration from the live cilium-config
-// ConfigMap via the Kubernetes API (the provisioner's own client, which resolves
-// the in-cluster config or the admin kubeconfig). Returns ("", nil) when the
-// ConfigMap is absent, and ("", err) when the cluster is not reachable.
-func liveCiliumAcceleration(ctx context.Context) (string, error) {
+// defaultKubernetesInstalled reports whether Kubernetes has been provisioned on
+// this host (the kubeadm admin kubeconfig exists).
+func defaultKubernetesInstalled() bool {
+	_, err := os.Stat(adminKubeconfigPath)
+	return err == nil
+}
+
+// defaultReadCiliumState reports whether Cilium is installed (its cilium-config
+// ConfigMap exists) and, if so, its bpf-lb-acceleration value. It uses the
+// provisioner's own Kubernetes client (resolving the in-cluster config or admin
+// kubeconfig). A non-nil error means the cluster/API is not reachable.
+func defaultReadCiliumState(ctx context.Context) (installed bool, acceleration string, err error) {
 	kc, err := kube.NewClient()
 	if err != nil {
-		return "", err
+		return false, "", err
 	}
-	return kc.GetResourceNestedString(ctx, "v1", "ConfigMap", "kube-system", "cilium-config", "data", "bpf-lb-acceleration")
+
+	exists, err := kc.ResourceExists(ctx, "v1", "ConfigMap", "kube-system", "cilium-config")
+	if err != nil {
+		return false, "", err
+	}
+	if !exists {
+		return false, "", nil
+	}
+
+	acc, err := kc.GetResourceNestedString(ctx, "v1", "ConfigMap", "kube-system", "cilium-config", "data", "bpf-lb-acceleration")
+	if err != nil {
+		return true, "", err
+	}
+	return true, acc, nil
 }

--- a/internal/workflows/migration_cilium_acceleration.go
+++ b/internal/workflows/migration_cilium_acceleration.go
@@ -25,10 +25,10 @@ package workflows
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/automa-saga/automa/automa_steps"
 	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/kube"
 	"github.com/hashgraph/solo-weaver/internal/migration"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/hashgraph/solo-weaver/pkg/software"
@@ -40,18 +40,15 @@ import (
 // upgrading from a version below this boundary to this version or later.
 const ciliumAccelerationMinVersion = "0.19.1"
 
-// adminKubeconfigPath is the kubeadm-written admin kubeconfig used to read the
-// live cilium-config ConfigMap.
-const adminKubeconfigPath = "/etc/kubernetes/admin.conf"
-
 // disabledAcceleration is the target bpf-lb-acceleration value (tc-eBPF, no XDP).
 const disabledAcceleration = "disabled"
 
-// runShell and reconfigureCiliumConfig are seams so tests can stub shell
-// execution and the on-disk config re-render.
+// Seams so tests can stub the live-config read, the on-disk re-render, and shell
+// execution without touching a cluster or the filesystem.
 var (
 	runShell                = automa_steps.RunBashScript
 	reconfigureCiliumConfig = software.ReconfigureCiliumConfig
+	readCiliumAcceleration  = liveCiliumAcceleration
 )
 
 // CiliumAccelerationMigration re-renders cilium-config.yaml and runs `cilium upgrade`
@@ -80,14 +77,15 @@ func NewCiliumAccelerationMigration() *CiliumAccelerationMigration {
 // (the migration already ran). Applies() only gates on the CLI version boundary,
 // so these checks make repeated invocations within the upgrade window harmless.
 func (m *CiliumAccelerationMigration) Execute(ctx context.Context, mctx *migration.Context) error {
-	acc, err := liveCiliumAcceleration()
+	acc, err := readCiliumAcceleration(ctx)
 	if err != nil {
 		logx.As().Debug().Err(err).
-			Msg("cilium acceleration migration: no reachable cilium-config (no cluster on this node?); skipping")
+			Msg("cilium acceleration migration: cilium-config not reachable (no cluster on this node?); skipping")
 		return nil
 	}
-	if acc == disabledAcceleration {
-		logx.As().Info().Msg("cilium acceleration migration: bpf-lb-acceleration already 'disabled'; nothing to do")
+	if acc == "" || acc == disabledAcceleration {
+		logx.As().Info().Str("acceleration", acc).
+			Msg("cilium acceleration migration: nothing to do (no cilium-config or already disabled)")
 		return nil
 	}
 
@@ -122,15 +120,13 @@ func (m *CiliumAccelerationMigration) Rollback(ctx context.Context, mctx *migrat
 }
 
 // liveCiliumAcceleration reads bpf-lb-acceleration from the live cilium-config
-// ConfigMap. Returns an error when the ConfigMap cannot be read (e.g. no cluster).
-func liveCiliumAcceleration() (string, error) {
-	cmd := []string{
-		fmt.Sprintf("/usr/bin/sudo env KUBECONFIG=%s /usr/local/bin/kubectl -n kube-system get configmap cilium-config -o jsonpath='{.data.bpf-lb-acceleration}'",
-			adminKubeconfigPath),
-	}
-	out, err := runShell(cmd, "")
+// ConfigMap via the Kubernetes API (the provisioner's own client, which resolves
+// the in-cluster config or the admin kubeconfig). Returns ("", nil) when the
+// ConfigMap is absent, and ("", err) when the cluster is not reachable.
+func liveCiliumAcceleration(ctx context.Context) (string, error) {
+	kc, err := kube.NewClient()
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(out), nil
+	return kc.GetResourceNestedString(ctx, "v1", "ConfigMap", "kube-system", "cilium-config", "data", "bpf-lb-acceleration")
 }

--- a/internal/workflows/migration_cilium_acceleration_test.go
+++ b/internal/workflows/migration_cilium_acceleration_test.go
@@ -51,57 +51,65 @@ func TestCiliumAccelerationMigration_Applies(t *testing.T) {
 }
 
 func TestCiliumAccelerationMigration_Execute(t *testing.T) {
-	orig := runShell
-	t.Cleanup(func() { runShell = orig })
+	origRead, origReconfigure, origShell := readCiliumAcceleration, reconfigureCiliumConfig, runShell
+	t.Cleanup(func() {
+		readCiliumAcceleration, reconfigureCiliumConfig, runShell = origRead, origReconfigure, origShell
+	})
 
 	m := NewCiliumAccelerationMigration()
 	mctx := newMctx("0.18.1", ciliumAccelerationMinVersion)
 
-	t.Run("skips upgrade when acceleration already disabled", func(t *testing.T) {
-		var upgraded bool
+	// trackUpgrade records whether `cilium upgrade` was shelled out and its command.
+	trackUpgrade := func(cmd *string, ran *bool) {
 		runShell = func(scripts []string, _ string) (string, error) {
 			joined := strings.Join(scripts, " ")
 			if strings.Contains(joined, "cilium upgrade") {
-				upgraded = true
-				return "", nil
+				*ran = true
+				*cmd = joined
 			}
-			return "disabled", nil // live cilium-config read
+			return "", nil
 		}
+	}
+
+	t.Run("skips upgrade when acceleration already disabled", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		readCiliumAcceleration = func(context.Context) (string, error) { return "disabled", nil }
+		trackUpgrade(&cmd, &ran)
 		require.NoError(t, m.Execute(context.Background(), mctx))
-		assert.False(t, upgraded, "cilium upgrade must not run when already disabled")
+		assert.False(t, ran, "cilium upgrade must not run when already disabled")
 	})
 
-	t.Run("no-ops when cilium-config is unreachable", func(t *testing.T) {
-		var upgraded bool
-		runShell = func(scripts []string, _ string) (string, error) {
-			joined := strings.Join(scripts, " ")
-			if strings.Contains(joined, "cilium upgrade") {
-				upgraded = true
-				return "", nil
-			}
-			return "", assert.AnError // read fails: no cluster
-		}
+	t.Run("skips upgrade when cilium-config is absent (empty value)", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		readCiliumAcceleration = func(context.Context) (string, error) { return "", nil }
+		trackUpgrade(&cmd, &ran)
 		require.NoError(t, m.Execute(context.Background(), mctx))
-		assert.False(t, upgraded, "cilium upgrade must not run when there is no live cluster")
+		assert.False(t, ran, "cilium upgrade must not run when there is no cilium-config")
+	})
+
+	t.Run("no-ops when the cluster is unreachable", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		readCiliumAcceleration = func(context.Context) (string, error) { return "", assert.AnError }
+		trackUpgrade(&cmd, &ran)
+		require.NoError(t, m.Execute(context.Background(), mctx))
+		assert.False(t, ran, "cilium upgrade must not run when the cluster is unreachable")
 	})
 
 	t.Run("runs cilium upgrade when acceleration is best-effort", func(t *testing.T) {
-		origReconfigure := reconfigureCiliumConfig
-		t.Cleanup(func() { reconfigureCiliumConfig = origReconfigure })
-		reconfigureCiliumConfig = func() (string, error) { return "/opt/solo/weaver/sandbox/etc/weaver/cilium-config.yaml", nil }
-
-		var upgradeCmd string
-		runShell = func(scripts []string, _ string) (string, error) {
-			joined := strings.Join(scripts, " ")
-			if strings.Contains(joined, "cilium upgrade") {
-				upgradeCmd = joined
-				return "", nil
-			}
-			return "best-effort", nil
+		var ran bool
+		var cmd string
+		readCiliumAcceleration = func(context.Context) (string, error) { return "best-effort", nil }
+		reconfigureCiliumConfig = func() (string, error) {
+			return "/opt/solo/weaver/sandbox/etc/weaver/cilium-config.yaml", nil
 		}
+		trackUpgrade(&cmd, &ran)
 		require.NoError(t, m.Execute(context.Background(), mctx))
-		assert.Contains(t, upgradeCmd, "cilium upgrade")
-		assert.Contains(t, upgradeCmd, "--values")
-		assert.Contains(t, upgradeCmd, "--wait")
+		require.True(t, ran, "cilium upgrade must run when acceleration is best-effort")
+		assert.Contains(t, cmd, "cilium upgrade")
+		assert.Contains(t, cmd, "--values")
+		assert.Contains(t, cmd, "--wait")
 	})
 }

--- a/internal/workflows/migration_cilium_acceleration_test.go
+++ b/internal/workflows/migration_cilium_acceleration_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package workflows
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/automa-saga/automa"
+	"github.com/hashgraph/solo-weaver/internal/migration"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMctx(installed, current string) *migration.Context {
+	mctx := &migration.Context{Component: migration.ScopeStartup, Data: &automa.SyncStateBag{}}
+	mctx.Data.Set(migration.CtxKeyInstalledCLIVersion, installed)
+	mctx.Data.Set(migration.CtxKeyCurrentCLIVersion, current)
+	return mctx
+}
+
+func TestCiliumAccelerationMigration_Metadata(t *testing.T) {
+	m := NewCiliumAccelerationMigration()
+	assert.Equal(t, "cilium-disable-xdp-acceleration-v"+ciliumAccelerationMinVersion, m.ID())
+	assert.Contains(t, m.Description(), "acceleration=disabled")
+}
+
+func TestCiliumAccelerationMigration_Applies(t *testing.T) {
+	m := NewCiliumAccelerationMigration()
+
+	tests := []struct {
+		name      string
+		installed string
+		current   string
+		want      bool
+	}{
+		{"upgrade across boundary applies", "0.18.1", "0.19.1", true},
+		{"upgrade from below to above applies", "0.18.1", "0.20.0", true},
+		{"fresh install does not apply", "", "0.19.1", false},
+		{"already past boundary does not apply", "0.19.1", "0.20.0", false},
+		{"below boundary on both sides does not apply", "0.18.0", "0.18.1", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := m.Applies(newMctx(tc.installed, tc.current))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestCiliumAccelerationMigration_Execute(t *testing.T) {
+	orig := runShell
+	t.Cleanup(func() { runShell = orig })
+
+	m := NewCiliumAccelerationMigration()
+	mctx := newMctx("0.18.1", ciliumAccelerationMinVersion)
+
+	t.Run("skips upgrade when acceleration already disabled", func(t *testing.T) {
+		var upgraded bool
+		runShell = func(scripts []string, _ string) (string, error) {
+			joined := strings.Join(scripts, " ")
+			if strings.Contains(joined, "cilium upgrade") {
+				upgraded = true
+				return "", nil
+			}
+			return "disabled", nil // live cilium-config read
+		}
+		require.NoError(t, m.Execute(context.Background(), mctx))
+		assert.False(t, upgraded, "cilium upgrade must not run when already disabled")
+	})
+
+	t.Run("no-ops when cilium-config is unreachable", func(t *testing.T) {
+		var upgraded bool
+		runShell = func(scripts []string, _ string) (string, error) {
+			joined := strings.Join(scripts, " ")
+			if strings.Contains(joined, "cilium upgrade") {
+				upgraded = true
+				return "", nil
+			}
+			return "", assert.AnError // read fails: no cluster
+		}
+		require.NoError(t, m.Execute(context.Background(), mctx))
+		assert.False(t, upgraded, "cilium upgrade must not run when there is no live cluster")
+	})
+
+	t.Run("runs cilium upgrade when acceleration is best-effort", func(t *testing.T) {
+		origReconfigure := reconfigureCiliumConfig
+		t.Cleanup(func() { reconfigureCiliumConfig = origReconfigure })
+		reconfigureCiliumConfig = func() (string, error) { return "/opt/solo/weaver/sandbox/etc/weaver/cilium-config.yaml", nil }
+
+		var upgradeCmd string
+		runShell = func(scripts []string, _ string) (string, error) {
+			joined := strings.Join(scripts, " ")
+			if strings.Contains(joined, "cilium upgrade") {
+				upgradeCmd = joined
+				return "", nil
+			}
+			return "best-effort", nil
+		}
+		require.NoError(t, m.Execute(context.Background(), mctx))
+		assert.Contains(t, upgradeCmd, "cilium upgrade")
+		assert.Contains(t, upgradeCmd, "--values")
+		assert.Contains(t, upgradeCmd, "--wait")
+	})
+}

--- a/internal/workflows/migration_cilium_acceleration_test.go
+++ b/internal/workflows/migration_cilium_acceleration_test.go
@@ -51,9 +51,9 @@ func TestCiliumAccelerationMigration_Applies(t *testing.T) {
 }
 
 func TestCiliumAccelerationMigration_Execute(t *testing.T) {
-	origRead, origReconfigure, origShell := readCiliumAcceleration, reconfigureCiliumConfig, runShell
+	origK8s, origState, origReconfigure, origShell := kubernetesInstalled, readCiliumState, reconfigureCiliumConfig, runShell
 	t.Cleanup(func() {
-		readCiliumAcceleration, reconfigureCiliumConfig, runShell = origRead, origReconfigure, origShell
+		kubernetesInstalled, readCiliumState, reconfigureCiliumConfig, runShell = origK8s, origState, origReconfigure, origShell
 	})
 
 	m := NewCiliumAccelerationMigration()
@@ -70,38 +70,54 @@ func TestCiliumAccelerationMigration_Execute(t *testing.T) {
 			return "", nil
 		}
 	}
+	stateReturns := func(installed bool, acc string, err error) {
+		readCiliumState = func(context.Context) (bool, string, error) { return installed, acc, err }
+	}
 
-	t.Run("skips upgrade when acceleration already disabled", func(t *testing.T) {
+	t.Run("skips when Kubernetes is not installed", func(t *testing.T) {
 		var ran bool
 		var cmd string
-		readCiliumAcceleration = func(context.Context) (string, error) { return "disabled", nil }
+		kubernetesInstalled = func() bool { return false }
+		stateReturns(true, "best-effort", nil) // must not even be consulted
 		trackUpgrade(&cmd, &ran)
 		require.NoError(t, m.Execute(context.Background(), mctx))
-		assert.False(t, ran, "cilium upgrade must not run when already disabled")
+		assert.False(t, ran, "must not run before Kubernetes is installed")
 	})
 
-	t.Run("skips upgrade when cilium-config is absent (empty value)", func(t *testing.T) {
+	// Remaining cases assume Kubernetes is present.
+	kubernetesInstalled = func() bool { return true }
+
+	t.Run("skips when Cilium is not installed", func(t *testing.T) {
 		var ran bool
 		var cmd string
-		readCiliumAcceleration = func(context.Context) (string, error) { return "", nil }
+		stateReturns(false, "", nil) // no cilium-config
 		trackUpgrade(&cmd, &ran)
 		require.NoError(t, m.Execute(context.Background(), mctx))
-		assert.False(t, ran, "cilium upgrade must not run when there is no cilium-config")
+		assert.False(t, ran, "must not run before Cilium is installed")
 	})
 
 	t.Run("no-ops when the cluster is unreachable", func(t *testing.T) {
 		var ran bool
 		var cmd string
-		readCiliumAcceleration = func(context.Context) (string, error) { return "", assert.AnError }
+		stateReturns(false, "", assert.AnError)
 		trackUpgrade(&cmd, &ran)
 		require.NoError(t, m.Execute(context.Background(), mctx))
-		assert.False(t, ran, "cilium upgrade must not run when the cluster is unreachable")
+		assert.False(t, ran, "must not run when the cluster is unreachable")
+	})
+
+	t.Run("skips upgrade when acceleration already disabled", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		stateReturns(true, "disabled", nil)
+		trackUpgrade(&cmd, &ran)
+		require.NoError(t, m.Execute(context.Background(), mctx))
+		assert.False(t, ran, "cilium upgrade must not run when already disabled")
 	})
 
 	t.Run("runs cilium upgrade when acceleration is best-effort", func(t *testing.T) {
 		var ran bool
 		var cmd string
-		readCiliumAcceleration = func(context.Context) (string, error) { return "best-effort", nil }
+		stateReturns(true, "best-effort", nil)
 		reconfigureCiliumConfig = func() (string, error) {
 			return "/opt/solo/weaver/sandbox/etc/weaver/cilium-config.yaml", nil
 		}

--- a/pkg/software/cilium_installer.go
+++ b/pkg/software/cilium_installer.go
@@ -3,6 +3,7 @@
 package software
 
 import (
+	"os"
 	"path"
 
 	"github.com/hashgraph/solo-weaver/internal/network"
@@ -86,11 +87,13 @@ func (ci *ciliumInstaller) getConfigurationDir() string {
 	return path.Join(models.Paths().SandboxDir, "etc", "weaver")
 }
 
-// createCiliumConfigFile creates the cilium configuration file from template
-func (ci *ciliumInstaller) createCiliumConfigFile() error {
+// renderCiliumConfig renders the embedded cilium-config template with the host's
+// machine IP and sandbox dir. Shared by install-time Configure() and the startup
+// migration that re-applies the template to already-provisioned clusters.
+func renderCiliumConfig() (string, error) {
 	machineIp, err := network.GetMachineIP()
 	if err != nil {
-		return errorx.IllegalState.Wrap(err, "failed to get machine IP address")
+		return "", errorx.IllegalState.Wrap(err, "failed to get machine IP address")
 	}
 
 	tmplData := struct {
@@ -103,7 +106,46 @@ func (ci *ciliumInstaller) createCiliumConfigFile() error {
 
 	rendered, err := templates.Render(ciliumTemplateFile, tmplData)
 	if err != nil {
-		return errorx.IllegalState.Wrap(err, "failed to render cilium configuration template")
+		return "", errorx.IllegalState.Wrap(err, "failed to render cilium configuration template")
+	}
+
+	return rendered, nil
+}
+
+// CiliumConfigPath returns the canonical path of the rendered cilium-config.yaml
+// in the weaver sandbox.
+func CiliumConfigPath() string {
+	return path.Join(models.Paths().SandboxDir, "etc", "weaver", ciliumConfigFileName)
+}
+
+// ReconfigureCiliumConfig re-renders cilium-config.yaml from the embedded template
+// to its canonical sandbox path and returns that path. Used by the startup
+// migration that re-applies the updated template to already-provisioned clusters
+// whose Configure()/IsConfigured guard would otherwise skip it.
+func ReconfigureCiliumConfig() (string, error) {
+	rendered, err := renderCiliumConfig()
+	if err != nil {
+		return "", err
+	}
+
+	configurationDir := path.Join(models.Paths().SandboxDir, "etc", "weaver")
+	if err := os.MkdirAll(configurationDir, 0o755); err != nil {
+		return "", errorx.IllegalState.Wrap(err, "failed to create cilium configuration directory %s", configurationDir)
+	}
+
+	configPath := CiliumConfigPath()
+	if err := os.WriteFile(configPath, []byte(rendered), 0o644); err != nil {
+		return "", errorx.IllegalState.Wrap(err, "failed to write cilium configuration file %s", configPath)
+	}
+
+	return configPath, nil
+}
+
+// createCiliumConfigFile creates the cilium configuration file from template
+func (ci *ciliumInstaller) createCiliumConfigFile() error {
+	rendered, err := renderCiliumConfig()
+	if err != nil {
+		return err
 	}
 
 	configurationDir := ci.getConfigurationDir()


### PR DESCRIPTION
## Context

Follow-up to #674 (merged), which set `loadBalancer.acceleration: "disabled"` (tc-eBPF) in the embedded Cilium template to stop native XDP from resetting the ixgbe (Intel X550) PHY and flapping the public NIC (#669).

As @brunodam noted on #674, that template change only helps **new** clusters. On an already-provisioned node the Cilium setup steps are guarded — `configureCilium` skips on the persisted `IsConfigured` flag, and `installCiliumCNI` skips when `cilium status` succeeds — so existing clusters never re-apply the template and keep `bpf-lb-acceleration: best-effort` (native XDP).

## Change

Adds a startup-scoped `CLIVersionMigration` (`CiliumAccelerationMigration`) that, on the first provisioner run after upgrading across the version boundary (`minVersion = 0.19.1`), brings existing clusters onto the new template:

1. Reads `bpf-lb-acceleration` from the live `cilium-config` ConfigMap.
2. No-ops when it can't be read (no cluster on this node) or is already `disabled` (already migrated) — idempotent / effectively one-shot regardless of when the on-disk provisioner version advances.
3. Otherwise re-renders `cilium-config.yaml` and runs `cilium upgrade --values <config> --wait`.

`Applies()` is the inherited version-boundary gate; all live-state checks are in `Execute` with safe no-op fallbacks. Adds exported `software.ReconfigureCiliumConfig` / `CiliumConfigPath`, with the install path and the migration sharing a `renderCiliumConfig` helper.

## minVersion note

`0.19.1` per semantic-release (only `fix:`/`ci:` commits since v0.19.0). If a `feat:` lands before the cut, bump the constant to the resulting minor.

## Tests

`internal/workflows/migration_cilium_acceleration_test.go` covers `Applies` (version boundary) and `Execute` (already-disabled / no-cluster / best-effort). Review guide: `docs/claude/reviews/00669-cilium-acceleration-migration.md`.