### PR TITLE
fix(upgrade): pin shared self-upgrade.yaml, .bak, and CR phase contracts

### DIFF
--- a/.claude/skills/sanity-validators/SKILL.md
+++ b/.claude/skills/sanity-validators/SKILL.md
@@ -49,6 +49,7 @@ All sanitizers return `ErrInvalidName` when filtering leaves nothing.
 |---|---|---|
 | `ValidateIdentifier` | `[A-Za-z0-9_-]`, non-empty | Namespace / release / profile names; anything that flows into Kubernetes object names. |
 | `ValidateUsername` | `[A-Za-z0-9_.-]`, non-empty, no `..`, no shell metachars | POSIX/Linux usernames (`SUDO_USER`, owner accounts). Permits `.` for `firstname.lastname` accounts. |
+| `ValidateOperationID` | `[A-Za-z0-9_.-]`, non-empty, no `..`, no shell metachars | Network-upgrade `operationId` (CR `spec.operationId`). Flows into `.bak` archive paths written as root. Permits `.` for dotted version strings (e.g. `upgrade-v0.76.0-20060102T150405Z`). |
 | `ValidateDNSName` | `[A-Za-z0-9.-]` matching RFC 952/1123 host pattern | Hostnames, FQDNs, cluster names derived from DNS. |
 | `ValidateHexToken` | `[0-9a-fA-F]`, length ≤ 4096 | Teleport join tokens and similar hex secrets. |
 | `ValidateHostPort` | hostname or hostname:port; no path components, no shell metachars | `host:port` style endpoints. Use `ValidateURL` for full URLs. |
@@ -63,6 +64,7 @@ Match by what the string represents in the real world, not by what it looks like
 
 - **Kubernetes namespace / release / profile name** → `ValidateIdentifier`
 - **Linux user account** (SUDO_USER, file owner, sudoers principal) → `ValidateUsername`
+- **Network-upgrade operationId** (CR `spec.operationId`, embedded in `.bak` paths) → `ValidateOperationID`
 - **Kernel module name** → `SanitizeModuleName` (current callers want the sanitized form for the modprobe call)
 - **Helm chart reference** → `ValidateChartReference`
 - **Hostname / FQDN / cluster DNS name** → `ValidateDNSName`

--- a/docs/dev/upgrade-contracts.md
+++ b/docs/dev/upgrade-contracts.md
@@ -1,0 +1,203 @@
+# Upgrade Contracts (self-upgrade.yaml, .bak naming, CR phase handshake)
+
+This page pins three contracts shared across two parallel tracks:
+
+- **Epic #502 — Network Upgrade (Execute Phase):** the daemon-side execute
+  workflow that reacts to `NetworkUpgradeExecute` CRs.
+- **Epic #500 — Self-Upgrade Protocol:** the daemon upgrading its own binaries.
+
+They are defined once so both tracks build against the same definitions rather
+than redefining them. This is a types + constants + docs contract; it carries no
+business logic.
+
+**It can be deleted once the features are implemented and the contracts are stable.** The contracts themselves live in `internal/consensus` and `internal/selfupgrade` (see below); this page is the single source of truth for their design and intended use
+
+| Contract | Package | Consumed by |
+|---|---|---|
+| CR phase + `DaemonResult` condition constants | `internal/consensus` | #706, #708, #709, #717, #500 spawn/recover |
+| `self-upgrade.yaml` schema | `internal/selfupgrade` | #529 (writer), #717 (recover) |
+| `.bak` binary naming convention | `internal/selfupgrade` | #526 (archive), #528 / #717 (recover) |
+
+## Package placement & the import rule
+
+`internal/consensus` holds consensus-node contracts shared between the daemon
+(`internal/daemon/consensus`) and the CLI/BLL. Both are named `package consensus`,
+so a single file must **never import both** — daemon implementation files import
+`internal/consensus` under an alias (`cn`); CLI/BLL files import it directly.
+This one-way dependency keeps the build cycle-free.
+
+`internal/selfupgrade` is a separate package because the self-upgrade state file
+and `.bak` archives concern the provisioner upgrading **its own binaries**, not a
+consensus node. Keeping it out of `internal/consensus` avoids a category error and
+lets the CLI self-upgrade code import it without dragging in consensus types.
+
+## 1. NetworkUpgradeExecute CR phase + condition handshake
+
+Defined in `internal/consensus/phase.go` as the `Phase`, `ConditionType`, and
+`ConditionStatus` typed string constants.
+
+### Writer ownership invariant (finalized in #706)
+
+- The **reconciler is the sole writer of terminal phases** `Succeeded` and `Failed`.
+- The **daemon writes only two phases**:
+  - `PendingInfraUpgrade` — written **durably, before any infra-mutating work**.
+    This is the single crash-recovery resume anchor: on restart the daemon
+    re-reads the CR, sees this phase, and resumes the infra upgrade from here.
+  - `PendingNodeUpgrade` — the daemon's final write, **after** it sets the
+    `DaemonResult` condition, handing control back to the reconciler.
+- There is **no `InProgress` phase**. Progress is not modelled as a phase; the
+  daemon reports its outcome via the `DaemonResult` condition (`True`/`False`),
+  and the reconciler maps that to the terminal phase.
+
+`Phase.IsTerminal()` and `Phase.IsDaemonWritable()` codify the invariant in code;
+the unit tests assert that no phase is both (the daemon can never write a terminal
+phase) and that no phase is named `InProgress`.
+
+### State machine
+
+```
+        reconciler              reconciler                 daemon (durable)
+  ┌──────────────────┐   ┌────────────────────────┐   ┌──────────────────────┐
+  │     Pending      │──▶│ ReadyForProvisionerDaemon│─▶│  PendingInfraUpgrade  │
+  └──────────────────┘   └────────────────────────┘   └──────────┬───────────┘
+                                                                  │ infra work
+                                                                  │ done
+                                                                  ▼
+                                              daemon sets DaemonResult condition
+                                                  (True on success, False on
+                                                   failure / recovered panic)
+                                                                  │
+                                                                  ▼
+                                                   ┌──────────────────────────┐
+                                                   │    PendingNodeUpgrade     │ (daemon)
+                                                   └──────────────┬───────────┘
+                                                                  │ reconciler reads
+                                                                  │ DaemonResult
+                                            DaemonResult=True      │      DaemonResult=False
+                                          ┌───────────────────────┴───────────────────────┐
+                                          ▼                                                 ▼
+                                ┌──────────────────┐                            ┌──────────────────┐
+                                │    Succeeded     │ (reconciler)               │      Failed      │ (reconciler)
+                                └──────────────────┘                            └──────────────────┘
+```
+
+- **Resume:** a crash anywhere after `PendingInfraUpgrade` is written resumes from
+  that phase, because the phase lives durably in etcd (#709 / #717).
+- **Failure path:** the daemon never writes `Failed`; it sets `DaemonResult=False`,
+  transitions to `PendingNodeUpgrade`, and the reconciler writes `Failed`.
+
+## 2. self-upgrade.yaml schema
+
+Defined in `internal/selfupgrade/selfupgrade.go`. Lives at the HIP-authoritative
+path `WeaverPaths.SelfUpgradeYAMLPath` = `/opt/solo/weaver/daemon/self-upgrade.yaml`.
+
+The **old daemon writes this file at step 0** — before spawning the detached
+upgrade process and before any binary swap begins. It is both a handoff record and
+a crash-diagnostic artifact:
+
+- **Crash diagnostics** — if the detached upgrader dies mid-swap, the recover tool
+  reads it to learn the target versions, the last step reached, and whether the
+  `.bak` binaries are still present.
+- **PID tracking** — `childPid` lets a tool check whether the detached process is
+  still alive (`kill -0`).
+- **Recovery input** — `solo-provisioner consensus node upgrade-recover` (#717)
+  inspects it to decide whether to restore a `.bak` binary and restart the daemon.
+
+Because it is written *before* the swap, a leftover `status: in-progress` is itself
+the failure signal — a clean run always ends `succeeded`. On failure the detached
+process writes `failed` and leaves the `.bak` files intact.
+
+### Fields
+
+```yaml
+schemaVersion: 1                 # strict; an unsupported version is rejected
+timestamp: 2026-06-16T10:30:00Z  # RFC3339 UTC, when the operation began
+operationId: op-...              # ties to NetworkUpgradeExecute spec.operationId
+status: in-progress              # in-progress | succeeded | failed
+childPid: 4242                   # detached upgrader PID (liveness check)
+currentStep: swap-cli-binary     # last step begun (crash localisation)
+fromCliVersion: v1.1.0
+toCliVersion: v1.2.3
+fromDaemonVersion: daemon-v1.1.0
+toDaemonVersion: daemon-v1.2.3
+cliBakPath: /opt/solo/weaver/backup/solo-provisioner/solo-provisioner-op-...bak
+daemonBakPath: /opt/solo/weaver/backup/solo-provisioner/solo-provisioner-daemon-op-...bak
+```
+
+### Loading / saving
+
+- `selfupgrade.Load(path)` strict-decodes (unknown fields rejected) and rejects any
+  `schemaVersion` greater than this build supports.
+- `selfupgrade.Save(path, s)` stamps `schemaVersion` and writes atomically
+  (write-temp-then-rename) so a crash mid-write never leaves a torn file.
+
+## 3. .bak binary naming convention
+
+Defined in `internal/selfupgrade/bak.go`. The live binaries are installed in
+`WeaverPaths.BinDir` (`/opt/solo/weaver/bin`), which is `root:root`. Their archives
+are **not** kept there — they live in a dedicated backup subdirectory,
+`BakDir` = `/opt/solo/weaver/backup/solo-provisioner` (under `WeaverPaths.BackupDir`),
+so the bin dir holds only live executables. Both trees are under `/opt/solo/weaver`
+(same filesystem as the live binary), so the swap's rename stays atomic; the
+self-upgrade swap runs as root, so writing into either tree is fine.
+
+```
+solo-provisioner-<operationId>.bak          # archived CLI binary
+solo-provisioner-daemon-<operationId>.bak   # archived daemon binary
+```
+
+Helpers (one source of truth for both producing and parsing):
+
+- `BakDir(backupDir)` — the archive directory (`backupDir/solo-provisioner`).
+- `CLIBakName(operationID)` / `DaemonBakName(operationID)` — produce the filename
+  (`(string, error)`; reject a non-identifier-safe `operationId`).
+- `CLIBakPath(bakDir, operationID)` / `DaemonBakPath(bakDir, operationID)` —
+  absolute paths (`(string, error)`).
+- `ParseBakName(name)` — returns the `Binary` and the embedded `operationId`.
+
+**operationId safety:** the producers validate `operationId` via
+`sanity.ValidateOperationID` (charset `[A-Za-z0-9_.-]`, non-empty, no `..`, no
+shell metacharacters). A `.` is permitted so ids can embed dotted version strings
+(e.g. `upgrade-v0.76.0-20060102T150405Z`), while `..`, path separators, and shell
+metacharacters are rejected so a crafted id cannot escape `bakDir` after
+`filepath.Join` — important because the swap runs as root. The upgrade/self-upgrade
+flows consume the id from the CR's `spec.operationId`; the migration flow
+constructs its own (`migration-<timestamp>`). Any constructed id must satisfy this
+validator.
+
+**Parsing gotcha:** the daemon name embeds the CLI name as a prefix
+(`solo-provisioner-daemon-...` starts with `solo-provisioner-...`), so `ParseBakName`
+tests the daemon prefix first to avoid misclassifying a daemon archive as a CLI
+archive with an `operationId` of `daemon-...`.
+
+## Schema versioning helper (pkg/schema)
+
+`self-upgrade.yaml` loads via the reusable `pkg/schema` package, which captures the
+versioned owned-state-file pattern for any future schema:
+
+1. probe the version key from raw YAML,
+2. normalise absent/zero to 1,
+3. reject a version newer than this build supports,
+4. strict-decode (KnownFields, single document) into the sealed per-version struct,
+5. walk the migration chain via `Migratable[T].MigrateToLatest()`.
+
+Each schema supplies only its sealed `vN` structs and their `MigrateToLatest`
+field transforms; the orchestration is shared. The version key is configurable
+via `Versioned.VersionKey` and defaults to `schemaVersion` when left empty, so
+solo-weaver state files stay consistent while an external consumer can adopt any
+key it prefers. `daemon.yaml` is standardised on `schemaVersion` as of the rename
+in this change.
+
+`pkg/schema` is not restricted to provisioner-owned files. It is equally suitable
+for council-signed manifests: signature verification operates on the raw bytes
+before `Decode` is called, so in-memory migration never touches the signed payload.
+`pkg/manifests` currently uses its own `ValidateSchemaVersion` allow-list instead,
+but migrating it to `pkg/schema` is a straightforward follow-up if the need arises.
+
+## See also
+
+- `internal/consensus/phase.go` — phase / condition constants and invariant helpers
+- `internal/selfupgrade/selfupgrade.go` — self-upgrade.yaml schema, Load/Save
+- `internal/selfupgrade/bak.go` — .bak naming helpers
+- `pkg/schema/schema.go` — generic versioned loader
+- `internal/daemon/consensus/upgrade_monitor.go` — daemon consumer of the phase constants

--- a/internal/consensus/phase.go
+++ b/internal/consensus/phase.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package consensus holds contracts shared across the consensus-node tracks:
+// the daemon-side execute-phase workflow (internal/daemon/consensus, epic #502)
+// and the CLI-side recover/self-upgrade stories (epic #500). Keeping these
+// definitions in one low-level package lets both tracks import a single source
+// of truth without an import cycle.
+//
+// Import rule: no file may import both this package (internal/consensus) and
+// internal/daemon/consensus — they share the package name "consensus" and are
+// distinct layers. Daemon implementation files live in internal/daemon/consensus
+// and import this package (aliased); CLI/BLL files import this package directly.
+package consensus
+
+// Phase is a NetworkUpgradeExecute CR status.phase value, as defined in the CRD.
+//
+// Writer ownership (finalized in #706):
+//
+//   - The reconciler is the SOLE writer of the terminal phases Succeeded and
+//     Failed. The daemon never writes them.
+//   - The daemon writes only PendingInfraUpgrade (the durable crash-recovery
+//     resume point, persisted before any infra-mutating work) and the final
+//     PendingNodeUpgrade (written after it sets the DaemonResult condition).
+//   - There is no InProgress phase. Progress is not modelled as a phase; the
+//     daemon's terminal outcome is communicated via the DaemonResult condition,
+//     and the reconciler maps that to Succeeded/Failed.
+//
+// State machine (see docs/dev/upgrade-contracts.md for the full diagram):
+//
+//	Pending ──▶ ReadyForProvisionerDaemon ──▶ PendingInfraUpgrade ──▶ PendingNodeUpgrade ──▶ Succeeded
+//	  (reconciler)        (reconciler)            (daemon, durable)        (daemon)            (reconciler)
+//	                                                                            │
+//	                                                              DaemonResult=False │
+//	                                                                            ▼
+//	                                                                          Failed (reconciler)
+type Phase string
+
+const (
+	// PhasePending is the initial phase set by the reconciler when the CR is created.
+	PhasePending Phase = "Pending"
+
+	// PhaseReadyForProvisionerDaemon is set by the reconciler to hand the operation
+	// to the daemon. The daemon's upgrade monitor triggers handleExecute on this phase.
+	PhaseReadyForProvisionerDaemon Phase = "ReadyForProvisionerDaemon"
+
+	// PhasePendingInfraUpgrade is written by the daemon — durably, in etcd —
+	// before it performs any infra-mutating work. It is the single crash-recovery
+	// anchor: on restart the daemon re-reads the CR, sees this phase, and resumes
+	// the infra upgrade from here (#709 / #717).
+	PhasePendingInfraUpgrade Phase = "PendingInfraUpgrade"
+
+	// PhasePendingNodeUpgrade is the daemon's final phase write. The daemon sets
+	// the DaemonResult condition (True/False) and then transitions the CR to this
+	// phase, handing control back to the reconciler.
+	PhasePendingNodeUpgrade Phase = "PendingNodeUpgrade"
+
+	// PhaseSucceeded is a terminal phase written ONLY by the reconciler.
+	PhaseSucceeded Phase = "Succeeded"
+
+	// PhaseFailed is a terminal phase written ONLY by the reconciler.
+	PhaseFailed Phase = "Failed"
+)
+
+// ConditionType is a NetworkUpgradeExecute CR status condition type.
+type ConditionType string
+
+// DaemonResultCondition is the condition the daemon sets to report the outcome
+// of the execute phase back to the reconciler. Its status (True/False) is the
+// terminal handshake signal; the reconciler reads it to decide whether to write
+// PhaseSucceeded or PhaseFailed.
+const DaemonResultCondition ConditionType = "DaemonResult"
+
+// ConditionStatus mirrors metav1.ConditionStatus values used on the DaemonResult condition.
+type ConditionStatus string
+
+const (
+	// ConditionTrue on DaemonResult means the daemon completed the execute phase successfully.
+	ConditionTrue ConditionStatus = "True"
+
+	// ConditionFalse on DaemonResult means the daemon's execute phase failed
+	// (including a recovered panic). The reconciler maps this to PhaseFailed.
+	ConditionFalse ConditionStatus = "False"
+)
+
+// IsTerminal reports whether p is a terminal phase. Terminal phases are written
+// ONLY by the reconciler; the daemon must never write them.
+func (p Phase) IsTerminal() bool {
+	return p == PhaseSucceeded || p == PhaseFailed
+}
+
+// IsDaemonWritable reports whether the daemon is permitted to write p. The
+// daemon writes exactly two phases: the durable resume anchor PendingInfraUpgrade
+// and the handshake-completing PendingNodeUpgrade.
+func (p Phase) IsDaemonWritable() bool {
+	return p == PhasePendingInfraUpgrade || p == PhasePendingNodeUpgrade
+}

--- a/internal/consensus/phase_test.go
+++ b/internal/consensus/phase_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package consensus_test
+
+import (
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/internal/consensus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPhaseConstants_MatchCRDStrings(t *testing.T) {
+	// Pin the on-the-wire string values: these must match the CRD and the
+	// reconciler exactly, so a rename here is a deliberate contract change.
+	assert.Equal(t, "Pending", string(consensus.PhasePending))
+	assert.Equal(t, "ReadyForProvisionerDaemon", string(consensus.PhaseReadyForProvisionerDaemon))
+	assert.Equal(t, "PendingInfraUpgrade", string(consensus.PhasePendingInfraUpgrade))
+	assert.Equal(t, "PendingNodeUpgrade", string(consensus.PhasePendingNodeUpgrade))
+	assert.Equal(t, "Succeeded", string(consensus.PhaseSucceeded))
+	assert.Equal(t, "Failed", string(consensus.PhaseFailed))
+	assert.Equal(t, "DaemonResult", string(consensus.DaemonResultCondition))
+	assert.Equal(t, "True", string(consensus.ConditionTrue))
+	assert.Equal(t, "False", string(consensus.ConditionFalse))
+}
+
+func TestIsTerminal(t *testing.T) {
+	// Only Succeeded/Failed are terminal — the reconciler is their sole writer.
+	assert.True(t, consensus.PhaseSucceeded.IsTerminal())
+	assert.True(t, consensus.PhaseFailed.IsTerminal())
+
+	for _, p := range []consensus.Phase{
+		consensus.PhasePending,
+		consensus.PhaseReadyForProvisionerDaemon,
+		consensus.PhasePendingInfraUpgrade,
+		consensus.PhasePendingNodeUpgrade,
+	} {
+		assert.False(t, p.IsTerminal(), "phase %q must not be terminal", p)
+	}
+}
+
+func TestIsDaemonWritable(t *testing.T) {
+	// The daemon writes exactly the durable resume anchor and the handshake phase.
+	assert.True(t, consensus.PhasePendingInfraUpgrade.IsDaemonWritable())
+	assert.True(t, consensus.PhasePendingNodeUpgrade.IsDaemonWritable())
+
+	// The daemon must never write reconciler-owned phases.
+	for _, p := range []consensus.Phase{
+		consensus.PhasePending,
+		consensus.PhaseReadyForProvisionerDaemon,
+		consensus.PhaseSucceeded,
+		consensus.PhaseFailed,
+	} {
+		assert.False(t, p.IsDaemonWritable(), "daemon must not write phase %q", p)
+	}
+}
+
+func TestDaemonNeverWritesTerminal(t *testing.T) {
+	// The core #706 invariant: no phase is both daemon-writable and terminal.
+	for _, p := range []consensus.Phase{
+		consensus.PhasePending,
+		consensus.PhaseReadyForProvisionerDaemon,
+		consensus.PhasePendingInfraUpgrade,
+		consensus.PhasePendingNodeUpgrade,
+		consensus.PhaseSucceeded,
+		consensus.PhaseFailed,
+	} {
+		assert.False(t, p.IsDaemonWritable() && p.IsTerminal(),
+			"phase %q violates the sole-terminal-writer invariant", p)
+	}
+}
+
+func TestNoInProgressPhase(t *testing.T) {
+	// There is deliberately no InProgress phase. Guard against one being
+	// reintroduced by asserting none of the defined phases use that string.
+	for _, p := range []consensus.Phase{
+		consensus.PhasePending,
+		consensus.PhaseReadyForProvisionerDaemon,
+		consensus.PhasePendingInfraUpgrade,
+		consensus.PhasePendingNodeUpgrade,
+		consensus.PhaseSucceeded,
+		consensus.PhaseFailed,
+	} {
+		assert.NotEqual(t, "InProgress", string(p))
+	}
+}

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -22,7 +22,7 @@ const (
 //
 // Example daemon.yaml:
 //
-//	schema_version: 1
+//	schemaVersion: 1
 //	components:
 //	  consensus_node:
 //	    enabled: true
@@ -43,7 +43,7 @@ type DaemonConfig struct {
 	// SchemaVersion identifies the config file format. Always written as
 	// CurrentSchemaVersion by WriteDaemonConfig. A value of 0 means the file
 	// predates schema versioning and is treated as version 1 for compatibility.
-	SchemaVersion int `yaml:"schema_version"`
+	SchemaVersion int `yaml:"schemaVersion"`
 
 	Components DaemonComponents `yaml:"components"`
 }
@@ -179,7 +179,7 @@ func WriteDaemonConfig(path string, cfg DaemonConfig) error {
 // in cmd/daemon/main.go; call Validate() again after overrides are applied.
 //
 // Loading uses a two-phase approach:
-//  1. Probe: unmarshal only schema_version to determine the on-disk format.
+//  1. Probe: unmarshal only schemaVersion to determine the on-disk format.
 //  2. Parse + migrate: unmarshal into the versioned struct for that version,
 //     then walk the migration chain (vN.migrateToLatest()) to produce the
 //     current DaemonConfig. Each step in the chain is a pure field transform
@@ -197,7 +197,7 @@ func LoadDaemonConfig(path string) (DaemonConfig, error) {
 
 	// Phase 1: probe the schema version only.
 	var probe struct {
-		SchemaVersion int `yaml:"schema_version"`
+		SchemaVersion int `yaml:"schemaVersion"`
 	}
 	if err := yaml.Unmarshal(data, &probe); err != nil {
 		return DaemonConfig{}, ErrConfigMalformed.Wrap(err, "invalid daemon config at %s", path)
@@ -208,7 +208,7 @@ func LoadDaemonConfig(path string) (DaemonConfig, error) {
 	}
 	if version > CurrentSchemaVersion {
 		return DaemonConfig{}, ErrConfigMalformed.New(
-			"daemon config %s was written by a newer binary (schema_version %d > supported %d); "+
+			"daemon config %s was written by a newer binary (schemaVersion %d > supported %d); "+
 				"upgrade solo-provisioner-daemon to a compatible version",
 			path, version, CurrentSchemaVersion)
 	}
@@ -229,7 +229,7 @@ func LoadDaemonConfig(path string) (DaemonConfig, error) {
 	default:
 		// Should never reach here given the version > CurrentSchemaVersion guard above.
 		return DaemonConfig{}, ErrConfigMalformed.New(
-			"unsupported daemon config schema_version %d at %s", version, path)
+			"unsupported daemon config schemaVersion %d at %s", version, path)
 	}
 
 	if err := cfg.Validate(); err != nil {

--- a/internal/daemon/config_test.go
+++ b/internal/daemon/config_test.go
@@ -25,11 +25,11 @@ func writeTempConfig(t *testing.T, content string) string {
 }
 
 func TestLoadDaemonConfig_NewerSchemaVersion(t *testing.T) {
-	// A daemon.yaml written by a future binary — schema_version 99 with unknown
+	// A daemon.yaml written by a future binary — schemaVersion 99 with unknown
 	// top-level keys (components) that would cause a strict-decode error if the
 	// version guard ran after the full unmarshal.
 	yaml := `
-schema_version: 99
+schemaVersion: 99
 components:
   consensus_node:
     enabled: true
@@ -58,7 +58,7 @@ components:
 
 func TestLoadDaemonConfig_ValidV1(t *testing.T) {
 	yaml := `
-schema_version: 1
+schemaVersion: 1
 components:
   consensus_node:
     enabled: true
@@ -88,7 +88,7 @@ func TestLoadDaemonConfig_MissingFile(t *testing.T) {
 }
 
 func TestLoadDaemonConfig_MalformedYAML(t *testing.T) {
-	path := writeTempConfig(t, "schema_version: [not a number}")
+	path := writeTempConfig(t, "schemaVersion: [not a number}")
 	_, err := daemon.LoadDaemonConfig(path)
 	require.Error(t, err)
 	assert.True(t, errorx.IsOfType(err, daemon.ErrConfigMalformed),
@@ -96,7 +96,7 @@ func TestLoadDaemonConfig_MalformedYAML(t *testing.T) {
 }
 
 func TestLoadDaemonConfig_NoSchemaVersionTreatedAsV1(t *testing.T) {
-	// Files predating schema versioning have no schema_version field.
+	// Files predating schema versioning have no schemaVersion field.
 	// They must be accepted as version 1.
 	yaml := `
 components:
@@ -118,11 +118,36 @@ components:
 		"migrated config should carry the current schema version")
 }
 
+func TestLoadDaemonConfig_LegacySchemaVersionKeyStillLoads(t *testing.T) {
+	// A daemon.yaml written before the schema_version -> schemaVersion rename
+	// must still load. The legacy key is ignored (non-strict decode); the probe
+	// sees no schemaVersion and normalises the absent value to v1.
+	yaml := `
+schema_version: 1
+components:
+  consensus_node:
+    enabled: true
+    kubeconfig: /opt/solo/weaver/config/daemon.kubeconfig
+    node_id: "5"
+    orbit: hedera-network
+    monitors:
+      upgrade: true
+      migration: true
+`
+	path := writeTempConfig(t, yaml)
+
+	cfg, err := daemon.LoadDaemonConfig(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Components.ConsensusNode)
+	assert.Equal(t, "5", cfg.Components.ConsensusNode.NodeID)
+	assert.Equal(t, daemon.CurrentSchemaVersion, cfg.SchemaVersion)
+}
+
 func TestLoadDaemonConfig_NewerVersionErrorIsErrConfigMalformed(t *testing.T) {
 	// Confirm the error type is precisely ErrConfigMalformed (not a sub-type of
 	// ErrConfig or any other namespace) so the doctor layer applies the right
 	// exit-code mapping.
-	yaml := "schema_version: 99\ncomponents: {}\n"
+	yaml := "schemaVersion: 99\ncomponents: {}\n"
 	path := writeTempConfig(t, yaml)
 
 	_, err := daemon.LoadDaemonConfig(path)

--- a/internal/daemon/config_v1.go
+++ b/internal/daemon/config_v1.go
@@ -2,16 +2,23 @@
 
 package daemon
 
-// daemonConfigV1 is the on-disk representation for schema_version: 1.
+// daemonConfigV1 is the on-disk representation for schemaVersion: 1.
+//
+// Backward compatibility: the daemon loader is non-strict (plain yaml.Unmarshal,
+// not KnownFields), and the schema version is resolved by the probe in
+// LoadDaemonConfig, not by this struct's tag. A pre-rename file carrying the
+// legacy `schema_version` key therefore still loads correctly: the unknown key
+// is ignored, the probe sees no `schemaVersion` and normalises the absent value
+// to 1. No migration step is required for the key rename.
 // This struct is sealed — never modify it after it ships. When a breaking
 // structural change is needed, add daemonConfigV2 and write
 // daemonConfigV1.migrate() → daemonConfigV2, then update migrateToLatest()
 // to delegate down the chain.
 //
 // Field layout must match the YAML written by WriteDaemonConfig at the time
-// schema_version 1 was current.
+// schemaVersion 1 was current.
 type daemonConfigV1 struct {
-	SchemaVersion int                `yaml:"schema_version"`
+	SchemaVersion int                `yaml:"schemaVersion"`
 	Components    daemonComponentsV1 `yaml:"components"`
 }
 

--- a/internal/daemon/consensus/upgrade_monitor.go
+++ b/internal/daemon/consensus/upgrade_monitor.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/automa-saga/logx"
+	cn "github.com/hashgraph/solo-weaver/internal/consensus"
 	"github.com/hashgraph/solo-weaver/pkg/daemonkit"
 	"github.com/hashgraph/solo-weaver/pkg/filepruner"
 	"github.com/hashgraph/solo-weaver/pkg/sanity"
@@ -32,13 +33,10 @@ var networkUpgradeExecuteGVR = schema.GroupVersionResource{
 }
 
 const (
-	// NetworkUpgradeExecute status.phase values, as defined in the CRD.
-	executePhasePending                   = "Pending"
-	executePhaseReadyForProvisionerDaemon = "ReadyForProvisionerDaemon"
-	executePhasePendingInfraUpgrade       = "PendingInfraUpgrade"
-	executePhasePendingNodeUpgrade        = "PendingNodeUpgrade"
-	executePhaseSucceeded                 = "Succeeded"
-	executePhaseFailed                    = "Failed"
+	// NetworkUpgradeExecute status.phase values are defined as the shared
+	// contract in internal/consensus (cn.Phase*). They are referenced directly
+	// at the call sites; only the phases this monitor actually compares against
+	// are used here.
 
 	backoffInitial = 2 * time.Second
 	backoffMax     = 5 * time.Minute
@@ -414,7 +412,7 @@ func (um *UpgradeMonitor) listAndSeed(ctx context.Context) (string, error) {
 			continue
 		}
 		switch phase {
-		case executePhaseSucceeded, executePhaseFailed:
+		case string(cn.PhaseSucceeded), string(cn.PhaseFailed):
 			um.completedOpIDs[opID] = struct{}{}
 		}
 	}
@@ -429,7 +427,7 @@ func (um *UpgradeMonitor) listAndSeed(ctx context.Context) (string, error) {
 	for i := range list.Items {
 		cr := &list.Items[i]
 		phase, _, _ := unstructured.NestedString(cr.Object, "status", "phase")
-		if phase == executePhaseReadyForProvisionerDaemon {
+		if phase == string(cn.PhaseReadyForProvisionerDaemon) {
 			pending = append(pending, cr)
 		}
 	}
@@ -521,7 +519,7 @@ func (um *UpgradeMonitor) runWatch(ctx context.Context, resourceVersion string) 
 //     that are no longer at ReadyForProvisionerDaemon, making (1) restart-safe.
 func (um *UpgradeMonitor) handleEvent(ctx context.Context, cr *unstructured.Unstructured) {
 	phase, _, _ := unstructured.NestedString(cr.Object, "status", "phase")
-	if phase != executePhaseReadyForProvisionerDaemon {
+	if phase != string(cn.PhaseReadyForProvisionerDaemon) {
 		return
 	}
 

--- a/internal/selfupgrade/bak.go
+++ b/internal/selfupgrade/bak.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package selfupgrade
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
+	"github.com/joomcode/errorx"
+)
+
+// Binary identifies which solo-provisioner binary a .bak archive belongs to.
+type Binary string
+
+const (
+	// BinaryCLI is the operator-facing CLI binary, solo-provisioner.
+	BinaryCLI Binary = "solo-provisioner"
+
+	// BinaryDaemon is the long-running daemon binary, solo-provisioner-daemon.
+	BinaryDaemon Binary = "solo-provisioner-daemon"
+
+	// bakExtension is the suffix on every archived binary filename.
+	bakExtension = ".bak"
+)
+
+// .bak naming convention (shared by archive #526 and recover #528/#717):
+//
+//	solo-provisioner-<operationId>.bak           — archived CLI binary
+//	solo-provisioner-daemon-<operationId>.bak    — archived daemon binary
+//
+// The live binaries are installed in WeaverPaths.BinDir (/opt/solo/weaver/bin),
+// which is root:root. Their archives are NOT kept there: they live in a
+// dedicated backup subdirectory, BakDir = /opt/solo/weaver/backup/solo-provisioner
+// (under WeaverPaths.BackupDir). This keeps the bin dir to live executables only
+// and the backup tree to archives. Both are under /opt/solo/weaver, i.e. the
+// same filesystem as the live binary, so the swap's rename stays atomic. The
+// self-upgrade swap runs as root, so writing into either tree is fine.
+//
+// Note the daemon name embeds the CLI name as a prefix, so any parser MUST test
+// the daemon prefix first. ParseBakName does.
+
+// bakSubdir is the dedicated subdirectory under WeaverPaths.BackupDir that holds
+// archived solo-provisioner binaries.
+const bakSubdir = "solo-provisioner"
+
+// BakDir returns the directory archived binaries live in, given the weaver
+// backup directory (WeaverPaths.BackupDir): backupDir/solo-provisioner.
+func BakDir(backupDir string) string {
+	return filepath.Join(backupDir, bakSubdir)
+}
+
+// CLIBakName returns the .bak filename for the CLI binary archived under
+// operationID. It rejects an operationID that is not path-safe (sanity
+// .ValidateOperationID) so the id can never introduce a path separator or ".."
+// traversal sequence into the filename.
+func CLIBakName(operationID string) (string, error) {
+	if err := sanity.ValidateOperationID(operationID); err != nil {
+		return "", err
+	}
+	return string(BinaryCLI) + "-" + operationID + bakExtension, nil
+}
+
+// DaemonBakName returns the .bak filename for the daemon binary archived under
+// operationID, with the same validation as CLIBakName.
+func DaemonBakName(operationID string) (string, error) {
+	if err := sanity.ValidateOperationID(operationID); err != nil {
+		return "", err
+	}
+	return string(BinaryDaemon) + "-" + operationID + bakExtension, nil
+}
+
+// CLIBakPath returns the absolute .bak path for the CLI binary in bakDir
+// (typically BakDir(WeaverPaths.BackupDir)). The operationID is validated, so a
+// crafted id cannot escape bakDir.
+func CLIBakPath(bakDir, operationID string) (string, error) {
+	name, err := CLIBakName(operationID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(bakDir, name), nil
+}
+
+// DaemonBakPath returns the absolute .bak path for the daemon binary in bakDir
+// (typically BakDir(WeaverPaths.BackupDir)), with the same validation as CLIBakPath.
+func DaemonBakPath(bakDir, operationID string) (string, error) {
+	name, err := DaemonBakName(operationID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(bakDir, name), nil
+}
+
+// ParseBakName parses a .bak filename produced by CLIBakName/DaemonBakName,
+// returning which binary it archives and the embedded operationId. It accepts a
+// bare filename or a path (only the base name is parsed). The daemon prefix is
+// tested before the CLI prefix because the daemon name contains the CLI name.
+func ParseBakName(name string) (Binary, string, error) {
+	base := filepath.Base(name)
+
+	stem, ok := strings.CutSuffix(base, bakExtension)
+	if !ok {
+		return "", "", errorx.IllegalFormat.New("%q is not a .bak archive (missing %s suffix)", base, bakExtension)
+	}
+
+	// Daemon first: "solo-provisioner-daemon-" extends "solo-provisioner-".
+	if opID, ok := strings.CutPrefix(stem, string(BinaryDaemon)+"-"); ok {
+		if opID == "" {
+			return "", "", errorx.IllegalFormat.New("%q has an empty operationId", base)
+		}
+		return BinaryDaemon, opID, nil
+	}
+	if opID, ok := strings.CutPrefix(stem, string(BinaryCLI)+"-"); ok {
+		if opID == "" {
+			return "", "", errorx.IllegalFormat.New("%q has an empty operationId", base)
+		}
+		return BinaryCLI, opID, nil
+	}
+
+	return "", "", errorx.IllegalFormat.New(
+		"%q does not match the %s-<operationId>%s or %s-<operationId>%s pattern",
+		base, BinaryCLI, bakExtension, BinaryDaemon, bakExtension)
+}

--- a/internal/selfupgrade/bak_test.go
+++ b/internal/selfupgrade/bak_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package selfupgrade_test
+
+import (
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/internal/selfupgrade"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBakName_Produce(t *testing.T) {
+	cliName, err := selfupgrade.CLIBakName("op123")
+	require.NoError(t, err)
+	assert.Equal(t, "solo-provisioner-op123.bak", cliName)
+
+	daemonName, err := selfupgrade.DaemonBakName("op123")
+	require.NoError(t, err)
+	assert.Equal(t, "solo-provisioner-daemon-op123.bak", daemonName)
+
+	bakDir := selfupgrade.BakDir("/opt/solo/weaver/backup")
+	assert.Equal(t, "/opt/solo/weaver/backup/solo-provisioner", bakDir)
+
+	cliPath, err := selfupgrade.CLIBakPath(bakDir, "op123")
+	require.NoError(t, err)
+	assert.Equal(t, "/opt/solo/weaver/backup/solo-provisioner/solo-provisioner-op123.bak", cliPath)
+
+	daemonPath, err := selfupgrade.DaemonBakPath(bakDir, "op123")
+	require.NoError(t, err)
+	assert.Equal(t, "/opt/solo/weaver/backup/solo-provisioner/solo-provisioner-daemon-op123.bak", daemonPath)
+}
+
+func TestBakName_RoundTrip(t *testing.T) {
+	const opID = "op-2026-06-16-abc123"
+
+	cliName, err := selfupgrade.CLIBakName(opID)
+	require.NoError(t, err)
+	cliBin, cliOp, err := selfupgrade.ParseBakName(cliName)
+	require.NoError(t, err)
+	assert.Equal(t, selfupgrade.BinaryCLI, cliBin)
+	assert.Equal(t, opID, cliOp)
+
+	daemonName, err := selfupgrade.DaemonBakName(opID)
+	require.NoError(t, err)
+	dBin, dOp, err := selfupgrade.ParseBakName(daemonName)
+	require.NoError(t, err)
+	assert.Equal(t, selfupgrade.BinaryDaemon, dBin)
+	assert.Equal(t, opID, dOp)
+}
+
+func TestBakName_RejectsUnsafeOperationID(t *testing.T) {
+	// A traversing / non-identifier operationId must be rejected by every
+	// producer so it can never reach the filesystem as a root-written path.
+	for _, bad := range []string{"../evil", "a/b", "a..b", "", "op id", "op;rm"} {
+		if _, err := selfupgrade.CLIBakName(bad); err == nil {
+			t.Errorf("CLIBakName(%q) should have errored", bad)
+		}
+		if _, err := selfupgrade.DaemonBakName(bad); err == nil {
+			t.Errorf("DaemonBakName(%q) should have errored", bad)
+		}
+		if _, err := selfupgrade.CLIBakPath("/opt/solo/weaver/backup/solo-provisioner", bad); err == nil {
+			t.Errorf("CLIBakPath(%q) should have errored", bad)
+		}
+		if _, err := selfupgrade.DaemonBakPath("/opt/solo/weaver/backup/solo-provisioner", bad); err == nil {
+			t.Errorf("DaemonBakPath(%q) should have errored", bad)
+		}
+	}
+}
+
+func TestParseBakName_DaemonPrefixWinsOverCLI(t *testing.T) {
+	// The CLI name is a prefix of the daemon name; the parser must not
+	// misclassify a daemon archive as a CLI archive with opID "daemon-op123".
+	bin, op, err := selfupgrade.ParseBakName("solo-provisioner-daemon-op123.bak")
+	require.NoError(t, err)
+	assert.Equal(t, selfupgrade.BinaryDaemon, bin)
+	assert.Equal(t, "op123", op)
+}
+
+func TestParseBakName_FromPath(t *testing.T) {
+	bin, op, err := selfupgrade.ParseBakName("/opt/solo/weaver/bin/solo-provisioner-op123.bak")
+	require.NoError(t, err)
+	assert.Equal(t, selfupgrade.BinaryCLI, bin)
+	assert.Equal(t, "op123", op)
+}
+
+func TestParseBakName_Errors(t *testing.T) {
+	cases := map[string]string{
+		"missing suffix":    "solo-provisioner-op123",
+		"wrong prefix":      "some-other-binary-op123.bak",
+		"empty cli opID":    "solo-provisioner-.bak",
+		"empty daemon opID": "solo-provisioner-daemon-.bak",
+		"not a binary":      "random.bak",
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := selfupgrade.ParseBakName(input)
+			require.Error(t, err, "expected parse error for %q", input)
+		})
+	}
+}

--- a/internal/selfupgrade/selfupgrade.go
+++ b/internal/selfupgrade/selfupgrade.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package selfupgrade defines the on-disk contracts for the daemon's binary
+// self-upgrade protocol (epic #500): the self-upgrade.yaml state file and the
+// .bak archived-binary naming convention.
+//
+// self-upgrade.yaml is written by the OLD daemon immediately before it spawns
+// the detached upgrade process — at step 0, before any binary swap begins. It
+// is both a handoff record and a crash-diagnostic artifact:
+//
+//   - Crash diagnostics: if the detached upgrader dies mid-swap, the recover
+//     tool reads this file to learn what version was being installed, which step
+//     it had reached, and whether the .bak binaries are still present.
+//   - PID tracking: ChildPID lets an operator/recovery tool check whether the
+//     detached process is still alive (kill -0).
+//   - Recovery input: `solo-provisioner consensus node upgrade-recover` (#717)
+//     inspects this file to decide whether to restore a .bak binary and restart
+//     the daemon.
+//
+// Because the file is written before the swap, a leftover Status of "in-progress"
+// is itself the failure signal: a clean run always ends with "succeeded". On
+// failure the detached process writes "failed" and leaves the .bak files intact.
+package selfupgrade
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/hashgraph/solo-weaver/pkg/schema"
+	"github.com/joomcode/errorx"
+	"gopkg.in/yaml.v3"
+)
+
+// CurrentSchemaVersion is the schemaVersion written by this build. Increment it
+// only when a breaking structural change is made to SelfUpgradeYAML, and add a
+// corresponding sealed selfUpgradeV{N} struct + migration step.
+const CurrentSchemaVersion = 1
+
+var (
+	// ErrNamespace groups self-upgrade state errors.
+	ErrNamespace = errorx.NewNamespace("selfupgrade")
+
+	// ErrState is returned when self-upgrade.yaml cannot be read or written.
+	ErrState = ErrNamespace.NewType("state")
+)
+
+// Status is the lifecycle status recorded in self-upgrade.yaml.
+type Status string
+
+const (
+	// StatusInProgress is written at step 0, before the binary swap begins. If it
+	// survives to recovery time, the upgrade crashed mid-swap.
+	StatusInProgress Status = "in-progress"
+
+	// StatusSucceeded is written by the detached upgrader after a clean swap; the
+	// .bak files are removed on success.
+	StatusSucceeded Status = "succeeded"
+
+	// StatusFailed is written by the detached upgrader on failure; the .bak files
+	// are left intact for recovery.
+	StatusFailed Status = "failed"
+)
+
+// SelfUpgradeYAML is the current in-memory shape of self-upgrade.yaml. It lives
+// at WeaverPaths.SelfUpgradeYAMLPath (/opt/solo/weaver/daemon/self-upgrade.yaml).
+type SelfUpgradeYAML struct {
+	// SchemaVersion identifies the file format. Stamped to CurrentSchemaVersion by Save.
+	SchemaVersion int `yaml:"schemaVersion"`
+
+	// Timestamp is when the operation was initiated (RFC3339, UTC).
+	Timestamp time.Time `yaml:"timestamp"`
+
+	// OperationID ties this self-upgrade to the originating NetworkUpgradeExecute
+	// CR's spec.operationId. Also embedded in the .bak filenames (see bak.go).
+	OperationID string `yaml:"operationId"`
+
+	// Status is the lifecycle marker — the primary success/failure signal.
+	Status Status `yaml:"status"`
+
+	// ChildPID is the PID of the detached upgrade process, for liveness checks.
+	ChildPID int `yaml:"childPid,omitempty"`
+
+	// CurrentStep is the last step the detached upgrader began. Used to localise
+	// a crash during recovery diagnostics.
+	CurrentStep string `yaml:"currentStep,omitempty"`
+
+	// Version transition — the from/to versions of each binary being swapped.
+	FromCLIVersion    string `yaml:"fromCliVersion,omitempty"`
+	ToCLIVersion      string `yaml:"toCliVersion,omitempty"`
+	FromDaemonVersion string `yaml:"fromDaemonVersion,omitempty"`
+	ToDaemonVersion   string `yaml:"toDaemonVersion,omitempty"`
+
+	// .bak references — absolute paths to the archived binaries the recover tool
+	// restores when an upgrade is rolled back. Empty when no archive was taken yet.
+	CLIBakPath    string `yaml:"cliBakPath,omitempty"`
+	DaemonBakPath string `yaml:"daemonBakPath,omitempty"`
+}
+
+// selfUpgradeV1 is the sealed on-disk representation for schemaVersion: 1.
+// Never modify it after it ships — introduce selfUpgradeV2 and a migration step
+// instead. Field layout must match the YAML written by Save when v1 was current.
+type selfUpgradeV1 struct {
+	SchemaVersion     int       `yaml:"schemaVersion"`
+	Timestamp         time.Time `yaml:"timestamp"`
+	OperationID       string    `yaml:"operationId"`
+	Status            Status    `yaml:"status"`
+	ChildPID          int       `yaml:"childPid,omitempty"`
+	CurrentStep       string    `yaml:"currentStep,omitempty"`
+	FromCLIVersion    string    `yaml:"fromCliVersion,omitempty"`
+	ToCLIVersion      string    `yaml:"toCliVersion,omitempty"`
+	FromDaemonVersion string    `yaml:"fromDaemonVersion,omitempty"`
+	ToDaemonVersion   string    `yaml:"toDaemonVersion,omitempty"`
+	CLIBakPath        string    `yaml:"cliBakPath,omitempty"`
+	DaemonBakPath     string    `yaml:"daemonBakPath,omitempty"`
+}
+
+// MigrateToLatest is the terminal step of the migration chain at v1.
+func (v *selfUpgradeV1) MigrateToLatest() SelfUpgradeYAML {
+	return SelfUpgradeYAML{
+		SchemaVersion:     CurrentSchemaVersion,
+		Timestamp:         v.Timestamp,
+		OperationID:       v.OperationID,
+		Status:            v.Status,
+		ChildPID:          v.ChildPID,
+		CurrentStep:       v.CurrentStep,
+		FromCLIVersion:    v.FromCLIVersion,
+		ToCLIVersion:      v.ToCLIVersion,
+		FromDaemonVersion: v.FromDaemonVersion,
+		ToDaemonVersion:   v.ToDaemonVersion,
+		CLIBakPath:        v.CLIBakPath,
+		DaemonBakPath:     v.DaemonBakPath,
+	}
+}
+
+// stateSchema is the versioned loader for self-upgrade.yaml.
+var stateSchema = schema.Versioned[SelfUpgradeYAML]{
+	CurrentVersion: CurrentSchemaVersion,
+	Factories: map[int]func() schema.Migratable[SelfUpgradeYAML]{
+		1: func() schema.Migratable[SelfUpgradeYAML] { return &selfUpgradeV1{} },
+	},
+}
+
+// DefaultPath returns the HIP-authoritative self-upgrade.yaml path for the
+// default weaver home (/opt/solo/weaver/daemon/self-upgrade.yaml).
+func DefaultPath() string {
+	return models.Paths().SelfUpgradeYAMLPath
+}
+
+// Load reads and strict-decodes self-upgrade.yaml at path, rejecting unknown
+// fields and any schemaVersion the running build does not support.
+func Load(path string) (SelfUpgradeYAML, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return SelfUpgradeYAML{}, ErrState.Wrap(err, "cannot read self-upgrade state at %s", path)
+	}
+	s, err := stateSchema.Decode(data)
+	if err != nil {
+		return SelfUpgradeYAML{}, err
+	}
+	return s, nil
+}
+
+// Save stamps SchemaVersion = CurrentSchemaVersion and atomically writes s to
+// path (write-temp-then-rename so a crash mid-write never leaves a torn file),
+// creating any missing parent directories.
+func Save(path string, s SelfUpgradeYAML) error {
+	s.SchemaVersion = CurrentSchemaVersion
+
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		return ErrState.Wrap(err, "cannot serialise self-upgrade state")
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, models.DefaultDirOrExecPerm); err != nil {
+		return ErrState.Wrap(err, "cannot create self-upgrade state directory %s", dir)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, models.DefaultFilePerm); err != nil {
+		return ErrState.Wrap(err, "cannot write self-upgrade state to %s", tmp)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		// Best-effort cleanup so a failed finalise does not leave a stale .tmp
+		// behind to accumulate or confuse recovery tooling.
+		_ = os.Remove(tmp)
+		return ErrState.Wrap(err, "cannot finalise self-upgrade state at %s", path)
+	}
+	return nil
+}

--- a/internal/selfupgrade/selfupgrade_test.go
+++ b/internal/selfupgrade/selfupgrade_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package selfupgrade_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hashgraph/solo-weaver/internal/selfupgrade"
+	"github.com/hashgraph/solo-weaver/pkg/schema"
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sample() selfupgrade.SelfUpgradeYAML {
+	return selfupgrade.SelfUpgradeYAML{
+		Timestamp:         time.Date(2026, 6, 16, 10, 30, 0, 0, time.UTC),
+		OperationID:       "op-2026-06-16-abc123",
+		Status:            selfupgrade.StatusInProgress,
+		ChildPID:          4242,
+		CurrentStep:       "swap-cli-binary",
+		FromCLIVersion:    "v1.1.0",
+		ToCLIVersion:      "v1.2.3",
+		FromDaemonVersion: "daemon-v1.1.0",
+		ToDaemonVersion:   "daemon-v1.2.3",
+		CLIBakPath:        "/opt/solo/weaver/backup/solo-provisioner/solo-provisioner-op-2026-06-16-abc123.bak",
+		DaemonBakPath:     "/opt/solo/weaver/backup/solo-provisioner/solo-provisioner-daemon-op-2026-06-16-abc123.bak",
+	}
+}
+
+func TestSaveLoad_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "self-upgrade.yaml")
+	want := sample()
+
+	require.NoError(t, selfupgrade.Save(path, want))
+
+	got, err := selfupgrade.Load(path)
+	require.NoError(t, err)
+
+	// Save stamps the schema version even though the in-memory sample left it 0.
+	assert.Equal(t, selfupgrade.CurrentSchemaVersion, got.SchemaVersion)
+
+	// Compare field-by-field; time.Time needs Equal (location/monotonic safety).
+	assert.True(t, want.Timestamp.Equal(got.Timestamp), "timestamp round-trip")
+	want.SchemaVersion = selfupgrade.CurrentSchemaVersion
+	want.Timestamp = got.Timestamp // normalise for the struct-level compare below
+	assert.Equal(t, want, got)
+}
+
+func TestSave_IsAtomicAndStampsVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "self-upgrade.yaml")
+	require.NoError(t, selfupgrade.Save(path, sample()))
+
+	// Parent dirs created; no leftover .tmp file.
+	_, err := os.Stat(path)
+	require.NoError(t, err)
+	_, err = os.Stat(path + ".tmp")
+	assert.True(t, os.IsNotExist(err), "temp file must not remain after rename")
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "schemaVersion: 1")
+}
+
+func TestLoad_RejectsUnknownSchemaVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "self-upgrade.yaml")
+	require.NoError(t, os.WriteFile(path,
+		[]byte("schemaVersion: 99\noperationId: op-x\nstatus: in-progress\n"), 0o600))
+
+	_, err := selfupgrade.Load(path)
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, schema.ErrUnsupportedVersion),
+		"expected ErrUnsupportedVersion, got %T: %v", err, err)
+}
+
+func TestLoad_RejectsUnknownField(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "self-upgrade.yaml")
+	require.NoError(t, os.WriteFile(path,
+		[]byte("schemaVersion: 1\noperationId: op-x\nbogus: true\n"), 0o600))
+
+	_, err := selfupgrade.Load(path)
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, schema.ErrMalformed),
+		"expected ErrMalformed, got %T: %v", err, err)
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	_, err := selfupgrade.Load(filepath.Join(t.TempDir(), "absent.yaml"))
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, selfupgrade.ErrState),
+		"expected ErrState, got %T: %v", err, err)
+}

--- a/pkg/models/weaver_paths.go
+++ b/pkg/models/weaver_paths.go
@@ -24,6 +24,12 @@ type WeaverPaths struct {
 	DaemonCNKubeconfigPath string // /opt/solo/weaver/config/daemon-cn.kubeconfig
 	DaemonBNKubeconfigPath string // /opt/solo/weaver/config/daemon-bn.kubeconfig
 
+	// SelfUpgradeYAMLPath is the HIP-authoritative state file for the daemon's
+	// binary self-upgrade protocol: /opt/solo/weaver/daemon/self-upgrade.yaml.
+	// Written by the old daemon before spawning the detached upgrader; consumed
+	// by `consensus node upgrade-recover`. See internal/selfupgrade.
+	SelfUpgradeYAMLPath string
+
 	// InfraVersionsPath is the optional infrastructure-versions.yaml manifest dropped
 	// into the config directory by the build.zip deployment package (HIP XXXX0).
 	// When present, solo-provisioner validates its declared versions against the
@@ -78,6 +84,7 @@ func NewWeaverPaths(home string) *WeaverPaths {
 	pp.DaemonKubeconfigPath = path.Join(pp.ConfigDir, "daemon.kubeconfig")
 	pp.DaemonCNKubeconfigPath = path.Join(pp.ConfigDir, "daemon-cn.kubeconfig")
 	pp.DaemonBNKubeconfigPath = path.Join(pp.ConfigDir, "daemon-bn.kubeconfig")
+	pp.SelfUpgradeYAMLPath = path.Join(pp.DaemonDir, "self-upgrade.yaml")
 	pp.DaemonEventsDir = path.Join(pp.DaemonDir, "events")
 	pp.DaemonConsensusEventsDir = path.Join(pp.DaemonEventsDir, "consensus")
 	pp.DaemonConsensusUpgradeEventsDir = path.Join(pp.DaemonConsensusEventsDir, "upgrade")

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -80,6 +80,17 @@ func isValidUsernameChar(b byte) bool {
 	return isValidIdentifierChar(b) || b == '.'
 }
 
+// isValidOperationIDChar checks if a byte is a valid character for an upgrade
+// operationId. The set is the identifier set plus '.', because operationIds may
+// embed dotted version strings (e.g. "upgrade-v0.76.0-20060102T150405Z"). It is a
+// separate predicate from isValidUsernameChar even though the set is identical
+// today, so the two domains can diverge without affecting each other (issue #602
+// convention). The '..' traversal sequence is rejected upstream in
+// ValidateOperationID.
+func isValidOperationIDChar(b byte) bool {
+	return isValidIdentifierChar(b) || b == '.'
+}
+
 // SanitizeIdentifier strips any non-identifier characters from s and returns
 // the cleaned form. Identifier characters are alphanumerics, underscore, and
 // hyphen ([A-Za-z0-9_-]). Returns ErrInvalidName when no valid characters
@@ -266,6 +277,39 @@ func ValidateUsername(s string) error {
 	for i := 0; i < len(s); i++ {
 		if !isValidUsernameChar(s[i]) {
 			return errorx.IllegalArgument.New("username contains invalid characters: %s", s)
+		}
+	}
+
+	return nil
+}
+
+// ValidateOperationID validates a consensus-node operationId. The id is either
+// authored by the orbit reconciler (NetworkUpgradeExecute CR spec.operationId) or
+// constructed by solo-weaver itself (e.g. the migration flow derives
+// "migration-<timestamp>"). Either way it flows into .bak archive filenames
+// written by the self-upgrade swap as root, so it must be safe to embed in a
+// path: [A-Za-z0-9_.-], non-empty, no ".." traversal sequence, no shell
+// metacharacters. The '.' is permitted so operationIds can embed dotted version
+// strings (e.g. "upgrade-v0.76.0-20060102T150405Z").
+func ValidateOperationID(s string) error {
+	if s == "" {
+		return errorx.IllegalArgument.New("operationId cannot be empty")
+	}
+
+	// Check for path traversal attempts before the per-char loop.
+	if strings.Contains(s, "..") {
+		return errorx.IllegalArgument.New("operationId contains path traversal sequences: %s", s)
+	}
+
+	// Check for shell metacharacters (narrower, more specific message).
+	if shellMetachars.MatchString(s) {
+		return errorx.IllegalArgument.New("operationId contains shell metacharacters: %s", s)
+	}
+
+	// Every byte must be a valid operationId character.
+	for i := 0; i < len(s); i++ {
+		if !isValidOperationIDChar(s[i]) {
+			return errorx.IllegalArgument.New("operationId contains invalid characters: %s", s)
 		}
 	}
 

--- a/pkg/sanity/sanity_test.go
+++ b/pkg/sanity/sanity_test.go
@@ -780,6 +780,61 @@ func TestSanity_ValidateUsername(t *testing.T) {
 	}
 }
 
+func TestSanity_ValidateOperationID(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		shouldErr bool
+		errMsg    string
+	}{
+		// Valid operationIds
+		{name: "simple", input: "op123", shouldErr: false},
+		{name: "hyphenated", input: "op-2026-06-16-abc123", shouldErr: false},
+		{name: "underscore", input: "OP_1", shouldErr: false},
+		{name: "single char", input: "a", shouldErr: false},
+		{name: "migration convention", input: "migration-20060102T150405Z", shouldErr: false},
+		{name: "dotted version string", input: "upgrade-v0.76.0-20060102T150405Z", shouldErr: false},
+		{name: "single dot", input: "op.123", shouldErr: false},
+
+		// Invalid - empty
+		{name: "empty", input: "", shouldErr: true, errMsg: "operationId cannot be empty"},
+
+		// Invalid - path traversal
+		{name: "dotdot traversal", input: "../evil", shouldErr: true, errMsg: "path traversal"},
+		{name: "embedded dotdot", input: "a..b", shouldErr: true, errMsg: "path traversal"},
+		{name: "forward slash", input: "a/b", shouldErr: true, errMsg: "invalid characters"},
+		{name: "backslash", input: "a\\b", shouldErr: true, errMsg: "invalid characters"},
+
+		// Invalid - shell metacharacters
+		{name: "semicolon", input: "op;rm", shouldErr: true, errMsg: "shell metacharacters"},
+		{name: "dollar", input: "op$x", shouldErr: true, errMsg: "shell metacharacters"},
+		{name: "backtick", input: "op`x`", shouldErr: true, errMsg: "shell metacharacters"},
+		{name: "pipe", input: "op|x", shouldErr: true, errMsg: "shell metacharacters"},
+
+		// Invalid - whitespace and control bytes
+		{name: "space", input: "op id", shouldErr: true, errMsg: "invalid characters"},
+		{name: "null byte", input: "op\x00x", shouldErr: true, errMsg: "invalid characters"},
+		{name: "newline", input: "op\nx", shouldErr: true, errMsg: "invalid characters"},
+		{name: "tab", input: "op\tx", shouldErr: true, errMsg: "invalid characters"},
+		{name: "escape", input: "op\x1bx", shouldErr: true, errMsg: "invalid characters"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := require.New(t)
+			err := ValidateOperationID(tc.input)
+			if tc.shouldErr {
+				req.Error(err, "expected error for input: %q", tc.input)
+				if tc.errMsg != "" {
+					req.Contains(err.Error(), tc.errMsg)
+				}
+			} else {
+				req.NoError(err, "expected no error for input: %q", tc.input)
+			}
+		})
+	}
+}
+
 func TestSanity_SanitizePath(t *testing.T) {
 	testCases := []struct {
 		name      string

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package schema provides a generic versioned-YAML loader for any file that
+// embeds a schema version field. It handles version probing, unknown-field
+// rejection, and in-memory migration to the latest struct shape.
+//
+// The pattern, extracted once so every versioned file behaves identically:
+//
+//  1. Probe the version field (Versioned.VersionKey, default "schemaVersion")
+//     from raw YAML before decoding the body.
+//  2. Normalise an absent/zero version to 1 (files predating versioning).
+//  3. Reject any version greater than the running build supports (a file
+//     written by a newer binary) with a human-readable "newer binary" error
+//     rather than a surprising decode failure against the current shape.
+//  4. Strict-decode (KnownFields, single document) into the sealed per-version
+//     struct registered for that version.
+//  5. Walk the migration chain via Migratable.MigrateToLatest() to produce the
+//     current in-memory type T.
+//
+// The genuinely domain-specific parts — the sealed vN structs and their
+// MigrateToLatest field transforms — stay in each consuming package. Only the
+// cross-cutting orchestration lives here.
+package schema
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math"
+
+	"github.com/joomcode/errorx"
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultVersionKey is the YAML field solo-weaver owned state files use to carry
+// their schema version. It is the default when Versioned.VersionKey is empty;
+// external schemas may override it with any key they prefer.
+const DefaultVersionKey = "schemaVersion"
+
+var (
+	// ErrNamespace groups all schema-loading errors.
+	ErrNamespace = errorx.NewNamespace("schema")
+
+	// ErrMalformed is returned when the document cannot be probed or strict-decoded.
+	ErrMalformed = ErrNamespace.NewType("malformed")
+
+	// ErrUnsupportedVersion is returned when the document declares a schemaVersion
+	// the running build does not support (typically a file written by a newer binary).
+	ErrUnsupportedVersion = ErrNamespace.NewType("unsupported_version")
+)
+
+// Migratable is a sealed, versioned on-disk struct that knows how to migrate
+// itself up to the latest in-memory shape T. Each owned state file defines one
+// implementation per historical version; the terminal version's MigrateToLatest
+// is the identity-style transform into T, and earlier versions delegate down the
+// chain (vN.migrate().MigrateToLatest()).
+type Migratable[T any] interface {
+	MigrateToLatest() T
+}
+
+// Versioned describes one owned-state-file schema: the YAML key that carries the
+// version, the highest version this build writes, and a factory per supported
+// version that returns a fresh pointer to strict-decode into.
+type Versioned[T any] struct {
+	// VersionKey is the YAML field carrying the schema version. Empty means
+	// DefaultVersionKey ("schemaVersion"); external schemas may set any key.
+	VersionKey string
+
+	// CurrentVersion is the highest schema version this build understands and writes.
+	CurrentVersion int
+
+	// Factories maps a supported version to a constructor returning a fresh
+	// sealed struct (as a Migratable[T]) to decode that version's document into.
+	Factories map[int]func() Migratable[T]
+}
+
+// Decode runs the full owned-state-file load pattern on raw YAML bytes and
+// returns the migrated current type T. See the package doc for the steps.
+func (s Versioned[T]) Decode(data []byte) (T, error) {
+	var zero T
+
+	key := s.VersionKey
+	if key == "" {
+		key = DefaultVersionKey
+	}
+
+	// Phase 1: probe the version key only, via a top-level map so the key is
+	// dynamic. An absent key means a pre-versioning file (treated as v1); an
+	// explicit zero is likewise normalised to v1.
+	var top map[string]any
+	if err := yaml.Unmarshal(data, &top); err != nil {
+		return zero, ErrMalformed.Wrap(err, "cannot read %s", key)
+	}
+
+	version := 1
+	if raw, ok := top[key]; ok {
+		v, err := toInt(raw)
+		if err != nil {
+			return zero, ErrMalformed.Wrap(err, "%s must be an integer", key)
+		}
+		if v != 0 {
+			version = v
+		}
+	}
+
+	if version > s.CurrentVersion {
+		return zero, ErrUnsupportedVersion.New(
+			"document was written by a newer binary (%s %d > supported %d); upgrade to a compatible version",
+			key, version, s.CurrentVersion)
+	}
+
+	factory, ok := s.Factories[version]
+	if !ok {
+		return zero, ErrUnsupportedVersion.New("unsupported %s %d", key, version)
+	}
+
+	// Phase 2: strict-decode into the sealed per-version struct, then migrate.
+	obj := factory()
+	if err := decodeStrictSingleDoc(data, obj); err != nil {
+		return zero, ErrMalformed.Wrap(err, "invalid v%d document", version)
+	}
+	return obj.MigrateToLatest(), nil
+}
+
+// decodeStrictSingleDoc decodes data into out with KnownFields(true) (unknown
+// fields are an error) and rejects inputs containing more than one YAML
+// document. Owned state files are written by us as exactly one document; a
+// trailing document or unknown field signals corruption or a format drift we
+// want to surface loudly rather than silently ignore.
+func decodeStrictSingleDoc(data []byte, out any) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(out); err != nil {
+		return err
+	}
+	var discard any
+	err := dec.Decode(&discard)
+	switch {
+	case err == nil:
+		return ErrMalformed.New("must contain exactly one YAML document; additional documents are not permitted")
+	case errors.Is(err, io.EOF):
+		return nil
+	default:
+		return err
+	}
+}
+
+// toInt coerces a YAML-decoded scalar to an int. yaml.v3 decodes integers as
+// int (falling back to int64/uint64 for values that overflow int, and float64
+// for non-integral numbers), so accept the wider numeric types defensively and
+// reject anything out of int range or fractional rather than silently wrapping.
+func toInt(v any) (int, error) {
+	switch n := v.(type) {
+	case int:
+		return n, nil
+	case int64:
+		if n < math.MinInt || n > math.MaxInt {
+			return 0, errorx.IllegalFormat.New("version %d is out of range", n)
+		}
+		return int(n), nil
+	case uint64:
+		if n > math.MaxInt {
+			return 0, errorx.IllegalFormat.New("version %d is out of range", n)
+		}
+		return int(n), nil
+	case float64:
+		if n != math.Trunc(n) {
+			return 0, errorx.IllegalFormat.New("expected an integer, got fractional %v", n)
+		}
+		if n < math.MinInt || n > math.MaxInt {
+			return 0, errorx.IllegalFormat.New("version %v is out of range", n)
+		}
+		return int(n), nil
+	default:
+		return 0, errorx.IllegalFormat.New("expected an integer, got %T", v)
+	}
+}

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/pkg/schema"
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// demo is the current in-memory shape used by the tests.
+type demo struct {
+	Name string
+	Size int
+}
+
+// demoV1 is the sealed v1 on-disk struct.
+type demoV1 struct {
+	SchemaVersion int    `yaml:"schemaVersion"`
+	Name          string `yaml:"name"`
+	Size          int    `yaml:"size"`
+}
+
+func (v *demoV1) MigrateToLatest() demo {
+	return demo{Name: v.Name, Size: v.Size}
+}
+
+func newDemoSchema() schema.Versioned[demo] {
+	return schema.Versioned[demo]{
+		CurrentVersion: 1,
+		Factories: map[int]func() schema.Migratable[demo]{
+			1: func() schema.Migratable[demo] { return &demoV1{} },
+		},
+	}
+}
+
+func TestDecode_V1(t *testing.T) {
+	got, err := newDemoSchema().Decode([]byte("schemaVersion: 1\nname: alpha\nsize: 7\n"))
+	require.NoError(t, err)
+	assert.Equal(t, demo{Name: "alpha", Size: 7}, got)
+}
+
+func TestDecode_AbsentVersionTreatedAsV1(t *testing.T) {
+	got, err := newDemoSchema().Decode([]byte("name: beta\nsize: 1\n"))
+	require.NoError(t, err)
+	assert.Equal(t, demo{Name: "beta", Size: 1}, got)
+}
+
+func TestDecode_RejectsNewerVersion(t *testing.T) {
+	_, err := newDemoSchema().Decode([]byte("schemaVersion: 99\nname: x\n"))
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, schema.ErrUnsupportedVersion),
+		"expected ErrUnsupportedVersion, got %T: %v", err, err)
+	assert.Contains(t, err.Error(), "newer binary")
+	assert.Contains(t, err.Error(), "99")
+}
+
+func TestDecode_RejectsUnknownField(t *testing.T) {
+	_, err := newDemoSchema().Decode([]byte("schemaVersion: 1\nname: x\nbogus: true\n"))
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, schema.ErrMalformed),
+		"expected ErrMalformed, got %T: %v", err, err)
+}
+
+func TestDecode_RejectsMultiDocument(t *testing.T) {
+	_, err := newDemoSchema().Decode([]byte("schemaVersion: 1\nname: x\n---\nname: y\n"))
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, schema.ErrMalformed),
+		"expected ErrMalformed, got %T: %v", err, err)
+}
+
+func TestDecode_RejectsInvalidYAML(t *testing.T) {
+	_, err := newDemoSchema().Decode([]byte("schemaVersion: [not a number}"))
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, schema.ErrMalformed),
+		"expected ErrMalformed, got %T: %v", err, err)
+}
+
+func TestDecode_RejectsNonIntegerVersion(t *testing.T) {
+	_, err := newDemoSchema().Decode([]byte("schemaVersion: not-a-number\nname: x\n"))
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, schema.ErrMalformed),
+		"expected ErrMalformed, got %T: %v", err, err)
+}
+
+func TestDecode_RejectsFractionalAndOutOfRangeVersion(t *testing.T) {
+	cases := map[string]string{
+		"fractional":    "schemaVersion: 1.5\nname: x\n",
+		"overflows int": "schemaVersion: 99999999999999999999\nname: x\n",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := newDemoSchema().Decode([]byte(in))
+			require.Error(t, err)
+			assert.True(t, errorx.IsOfType(err, schema.ErrMalformed),
+				"expected ErrMalformed, got %T: %v", err, err)
+		})
+	}
+}
+
+// legacyV1 mirrors demoV1 but reads its version from a custom key, exercising
+// the VersionKey override.
+type legacyV1 struct {
+	SchemaVersion int    `yaml:"schema_version"`
+	Name          string `yaml:"name"`
+	Size          int    `yaml:"size"`
+}
+
+func (v *legacyV1) MigrateToLatest() demo { return demo{Name: v.Name, Size: v.Size} }
+
+func TestDecode_CustomVersionKey(t *testing.T) {
+	s := schema.Versioned[demo]{
+		VersionKey:     "schema_version",
+		CurrentVersion: 1,
+		Factories: map[int]func() schema.Migratable[demo]{
+			1: func() schema.Migratable[demo] { return &legacyV1{} },
+		},
+	}
+
+	got, err := s.Decode([]byte("schema_version: 1\nname: gamma\nsize: 3\n"))
+	require.NoError(t, err)
+	assert.Equal(t, demo{Name: "gamma", Size: 3}, got)
+
+	// A newer version under the custom key is still rejected, and the message
+	// names the custom key.
+	_, err = s.Decode([]byte("schema_version: 5\nname: x\n"))
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, schema.ErrUnsupportedVersion))
+	assert.Contains(t, err.Error(), "schema_version")
+}


### PR DESCRIPTION
## Description
This pull request introduces and documents a set of contracts and invariants for the network upgrade and self-upgrade flows, centralizing type and constant definitions to avoid duplication and ensure correctness across the daemon and CLI code paths. It also standardizes the schema version field in `daemon.yaml` to `schemaVersion` for consistency, and adds comprehensive documentation and tests to pin these contracts.

**Key changes:**

### Upgrade and Self-Upgrade Contracts

- Added a new documentation file (`docs/dev/upgrade-contracts.md`) detailing the contracts for the network upgrade execute phase, self-upgrade state file schema, and `.bak` binary naming conventions. This includes state machine diagrams, invariants, and rationale for package placement to prevent import cycles.

### Consensus Phase Constants and Invariants

- Introduced `internal/consensus/phase.go` to define all phase and condition constants for the NetworkUpgradeExecute CR, including strict writer ownership rules and helper methods (`IsTerminal`, `IsDaemonWritable`) to enforce invariants in code.
- Added `internal/consensus/phase_test.go` with tests that pin string values, assert invariants (e.g., only the reconciler writes terminal phases, no `InProgress` phase exists), and guard against accidental contract changes.

### Schema Version Field Standardization

- Standardized the schema version field in `daemon.yaml` and related code from `schema_version` to `schemaVersion`, updating struct tags, comments, error messages, and test fixtures for consistency and forward compatibility. [[1]](diffhunk://#diff-cbd296be5f2e8a99912693bd2cfcd8b8a3d2642dfb9d65d14da2308e5c39b702L25-R25) [[2]](diffhunk://#diff-cbd296be5f2e8a99912693bd2cfcd8b8a3d2642dfb9d65d14da2308e5c39b702L46-R46) [[3]](diffhunk://#diff-cbd296be5f2e8a99912693bd2cfcd8b8a3d2642dfb9d65d14da2308e5c39b702L182-R182) [[4]](diffhunk://#diff-cbd296be5f2e8a99912693bd2cfcd8b8a3d2642dfb9d65d14da2308e5c39b702L200-R200) [[5]](diffhunk://#diff-cbd296be5f2e8a99912693bd2cfcd8b8a3d2642dfb9d65d14da2308e5c39b702L211-R211) [[6]](diffhunk://#diff-cbd296be5f2e8a99912693bd2cfcd8b8a3d2642dfb9d65d14da2308e5c39b702L232-R232) [[7]](diffhunk://#diff-5f192e9f8e449a10f40663677cb053783470abb5426f7dfaa10d28856276aed4L28-R32) [[8]](diffhunk://#diff-5f192e9f8e449a10f40663677cb053783470abb5426f7dfaa10d28856276aed4L61-R61) [[9]](diffhunk://#diff-5f192e9f8e449a10f40663677cb053783470abb5426f7dfaa10d28856276aed4L91-R99)

These changes establish a clear and enforceable contract for upgrade workflows, improve maintainability by centralizing definitions, and prevent subtle bugs or mismatches during upgrades.



This pull request changes the following:

* TBD

### Related Issues

* Closes #721
