### PR TITLE
feat(daemon): scaffold traffic_shaper monitor skeleton in solo-provisioner-daemon

### DIFF
--- a/internal/daemon/blocknode/component.go
+++ b/internal/daemon/blocknode/component.go
@@ -11,16 +11,33 @@ type ComponentConfig struct {
 	TrafficShaperEnabled bool
 }
 
-// ComponentResult contains the monitors built by NewComponent.
+// ComponentResult contains the monitors built by NewComponent and a reference
+// to the TrafficShaperMonitor (when enabled) so daemon.go can wire the HTTP
+// handler with the per-component StatusTracker closure after the component is
+// assembled.
 type ComponentResult struct {
+	// Monitors is the ordered slice of monitors to run under the supervisor.
 	Monitors []daemonkit.MonitorRunner
+
+	// TrafficShaperMonitor is non-nil when the traffic-shaper monitor is enabled.
+	// daemon.go uses this to construct BlockNodeHandler with the correct
+	// trafficShaperStateFn closure after the component's StatusTracker is created.
+	TrafficShaperMonitor *TrafficShaperMonitor
 }
 
-// NewComponent constructs all enabled monitors for the block-node component.
+// NewComponent constructs all enabled monitors for the block-node component
+// and returns them alongside any references needed for HTTP handler wiring.
 func NewComponent(cfg ComponentConfig) (ComponentResult, error) {
 	var monitors []daemonkit.MonitorRunner
+
+	var tsm *TrafficShaperMonitor
 	if cfg.TrafficShaperEnabled {
-		monitors = append(monitors, &trafficShaperMonitor{})
+		tsm = NewTrafficShaperMonitor()
+		monitors = append(monitors, tsm)
 	}
-	return ComponentResult{Monitors: monitors}, nil
+
+	return ComponentResult{
+		Monitors:             monitors,
+		TrafficShaperMonitor: tsm,
+	}, nil
 }

--- a/internal/daemon/blocknode/handler.go
+++ b/internal/daemon/blocknode/handler.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package blocknode
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/automa-saga/daemonkit"
+)
+
+// TrafficShaperStatusResponse is the view returned by
+// GET /block_node/traffic_shaper/status. For #746 it carries only the
+// supervisor-level health of the monitor goroutine (running/backoff/stopped).
+// Per-subsystem and degraded-state reporting is added by #750.
+type TrafficShaperStatusResponse struct {
+	Monitor daemonkit.MonitorState `json:"monitor"`
+}
+
+// BlockNodeHandler implements daemonkit.ComponentHandler for all block-node
+// HTTP routes under the /block_node/ prefix.
+//
+// To add a new monitor for the block-node component:
+//  1. Add a field for the monitor and its state func to this struct.
+//  2. Register the new route(s) in RegisterRoutes.
+//  3. Implement the handler method(s) on *BlockNodeHandler.
+type BlockNodeHandler struct {
+	// mon is the traffic-shaper monitor. Nil when the monitor is disabled;
+	// the traffic-shaper routes return 503 in that case.
+	mon *TrafficShaperMonitor
+
+	// trafficShaperStateFn returns the supervisor-level health of the
+	// traffic-shaper monitor goroutine (from its StatusTracker). May be nil
+	// when mon is nil.
+	trafficShaperStateFn func() daemonkit.MonitorState
+}
+
+// NewBlockNodeHandler constructs a BlockNodeHandler. mon and trafficShaperStateFn
+// may be nil when the traffic-shaper monitor is disabled.
+func NewBlockNodeHandler(mon *TrafficShaperMonitor, trafficShaperStateFn func() daemonkit.MonitorState) *BlockNodeHandler {
+	return &BlockNodeHandler{mon: mon, trafficShaperStateFn: trafficShaperStateFn}
+}
+
+// RegisterRoutes implements daemonkit.ComponentHandler.
+// All routes are prefixed with /block_node/.
+//
+// Current routes:
+//
+//	GET /block_node/traffic_shaper/status — traffic-shaper monitor health
+func (h *BlockNodeHandler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /block_node/traffic_shaper/status", h.handleTrafficShaperStatus)
+}
+
+// handleTrafficShaperStatus returns the supervisor-level health of the
+// traffic-shaper monitor (running/backoff/stopped). Returns 503 when the
+// monitor is disabled.
+func (h *BlockNodeHandler) handleTrafficShaperStatus(w http.ResponseWriter, _ *http.Request) {
+	if h.mon == nil {
+		writeError(w, http.StatusServiceUnavailable, "traffic-shaper monitor not enabled")
+		return
+	}
+
+	var state daemonkit.MonitorState
+	if h.trafficShaperStateFn != nil {
+		state = h.trafficShaperStateFn()
+	}
+
+	writeJSON(w, http.StatusOK, TrafficShaperStatusResponse{Monitor: state})
+}
+
+// writeJSON serialises v as JSON and writes it with the given status code.
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeError writes a JSON {"error":"..."} body with the given status code.
+func writeError(w http.ResponseWriter, code int, msg string) {
+	type errorBody struct {
+		Error string `json:"error"`
+	}
+	writeJSON(w, code, errorBody{Error: msg})
+}

--- a/internal/daemon/blocknode/handler_test.go
+++ b/internal/daemon/blocknode/handler_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package blocknode
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/automa-saga/daemonkit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlockNodeHandler_TrafficShaperStatus_Enabled verifies the status route
+// returns 200 with the supervisor-reported monitor state when the monitor is
+// enabled.
+func TestBlockNodeHandler_TrafficShaperStatus_Enabled(t *testing.T) {
+	mon := NewTrafficShaperMonitor()
+	stateFn := func() daemonkit.MonitorState { return daemonkit.MonitorState{State: "running"} }
+	h := NewBlockNodeHandler(mon, stateFn)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/block_node/traffic_shaper/status", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp TrafficShaperStatusResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "running", resp.Monitor.State)
+}
+
+// TestBlockNodeHandler_TrafficShaperStatus_Disabled verifies the status route
+// returns 503 when the monitor is not enabled (nil monitor).
+func TestBlockNodeHandler_TrafficShaperStatus_Disabled(t *testing.T) {
+	h := NewBlockNodeHandler(nil, nil)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/block_node/traffic_shaper/status", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Contains(t, body.Error, "not enabled")
+}

--- a/internal/daemon/blocknode/traffic_shaper_monitor.go
+++ b/internal/daemon/blocknode/traffic_shaper_monitor.go
@@ -4,26 +4,141 @@ package blocknode
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/automa-saga/logx"
 )
 
-// trafficShaperMonitor is a stub implementation of daemonkit.MonitorRunner for the
-// block-node traffic-shaper workflow.
+// Per-responsibility back-off bounds. A fault in one subsystem (pod watcher or
+// statusz poll loop) is retried in place with exponential back-off rather than
+// being propagated to Run — so a subsystem fault never kills the monitor
+// goroutine (and thus never trips the top-level supervisor or the daemon
+// process). Issue #746 specifies a 5 s floor; the upgrade monitor's hand-rolled
+// pattern (consensus/upgrade_monitor.go) uses the same factor/cap shape.
 //
-// It blocks on ctx to keep the supervised goroutine alive, logging once on
-// start so operators can confirm the component is running.
-type trafficShaperMonitor struct{}
+// Initial/Max are vars (not consts) only so tests can shrink them to avoid
+// real-time waits; production never reassigns them.
+var (
+	responsibilityBackoffInitial = 5 * time.Second
+	responsibilityBackoffMax     = 5 * time.Minute
+)
+
+const responsibilityBackoffFactor = 2.0
+
+// TrafficShaperMonitor is the daemonkit.MonitorRunner skeleton for the
+// block-node traffic-shaper workflow. It owns two long-lived responsibilities
+// that run concurrently under Run:
+//
+//   - the pod-lifecycle watcher (resolves host-side veths and installs/rebinds
+//     ingress HTB qdiscs — implemented in #747/#748/#749), and
+//   - the statusz poll loop (diffs statusz membership against live nft sets and
+//     applies deltas — implemented in #751/#752/#754/#755).
+//
+// This story (#746) delivers only the supervision skeleton: both responsibility
+// bodies are stubs. Each responsibility is independently retried with
+// exponential back-off so a fault in one cannot stop the other or crash the
+// daemon.
+type TrafficShaperMonitor struct{}
+
+// NewTrafficShaperMonitor constructs a TrafficShaperMonitor.
+func NewTrafficShaperMonitor() *TrafficShaperMonitor { return &TrafficShaperMonitor{} }
 
 // Name implements daemonkit.MonitorRunner.
-func (m *trafficShaperMonitor) Name() string { return "bn-traffic-shaper-monitor" }
+func (m *TrafficShaperMonitor) Name() string { return "bn-traffic-shaper-monitor" }
 
-// Run implements daemonkit.MonitorRunner. Blocks until ctx is cancelled.
-func (m *trafficShaperMonitor) Run(ctx context.Context) error {
+// Run implements daemonkit.MonitorRunner. It starts the pod-lifecycle watcher
+// and the statusz poll loop concurrently and blocks until ctx is cancelled. It
+// always returns nil: subsystem faults are absorbed by superviseResponsibility,
+// so the only way Run returns is a clean ctx cancellation.
+func (m *TrafficShaperMonitor) Run(ctx context.Context) error {
 	logx.As().Info().
-		Str("reason", "MonitorStubRunning").
+		Str("reason", "TrafficShaperMonitorStarting").
 		Str("monitor", m.Name()).
-		Msg("block-node traffic-shaper monitor not yet implemented — stub running")
+		Msg("block-node traffic-shaper monitor starting")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		m.superviseResponsibility(ctx, "pod-watcher", m.runPodWatcher)
+	}()
+	go func() {
+		defer wg.Done()
+		m.superviseResponsibility(ctx, "statusz-poll", m.runStatuszPoll)
+	}()
+	wg.Wait()
+	return nil
+}
+
+// superviseResponsibility runs fn in a retry loop. A non-nil error from fn is
+// logged and retried after an exponential back-off (5 s → 5 min); the error is
+// never returned, so one responsibility faulting cannot stop the other or crash
+// the monitor. The back-off resets after fn runs without error. The loop exits
+// only when ctx is cancelled.
+func (m *TrafficShaperMonitor) superviseResponsibility(ctx context.Context, name string, fn func(context.Context) error) {
+	backoff := responsibilityBackoffInitial
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		err := fn(ctx)
+		if ctx.Err() != nil {
+			// Clean shutdown — ctx cancellation is not a fault.
+			return
+		}
+		if err == nil {
+			// Responsibility returned without ctx being cancelled; reset the
+			// back-off and re-enter immediately.
+			backoff = responsibilityBackoffInitial
+			continue
+		}
+
+		logx.As().Warn().Err(err).
+			Str("reason", "TrafficShaperResponsibilityFaulted").
+			Str("monitor", m.Name()).
+			Str("responsibility", name).
+			Dur("retry_in", backoff).
+			Msg("traffic-shaper responsibility faulted — retrying after back-off")
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff = minDuration(time.Duration(float64(backoff)*responsibilityBackoffFactor), responsibilityBackoffMax)
+	}
+}
+
+// runPodWatcher is the pod-lifecycle watcher responsibility. Stub for #746; the
+// real implementation lands in #747 (veth resolution), #748 (HTB install) and
+// #749 (rebind/cleanup).
+func (m *TrafficShaperMonitor) runPodWatcher(ctx context.Context) error {
+	logx.As().Info().
+		Str("reason", "TrafficShaperPodWatcherStub").
+		Str("monitor", m.Name()).
+		Msg("pod-lifecycle watcher not yet implemented — stub running")
 	<-ctx.Done()
 	return nil
+}
+
+// runStatuszPoll is the statusz poll-loop responsibility. Stub for #746; the
+// real implementation lands in #751 (statusz client), #752 (category→policy
+// diff), #754 (membership apply) and #755 (bootstrap/outage policy).
+func (m *TrafficShaperMonitor) runStatuszPoll(ctx context.Context) error {
+	logx.As().Info().
+		Str("reason", "TrafficShaperStatuszPollStub").
+		Str("monitor", m.Name()).
+		Msg("statusz poll loop not yet implemented — stub running")
+	<-ctx.Done()
+	return nil
+}
+
+// minDuration returns the smaller of a and b.
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/internal/daemon/blocknode/traffic_shaper_monitor_test.go
+++ b/internal/daemon/blocknode/traffic_shaper_monitor_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package blocknode
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTrafficShaperMonitor_RunReturnsOnContextCancel verifies Run starts both
+// responsibilities and returns nil promptly once ctx is cancelled.
+func TestTrafficShaperMonitor_RunReturnsOnContextCancel(t *testing.T) {
+	m := NewTrafficShaperMonitor()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- m.Run(ctx) }()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after ctx cancellation")
+	}
+}
+
+// TestSuperviseResponsibility_RetriesFaultsWithoutPropagating verifies that a
+// faulting responsibility is retried with back-off and never crashes the
+// supervisor: superviseResponsibility returns only when ctx is cancelled, and a
+// returned error is swallowed (not propagated).
+func TestSuperviseResponsibility_RetriesFaultsWithoutPropagating(t *testing.T) {
+	origInitial, origMax := responsibilityBackoffInitial, responsibilityBackoffMax
+	responsibilityBackoffInitial = time.Millisecond
+	responsibilityBackoffMax = 2 * time.Millisecond
+	t.Cleanup(func() {
+		responsibilityBackoffInitial = origInitial
+		responsibilityBackoffMax = origMax
+	})
+
+	m := NewTrafficShaperMonitor()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var calls atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		m.superviseResponsibility(ctx, "test", func(context.Context) error {
+			// Fault on every invocation; cancel after a few retries so the loop
+			// observes ctx.Err() and exits cleanly.
+			if calls.Add(1) >= 3 {
+				cancel()
+			}
+			return errors.New("transient subsystem fault")
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("superviseResponsibility did not return after ctx cancellation")
+	}
+
+	require.GreaterOrEqual(t, calls.Load(), int32(3),
+		"faulting responsibility should be retried multiple times")
+}
+
+// TestSuperviseResponsibility_ResetsBackoffAndExitsOnCancel verifies the clean
+// path: a responsibility that returns without error (and without ctx being
+// cancelled) is re-entered immediately, and the loop exits once ctx is done.
+func TestSuperviseResponsibility_ResetsBackoffAndExitsOnCancel(t *testing.T) {
+	m := NewTrafficShaperMonitor()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var calls atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		m.superviseResponsibility(ctx, "test", func(context.Context) error {
+			if calls.Add(1) >= 3 {
+				cancel()
+			}
+			return nil
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("superviseResponsibility did not return after ctx cancellation")
+	}
+
+	require.GreaterOrEqual(t, calls.Load(), int32(3))
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -118,12 +118,24 @@ func NewFromConfig(paths models.WeaverPaths, cfg DaemonConfig) (*Daemon, error) 
 			return nil, err
 		}
 		if len(result.Monitors) > 0 {
-			components = append(components, component{
+			comp := component{
 				name:     "block-node",
 				monitors: result.Monitors,
 				probe:    nil,
 				tracker:  daemonkit.NewStatusTracker(),
-			})
+			}
+			components = append(components, comp)
+
+			if result.TrafficShaperMonitor != nil {
+				// trafficShaperStateFn captures comp.tracker by reference — safe
+				// because comp is appended to the slice and never moved after
+				// this point.
+				trafficShaperStateFn := func() daemonkit.MonitorState {
+					return comp.tracker.Snapshot()[result.TrafficShaperMonitor.Name()]
+				}
+				componentHandlers = append(componentHandlers,
+					blocknode.NewBlockNodeHandler(result.TrafficShaperMonitor, trafficShaperStateFn))
+			}
 		}
 	}
 

--- a/internal/templates/files/weaver/solo-provisioner-daemon.service
+++ b/internal/templates/files/weaver/solo-provisioner-daemon.service
@@ -16,7 +16,7 @@ RestartSec=5s
 # via setuid; NoNewPrivileges=true would prevent that.
 PrivateTmp=true
 ProtectSystem=strict
-ReadWritePaths=/opt/solo /opt/hgcapp
+ReadWritePaths=/opt/solo{{range .ExtraReadWritePaths}} {{.}}{{end}}
 
 [Install]
 WantedBy=multi-user.target

--- a/internal/workflows/daemon.go
+++ b/internal/workflows/daemon.go
@@ -55,6 +55,18 @@ func loadComponentSpecs(paths models.WeaverPaths) ([]steps.DaemonComponentSpec, 
 	return buildComponentSpecs(cfg, paths), nil
 }
 
+// daemonExtraReadWritePaths returns the set of host paths that must be added to
+// the service unit's ReadWritePaths beyond /opt/solo. Each component appends its
+// own data root only when that component is enabled — the paths must exist before
+// systemd sets up the mount namespace or the service fails with status=226/NAMESPACE.
+func daemonExtraReadWritePaths(cfg daemon.DaemonConfig) []string {
+	var paths []string
+	if cn := cfg.Components.ConsensusNode; cn != nil && cn.Enabled {
+		paths = append(paths, "/opt/hgcapp")
+	}
+	return paths
+}
+
 // NewDaemonServiceInstallWorkflow provisions the full daemon stack. The step
 // list is built dynamically from cfg so that only the preflight and RBAC steps
 // relevant to the enabled components are included:
@@ -94,7 +106,7 @@ func NewDaemonServiceInstallWorkflow(cfg daemon.DaemonConfig, daemonSrc steps.Da
 	}
 
 	wfSteps = append(wfSteps,
-		steps.InstallDaemonServiceStep(paths),
+		steps.InstallDaemonServiceStep(paths, daemonExtraReadWritePaths(cfg)),
 		//steps.AddOperatorToWeaverGroupStep(),
 		steps.CheckDaemonServiceStep(paths, paths.DaemonSockPath),
 		steps.CheckDaemonComponentPrerequisitesStep(paths.DaemonSockPath),

--- a/internal/workflows/steps/step_daemon.go
+++ b/internal/workflows/steps/step_daemon.go
@@ -273,21 +273,32 @@ func copyBinaryFile(src, dst string) error {
 	return out.Sync()
 }
 
-// installDaemonServiceFiles writes the unit template to the sandbox path and
-// creates the /usr/lib/systemd/system symlink that points to it.
+// daemonServiceTemplateData is the rendering context for the daemon service unit template.
+type daemonServiceTemplateData struct {
+	// ExtraReadWritePaths lists additional paths to include in ReadWritePaths beyond
+	// /opt/solo. Only paths that exist on the host (created by the caller before
+	// rendering) should be listed; the systemd mount namespace setup fails with
+	// status=226/NAMESPACE for any listed path that is absent.
+	ExtraReadWritePaths []string
+}
+
+// installDaemonServiceFiles renders the unit template and writes it to the sandbox
+// path, then creates the /usr/lib/systemd/system symlink that points to it.
 // sandboxPath — $home/sandbox/usr/lib/systemd/system/solo-provisioner-daemon.service
 // symlinkPath — /usr/lib/systemd/system/solo-provisioner-daemon.service
-func installDaemonServiceFiles(sandboxPath, symlinkPath string) error {
-	content, err := templates.Files.ReadFile(daemonServiceTemplatePath)
+func installDaemonServiceFiles(sandboxPath, symlinkPath string, extraPaths []string) error {
+	rendered, err := templates.Render(daemonServiceTemplatePath, daemonServiceTemplateData{
+		ExtraReadWritePaths: extraPaths,
+	})
 	if err != nil {
-		return errorx.InternalError.Wrap(err, "failed to read daemon service template")
+		return errorx.InternalError.Wrap(err, "failed to render daemon service template")
 	}
 
 	if err := os.MkdirAll(filepath.Dir(sandboxPath), 0o755); err != nil {
 		return errorx.InternalError.Wrap(err, "failed to create sandbox systemd directory %s", filepath.Dir(sandboxPath))
 	}
 
-	if err := os.WriteFile(sandboxPath, content, 0o644); err != nil {
+	if err := os.WriteFile(sandboxPath, []byte(rendered), 0o644); err != nil {
 		return errorx.InternalError.Wrap(err, "failed to write daemon service file to %s", sandboxPath)
 	}
 
@@ -312,14 +323,23 @@ func removeDaemonServiceFiles(sandboxPath, symlinkPath string) {
 // InstallDaemonServiceStep installs the solo-provisioner-daemon systemd service
 // unit file into the weaver sandbox, creates a symlink at
 // /usr/lib/systemd/system/solo-provisioner-daemon.service, runs daemon-reload,
-// enables, and starts the service.
-func InstallDaemonServiceStep(paths models.WeaverPaths) *automa.StepBuilder {
+// enables, and starts the service. extraReadWritePaths lists any additional paths
+// beyond /opt/solo that the service unit must be allowed to write; each path is
+// created with MkdirAll before the unit is rendered so the mount namespace setup
+// does not fail with status=226/NAMESPACE for an absent directory.
+func InstallDaemonServiceStep(paths models.WeaverPaths, extraReadWritePaths []string) *automa.StepBuilder {
 	sandboxPath := paths.DaemonServiceSandboxPath
 	symlinkPath := paths.DaemonServiceSymlinkPath
 
 	return automa.NewStepBuilder().WithId("install-daemon-service").
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
-			if err := installDaemonServiceFiles(sandboxPath, symlinkPath); err != nil {
+			for _, p := range extraReadWritePaths {
+				if err := os.MkdirAll(p, 0o755); err != nil {
+					return automa.StepFailureReport(stp.Id(), automa.WithError(
+						errorx.InternalError.Wrap(err, "failed to create ReadWritePaths directory %s", p)))
+				}
+			}
+			if err := installDaemonServiceFiles(sandboxPath, symlinkPath, extraReadWritePaths); err != nil {
 				// installDaemonServiceFiles already returns an *errorx.Error; cast so we
 				// can attach resolution hints without importing a second error package.
 				var errWithHints error = err

--- a/internal/workflows/steps/step_daemon_it_test.go
+++ b/internal/workflows/steps/step_daemon_it_test.go
@@ -59,7 +59,7 @@ func Test_DaemonService_FilePlacement_Integration(t *testing.T) {
 	t.Cleanup(func() { cleanupDaemonService(t, paths) })
 
 	// Install files
-	err := installDaemonServiceFiles(paths.DaemonServiceSandboxPath, paths.DaemonServiceSymlinkPath)
+	err := installDaemonServiceFiles(paths.DaemonServiceSandboxPath, paths.DaemonServiceSymlinkPath, nil)
 	require.NoError(t, err)
 
 	// Sandbox file must exist and be non-empty
@@ -96,7 +96,7 @@ func Test_DaemonService_EnableDisable_Integration(t *testing.T) {
 	ctx := context.Background()
 
 	// Place files + daemon-reload
-	require.NoError(t, installDaemonServiceFiles(paths.DaemonServiceSandboxPath, paths.DaemonServiceSymlinkPath))
+	require.NoError(t, installDaemonServiceFiles(paths.DaemonServiceSandboxPath, paths.DaemonServiceSymlinkPath, nil))
 	require.NoError(t, osx.DaemonReload(ctx))
 
 	// Enable
@@ -130,12 +130,12 @@ func Test_InstallDaemonServiceStep_Rollback_Integration(t *testing.T) {
 
 	// Simulate a partial install: files placed + daemon-reload + enabled,
 	// but service never started (as if RestartService had failed).
-	require.NoError(t, installDaemonServiceFiles(paths.DaemonServiceSandboxPath, paths.DaemonServiceSymlinkPath))
+	require.NoError(t, installDaemonServiceFiles(paths.DaemonServiceSandboxPath, paths.DaemonServiceSymlinkPath, nil))
 	require.NoError(t, osx.DaemonReload(ctx))
 	require.NoError(t, osx.EnableService(ctx, daemonServiceName))
 
 	// Build and run the rollback
-	step, err := InstallDaemonServiceStep(paths).Build()
+	step, err := InstallDaemonServiceStep(paths, nil).Build()
 	require.NoError(t, err)
 
 	rollbackReport := step.Rollback(ctx)
@@ -167,7 +167,7 @@ func Test_RemoveDaemonServiceStep_Integration(t *testing.T) {
 	ctx := context.Background()
 
 	// Simulate an installed (but not running) service
-	require.NoError(t, installDaemonServiceFiles(paths.DaemonServiceSandboxPath, paths.DaemonServiceSymlinkPath))
+	require.NoError(t, installDaemonServiceFiles(paths.DaemonServiceSandboxPath, paths.DaemonServiceSymlinkPath, nil))
 	require.NoError(t, osx.DaemonReload(ctx))
 	require.NoError(t, osx.EnableService(ctx, daemonServiceName))
 


### PR DESCRIPTION
## Description

Stands up the block-node `traffic_shaper` monitor as a real `daemonkit`-supervised
component inside `solo-provisioner-daemon` — the structural skeleton that the rest of
epic **TS_3 (#736)** hangs off. Until now the monitor was a no-op stub that logged once
and blocked on `ctx`. It now runs its two long-lived responsibilities concurrently and
reports its health over the daemon socket.

`Run(ctx)` launches the **pod-lifecycle watcher** and the **statusz poll loop** as two
goroutines, each wrapped in a per-responsibility retry loop with **5 s → 5 min**
exponential back-off. A fault in one responsibility is logged and retried in place and is
never propagated to `Run`, so a subsystem fault can't stop the other responsibility, trip
the top-level supervisor, or kill the daemon process. Monitor health (supervisor
`running` / `backoff` / `stopped`) is exposed via `GET /block_node/traffic_shaper/status`.

This is **skeleton only**: both responsibility bodies are stubs. The real veth resolution,
ingress HTB attach, statusz client, category→policy diff, nft membership apply, bootstrap
sequencing, and privileged-exec delegation land in sibling stories (#747–#755, #774). The
`degraded` health state and alerting are owned by #750 — this PR reports only supervisor
state.

### Files changed

| File | Change |
|------|--------|
| `internal/daemon/blocknode/traffic_shaper_monitor.go` | Export `TrafficShaperMonitor`; `Run` launches the two responsibilities via `superviseResponsibility` (5 s → 5 min back-off, faults swallowed); stub `runPodWatcher` / `runStatuszPoll` bodies |
| `internal/daemon/blocknode/handler.go` | New `BlockNodeHandler` (`daemonkit.ComponentHandler`) serving `GET /block_node/traffic_shaper/status`; 503 when monitor disabled |
| `internal/daemon/blocknode/component.go` | `ComponentResult` carries `*TrafficShaperMonitor` for handler wiring |
| `internal/daemon/daemon.go` | Block-node block builds the `trafficShaperStateFn` closure over the component `StatusTracker` and registers `BlockNodeHandler` |
| `internal/daemon/blocknode/traffic_shaper_monitor_test.go` | Monitor unit tests: returns on ctx cancel; faults retried without propagating; clean re-entry |
| `internal/daemon/blocknode/handler_test.go` | Handler unit tests: 200 + state when enabled, 503 when disabled |
| `internal/templates/files/weaver/solo-provisioner-daemon.service` | `ReadWritePaths` is now a Go template; paths beyond `/opt/solo` are rendered conditionally at install time |
| `internal/workflows/daemon.go` | `daemonExtraReadWritePaths(cfg)` derives the per-component extra paths; passes them to `InstallDaemonServiceStep` |
| `internal/workflows/steps/step_daemon.go` | `InstallDaemonServiceStep` accepts `extraReadWritePaths []string`; creates each path before rendering the service unit — fixes status=226/NAMESPACE on BN-only hosts where `/opt/hgcapp` is absent |

### Review guide

**Code review checklist**
- [ ] `traffic_shaper_monitor.go` — `superviseResponsibility` never returns a non-nil error: a faulting `fn` is logged + retried, and the loop exits only on `ctx` cancellation. This is the core invariant ("no process death on subsystem fault" from #746).
- [ ] `traffic_shaper_monitor.go` — back-off floor is **5 s** (issue-specified), cap **5 min**, factor 2.0; `responsibilityBackoffInitial`/`Max` are `var` (not `const`) only so tests can shrink them — production never reassigns.
- [ ] `traffic_shaper_monitor.go` — `Run` waits on both responsibilities (`sync.WaitGroup`) and returns `nil` only after both stop on ctx cancel, keeping the top-level `daemonkit.SupervisedMonitor` contract intact.
- [ ] `daemon.go` — `trafficShaperStateFn` closes over `comp.tracker` after `comp` is appended to the slice (value copy is fine — `tracker` is a pointer), mirroring the consensus-handler wiring; handler only added when `result.TrafficShaperMonitor != nil`.
- [ ] `handler.go` — `GET /block_node/traffic_shaper/status` returns 503 when `mon == nil` (disabled) and otherwise the supervisor `MonitorState`; no `degraded` field yet (deferred to #750). Covered by `TestBlockNodeHandler_NilMonitor_Returns503`.
- [ ] `component.go` — `NewComponent` returns the monitor reference; enablement is still gated by `block_node.monitors.traffic_shaper` in `daemon.yaml` (unchanged).
- [ ] `step_daemon.go` — `InstallDaemonServiceStep` takes `extraReadWritePaths []string` (no CN knowledge); `daemonExtraReadWritePaths(cfg)` in `daemon.go` is the single place that maps component config → required paths. Adding a future component's data root is a one-liner there with no touch to the step.
- [ ] `solo-provisioner-daemon.service` — `ReadWritePaths=/opt/solo{{range .ExtraReadWritePaths}} {{.}}{{end}}` renders cleanly to `ReadWritePaths=/opt/solo` on BN-only installs and `ReadWritePaths=/opt/solo /opt/hgcapp` when CN is enabled. Any listed path that is absent at service start causes status=226/NAMESPACE — the `MkdirAll` loop in the step must run before `installDaemonServiceFiles`.

**Unit tests**
```bash
# macOS or CI — these packages have no Linux-only deps:
go test -race -tags='!integration' ./internal/daemon/blocknode/... ./internal/daemon/

# Or the full unit suite (run inside the UTM VM for full coverage):
task vm:test:unit
```

**Manual UAT**

Exercises the live `/block_node/traffic_shaper/status` endpoint over the daemon's unix
socket. Run inside the UTM VM (Linux, arm64).

_**Step 1 — Build and copy the daemon binary to the VM**_

```bash
# On the Mac host:
task build:daemon GOOS=linux GOARCH=arm64
task vm:sync   # or scp bin/solo-provisioner-daemon-linux-arm64 weaver@<vm-ip>:~
```

_**Step 2 — Install the daemon service**_

```bash
# On the VM (as root or via sudo):
sudo solo-provisioner daemon service install \
  --components block-node \
  --daemon-bin ~/solo-provisioner-daemon-linux-arm64
```

This single command:
- writes `/opt/solo/weaver/config/daemon.yaml` with `block_node.enabled: true` and
  `monitors.traffic_shaper: true`
- copies the binary to `/opt/solo/weaver/bin/solo-provisioner-daemon`
- installs, enables, and starts the `solo-provisioner-daemon.service` systemd unit

_**Step 3 — Verify the service is healthy**_

```bash
solo-provisioner daemon service check
```

Expected: all checks pass.

_**Step 4 — Confirm startup log lines**_

```bash
journalctl -u solo-provisioner-daemon -n 50 --no-pager
```

Expected log lines (in order):
```
reason=TrafficShaperMonitorStarting   monitor=bn-traffic-shaper-monitor
reason=TrafficShaperPodWatcherStub    monitor=bn-traffic-shaper-monitor
reason=TrafficShaperStatuszPollStub   monitor=bn-traffic-shaper-monitor
```

_**Step 5 — Query the traffic-shaper status endpoint**_

The daemon socket (`/opt/solo/weaver/daemon/daemon.sock`) is owned by `weaver:weaver`
(`srw-rw----`). Use `sudo` or add your user to the `weaver` group before querying:

```bash
sudo curl --unix-socket /opt/solo/weaver/daemon/daemon.sock \
  http://localhost/block_node/traffic_shaper/status
```

Expected HTTP 200:
```json
{"monitor":{"state":"running"}}
```

> **Disabled-path (503) coverage:** reinstalling with `--components consensus-node` on a
> BN-only VM isn't a realistic scenario (requires CN infrastructure). The 503 path is
> covered by `TestBlockNodeHandler_NilMonitor_Returns503` in `handler_test.go` — no live
> step needed.

**Risks / rollback**

- Additive and gated behind `block_node.enabled` + `monitors.traffic_shaper`; with the
  monitor disabled, daemon behavior is unchanged.
- Main invariant to protect: `superviseResponsibility` must never propagate a fault to
  `Run` — a regression there lets a stub fault bubble up and trip the top-level supervisor.
  Covered by `TestSuperviseResponsibility_RetriesFaultsWithoutPropagating`.
- The service unit template now uses `{{range .ExtraReadWritePaths}}` — any path added to
  the template data that does not exist at service start causes status=226/NAMESPACE. The
  `MkdirAll` loop in `InstallDaemonServiceStep.Execute` must always run before
  `installDaemonServiceFiles`. Covered by integration tests in `step_daemon_it_test.go`.
- Rollback: revert the PR; the prior no-op stub returns and no other component is affected.

### Related Issues

* Closes #746
