### PR TITLE
feat(cilium): enable host-legacy-routing and guard BandwidthManager disabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
    ```
 5. **Before committing or pushing**, always show the full commit message and the list of files to be committed/pushed, and wait for explicit user approval before proceeding.
 6. **When you add, rename, remove, or change the semantics of a CLI flag or subcommand** (under `cmd/cli/commands/...`), also update `docs/quickstart.md` — the relevant command's example block, its **Additional Flags** table, and any nearby explanatory text. Flag descriptions there must match the description string in `cmd/cli/commands/common/flags_common.go` and the `--help` output. CLI surface changes that miss this step ship docs that drift out of date.
+7. **When you change an embedded template or any config consumed at install time** (e.g. `internal/templates/files/**`), trace the **existing-cluster upgrade path** before assuming the change is fresh-install-only. Startup migrations (`internal/workflows/migration_*.go`, registered in `cmd/cli/commands/root.go` `RegisterMigrations()`) run on every CLI invocation and, when crossing their version boundary, **re-render the entire template and re-apply it** (e.g. `software.ReconfigureCiliumConfig()` + `cilium upgrade --values`). That means a template edit you intended only for new installs can **leak into already-provisioned clusters** that cross such a boundary. Confirm whether that application is intended, and call out any unintended/early application in the PR's **Risks** section.
 
 ## Writing Markdown Files
 
@@ -241,3 +242,4 @@ Detailed framework docs live in `docs/dev/`:
 - Deployment profiles: `local`, `perfnet`, `testnet`, `previewnet`, `mainnet`
 - PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/)
 - License headers (SPDX) are required on all source files — enforced by `task license:check`
+- Prefer pure-Go over shelling out to external binaries. Read cluster state through the Kubernetes API (`internal/kube` client, injected as `kube.ClientProviderFromContext` — pass `kube.ClientFromContext` at the call site) rather than execing tool binaries (`cilium`, `kubectl`, …) and parsing their stdout — running binaries from the sandbox bin dir is a malicious-binary risk (see `docs/dev/security-model.md`). Follow the `step_cluster_*` pattern: take a provider, resolve the client once in `Execute`, and read via a named helper

--- a/internal/templates/files/cilium/cilium-config.yaml
+++ b/internal/templates/files/cilium/cilium-config.yaml
@@ -59,7 +59,11 @@ ipMasqAgent:
     nonMasqueradeCIDRs: []
 bpf:
   masquerade: true
-  hostLegacyRouting: false
+  # hostLegacyRouting must be true for the BN traffic shaper: it forces traffic
+  # through the host legacy routing path so nft/tc in the host netns can set and
+  # preserve skb->priority across reboots. Renders to the cilium-config ConfigMap
+  # key `enable-host-legacy-routing: "true"`.
+  hostLegacyRouting: true
   lbExternalClusterIP: true
   preallocateMaps: true
 

--- a/internal/workflows/steps/const.go
+++ b/internal/workflows/steps/const.go
@@ -24,4 +24,9 @@ const (
 
 	IsReady   = "isReady"
 	IsPending = "isPending"
+
+	// BandwidthManagerStatus reports the raw Cilium "enable-bandwidth-manager"
+	// cilium-config ConfigMap value ("true"/"false"/"" when unset) recorded by
+	// the guard step in StartCilium.
+	BandwidthManagerStatus = "bandwidthManagerStatus"
 )

--- a/internal/workflows/steps/step_cilium.go
+++ b/internal/workflows/steps/step_cilium.go
@@ -5,12 +5,15 @@ package steps
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/automa/automa_steps"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
 
+	"github.com/hashgraph/solo-weaver/internal/kube"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
 	"github.com/hashgraph/solo-weaver/pkg/software"
 )
@@ -176,7 +179,7 @@ func configureCilium(provider func(opts ...software.InstallerOption) (software.S
 func StartCilium() *automa.WorkflowBuilder {
 	return automa.NewWorkflowBuilder().WithId("start-cilium").Steps(
 		installCiliumCNI("1.18.1"), // we cannot write in pure Go because we need to run cilium binary
-
+		guardBandwidthManagerDisabled(),
 	).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
 			notify.As().StepStart(ctx, stp, "Starting Cilium")
@@ -248,5 +251,103 @@ func installCiliumCNI(version string) *automa.StepBuilder {
 			}
 
 			return automa.SuccessReport(stp)
+		})
+}
+
+// Cilium agent config surfaces the Bandwidth Manager guard inspects. The
+// cilium-config ConfigMap is created by `cilium install` and read by the agent.
+const (
+	ciliumConfigMapNamespace = "kube-system"
+	ciliumConfigMapName      = "cilium-config"
+	// bandwidthManagerConfigKey is the cilium-config data key set by the Cilium
+	// agent flag --enable-bandwidth-manager. "true" when enabled; "false" or
+	// absent when disabled.
+	bandwidthManagerConfigKey = "enable-bandwidth-manager"
+)
+
+// bandwidthManagerEnabled reports whether a cilium-config enable-bandwidth-manager
+// value means the Bandwidth Manager is on. An empty value (key absent) is disabled.
+func bandwidthManagerEnabled(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), "true")
+}
+
+// ciliumBandwidthManagerState reads the cilium-config ConfigMap via the Kubernetes
+// API (pure Go, no shell) and reports whether the Bandwidth Manager is enabled
+// along with the raw enable-bandwidth-manager value. Mirrors the cilium-config
+// read in migration_cilium_acceleration.go. It errors if cilium-config is absent,
+// since the guard cannot otherwise verify the precondition.
+func ciliumBandwidthManagerState(ctx context.Context, k *kube.Client) (enabled bool, value string, err error) {
+	exists, err := k.ResourceExists(ctx, "v1", "ConfigMap", ciliumConfigMapNamespace, ciliumConfigMapName)
+	if err != nil {
+		return false, "", errorx.ExternalError.Wrap(err, "failed to check for the %q ConfigMap in namespace %q", ciliumConfigMapName, ciliumConfigMapNamespace).
+			WithProperty(models.ErrPropertyResolution, []string{
+				"Ensure the cluster API is reachable (kubeconfig valid, API server up):",
+				"  kubectl -n kube-system get configmap cilium-config",
+			})
+	}
+	if !exists {
+		return false, "", errorx.IllegalState.New("Cilium ConfigMap %q not found in namespace %q", ciliumConfigMapName, ciliumConfigMapNamespace).
+			WithProperty(models.ErrPropertyResolution, []string{
+				"Confirm Cilium is installed and its ConfigMap exists:",
+				"  kubectl -n kube-system get configmap cilium-config -o yaml",
+			})
+	}
+
+	value, err = k.GetResourceNestedString(ctx, "v1", "ConfigMap", ciliumConfigMapNamespace, ciliumConfigMapName, "data", bandwidthManagerConfigKey)
+	if err != nil {
+		return false, "", errorx.ExternalError.Wrap(err, "failed to read %q from the %q ConfigMap", bandwidthManagerConfigKey, ciliumConfigMapName).
+			WithProperty(models.ErrPropertyResolution, []string{
+				"Ensure the cluster API is reachable (kubeconfig valid, API server up):",
+				"  kubectl -n kube-system get configmap cilium-config -o yaml",
+			})
+	}
+	return bandwidthManagerEnabled(value), value, nil
+}
+
+// guardBandwidthManagerDisabled fails fast if Cilium's Bandwidth Manager is
+// enabled. Bandwidth Manager is the only Cilium BPF writer of skb->priority, so
+// the BN traffic shaper's egress-priority survival guarantee is void whenever it
+// is on (traffic-shaper v4 design §10 risk 18). It reads cilium-config through the
+// Kubernetes API (pure Go, no shell) and is read-only, so there is no rollback.
+func guardBandwidthManagerDisabled() automa.Builder {
+	return automa.NewStepBuilder().WithId("guard-bandwidth-manager-disabled").
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepDetail(ctx, stp, "verifying Cilium Bandwidth Manager is disabled...")
+			return ctx, nil
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			meta := map[string]string{}
+			k, err := kube.NewClient()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			enabled, value, err := ciliumBandwidthManagerState(ctx, k)
+			if err != nil {
+				// ciliumBandwidthManagerState types its errors: ExternalError for
+				// kube-API failures, IllegalState for a missing ConfigMap. Forward
+				// as-is so the classification (and resolution hints) are preserved.
+				return automa.FailureReport(stp,
+					automa.WithError(err),
+					automa.WithMetadata(meta))
+			}
+
+			meta[BandwidthManagerStatus] = value
+
+			if enabled {
+				return automa.FailureReport(stp,
+					automa.WithError(errorx.IllegalState.New(
+						"Cilium Bandwidth Manager is enabled (%s=%q) — it is the only Cilium BPF writer of skb->priority and would void the BN egress-priority guarantee; it must be Disabled", bandwidthManagerConfigKey, value).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Disable the Cilium Bandwidth Manager, then re-run the install:",
+							"  set 'bandwidthManager.enabled: false' in the Cilium Helm values and run 'cilium upgrade'",
+							"Verify with: kubectl -n kube-system get configmap cilium-config -o jsonpath='{.data.enable-bandwidth-manager}'",
+						})),
+					automa.WithMetadata(meta))
+			}
+
+			return automa.SuccessReport(stp,
+				automa.WithDetail("Cilium Bandwidth Manager is disabled"),
+				automa.WithMetadata(meta))
 		})
 }

--- a/internal/workflows/steps/step_cilium_test.go
+++ b/internal/workflows/steps/step_cilium_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_bandwidthManagerEnabled covers the decision the StartCilium guard makes on
+// the cilium-config enable-bandwidth-manager value to assert the BN traffic
+// shaper precondition (Bandwidth Manager off, issue #741). The ConfigMap value is
+// the load-bearing contract, so these cases pin how it maps to enabled/disabled.
+func Test_bandwidthManagerEnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "true", value: "true", want: true},
+		{name: "mixed case true", value: "True", want: true},
+		{name: "true with whitespace", value: "  true ", want: true},
+		{name: "false", value: "false", want: false},
+		{name: "absent key (empty)", value: "", want: false},
+		{name: "disabled literal", value: "disabled", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, bandwidthManagerEnabled(tt.value))
+		})
+	}
+}

--- a/pkg/software/cilium_installer_test.go
+++ b/pkg/software/cilium_installer_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package software
+
+import (
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/internal/templates"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_ciliumConfigTemplate_HostLegacyRoutingAndLoadBalancer pins the
+// load-bearing Cilium ConfigMap values the BN traffic shaper depends on
+// (issue #741): host legacy routing must be enabled and the load-balancer mode
+// must stay DSR. These render statically (no template data), so a direct render
+// is enough to catch an accidental flip.
+func Test_ciliumConfigTemplate_HostLegacyRoutingAndLoadBalancer(t *testing.T) {
+	rendered, err := templates.Render(ciliumTemplateFile, struct {
+		SandboxDir string
+		MachineIP  string
+	}{
+		SandboxDir: "/opt/weaver",
+		MachineIP:  "10.0.0.1",
+	})
+	require.NoError(t, err)
+
+	// enable-host-legacy-routing: "true" — rendered from bpf.hostLegacyRouting.
+	require.Contains(t, rendered, "hostLegacyRouting: true")
+	require.NotContains(t, rendered, "hostLegacyRouting: false")
+
+	// loadBalancer.mode must remain DSR; BandwidthManager must not be enabled in
+	// the template (it stays at the Cilium default of Disabled).
+	require.Contains(t, rendered, "mode: dsr")
+	require.NotContains(t, rendered, "bandwidthManager")
+}


### PR DESCRIPTION
## Summary

Story 2.1 of the BN traffic-shaper static plane (epic #735). Applies the single Cilium ConfigMap knob the v4 design depends on and asserts its load-bearing precondition:

- **`enable-host-legacy-routing: "true"`** — flips `bpf.hostLegacyRouting` to `true` in the embedded `cilium-config` template. This forces traffic through the host legacy routing path so nft/tc in the host netns can set and preserve `skb->priority` across reboots (traffic-shaper v4 design §2, Decision 1).
- **Guard `BandwidthManager: Disabled`** — a new fail-fast step in `StartCilium()` asserts Bandwidth Manager is disabled. It is the only Cilium BPF writer of `skb->priority`, so the egress-priority survival guarantee is void if it is ever enabled (design §10, risk 18). The guard reads the `cilium-config` ConfigMap `enable-bandwidth-manager` key via the Kubernetes API (pure Go, no shell) following the `step_cluster_*` provider pattern, and fails with a clear `errorx.IllegalState` when enabled.

`loadBalancer.mode: dsr` and the implicitly-disabled Bandwidth Manager are left unchanged. **Fresh-install only** — the existing-cluster migration is the dedicated Story 2.10 (#781).

Also documents two conventions in `CLAUDE.md` that this change surfaced: prefer the kube API over shelling out to tool binaries, and trace the existing-cluster upgrade path when editing install-time templates.

## Changed files

| File | Change |
|---|---|
| `internal/templates/files/cilium/cilium-config.yaml` | `bpf.hostLegacyRouting: false` → `true` (+ rationale comment) |
| `internal/workflows/steps/step_cilium.go` | New `guardBandwidthManagerDisabled(provider)` step + `ciliumBandwidthManagerState` / `bandwidthManagerEnabled` helpers; wired into `StartCilium()` via `kube.ClientFromContext` |
| `internal/workflows/steps/const.go` | `BandwidthManagerStatus` report metadata key |
| `internal/workflows/steps/step_cilium_test.go` | Unit tests for `bandwidthManagerEnabled` |
| `pkg/software/cilium_installer_test.go` | Render test pinning `hostLegacyRouting: true`, `mode: dsr`, no `bandwidthManager` |
| `CLAUDE.md` | Two convention notes (kube-API-over-shell; existing-upgrade-path check) |

## Test plan

- [x] `task lint` — errorx lint 0 issues, gofmt clean
- [x] `go test ./pkg/software/ -run Test_ciliumConfigTemplate` (macOS) — passes
- [x] `GOOS=linux GOARCH=amd64 go vet -tags='!integration' ./internal/workflows/steps/ ./pkg/software/` — clean
- [ ] VM unit: `task vm:test:unit`
- [ ] VM integration: `task vm:test:integration TEST_NAME='^Test_StartCilium.*$'` — also confirm the live `cilium-config` `enable-bandwidth-manager` key name/value on a real cluster
- [ ] Manual UAT (fresh cluster): `solo-provisioner kube cluster install`; then
  - `kubectl -n kube-system get cm cilium-config -o jsonpath='{.data.enable-host-legacy-routing}'` → `true`
  - guard step passes (Bandwidth Manager disabled by default)

### Review guide

- **Template flip** — confirm `cilium-config.yaml` sets `hostLegacyRouting: true`; `loadBalancer.mode: dsr` unchanged; no `bandwidthManager` block added (stays Cilium-default Disabled).
- **Guard correctness** — `guardBandwidthManagerDisabled` reads `kube-system/cilium-config` `.data.enable-bandwidth-manager`; `""`/`"false"` → pass, `"true"` → fail-fast `IllegalState`; missing ConfigMap → `IllegalState`; API unreachable → `ExternalError`. Read-only, no rollback.
- **Pattern fidelity** — provider injected as `kube.ClientProviderFromContext`, resolved once in `Execute`, read in a named helper (mirrors `step_cluster_configmaps.go` / `step_health.go:144`). No shell exec (security-model.md "pure Go, no shell").
- **Idempotency** — fresh-install relies on existing `IsConfigured()` / `cilium status` skips; the guard is a read-only check, safe to re-run.

## Risks / rollback

- The template flip is **fresh-install only** by design (#781 owns the existing-cluster migration): on re-running an install, `configureCilium` and `installCiliumCNI` skip, so the live `enable-host-legacy-routing` stays `"false"`. The guard runs on the install path only and passes when Bandwidth Manager is disabled — it does not break existing installs.
- **Existing-cluster upgrade caveat (for BN team / #781):** the startup migration `CiliumAccelerationMigration` (v0.19.1) re-renders the *entire* `cilium-config` template and runs `cilium upgrade --values`, and `CiliumAgentRestartMigration` (v0.19.2) rolls the DaemonSet. So a cluster **still pre-0.19.x with non-`disabled` LB acceleration** that upgrades across that boundary would get `hostLegacyRouting: true` applied to the live datapath as a *side effect* of the acceleration migration — ahead of, and outside, #781's deliberate migration. Recent clusters (acceleration already `disabled`) are unaffected: those migrations no-op and the flip stays inert until #781.
- Rollback: revert the template line and remove the guard step; no persisted state is written by this PR.

Closes #741
