### PR TITLE
fix(blocknode): deep-merge custom --values over embedded profile base

### DIFF
--- a/internal/blocknode/manager_test.go
+++ b/internal/blocknode/manager_test.go
@@ -897,7 +897,9 @@ func TestInjectServiceAnnotations_CreatesServiceAndAnnotationsPath(t *testing.T)
 }
 
 // TestInjectServiceAnnotations_PreservesExistingAnnotation tests that a pre-existing
-// metallb.io/address-pool value in the operator's values file is not clobbered.
+// metallb.io/address-pool value in the operator's values file is not clobbered. The
+// input also pre-sets service.type so the byte-identical assertion is meaningful —
+// nothing needs to mutate.
 func TestInjectServiceAnnotations_PreservesExistingAnnotation(t *testing.T) {
 	manager := &Manager{
 		blockNodeInputs: models.BlockNodeInputs{
@@ -907,6 +909,7 @@ func TestInjectServiceAnnotations_PreservesExistingAnnotation(t *testing.T) {
 	}
 
 	input := []byte(`service:
+  type: LoadBalancer
   annotations:
     metallb.io/address-pool: my-custom-pool
 `)
@@ -914,7 +917,7 @@ func TestInjectServiceAnnotations_PreservesExistingAnnotation(t *testing.T) {
 	result, err := manager.injectServiceAnnotations(input)
 	require.NoError(t, err)
 
-	// The returned bytes must be identical to the input — no rewrite occurred.
+	// Both fields already correct → byte-identical short-circuit, no rewrite.
 	assert.Equal(t, input, result)
 	assert.Contains(t, string(result), "my-custom-pool")
 	assert.NotContains(t, string(result), "public-address-pool")
@@ -951,4 +954,192 @@ func TestInjectServiceAnnotations_PreservesOtherAnnotations(t *testing.T) {
 	// Sibling annotations preserved.
 	assert.Equal(t, "my-tag", annotations["custom.io/tag"])
 	assert.Equal(t, "some-value", annotations["another.io/key"])
+}
+
+// TestInjectServiceAnnotations_SetsLoadBalancerType tests that service.type: LoadBalancer
+// is injected when LoadBalancerEnabled is true and the operator left the type unset.
+// This is the defense-in-depth fix for #702: even if the values pipeline ever produced
+// a values document missing service.type, this step would restore it.
+func TestInjectServiceAnnotations_SetsLoadBalancerType(t *testing.T) {
+	manager := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{
+			LoadBalancerEnabled: true,
+		},
+		logger: testLogger(),
+	}
+
+	input := []byte(`service:
+  port: 40840
+`)
+
+	result, err := manager.injectServiceAnnotations(input)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+
+	service := vals["service"].(map[string]interface{})
+	assert.Equal(t, "LoadBalancer", service["type"])
+	// Port preserved.
+	assert.EqualValues(t, 40840, service["port"])
+}
+
+// TestInjectServiceAnnotations_PreservesExistingType tests that an explicit non-LoadBalancer
+// service.type set by the operator is not clobbered. Weaver warns about the mismatch but
+// honors the operator's choice — clobbering would silently override intent.
+func TestInjectServiceAnnotations_PreservesExistingType(t *testing.T) {
+	manager := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{
+			LoadBalancerEnabled: true,
+		},
+		logger: testLogger(),
+	}
+
+	input := []byte(`service:
+  type: ClusterIP
+`)
+
+	result, err := manager.injectServiceAnnotations(input)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+
+	service := vals["service"].(map[string]interface{})
+	assert.Equal(t, "ClusterIP", service["type"], "operator-set service.type must not be clobbered")
+}
+
+// TestMergeValues_OperatorWinsOnScalar verifies the deep-merge contract: operator scalars
+// override base scalars at the same path.
+func TestMergeValues_OperatorWinsOnScalar(t *testing.T) {
+	base := []byte(`service:
+  type: LoadBalancer
+  port: 40840
+`)
+	operator := []byte(`service:
+  port: 12345
+`)
+
+	merged, err := mergeValues(base, operator)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(merged, &vals))
+
+	service := vals["service"].(map[string]interface{})
+	assert.EqualValues(t, 12345, service["port"], "operator port should win")
+	assert.Equal(t, "LoadBalancer", service["type"], "base service.type should survive — operator didn't set it")
+}
+
+// TestMergeValues_BaseSurvivesWhereOperatorSilent verifies the central #702 invariant:
+// when an operator file omits service.type entirely, the base's service.type: LoadBalancer
+// survives the merge. Pre-fix this is the value that disappeared and caused
+// verify-block-node-reachable to fail.
+func TestMergeValues_BaseSurvivesWhereOperatorSilent(t *testing.T) {
+	base := []byte(`service:
+  type: LoadBalancer
+  port: 40840
+blockNode:
+  config:
+    BLOCK_NODE_EARLIEST_MANAGED_BLOCK: "100000000"
+`)
+	operator := []byte(`service:
+  annotations:
+    metallb.io/allow-shared-ip: shared
+`)
+
+	merged, err := mergeValues(base, operator)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(merged, &vals))
+
+	service := vals["service"].(map[string]interface{})
+	assert.Equal(t, "LoadBalancer", service["type"], "base service.type: LoadBalancer must survive — this is the #702 bug")
+	assert.EqualValues(t, 40840, service["port"], "base service.port must survive")
+
+	annotations := service["annotations"].(map[string]interface{})
+	assert.Equal(t, "shared", annotations["metallb.io/allow-shared-ip"], "operator annotation merged in")
+
+	blockNode := vals["blockNode"].(map[string]interface{})
+	config := blockNode["config"].(map[string]interface{})
+	assert.Equal(t, "100000000", config["BLOCK_NODE_EARLIEST_MANAGED_BLOCK"], "base blockNode.config must survive")
+}
+
+// TestMergeValues_DeepMergeNestedMaps verifies that nested maps deep-merge (not replace):
+// adding a sibling key under blockNode.config keeps the base's existing keys at the same path.
+func TestMergeValues_DeepMergeNestedMaps(t *testing.T) {
+	base := []byte(`blockNode:
+  config:
+    BLOCK_NODE_EARLIEST_MANAGED_BLOCK: "100000000"
+    MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "512"
+`)
+	operator := []byte(`blockNode:
+  config:
+    CUSTOM_OPERATOR_KEY: "custom-value"
+`)
+
+	merged, err := mergeValues(base, operator)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(merged, &vals))
+
+	config := vals["blockNode"].(map[string]interface{})["config"].(map[string]interface{})
+	assert.Equal(t, "100000000", config["BLOCK_NODE_EARLIEST_MANAGED_BLOCK"], "base config keys preserved")
+	assert.Equal(t, "512", config["MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE"], "base config keys preserved")
+	assert.Equal(t, "custom-value", config["CUSTOM_OPERATOR_KEY"], "operator config keys merged in")
+}
+
+// TestMergeValues_ListsReplaceNotConcatenate pins down helm's documented merge contract:
+// sequences are replaced wholesale by the operator (no element-wise concatenation). The
+// merge primitive's behavior on lists is the part most likely to surprise operators and
+// the part most likely to drift silently if the merge implementation is ever swapped, so
+// it deserves its own regression test.
+func TestMergeValues_ListsReplaceNotConcatenate(t *testing.T) {
+	base := []byte(`blockNode:
+  initContainers:
+    - name: init-storage-dirs
+      image: docker.io/library/busybox:latest
+    - name: init-config
+      image: docker.io/library/busybox:latest
+`)
+	operator := []byte(`blockNode:
+  initContainers:
+    - name: operator-init
+      image: my.registry/operator:latest
+`)
+
+	merged, err := mergeValues(base, operator)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(merged, &vals))
+
+	blockNode := vals["blockNode"].(map[string]interface{})
+	initContainers, ok := blockNode["initContainers"].([]interface{})
+	require.True(t, ok, "blockNode.initContainers should still be a sequence")
+
+	require.Len(t, initContainers, 1, "operator's sequence must replace the base's wholesale (no concat)")
+	first := initContainers[0].(map[string]interface{})
+	assert.Equal(t, "operator-init", first["name"], "operator's element survives; base's elements are dropped")
+}
+
+// TestMergeValues_EmptyOperator returns the base verbatim (semantically — keys all present).
+func TestMergeValues_EmptyOperator(t *testing.T) {
+	base := []byte(`service:
+  type: LoadBalancer
+  port: 40840
+`)
+	operator := []byte(``)
+
+	merged, err := mergeValues(base, operator)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(merged, &vals))
+
+	service := vals["service"].(map[string]interface{})
+	assert.Equal(t, "LoadBalancer", service["type"])
+	assert.EqualValues(t, 40840, service["port"])
 }

--- a/internal/blocknode/values.go
+++ b/internal/blocknode/values.go
@@ -13,32 +13,47 @@ import (
 	"github.com/hashgraph/solo-weaver/pkg/sanity"
 	"github.com/joomcode/errorx"
 	"gopkg.in/yaml.v3"
+	"helm.sh/helm/v3/pkg/chartutil"
 )
 
 // ComputeValuesFile generates the values file for helm installation based on profile and version.
 // It writes the result to a temp file and returns the path.
 //
-// When no custom values file is provided, the appropriate built-in template is rendered.
-// When a custom values file is provided, persistence settings are injected to ensure
-// weaver-managed PVCs are referenced (create: false + existingClaim) rather than letting
-// the chart create its own.
+// The profile's embedded base template is always rendered first; when an operator --values
+// file is provided, it is deep-merged on top of the base (operator keys win on conflict)
+// using the same semantics as `helm install -f`. This preserves base defaults such as
+// service.type: LoadBalancer, blockNode.config, initContainers, and persistence wiring
+// that an operator file would otherwise drop by replacing the base entirely.
 //
-// In both cases, effective retention thresholds are merged into blockNode.config.
+// Persistence overrides are then applied unconditionally so that weaver-managed PVCs are
+// referenced (create: false + existingClaim) regardless of what the operator file specified.
+// Retention thresholds and plugin/service-annotation injections follow.
 //
 // NOTE: Defense-in-depth path validation is applied even though the CLI layer also validates.
 func (m *Manager) ComputeValuesFile(profile string, valuesFile string) (string, error) {
-	var (
-		valuesContent []byte
-		err           error
-	)
-
-	if valuesFile == "" {
-		valuesContent, err = m.renderDefaultValues(profile)
-	} else {
-		valuesContent, err = m.readCustomValues(valuesFile)
-	}
+	valuesContent, err := m.renderDefaultValues(profile)
 	if err != nil {
 		return "", err
+	}
+
+	if valuesFile != "" {
+		operatorContent, err := m.readCustomValues(valuesFile)
+		if err != nil {
+			return "", err
+		}
+		// Return mergeValues' typed error directly so an IllegalFormat from a malformed
+		// operator YAML stays IllegalFormat — wrapping it as InternalError would
+		// misattribute the failure to weaver instead of the operator's --values file.
+		valuesContent, err = mergeValues(valuesContent, operatorContent)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Force weaver-managed PVC references regardless of what the operator file said.
+	valuesContent, err = m.injectPersistenceOverrides(valuesContent)
+	if err != nil {
+		return "", errorx.InternalError.Wrap(err, "failed to inject persistence overrides into values file")
 	}
 
 	// Merge effective retention thresholds into blockNode.config when non-empty.
@@ -113,9 +128,10 @@ func (m *Manager) renderDefaultValues(profile string) ([]byte, error) {
 	return []byte(rendered), nil
 }
 
-// readCustomValues reads and validates a user-supplied values file, then injects persistence
-// overrides to ensure weaver-managed PVCs are always referenced (create: false + existingClaim).
-// Defense-in-depth validation is applied even though the CLI layer also validates the path.
+// readCustomValues reads and validates a user-supplied values file and returns its raw
+// bytes. The caller is responsible for merging it on top of the profile base and applying
+// any post-merge invariants (persistence overrides, etc.). Defense-in-depth validation
+// is applied even though the CLI layer also validates the path.
 func (m *Manager) readCustomValues(valuesFile string) ([]byte, error) {
 	sanitizedPath, err := sanity.ValidateInputFile(valuesFile)
 	if err != nil {
@@ -129,15 +145,34 @@ func (m *Manager) readCustomValues(valuesFile string) ([]byte, error) {
 
 	logx.As().Info().Str("path", sanitizedPath).Msg("Using custom values file")
 
-	// Inject/override persistence settings to ensure weaver-managed PVCs are used.
-	// Since weaver creates PVs and PVCs outside of Helm, the chart must always use
-	// create: false with existingClaim pointing to the pre-created PVCs.
-	content, err = m.injectPersistenceOverrides(content)
-	if err != nil {
-		return nil, errorx.InternalError.Wrap(err, "failed to inject persistence overrides into custom values file")
+	return content, nil
+}
+
+// mergeValues deep-merges an operator-supplied values document on top of the profile
+// base using helm's own coalescing rules (the same logic that `helm install -f` applies):
+// nested maps are merged recursively, while scalars and sequences from the operator
+// replace whatever the base had. Operator keys win on conflict; base defaults survive
+// where the operator stays silent.
+func mergeValues(base, operator []byte) ([]byte, error) {
+	baseMap := map[string]interface{}{}
+	if err := yaml.Unmarshal(base, &baseMap); err != nil {
+		// The base is rendered from an embedded template, never operator input;
+		// a parse failure here is a developer bug, not malformed user input.
+		return nil, errorx.InternalError.Wrap(err, "failed to parse embedded base values YAML")
 	}
 
-	return content, nil
+	operatorMap := map[string]interface{}{}
+	if err := yaml.Unmarshal(operator, &operatorMap); err != nil {
+		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse custom values YAML")
+	}
+
+	merged := chartutil.CoalesceTables(operatorMap, baseMap)
+
+	result, err := yaml.Marshal(merged)
+	if err != nil {
+		return nil, errorx.InternalError.Wrap(err, "failed to marshal merged values YAML")
+	}
+	return result, nil
 }
 
 // persistenceEntry represents the required persistence settings for a storage type.
@@ -310,12 +345,14 @@ func (m *Manager) injectPluginsConfig(valuesContent []byte) ([]byte, error) {
 	return result, nil
 }
 
-// injectServiceAnnotations merges the MetalLB address-pool annotation into service.annotations
-// in the Helm values when LoadBalancerEnabled is true. This ensures the annotation is managed
-// natively by Helm across install and upgrade without requiring a post-deploy kubectl patch.
+// injectServiceAnnotations ensures the merged values express a LoadBalancer service when
+// LoadBalancerEnabled is true. It (a) sets service.type to LoadBalancer if absent — defense
+// in depth so the type can never go missing regardless of which values path is taken — and
+// (b) merges the MetalLB address-pool annotation into service.annotations.
 //
-// When the operator's values file already contains metallb.io/address-pool (e.g. pointing at a
-// custom pool), that value is left untouched — weaver never clobbers an explicitly set annotation.
+// When the operator's values file already contains either field, the existing value is
+// left untouched. An explicit non-LoadBalancer service.type triggers a warning so the
+// mismatch is visible in logs without weaver clobbering an explicit operator choice.
 // When LoadBalancerEnabled is false the values are returned unchanged.
 func (m *Manager) injectServiceAnnotations(valuesContent []byte) ([]byte, error) {
 	if !m.blockNodeInputs.LoadBalancerEnabled {
@@ -327,31 +364,56 @@ func (m *Manager) injectServiceAnnotations(valuesContent []byte) ([]byte, error)
 		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse values YAML for service annotation injection")
 	}
 
-	// Navigate to service.annotations, creating the path if needed.
 	service, ok := vals["service"].(map[string]interface{})
 	if !ok {
 		service = make(map[string]interface{})
 		vals["service"] = service
 	}
 
+	const (
+		typeKey       = "type"
+		typeLB        = "LoadBalancer"
+		annotationKey = "metallb.io/address-pool"
+		defaultPool   = "public-address-pool"
+	)
+
+	mutated := false
+
+	switch t := service[typeKey].(type) {
+	case nil:
+		service[typeKey] = typeLB
+		logx.As().Info().Msg("Injecting service.type: LoadBalancer (LoadBalancerEnabled=true and no operator override)")
+		mutated = true
+	case string:
+		if t != typeLB {
+			logx.As().Warn().
+				Str("service.type", t).
+				Msg("LoadBalancerEnabled=true but operator values set service.type to a non-LoadBalancer value; leaving as-is — verify-block-node-reachable will fail")
+		}
+	default:
+		logx.As().Warn().
+			Str("service.type", fmt.Sprintf("%v", t)).
+			Msg("LoadBalancerEnabled=true but operator values set service.type to a non-string value; leaving as-is")
+	}
+
 	annotations, ok := service["annotations"].(map[string]interface{})
 	if !ok {
 		annotations = make(map[string]interface{})
 	}
-
-	const annotationKey = "metallb.io/address-pool"
 	if existing, alreadySet := annotations[annotationKey]; alreadySet {
-		// Operator has explicitly set this annotation — leave it untouched.
 		logx.As().Debug().
 			Str(annotationKey, fmt.Sprintf("%v", existing)).
 			Msg("metallb.io/address-pool already set in values file; skipping injection")
-		return valuesContent, nil
+	} else {
+		annotations[annotationKey] = defaultPool
+		service["annotations"] = annotations
+		logx.As().Info().Msg("Injecting MetalLB address-pool annotation into service.annotations")
+		mutated = true
 	}
 
-	annotations[annotationKey] = "public-address-pool"
-	service["annotations"] = annotations
-
-	logx.As().Info().Msg("Injecting MetalLB address-pool annotation into service.annotations")
+	if !mutated {
+		return valuesContent, nil
+	}
 
 	result, err := yaml.Marshal(vals)
 	if err != nil {


### PR DESCRIPTION
## Problem

When `block node install` is given a custom `--values` file, weaver currently uses it **instead of** its embedded profile base (`full-values.yaml` / `nano-values.yaml`) rather than merging on top. The embedded base is the only place that sets `service.type: LoadBalancer`. So any operator file that doesn't itself set `service.type` produces a `ClusterIP` Service, and the post-install `verify-block-node-reachable` step hard-fails:

```
Error: common.illegal_state: no LoadBalancer Service found in namespace block-node; cannot probe reachability
```

The same replace-not-merge also silently drops the base's `blockNode.config` (e.g. `BLOCK_NODE_EARLIEST_MANAGED_BLOCK`), logging defaults, `initContainers`, and `persistence` wiring.

Reproduces on the supported colocation path, where `--values` is the **only** way to set `metallb.io/allow-shared-ip` (the CLI injects `address-pool` but not `allow-shared-ip`). Present since #469 (`664fe3d`); confirmed on 0.19.2 (`505960d`). Two hosts, same chart `block-node-server-0.35.0`, same weaver binary:

| host | `--values` passed? | resolved Service type |
|---|---|---|
| A (no custom values) | no → embedded base | `LoadBalancer` ✅ |
| B (custom values, for `allow-shared-ip`) | yes → operator file | `ClusterIP` ❌ → install fails at verify-block-node-reachable |

Root cause — `internal/blocknode/values.go`, `ComputeValuesFile`:

```go
if valuesFile == "" {
    valuesContent, err = m.renderDefaultValues(profile)   // embedded base — has service.type: LoadBalancer
} else {
    valuesContent, err = m.readCustomValues(valuesFile)    // operator file ONLY — base NOT merged
}
```

## Fix — deep-merge over the base using helm's own coalescing

`ComputeValuesFile` now always renders the profile base and, when an operator file is supplied, deep-merges it on top via `helm.sh/helm/v3/pkg/chartutil.CoalesceTables` — the same coalescing rules helm itself applies for `helm install -f`. Operator keys win on conflict; base defaults survive where the operator stays silent. List values are replaced (not concatenated) per helm semantics, matching operator expectations.

Post-merge invariants:

- `injectPersistenceOverrides` runs **unconditionally** (it was previously only on the custom-values branch) so weaver-managed PVCs are enforced — `create: false` + `existingClaim` — regardless of what the operator file specified.
- `injectRetentionConfig`, `injectPluginsConfig`, `injectServiceAnnotations` continue to run as before.

Defense in depth: `injectServiceAnnotations` now also sets `service.type: LoadBalancer` when `LoadBalancerEnabled=true` and the type is absent. An explicit non-`LoadBalancer` `service.type` set by the operator is **left untouched**, but a warning is logged so the mismatch is visible — weaver never clobbers an operator override silently.

### Files changed

| File | Change |
|---|---|
| `internal/blocknode/values.go` | `ComputeValuesFile` always renders base then deep-merges; new `mergeValues` helper using `chartutil.CoalesceTables`; `readCustomValues` slimmed to "read + sanitize bytes"; `injectPersistenceOverrides` now runs unconditionally post-merge; `injectServiceAnnotations` also asserts `service.type: LoadBalancer` and short-circuits byte-identical when nothing changed. |
| `internal/blocknode/manager_test.go` | 6 new tests covering the merge contract and the new type-assertion; updated `TestInjectServiceAnnotations_PreservesExistingAnnotation` input to pre-set `service.type: LoadBalancer` so the byte-identical short-circuit still applies. |

### Review guide

**Code review checklist**

- [ ] `values.go:33-82` — `ComputeValuesFile` orders operations correctly: render base → (optional) merge operator → persistence overrides → retention → plugins → service annotations → write to temp file.
- [ ] `values.go:153-171` — `mergeValues` passes `(operator, base)` to `CoalesceTables` so operator is the authoritative `dst`. Both halves unmarshal into `map[string]interface{}` via `yaml.v3` (gives string keys, which `chartutil` requires).
- [ ] `values.go:343-419` — `injectServiceAnnotations` distinguishes nil / string / other for `service.type`, and only re-marshals when something actually changed (`mutated` flag).
- [ ] No new sites use `errors.New` or `fmt.Errorf` — all wrapping goes through `errorx.*` per repo convention.

**Test commands**

```bash
# Targeted unit tests (macOS or VM)
go test -race -tags='!integration' -run 'MergeValues|InjectServiceAnnotations|ComputeValuesFile' ./internal/blocknode/...

# Full blocknode unit suite
go test -race -cover -tags='!integration' ./internal/blocknode/...

# Integration tests (UTM VM)
task vm:test:integration TEST_NAME='^Test_StepBlockNode.*Integration$'
```

**Manual UAT** (UTM VM with MetalLB, single-node `block` cluster)

1. Create a minimal operator values file at `/tmp/bn-values.yaml`:
   ```yaml
   service:
     annotations:
       metallb.io/allow-shared-ip: shared
   ```
2. `solo-provisioner block node install --profile testnet --load-balancer-enabled true --values /tmp/bn-values.yaml`.
3. Expected: install completes; `verify-block-node-reachable` passes.
   ```
   kubectl get svc -n block-node
   # NAME ... TYPE         CLUSTER-IP    EXTERNAL-IP    PORT(S) ...
   # ...      LoadBalancer 10.x.x.x      <metallb-ip>   40840:...
   ```
4. Verify the merged annotation is present:
   ```
   kubectl get svc -n block-node -o jsonpath='{.items[*].metadata.annotations}'
   # ... metallb.io/address-pool: public-address-pool ... metallb.io/allow-shared-ip: shared ...
   ```
5. Pre-fix repro (on `main` before this PR): same command fails at `verify-block-node-reachable` with `no LoadBalancer Service found in namespace block-node`.

**Risks / rollback**

- Operators who relied on `--values` *replacing* the base (e.g. expecting a base-defined `blockNode.config` key to be absent in the rendered values) will now see the base key survive the merge. This matches the `helm install -f` mental model, so it's a deliberate behavior change called out here for visibility.
- An explicit non-`LoadBalancer` `service.type` in the operator file no longer silently produces a working install — but a warning is logged and the operator's choice is honored. If the operator passes `--load-balancer-enabled true` with `service.type: ClusterIP`, `verify-block-node-reachable` will still fail (correctly — the cluster cannot expose the BN externally).
- Rollback: single commit, `git revert`. No state migration, no embedded-file changes, no Helm chart changes.

### Related Issues

* Closes #702
