### PR TITLE
feat(cilium): migrate host-legacy-routing for existing clusters

### DIFF
--- a/cmd/cli/commands/root.go
+++ b/cmd/cli/commands/root.go
@@ -133,6 +133,7 @@ func RegisterMigrations() {
 	migration.Register(migration.ScopeStartup, workflows.NewLegacyBinaryMigration())
 	migration.Register(migration.ScopeStartup, workflows.NewCiliumAccelerationMigration())
 	migration.Register(migration.ScopeStartup, workflows.NewCiliumAgentRestartMigration())
+	migration.Register(migration.ScopeStartup, workflows.NewCiliumHostLegacyRoutingMigration())
 
 	// ── Block-node upgrade migrations (run during block node upgrade workflow) ─
 	migration.Register(migration.ScopeBlockNode, blocknode.NewVerificationStorageMigration())

--- a/internal/workflows/migration_cilium_host_legacy_routing.go
+++ b/internal/workflows/migration_cilium_host_legacy_routing.go
@@ -93,12 +93,6 @@ func (m *CiliumHostLegacyRoutingMigration) Execute(ctx context.Context, mctx *mi
 		logx.As().Debug().Msg("cilium host-legacy-routing migration: Cilium not installed (no cilium-config); skipping")
 		return nil
 	}
-	if strings.EqualFold(hlr, "true") {
-		logx.As().Info().Str(hostLegacyRoutingConfigKey, hlr).
-			Msg("cilium host-legacy-routing migration: nothing to do (already enabled)")
-		return nil
-	}
-
 	if strings.EqualFold(strings.TrimSpace(bm), "true") {
 		return errorx.IllegalState.New(
 			"Cilium Bandwidth Manager is enabled (%s=%q) — it is the only Cilium BPF writer of skb->priority "+
@@ -109,6 +103,11 @@ func (m *CiliumHostLegacyRoutingMigration) Execute(ctx context.Context, mctx *mi
 				"  set 'bandwidthManager.enabled: false' in the Cilium Helm values and run 'cilium upgrade'",
 				"Verify with: kubectl -n kube-system get configmap cilium-config -o jsonpath='{.data.enable-bandwidth-manager}'",
 			})
+	}
+	if strings.EqualFold(strings.TrimSpace(hlr), "true") {
+		logx.As().Info().Str(hostLegacyRoutingConfigKey, hlr).
+			Msg("cilium host-legacy-routing migration: nothing to do (already enabled)")
+		return nil
 	}
 
 	configPath, err := reconfigureCiliumConfig()

--- a/internal/workflows/migration_cilium_host_legacy_routing.go
+++ b/internal/workflows/migration_cilium_host_legacy_routing.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// migration_cilium_host_legacy_routing.go sets enable-host-legacy-routing: "true"
+// in the Cilium ConfigMap on already-provisioned clusters.
+//
+// PR #787 (#741) set bpf.hostLegacyRouting=true in the embedded cilium-config
+// template so new installs pick up the setting automatically. This migration
+// closes the gap for existing clusters: on the first provisioner run after
+// upgrading across the 0.21.0 version boundary it re-renders cilium-config.yaml
+// and runs `cilium upgrade` so the live cluster adopts enable-host-legacy-routing=true.
+//
+// The BN traffic shaper requires skb->priority to be preserved on the host
+// legacy routing path. Cilium's Bandwidth Manager is the only other Cilium BPF
+// writer of skb->priority, so the migration fails fast when Bandwidth Manager is
+// enabled — keeping it on would void the traffic shaper's egress-priority guarantee.
+//
+// Registered in cmd/cli/commands/root.go RegisterMigrations() under
+// migration.ScopeStartup.
+
+package workflows
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/kube"
+	"github.com/hashgraph/solo-weaver/internal/migration"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// ciliumHostLegacyRoutingMinVersion is the CLI release that ships
+// bpf.hostLegacyRouting=true in the embedded cilium-config template (PR #787)
+// together with this migration. The migration applies when upgrading from a
+// version below this boundary to this version or later.
+const ciliumHostLegacyRoutingMinVersion = "0.21.0"
+
+// hostLegacyRoutingConfigKey is the cilium-config data key rendered from
+// bpf.hostLegacyRouting. "true" enables host legacy routing; absent or any other
+// value disables it.
+const hostLegacyRoutingConfigKey = "enable-host-legacy-routing"
+
+// ciliumBandwidthManagerKey is the cilium-config data key for the Bandwidth
+// Manager flag. Duplicated here (also defined in internal/workflows/steps) to
+// keep the migration self-contained with no cross-package dependency.
+const ciliumBandwidthManagerKey = "enable-bandwidth-manager"
+
+// readHostLegacyRoutingState is a seam so tests can stub the ConfigMap read.
+var readHostLegacyRoutingState = defaultReadHostLegacyRoutingState
+
+// CiliumHostLegacyRoutingMigration re-renders cilium-config.yaml and runs
+// `cilium upgrade` so already-provisioned clusters adopt
+// enable-host-legacy-routing=true required by the BN traffic shaper.
+type CiliumHostLegacyRoutingMigration struct {
+	migration.CLIVersionMigration
+}
+
+// NewCiliumHostLegacyRoutingMigration constructs the migration.
+func NewCiliumHostLegacyRoutingMigration() *CiliumHostLegacyRoutingMigration {
+	return &CiliumHostLegacyRoutingMigration{
+		CLIVersionMigration: migration.NewCLIVersionMigration(
+			"cilium-host-legacy-routing-v"+ciliumHostLegacyRoutingMinVersion,
+			"Re-render cilium-config and run 'cilium upgrade' so existing clusters adopt "+
+				"enable-host-legacy-routing=true required by the BN traffic shaper",
+			ciliumHostLegacyRoutingMinVersion,
+		),
+	}
+}
+
+// Execute re-renders cilium-config.yaml from the updated template and applies it
+// with `cilium upgrade --values <config> --wait`.
+//
+// It is idempotent: it no-ops when the cluster is unreachable, when Cilium is not
+// yet installed, or when enable-host-legacy-routing is already "true". It fails
+// fast if Bandwidth Manager is enabled — Bandwidth Manager is the only Cilium BPF
+// writer of skb->priority and its presence voids the traffic shaper's
+// egress-priority guarantee.
+func (m *CiliumHostLegacyRoutingMigration) Execute(ctx context.Context, mctx *migration.Context) error {
+	if !kubernetesInstalled() {
+		logx.As().Debug().Msg("cilium host-legacy-routing migration: Kubernetes not installed on this host; skipping")
+		return nil
+	}
+
+	installed, hlr, bm, err := readHostLegacyRoutingState(ctx)
+	if err != nil {
+		logx.As().Debug().Err(err).
+			Msg("cilium host-legacy-routing migration: Kubernetes API not reachable; skipping")
+		return nil
+	}
+	if !installed {
+		logx.As().Debug().Msg("cilium host-legacy-routing migration: Cilium not installed (no cilium-config); skipping")
+		return nil
+	}
+	if strings.EqualFold(hlr, "true") {
+		logx.As().Info().Str(hostLegacyRoutingConfigKey, hlr).
+			Msg("cilium host-legacy-routing migration: nothing to do (already enabled)")
+		return nil
+	}
+
+	if strings.EqualFold(strings.TrimSpace(bm), "true") {
+		return errorx.IllegalState.New(
+			"Cilium Bandwidth Manager is enabled (%s=%q) — it is the only Cilium BPF writer of skb->priority "+
+				"and would void the BN traffic shaper's egress-priority guarantee; it must be disabled before this migration can run",
+			ciliumBandwidthManagerKey, bm).
+			WithProperty(models.ErrPropertyResolution, []string{
+				"Disable the Cilium Bandwidth Manager, then re-run the provisioner:",
+				"  set 'bandwidthManager.enabled: false' in the Cilium Helm values and run 'cilium upgrade'",
+				"Verify with: kubectl -n kube-system get configmap cilium-config -o jsonpath='{.data.enable-bandwidth-manager}'",
+			})
+	}
+
+	configPath, err := reconfigureCiliumConfig()
+	if err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to re-render cilium-config.yaml")
+	}
+
+	logx.As().Info().
+		Str("config", configPath).
+		Str("from", hlr).
+		Str("to", "true").
+		Msg("Applying cilium-config (enable-host-legacy-routing=true) to existing cluster via 'cilium upgrade'")
+
+	upgrade := []string{
+		fmt.Sprintf("/usr/bin/sudo %s/cilium upgrade --values %s --wait",
+			models.Paths().SandboxBinDir, configPath),
+	}
+	if _, err := runShell(upgrade, ""); err != nil {
+		return errorx.IllegalState.Wrap(err, "failed to run 'cilium upgrade' to apply host-legacy-routing")
+	}
+
+	return nil
+}
+
+// Rollback is a no-op: re-running a known-good provisioner version re-applies the
+// desired template. We intentionally do not revert host-legacy-routing — it is
+// the required posture for the BN traffic shaper.
+func (m *CiliumHostLegacyRoutingMigration) Rollback(ctx context.Context, mctx *migration.Context) error {
+	logx.As().Warn().Msg("Rollback for cilium host-legacy-routing migration is not supported")
+	return nil
+}
+
+// defaultReadHostLegacyRoutingState reports whether Cilium is installed (its
+// cilium-config ConfigMap exists) and, if so, the enable-host-legacy-routing and
+// enable-bandwidth-manager values from the ConfigMap. A non-nil error means the
+// cluster/API is not reachable.
+func defaultReadHostLegacyRoutingState(ctx context.Context) (installed bool, hostLegacyRouting string, bandwidthManager string, err error) {
+	kc, err := kube.NewClient()
+	if err != nil {
+		return false, "", "", err
+	}
+
+	exists, err := kc.ResourceExists(ctx, "v1", "ConfigMap", "kube-system", "cilium-config")
+	if err != nil {
+		return false, "", "", err
+	}
+	if !exists {
+		return false, "", "", nil
+	}
+
+	hlr, err := kc.GetResourceNestedString(ctx, "v1", "ConfigMap", "kube-system", "cilium-config", "data", hostLegacyRoutingConfigKey)
+	if err != nil {
+		return true, "", "", err
+	}
+
+	bm, err := kc.GetResourceNestedString(ctx, "v1", "ConfigMap", "kube-system", "cilium-config", "data", ciliumBandwidthManagerKey)
+	if err != nil {
+		return true, hlr, "", err
+	}
+
+	return true, hlr, bm, nil
+}

--- a/internal/workflows/migration_cilium_host_legacy_routing_test.go
+++ b/internal/workflows/migration_cilium_host_legacy_routing_test.go
@@ -133,6 +133,17 @@ func TestCiliumHostLegacyRoutingMigration_Execute(t *testing.T) {
 		assert.False(t, ran, "cilium upgrade must not run when Bandwidth Manager is enabled")
 	})
 
+	t.Run("fails fast when Bandwidth Manager is enabled even if host-legacy-routing is already true", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		stateReturns(true, "true", "true", nil)
+		trackUpgrade(&cmd, &ran)
+		err := m.Execute(context.Background(), mctx)
+		require.Error(t, err, "must fail fast when Bandwidth Manager is enabled")
+		assert.Contains(t, err.Error(), "Bandwidth Manager is enabled")
+		assert.False(t, ran, "cilium upgrade must not run when Bandwidth Manager is enabled")
+	})
+
 	t.Run("runs cilium upgrade when host-legacy-routing is absent", func(t *testing.T) {
 		var ran bool
 		var cmd string

--- a/internal/workflows/migration_cilium_host_legacy_routing_test.go
+++ b/internal/workflows/migration_cilium_host_legacy_routing_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package workflows
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCiliumHostLegacyRoutingMigration_Metadata(t *testing.T) {
+	m := NewCiliumHostLegacyRoutingMigration()
+	assert.Equal(t, "cilium-host-legacy-routing-v"+ciliumHostLegacyRoutingMinVersion, m.ID())
+	assert.Contains(t, m.Description(), "enable-host-legacy-routing=true")
+}
+
+func TestCiliumHostLegacyRoutingMigration_Applies(t *testing.T) {
+	m := NewCiliumHostLegacyRoutingMigration()
+
+	tests := []struct {
+		name      string
+		installed string
+		current   string
+		want      bool
+	}{
+		{"upgrade across boundary applies", "0.20.0", ciliumHostLegacyRoutingMinVersion, true},
+		{"upgrade from below to above applies", "0.19.2", "0.22.0", true},
+		{"fresh install does not apply", "", ciliumHostLegacyRoutingMinVersion, false},
+		{"already past boundary does not apply", ciliumHostLegacyRoutingMinVersion, "0.22.0", false},
+		{"below boundary on both sides does not apply", "0.19.0", "0.20.0", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := m.Applies(newMctx(tc.installed, tc.current))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestCiliumHostLegacyRoutingMigration_Execute(t *testing.T) {
+	origK8s := kubernetesInstalled
+	origState := readHostLegacyRoutingState
+	origReconfigure := reconfigureCiliumConfig
+	origShell := runShell
+	t.Cleanup(func() {
+		kubernetesInstalled = origK8s
+		readHostLegacyRoutingState = origState
+		reconfigureCiliumConfig = origReconfigure
+		runShell = origShell
+	})
+
+	m := NewCiliumHostLegacyRoutingMigration()
+	mctx := newMctx("0.20.0", ciliumHostLegacyRoutingMinVersion)
+
+	// trackUpgrade records whether `cilium upgrade` was shelled out and its command.
+	trackUpgrade := func(cmd *string, ran *bool) {
+		runShell = func(scripts []string, _ string) (string, error) {
+			joined := strings.Join(scripts, " ")
+			if strings.Contains(joined, "cilium upgrade") {
+				*ran = true
+				*cmd = joined
+			}
+			return "", nil
+		}
+	}
+	stateReturns := func(installed bool, hlr, bm string, err error) {
+		readHostLegacyRoutingState = func(context.Context) (bool, string, string, error) {
+			return installed, hlr, bm, err
+		}
+	}
+
+	t.Run("skips when Kubernetes is not installed", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		kubernetesInstalled = func() bool { return false }
+		stateReturns(true, "", "", nil)
+		trackUpgrade(&cmd, &ran)
+		require.NoError(t, m.Execute(context.Background(), mctx))
+		assert.False(t, ran, "must not run before Kubernetes is installed")
+	})
+
+	// Remaining cases assume Kubernetes is present.
+	kubernetesInstalled = func() bool { return true }
+
+	t.Run("skips when Cilium is not installed", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		stateReturns(false, "", "", nil)
+		trackUpgrade(&cmd, &ran)
+		require.NoError(t, m.Execute(context.Background(), mctx))
+		assert.False(t, ran, "must not run before Cilium is installed")
+	})
+
+	t.Run("no-ops when the cluster is unreachable", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		stateReturns(false, "", "", assert.AnError)
+		trackUpgrade(&cmd, &ran)
+		require.NoError(t, m.Execute(context.Background(), mctx))
+		assert.False(t, ran, "must not run when the cluster is unreachable")
+	})
+
+	t.Run("skips upgrade when host-legacy-routing already true", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		stateReturns(true, "true", "", nil)
+		trackUpgrade(&cmd, &ran)
+		require.NoError(t, m.Execute(context.Background(), mctx))
+		assert.False(t, ran, "cilium upgrade must not run when already enabled")
+	})
+
+	t.Run("skips upgrade when host-legacy-routing already True (case-insensitive)", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		stateReturns(true, "True", "", nil)
+		trackUpgrade(&cmd, &ran)
+		require.NoError(t, m.Execute(context.Background(), mctx))
+		assert.False(t, ran, "cilium upgrade must not run when already enabled (case-insensitive)")
+	})
+
+	t.Run("fails fast when Bandwidth Manager is enabled", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		stateReturns(true, "", "true", nil)
+		trackUpgrade(&cmd, &ran)
+		err := m.Execute(context.Background(), mctx)
+		require.Error(t, err, "must fail fast when Bandwidth Manager is enabled")
+		assert.Contains(t, err.Error(), "Bandwidth Manager is enabled")
+		assert.False(t, ran, "cilium upgrade must not run when Bandwidth Manager is enabled")
+	})
+
+	t.Run("runs cilium upgrade when host-legacy-routing is absent", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		stateReturns(true, "", "", nil)
+		reconfigureCiliumConfig = func() (string, error) {
+			return "/opt/solo/weaver/sandbox/etc/weaver/cilium-config.yaml", nil
+		}
+		trackUpgrade(&cmd, &ran)
+		require.NoError(t, m.Execute(context.Background(), mctx))
+		require.True(t, ran, "cilium upgrade must run when host-legacy-routing is absent")
+		assert.Contains(t, cmd, "cilium upgrade")
+		assert.Contains(t, cmd, "--values")
+		assert.Contains(t, cmd, "--wait")
+	})
+
+	t.Run("runs cilium upgrade when host-legacy-routing is false", func(t *testing.T) {
+		var ran bool
+		var cmd string
+		stateReturns(true, "false", "", nil)
+		reconfigureCiliumConfig = func() (string, error) {
+			return "/opt/solo/weaver/sandbox/etc/weaver/cilium-config.yaml", nil
+		}
+		trackUpgrade(&cmd, &ran)
+		require.NoError(t, m.Execute(context.Background(), mctx))
+		require.True(t, ran, "cilium upgrade must run when host-legacy-routing is false")
+		assert.Contains(t, cmd, "cilium upgrade")
+		assert.Contains(t, cmd, "--values")
+		assert.Contains(t, cmd, "--wait")
+	})
+}


### PR DESCRIPTION
## Description

PR #787 set `bpf.hostLegacyRouting=true` in the embedded `cilium-config` template so
new installs pick up `enable-host-legacy-routing: "true"` automatically. This PR closes
the gap for already-provisioned clusters by adding a startup migration that, on the first
upgrade across the 0.21.0 version boundary, re-renders `cilium-config.yaml` and runs
`cilium upgrade` so the live cluster adopts the setting without a reinstall.

The migration follows the `migration_cilium_acceleration.go` pattern:
- **Idempotent** — no-ops when `enable-host-legacy-routing` is already `"true"` or when Kubernetes/Cilium is not installed.
- **Fail-fast guard** — errors if `enable-bandwidth-manager` is `"true"`. Bandwidth Manager is the only Cilium BPF writer of `skb->priority`; enabling it voids the BN traffic shaper's egress-priority guarantee.
- **No rollback** — host-legacy-routing is the required posture for the BN traffic shaper.

### Files changed

| File | Change |
|------|--------|
| `internal/workflows/migration_cilium_host_legacy_routing.go` | New `CiliumHostLegacyRoutingMigration` (v0.21.0 boundary) |
| `internal/workflows/migration_cilium_host_legacy_routing_test.go` | Unit tests: applies boundary, idempotency, BM guard, upgrade execution |
| `cmd/cli/commands/root.go` | Register new migration in `RegisterMigrations()` |

### Review guide

**Code review checklist**
- [ ] `migration_cilium_host_legacy_routing.go:40` — version boundary `0.21.0` matches the release that ships PR #787; bump if the release number changes before this merges.
- [ ] `migration_cilium_host_legacy_routing.go:84` — idempotency check uses `strings.EqualFold` (case-insensitive); confirm that covers all values Cilium may write (`"true"`, `"True"`, `"TRUE"`).
- [ ] `migration_cilium_host_legacy_routing.go:90` — BM guard fires before `reconfigureCiliumConfig()` so no upgrade is attempted when the precondition is violated.
- [ ] `migration_cilium_host_legacy_routing.go:56` — `readHostLegacyRoutingState` var is the only new package-level seam; `kubernetesInstalled`, `runShell`, and `reconfigureCiliumConfig` are reused from `migration_cilium_acceleration.go` (same package) — confirm no name collision.
- [ ] `cmd/cli/commands/root.go:135` — migration is appended after `NewCiliumAgentRestartMigration()` so version-ordered sequencing is preserved.

**Unit tests**
```bash
# Run on a Linux host or in CI (internal/workflows imports a Linux-only package):
go test -v -race -cover -tags='!integration' ./internal/workflows/ -run TestCiliumHostLegacyRouting

# Or via task (runs all unit tests):
task test:unit
```

**Manual UAT** (requires an existing BN cluster provisioned with `solo-provisioner < 0.21.0`)

1. Confirm host-legacy-routing is absent or false before the upgrade:
   ```bash
   kubectl -n kube-system get configmap cilium-config \
     -o jsonpath='{.data.enable-host-legacy-routing}'
   # expected: empty or "false"
   ```
2. Confirm Bandwidth Manager is disabled (precondition):
   ```bash
   kubectl -n kube-system get configmap cilium-config \
     -o jsonpath='{.data.enable-bandwidth-manager}'
   # expected: empty or "false"
   ```
3. Install the new `solo-provisioner` (>= 0.21.0) and run any provisioner command to trigger startup migrations:
   ```bash
   sudo solo-provisioner version
   ```
4. Verify the migration applied:
   ```bash
   kubectl -n kube-system get configmap cilium-config \
     -o jsonpath='{.data.enable-host-legacy-routing}'
   # expected: "true"
   ```
5. Run again — verify it is a no-op (no `cilium upgrade` invoked, log shows "nothing to do"):
   ```bash
   sudo solo-provisioner version 2>&1 | grep host-legacy-routing
   # expected: "nothing to do (already enabled)"
   ```
6. **BM guard UAT** (optional, on a test cluster): temporarily set `enable-bandwidth-manager: "true"` in the ConfigMap and re-run — the provisioner should exit with an error naming the Bandwidth Manager.

**Risks / rollback**
- `cilium upgrade` re-renders the full template and rolls the Cilium DaemonSet; on a loaded cluster this may cause a brief CNI interruption. The existing `--wait` flag ensures the provisioner does not return until the rollout is healthy.
- Rollback: downgrade `solo-provisioner` to < 0.21.0. The ConfigMap change is benign if left in place — host-legacy-routing has no negative side-effects when the traffic shaper is not deployed.

### Related Issues

* Closes #781
