### PR TITLE
fix(fsx): stream directory entries in RemoveContents to avoid memory spike on large BN PVs

### DIFF
--- a/internal/workflows/steps/step_cluster_uninstall.go
+++ b/internal/workflows/steps/step_cluster_uninstall.go
@@ -125,8 +125,14 @@ func CleanupWeaverFiles() *automa.StepBuilder {
 			// Open the directory so its entries can be read in batches instead of all at once.
 			dir, err := os.Open(weaverHome)
 			if err != nil {
-				// Directory doesn't exist, nothing to clean
-				logx.As().Debug().Err(err).Msg("Weaver home directory doesn't exist, nothing to clean")
+				if errors.Is(err, os.ErrNotExist) {
+					// Directory doesn't exist, nothing to clean
+					logx.As().Debug().Err(err).Msg("Weaver home directory doesn't exist, nothing to clean")
+					return automa.SuccessReport(stp)
+				}
+
+				// Best-effort teardown: log and continue.
+				logx.As().Warn().Err(err).Msg("Failed to open weaver home directory, continuing with teardown")
 				return automa.SuccessReport(stp)
 			}
 			defer fsx.Close(dir)

--- a/internal/workflows/steps/step_cluster_uninstall.go
+++ b/internal/workflows/steps/step_cluster_uninstall.go
@@ -4,6 +4,8 @@ package steps
 
 import (
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -15,6 +17,9 @@ import (
 	"github.com/hashgraph/solo-weaver/pkg/fsx"
 	osutil "github.com/hashgraph/solo-weaver/pkg/os"
 )
+
+// weaverHomeReadBatchSize is how many directory entries the weaver-home cleanup reads per batch.
+const weaverHomeReadBatchSize = 256
 
 // RemoveSystemdServiceFiles removes systemd service files created during cluster setup
 func RemoveSystemdServiceFiles() *automa.StepBuilder {
@@ -117,13 +122,14 @@ func CleanupWeaverFiles() *automa.StepBuilder {
 
 			weaverHome := "/opt/solo/weaver"
 
-			// Read the weaver home directory
-			entries, err := os.ReadDir(weaverHome)
+			// Open the directory so its entries can be read in batches instead of all at once.
+			dir, err := os.Open(weaverHome)
 			if err != nil {
 				// Directory doesn't exist, nothing to clean
 				logx.As().Debug().Err(err).Msg("Weaver home directory doesn't exist, nothing to clean")
 				return automa.SuccessReport(stp)
 			}
+			defer fsx.Close(dir)
 
 			// Remove each top-level directory/file except the below ones
 			skipDirs := map[string]bool{
@@ -131,18 +137,31 @@ func CleanupWeaverFiles() *automa.StepBuilder {
 				models.Paths().BinDir:       true,
 				models.Paths().LogsDir:      true,
 			}
-			for _, entry := range entries {
-				entryPath := filepath.Join(weaverHome, entry.Name())
 
-				// Skip the downloads, bin, and logs folders
-				if skipDirs[entryPath] {
-					logx.As().Debug().Str("path", entryPath).Msg("Preserving directory during cleanup")
-					continue
+			// Remove every top-level entry except the preserved folders.
+			for {
+				entries, readErr := dir.ReadDir(weaverHomeReadBatchSize)
+				for _, entry := range entries {
+					entryPath := filepath.Join(weaverHome, entry.Name())
+
+					// Skip the downloads, bin, and logs folders
+					if skipDirs[entryPath] {
+						logx.As().Debug().Str("path", entryPath).Msg("Preserving directory during cleanup")
+						continue
+					}
+
+					// Remove directories/files
+					if err := fsManager.RemoveAll(entryPath); err != nil {
+						logx.As().Warn().Err(err).Msgf("Failed to remove %s, continuing with teardown", entryPath)
+					}
 				}
 
-				// Remove directories/files
-				if err := fsManager.RemoveAll(entryPath); err != nil {
-					logx.As().Warn().Err(err).Msgf("Failed to remove %s, continuing with teardown", entryPath)
+				if errors.Is(readErr, io.EOF) {
+					break
+				}
+				if readErr != nil {
+					logx.As().Warn().Err(readErr).Msg("Failed to read weaver home directory, continuing with teardown")
+					break
 				}
 			}
 

--- a/pkg/fsx/manager_unix.go
+++ b/pkg/fsx/manager_unix.go
@@ -5,6 +5,7 @@
 package fsx
 
 import (
+	"errors"
 	"io"
 	"io/fs"
 	"os"
@@ -26,6 +27,8 @@ const (
 	// DefaultROPermissions is the default permissions used when creating read-only files and directories.
 	// TODO - set to 0500 for testing, bash version sets it to 0400 which can only be done with sudo as-is
 	DefaultROPermissions = 0500
+	// removeContentsBatchSize is how many directory entries RemoveContents reads per batch.
+	removeContentsBatchSize = 256
 )
 
 type Option func(*unixManager) error
@@ -594,15 +597,27 @@ func (m *unixManager) RemoveContents(path string) error {
 
 	// Remove all entries inside the directory while preserving the directory itself,
 	// including its inode, ownership, ACLs, extended attributes, and special mode bits.
-	entries, err := os.ReadDir(path)
+	// Entries are streamed in bounded batches rather than read all at once
+	dir, err := os.Open(path)
 	if err != nil {
-		return FileSystemError.New("failed to list directory contents for %q", path).WithUnderlyingErrors(err)
+		return FileSystemError.New("failed to open directory %q", path).WithUnderlyingErrors(err)
 	}
+	defer Close(dir)
 
-	for _, entry := range entries {
-		childPath := filepath.Join(path, entry.Name())
-		if err := os.RemoveAll(childPath); err != nil {
-			return FileSystemError.New("failed to remove directory entry %q", childPath).WithUnderlyingErrors(err)
+	for {
+		entries, readErr := dir.ReadDir(removeContentsBatchSize)
+		for _, entry := range entries {
+			childPath := filepath.Join(path, entry.Name())
+			if err := os.RemoveAll(childPath); err != nil {
+				return FileSystemError.New("failed to remove directory entry %q", childPath).WithUnderlyingErrors(err)
+			}
+		}
+
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return FileSystemError.New("failed to list directory contents for %q", path).WithUnderlyingErrors(readErr)
 		}
 	}
 

--- a/pkg/fsx/manager_unix_test.go
+++ b/pkg/fsx/manager_unix_test.go
@@ -1153,3 +1153,43 @@ func TestUnixManager_RemoveContents_ManyFiles(t *testing.T) {
 	assert.NoError(err)
 	assert.Empty(entries)
 }
+
+func TestUnixManager_RemoveContents_MultipleBatches(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	pm := setupMockPrincipalManager(t, ctrl)
+	assert, manager := setupTest(t, pm)
+
+	tempDir := t.TempDir()
+	testDir := filepath.Join(tempDir, "test-batches")
+	assert.NoError(os.MkdirAll(testDir, 0755))
+
+	// Create more than two batches of entries, mixing files and subdirectories
+	const entryCount = 2*removeContentsBatchSize + 17
+	for i := 0; i < entryCount; i++ {
+		if i%2 == 0 {
+			file := filepath.Join(testDir, fmt.Sprintf("file%d.txt", i))
+			assert.NoError(os.WriteFile(file, []byte(fmt.Sprintf("content %d", i)), 0644))
+			continue
+		}
+
+		subDir := filepath.Join(testDir, fmt.Sprintf("dir%d", i))
+		assert.NoError(os.MkdirAll(subDir, 0755))
+		assert.NoError(os.WriteFile(filepath.Join(subDir, "nested.txt"), []byte("nested"), 0644))
+	}
+
+	// Verify entries exist
+	entries, err := os.ReadDir(testDir)
+	assert.NoError(err)
+	assert.Len(entries, entryCount)
+
+	// Remove contents
+	err = manager.RemoveContents(testDir)
+	assert.NoError(err)
+
+	// Verify directory still exists and is empty
+	assert.True(manager.IsDirectory(testDir))
+	entries, err = os.ReadDir(testDir)
+	assert.NoError(err)
+	assert.Empty(entries)
+}


### PR DESCRIPTION
## Description
This pull request changes the following:

- **`pkg/fsx/manager_unix.go`** — `RemoveContents` now streams directory entries in bounded
  batches via `(*os.File).ReadDir(256)` instead of loading the whole listing with
  `os.ReadDir`, keeping memory usage constant on large block node PVs.
- **`internal/workflows/steps/step_cluster_uninstall.go`** — the `cleanup-weaver-files` step
  uses the same batched read pattern for consistency, preserving its skip-dirs and
  best-effort teardown behavior.
- **`pkg/fsx/manager_unix_test.go`** — adds `TestUnixManager_RemoveContents_MultipleBatches`,
  which exercises the batched loop across more than two full batches.

### Related Issues

* Closes #363 
