### PR TITLE
feat(network): add `network firewall` verbs on the inet host table

### DIFF
--- a/cmd/cli/commands/network/firewall/add.go
+++ b/cmd/cli/commands/network/firewall/add.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a single --mgmt-cidr or --in-cluster-port",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		mgr := newManager()
+		switch {
+		case cmd.Flags().Changed("mgmt-cidr"):
+			return mgr.AddMgmtCIDR(cmd.Context(), flagMgmtCIDR)
+		case cmd.Flags().Changed("in-cluster-port"):
+			return mgr.AddPort(cmd.Context(), flagInClusterPort)
+		default:
+			return errorx.IllegalArgument.New("one of --mgmt-cidr or --in-cluster-port is required")
+		}
+	},
+}
+
+func init() {
+	addCmd.Flags().StringVar(&flagMgmtCIDR, "mgmt-cidr", "", "A single management CIDR to add")
+	addCmd.Flags().IntVar(&flagInClusterPort, "in-cluster-port", 0, "A single in-cluster host-service port to add")
+	addCmd.MarkFlagsMutuallyExclusive("mgmt-cidr", "in-cluster-port")
+}

--- a/cmd/cli/commands/network/firewall/create.go
+++ b/cmd/cli/commands/network/firewall/create.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"context"
+
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/internal/kube"
+	fw "github.com/hashgraph/solo-weaver/internal/network/firewall"
+	"github.com/spf13/cobra"
+)
+
+// detectPodCIDR resolves the local node's pod CIDR from the cluster. It is
+// indirected through a var so command tests can stub cluster access.
+var detectPodCIDR = func(ctx context.Context) (string, error) {
+	c, err := kube.NewClient()
+	if err != nil {
+		return "", err
+	}
+	return c.DetectNodePodCIDR(ctx)
+}
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create the `inet host` table (create-if-missing; --force re-renders)",
+	Long: "Render and apply the full `inet host` table. create-if-missing: if the table already " +
+		"exists, no changes are made unless --force is passed, which re-renders from the flags.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// NewTable() seeds the design defaults (SSH 22, the stack in-cluster
+		// port set). Override a field only when its flag was explicitly set:
+		// the flag-binding vars are shared across verbs (see firewall.go), so a
+		// later verb's registration clobbers another verb's default in the
+		// shared variable. Reading the shared value unconditionally would wipe
+		// --in-cluster-ports to nil on a plain `create --force`; gating on
+		// Changed() keeps NewTable()'s default authoritative.
+		t := fw.NewTable()
+		if cmd.Flags().Changed("mgmt-cidrs") {
+			t.MgmtCIDRs = flagMgmtCIDRs
+		}
+		if cmd.Flags().Changed("in-cluster-ports") {
+			t.InClusterPorts = flagInClusterPorts
+		}
+		if cmd.Flags().Changed("ssh-port") {
+			t.SSHPort = flagSSHPort
+		}
+
+		// --pod-cidr defaults to auto-detection: when the operator does not
+		// pass it, resolve the local node's .spec.podCIDR from the cluster.
+		// Detection is best-effort — `network firewall create` is node-agnostic
+		// and may run before a cluster exists, so if no cluster is reachable we
+		// fall back to omitting the in-cluster-ports rule and tell the operator
+		// how to set it explicitly.
+		t.PodCIDR = flagPodCIDR
+		if t.PodCIDR == "" {
+			if cidr, err := detectPodCIDR(cmd.Context()); err != nil {
+				logx.As().Warn().Err(err).Msg(
+					"could not auto-detect pod CIDR; the in-cluster host-service ports rule will be omitted — pass --pod-cidr to set it explicitly")
+			} else {
+				t.PodCIDR = cidr
+				logx.As().Info().Str("pod_cidr", cidr).Msg("auto-detected pod CIDR from the local node")
+			}
+		}
+
+		if len(t.MgmtCIDRs) == 0 {
+			logx.As().Warn().Msg(
+				"no --mgmt-cidrs set: the SSH allow rule will match no sources under the default-drop policy — " +
+					"you will be locked out of new SSH connections; pass --mgmt-cidrs to set the management allowlist")
+		}
+
+		force, err := common.FlagForce().Value(cmd, args)
+		if err != nil {
+			return err
+		}
+
+		changed, err := newManager().Create(cmd.Context(), t, force)
+		if err != nil {
+			return err
+		}
+		if changed {
+			logx.As().Info().Msg("inet host firewall is in the desired state")
+		}
+		return nil
+	},
+}
+
+func init() {
+	createCmd.Flags().StringSliceVar(&flagMgmtCIDRs, "mgmt-cidrs", nil, "Management/SSH allowlist CIDRs (comma-separated or repeated)")
+	createCmd.Flags().IntSliceVar(&flagInClusterPorts, "in-cluster-ports", fw.DefaultInClusterPorts, "Host-service ports reachable from the pod CIDR")
+	createCmd.Flags().IntVar(&flagSSHPort, "ssh-port", fw.DefaultSSHPort, "SSH/management TCP port accepted from the allowlist")
+	createCmd.Flags().StringVar(&flagPodCIDR, "pod-cidr", "", "Pod CIDR allowed to reach the in-cluster host-service ports (default: auto-detected from the local node's .spec.podCIDR; the rule is omitted if no cluster is reachable)")
+}

--- a/cmd/cli/commands/network/firewall/delete.go
+++ b/cmd/cli/commands/network/firewall/delete.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Remove the `inet host` table and its on-disk artifact",
+	Long: "Remove the `inet host` table and /etc/solo-provisioner/network-host.nft. This does NOT " +
+		"disable the shared solo-provisioner-network-nft.service (shared with `inet weaver`); host-level " +
+		"teardown is orchestrated by `kube cluster uninstall`.",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if err := newManager().Delete(cmd.Context()); err != nil {
+			return err
+		}
+		logx.As().Info().Msg("inet host firewall removed")
+		return nil
+	},
+}

--- a/cmd/cli/commands/network/firewall/firewall.go
+++ b/cmd/cli/commands/network/firewall/firewall.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package firewall wires the `solo-provisioner network firewall` verbs to the
+// internal/network/firewall manager. The verbs manage the node-agnostic
+// `inet host` nftables table (SSH/mgmt allowlist, ICMP policy, in-cluster
+// host-service ports).
+package firewall
+
+import (
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	fw "github.com/hashgraph/solo-weaver/internal/network/firewall"
+	"github.com/spf13/cobra"
+)
+
+// Shared flag binding targets. Only one verb runs per invocation, so reusing
+// the same variables for value-passing across verbs is safe. Caveat: pflag
+// writes the flag's default into the bound variable at registration time, and
+// every verb's init() runs — so when two verbs bind the same variable with
+// different defaults (create defaults --in-cluster-ports to the stack set, set
+// defaults it to nil) the last registration wins the variable's initial value.
+// Verbs must therefore take their defaults from the model (NewTable) and gate
+// overrides on cmd.Flags().Changed(), never trust the shared variable's default.
+var (
+	flagMgmtCIDRs      []string
+	flagMgmtCIDR       string
+	flagInClusterPorts []int
+	flagInClusterPort  int
+	flagSSHPort        int
+	flagPodCIDR        string
+)
+
+var firewallCmd = &cobra.Command{
+	Use:   "firewall",
+	Short: "Manage the node-level host firewall (`inet host` nftables table)",
+	Long: "Manage the node-agnostic host firewall: the `inet host` nftables table that protects the " +
+		"bare-metal host (SSH/management allowlist, ICMP policy, in-cluster host-service ports). " +
+		"This table is separate from the `inet weaver` workload plane and applies to every node type.",
+	RunE: common.DefaultRunE,
+}
+
+func init() {
+	firewallCmd.AddCommand(createCmd, addCmd, removeCmd, setCmd, showCmd, deleteCmd)
+}
+
+// GetCmd returns the root of the `network firewall` command group.
+func GetCmd() *cobra.Command {
+	return firewallCmd
+}
+
+// newManager constructs the production manager (live nft kernel apply + systemd
+// service enable). Indirected through a var so command tests can stub it.
+var newManager = func() *fw.Manager { return fw.NewManager() }

--- a/cmd/cli/commands/network/firewall/firewall_test.go
+++ b/cmd/cli/commands/network/firewall/firewall_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	fw "github.com/hashgraph/solo-weaver/internal/network/firewall"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// captureRunner satisfies the Runner interface without touching the kernel.
+// Apply is intentionally absent — live rule application goes through
+// applyViaService (file write + service restart), not the Runner.
+type captureRunner struct {
+	exists bool
+}
+
+func (c *captureRunner) List(_ context.Context) (string, error) { return "", nil }
+func (c *captureRunner) Delete(_ context.Context) error         { c.exists = false; return nil }
+func (c *captureRunner) Exists(_ context.Context) (bool, error) { return c.exists, nil }
+
+func TestFirewallCmd_Structure(t *testing.T) {
+	cmd := GetCmd()
+	require.Equal(t, "firewall", cmd.Use)
+
+	want := map[string]bool{"create": false, "add": false, "remove": false, "set": false, "show": false, "delete": false}
+	for _, sub := range cmd.Commands() {
+		if _, ok := want[sub.Use]; ok {
+			want[sub.Use] = true
+		}
+	}
+	for verb, found := range want {
+		require.True(t, found, "verb %q not registered under firewall", verb)
+	}
+}
+
+func TestCreateCmd_Flags(t *testing.T) {
+	for _, name := range []string{"mgmt-cidrs", "in-cluster-ports", "ssh-port", "pod-cidr"} {
+		require.NotNil(t, createCmd.Flags().Lookup(name), "create is missing --%s", name)
+	}
+	// Defaults must match the firewall package defaults.
+	require.Equal(t, "22", createCmd.Flags().Lookup("ssh-port").DefValue)
+	// ICMP is a static ruleset, not flag-driven: there must be no icmp toggles.
+	require.Nil(t, createCmd.Flags().Lookup("icmp-mgmt"), "icmp-mgmt flag should be removed")
+	require.Nil(t, createCmd.Flags().Lookup("icmp-public"), "icmp-public flag should be removed")
+}
+
+func TestCreateCmd_DefaultsInClusterPortsWhenNotPassed(t *testing.T) {
+	// Regression: `create` (even with --force) without --in-cluster-ports must
+	// render the stack port set. The flag-binding var is shared with `set`
+	// (nil default), which clobbers create's default in the shared variable —
+	// so create must source the default from NewTable(), gated on Changed().
+	// This executes the real command so the shared-var registration is exercised.
+	r := &captureRunner{}
+	dir := t.TempDir()
+	nftPath := filepath.Join(dir, "network-host.nft")
+
+	origMgr, origDetect := newManager, detectPodCIDR
+	newManager = func() *fw.Manager {
+		return fw.NewManagerWithConfig(fw.Config{
+			Runner:   r,
+			NftPath:  nftPath,
+			LockPath: filepath.Join(dir, ".applying"),
+			ApplyViaService: func(context.Context) error {
+				r.exists = true
+				return nil
+			},
+		})
+	}
+	// No cluster reachable → pod rule omitted; the in_cluster_ports *set* still
+	// renders its elements, which is what we assert on.
+	detectPodCIDR = func(context.Context) (string, error) { return "", errors.New("no cluster") }
+	defer func() { newManager, detectPodCIDR = origMgr, origDetect }()
+
+	root := &cobra.Command{Use: "test"}
+	root.PersistentFlags().Bool("force", false, "force")
+	root.AddCommand(GetCmd())
+	root.SetArgs([]string{"firewall", "create", "--mgmt-cidrs", "10.0.0.0/8"})
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	require.NoError(t, root.Execute())
+
+	data, err := os.ReadFile(nftPath)
+	require.NoError(t, err, "create should have written the nft file")
+	require.Contains(t, string(data), "elements = { 4244, 6443, 7472, 10250 }",
+		"create without --in-cluster-ports must default to the stack port set")
+}
+
+func TestAddRemoveCmd_Flags(t *testing.T) {
+	for _, c := range []string{"add", "remove"} {
+		var cmd = addCmd
+		if c == "remove" {
+			cmd = removeCmd
+		}
+		require.NotNil(t, cmd.Flags().Lookup("mgmt-cidr"), "%s missing --mgmt-cidr", c)
+		require.NotNil(t, cmd.Flags().Lookup("in-cluster-port"), "%s missing --in-cluster-port", c)
+	}
+}

--- a/cmd/cli/commands/network/firewall/remove.go
+++ b/cmd/cli/commands/network/firewall/remove.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var removeCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove a single --mgmt-cidr or --in-cluster-port",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		mgr := newManager()
+		switch {
+		case cmd.Flags().Changed("mgmt-cidr"):
+			return mgr.RemoveMgmtCIDR(cmd.Context(), flagMgmtCIDR)
+		case cmd.Flags().Changed("in-cluster-port"):
+			return mgr.RemovePort(cmd.Context(), flagInClusterPort)
+		default:
+			return errorx.IllegalArgument.New("one of --mgmt-cidr or --in-cluster-port is required")
+		}
+	},
+}
+
+func init() {
+	removeCmd.Flags().StringVar(&flagMgmtCIDR, "mgmt-cidr", "", "A single management CIDR to remove")
+	removeCmd.Flags().IntVar(&flagInClusterPort, "in-cluster-port", 0, "A single in-cluster host-service port to remove")
+	removeCmd.MarkFlagsMutuallyExclusive("mgmt-cidr", "in-cluster-port")
+}

--- a/cmd/cli/commands/network/firewall/set.go
+++ b/cmd/cli/commands/network/firewall/set.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var setCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Atomically replace the full --mgmt-cidrs and/or --in-cluster-ports list",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		var mgmt []string
+		var ports []int
+
+		// A nil slice leaves that dimension unchanged; a changed flag (even with
+		// an empty value) replaces it.
+		if cmd.Flags().Changed("mgmt-cidrs") {
+			mgmt = flagMgmtCIDRs
+			if mgmt == nil {
+				mgmt = []string{}
+			}
+		}
+		if cmd.Flags().Changed("in-cluster-ports") {
+			ports = flagInClusterPorts
+			if ports == nil {
+				ports = []int{}
+			}
+		}
+
+		if mgmt == nil && ports == nil {
+			return errorx.IllegalArgument.New("at least one of --mgmt-cidrs or --in-cluster-ports is required")
+		}
+
+		return newManager().Set(cmd.Context(), mgmt, ports)
+	},
+}
+
+func init() {
+	setCmd.Flags().StringSliceVar(&flagMgmtCIDRs, "mgmt-cidrs", nil, "Full management allowlist (comma-separated; replaces the existing list)")
+	setCmd.Flags().IntSliceVar(&flagInClusterPorts, "in-cluster-ports", nil, "Full in-cluster host-service port list (comma-separated; replaces the existing list)")
+}

--- a/cmd/cli/commands/network/firewall/show.go
+++ b/cmd/cli/commands/network/firewall/show.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show the live `inet host` table",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		out, err := newManager().Show(cmd.Context())
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), out)
+		return nil
+	},
+}

--- a/cmd/cli/commands/network/network.go
+++ b/cmd/cli/commands/network/network.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package network
+
+import (
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/network/firewall"
+	"github.com/spf13/cobra"
+)
+
+var networkCmd = &cobra.Command{
+	Use:   "network",
+	Short: "Manage node-level network state (firewall, policy, shaping, load balancing)",
+	Long: "Manage node-level network state behind the solo-provisioner traffic shaper. " +
+		"The firewall scope manages the node-agnostic `inet host` nftables table.",
+	RunE: common.DefaultRunE, // runnable group; sub-commands inherit parent/root flags
+}
+
+func init() {
+	networkCmd.AddCommand(firewall.GetCmd())
+}
+
+// GetCmd returns the root of the `network` command group.
+func GetCmd() *cobra.Command {
+	return networkCmd
+}

--- a/cmd/cli/commands/root.go
+++ b/cmd/cli/commands/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/consensus"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/daemon"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/kube"
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/network"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/teleport"
 	"github.com/hashgraph/solo-weaver/internal/blocknode"
 	"github.com/hashgraph/solo-weaver/internal/doctor"
@@ -103,6 +104,7 @@ func init() {
 	rootCmd.AddCommand(selfUninstallCmd)
 	rootCmd.AddCommand(kube.GetCmd())
 	rootCmd.AddCommand(block.GetCmd())
+	rootCmd.AddCommand(network.GetCmd())
 	rootCmd.AddCommand(consensus.GetCmd())
 	rootCmd.AddCommand(teleport.GetCmd())
 	rootCmd.AddCommand(alloy.GetCmd())

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -371,6 +371,79 @@ sudo solo-provisioner kube cluster uninstall --continue-on-error
 
 ---
 
+### Network Commands
+
+Manage node-level network state behind the traffic shaper. The `firewall` scope manages the node-agnostic `inet host` nftables table — the host's own SSH/management allowlist, ICMP policy, and in-cluster host-service ports. It is separate from the `inet weaver` workload plane and applies to every node type (block, consensus, mirror, relay).
+
+#### Create the Host Firewall
+
+create-if-missing: if the `inet host` table already exists, the command makes no changes unless `--force` is passed (which re-renders from the flags). Every mutation applies to the live kernel in one atomic `nft -f` transaction and atomically rewrites `/etc/solo-provisioner/network-host.nft`.
+
+```bash
+# Create with a management allowlist and the default in-cluster ports
+sudo solo-provisioner network firewall create \
+  --mgmt-cidrs 10.0.0.0/8 \
+  --ssh-port 22 \
+  --pod-cidr 10.4.0.0/24 \
+  --in-cluster-ports 6443,4244,10250
+
+# Re-render an existing table from new flags
+sudo solo-provisioner network firewall create --mgmt-cidrs 10.0.0.0/8,192.168.0.0/16 --force
+```
+
+**Flags**:
+
+| Flag                 | Description                                                       | Default            |
+|----------------------|-------------------------------------------------------------------|--------------------|
+| `--mgmt-cidrs`       | Management/SSH allowlist CIDRs (comma-separated or repeated) — **omitting this flag leaves the SSH allow rule with an empty source set under the default-drop policy, which will lock you out of new SSH connections** | (none) |
+| `--in-cluster-ports` | Host-service ports reachable from the pod CIDR                     | `4244,6443,7472,10250` |
+| `--ssh-port`         | SSH/management TCP port accepted from the allowlist                | `22`               |
+| `--pod-cidr`         | Pod CIDR allowed to reach the in-cluster host-service ports        | auto-detected      |
+| `--force`            | Re-render the table even if it already exists (global flag)        | `false`            |
+
+When `--pod-cidr` is omitted it is **auto-detected** from the local node's `.spec.podCIDR` via the Kubernetes API (the node is matched by hostname, or the sole node on a single-node host). Detection is best-effort: `network firewall create` is node-agnostic and may run before a cluster exists, so if no cluster is reachable the command logs a warning and **omits the in-cluster-ports rule** — pass `--pod-cidr` explicitly to render it anyway.
+
+ICMP is a fixed, safe ruleset (not configurable): full ICMP from the management allowlist, and from every other source the path-health subset — `destination-unreachable` (Path MTU Discovery) and `time-exceeded` (traceroute) always accepted, with `echo-request` (ping) rate-limited to 10/second. There are deliberately no ICMP flags: dropping ICMP errors would silently break PMTUD for legitimate clients.
+
+> There is no `--service-ports`: BN ports live only in `network policy --ports` (the host firewall is bypassed by the eBPF datapath).
+
+#### Modify the Allowlist / Ports
+
+`add`/`remove` operate on a single element; `set` atomically replaces the full list.
+
+```bash
+sudo solo-provisioner network firewall add    --mgmt-cidr 10.1.0.0/16
+sudo solo-provisioner network firewall remove --mgmt-cidr 10.0.0.0/8
+sudo solo-provisioner network firewall set    --mgmt-cidrs 10.0.0.0/8,192.168.0.0/16
+
+sudo solo-provisioner network firewall add    --in-cluster-port 9100
+sudo solo-provisioner network firewall remove --in-cluster-port 10250
+sudo solo-provisioner network firewall set    --in-cluster-ports 6443,4244
+```
+
+**Flags**:
+
+| Verb           | Flag                 | Description                                                          |
+|----------------|----------------------|----------------------------------------------------------------------|
+| `add`/`remove` | `--mgmt-cidr`        | A single management CIDR (mutually exclusive with `--in-cluster-port`) |
+| `add`/`remove` | `--in-cluster-port`  | A single in-cluster host-service port                                |
+| `set`          | `--mgmt-cidrs`       | Full management allowlist (replaces the existing list)               |
+| `set`          | `--in-cluster-ports` | Full in-cluster host-service port list (replaces the existing list)  |
+
+#### Show / Delete the Host Firewall
+
+```bash
+# Show the live inet host table
+sudo solo-provisioner network firewall show
+
+# Remove the table and /etc/solo-provisioner/network-host.nft
+sudo solo-provisioner network firewall delete
+```
+
+> `delete` removes the table and `/etc/solo-provisioner/network-host.nft` but does not disable the shared `solo-provisioner-network-nft.service` (shared with `inet weaver`); disable it manually if you need it off.
+
+---
+
 ### Teleport Commands
 
 Configure secure access using Teleport agents.

--- a/internal/kube/podcidr.go
+++ b/internal/kube/podcidr.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"context"
+	"os"
+
+	"github.com/joomcode/errorx"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// DetectNodePodCIDR returns the pod CIDR assigned to the local node by reading
+// its .spec.podCIDR from the Kubernetes API. The local node is identified by the
+// OS hostname; when no node name matches the hostname but the cluster has
+// exactly one node, that node is used (the common single-node block-node host).
+//
+// It returns an error when the cluster is unreachable, the local node cannot be
+// identified, or the node has no pod CIDR assigned. Callers treating detection
+// as best-effort should fall back on error (e.g. omit the pod-scoped rule).
+func (c *Client) DetectNodePodCIDR(ctx context.Context) (string, error) {
+	list, err := c.List(ctx, KindNode, "", WaitOptions{})
+	if err != nil {
+		return "", errorx.Decorate(err, "failed to list nodes for pod-CIDR detection")
+	}
+	host, _ := os.Hostname()
+	return selectNodePodCIDR(list.Items, host)
+}
+
+// selectNodePodCIDR picks the local node from nodes and returns its
+// .spec.podCIDR. It is split out from DetectNodePodCIDR so the selection logic
+// is unit-testable without a live cluster.
+func selectNodePodCIDR(nodes []unstructured.Unstructured, hostname string) (string, error) {
+	if len(nodes) == 0 {
+		return "", errorx.IllegalState.New("cluster has no nodes")
+	}
+
+	var node *unstructured.Unstructured
+	if hostname != "" {
+		for i := range nodes {
+			if nodes[i].GetName() == hostname {
+				node = &nodes[i]
+				break
+			}
+		}
+	}
+	if node == nil {
+		if len(nodes) != 1 {
+			return "", errorx.IllegalState.New(
+				"cannot identify local node among %d nodes (hostname %q); pass --pod-cidr explicitly",
+				len(nodes), hostname)
+		}
+		node = &nodes[0]
+	}
+
+	cidr, found, err := unstructured.NestedString(node.Object, "spec", "podCIDR")
+	if err != nil {
+		return "", errorx.Decorate(err, "failed to read .spec.podCIDR from node %q", node.GetName())
+	}
+	if !found || cidr == "" {
+		return "", errorx.IllegalState.New("node %q has no .spec.podCIDR assigned", node.GetName())
+	}
+	return cidr, nil
+}

--- a/internal/kube/podcidr_test.go
+++ b/internal/kube/podcidr_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func testNode(name, cidr string) unstructured.Unstructured {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{"name": name},
+	}
+	if cidr != "" {
+		obj["spec"] = map[string]interface{}{"podCIDR": cidr}
+	}
+	return unstructured.Unstructured{Object: obj}
+}
+
+func TestSelectNodePodCIDR(t *testing.T) {
+	t.Run("matches by hostname", func(t *testing.T) {
+		nodes := []unstructured.Unstructured{
+			testNode("node-a", "10.4.0.0/24"),
+			testNode("node-b", "10.4.1.0/24"),
+		}
+		cidr, err := selectNodePodCIDR(nodes, "node-b")
+		require.NoError(t, err)
+		require.Equal(t, "10.4.1.0/24", cidr)
+	})
+
+	t.Run("single-node fallback when hostname does not match", func(t *testing.T) {
+		nodes := []unstructured.Unstructured{testNode("some-other-name", "10.4.0.0/24")}
+		cidr, err := selectNodePodCIDR(nodes, "unrelated-host")
+		require.NoError(t, err)
+		require.Equal(t, "10.4.0.0/24", cidr)
+	})
+
+	t.Run("empty hostname falls back on single node", func(t *testing.T) {
+		nodes := []unstructured.Unstructured{testNode("only", "10.4.2.0/24")}
+		cidr, err := selectNodePodCIDR(nodes, "")
+		require.NoError(t, err)
+		require.Equal(t, "10.4.2.0/24", cidr)
+	})
+
+	t.Run("no nodes is an error", func(t *testing.T) {
+		_, err := selectNodePodCIDR(nil, "node-a")
+		require.Error(t, err)
+	})
+
+	t.Run("ambiguous multi-node without hostname match is an error", func(t *testing.T) {
+		nodes := []unstructured.Unstructured{
+			testNode("node-a", "10.4.0.0/24"),
+			testNode("node-b", "10.4.1.0/24"),
+		}
+		_, err := selectNodePodCIDR(nodes, "node-c")
+		require.Error(t, err)
+	})
+
+	t.Run("node without podCIDR is an error", func(t *testing.T) {
+		nodes := []unstructured.Unstructured{testNode("node-a", "")}
+		_, err := selectNodePodCIDR(nodes, "node-a")
+		require.Error(t, err)
+	})
+}

--- a/internal/network/firewall/firewall_test.go
+++ b/internal/network/firewall/firewall_test.go
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRunner is an in-memory Runner for tests: it tracks table existence
+// without touching the kernel. Apply is intentionally absent — live rule
+// application goes through applyViaService, not the Runner.
+type fakeRunner struct {
+	exists  bool
+	listOut string
+	deleted bool
+}
+
+func (f *fakeRunner) List(_ context.Context) (string, error) { return f.listOut, nil }
+func (f *fakeRunner) Delete(_ context.Context) error         { f.deleted = true; f.exists = false; return nil }
+func (f *fakeRunner) Exists(_ context.Context) (bool, error) { return f.exists, nil }
+
+func sampleTable() *Table {
+	return &Table{
+		MgmtCIDRs:      []string{"10.0.0.0/8", "192.168.0.0/16"},
+		InClusterPorts: []int{4244, 6443, 7472, 10250},
+		SSHPort:        22,
+		PodCIDR:        "10.4.0.0/24",
+	}
+}
+
+// newTestManager wires a Manager with a fakeRunner and temp paths. The
+// applyViaService closure sets r.exists = true and increments applyCount so
+// tests can assert on how many times rules were applied without touching
+// systemd or the kernel.
+func newTestManager(t *testing.T, r *fakeRunner, applyCount *int) (*Manager, string) {
+	t.Helper()
+	dir := t.TempDir()
+	nftPath := filepath.Join(dir, "network-host.nft")
+	m := NewManagerWithConfig(Config{
+		Runner:   r,
+		NftPath:  nftPath,
+		LockPath: filepath.Join(dir, ".applying"),
+		ApplyViaService: func(context.Context) error {
+			*applyCount++
+			r.exists = true
+			return nil
+		},
+	})
+	return m, nftPath
+}
+
+func TestRender_SecurityInvariants(t *testing.T) {
+	doc, err := sampleTable().Render()
+	require.NoError(t, err)
+
+	// The chain must default-drop and must always admit SSH from the mgmt
+	// allowlist — a default-drop without an SSH allow would lock the host out.
+	require.Contains(t, doc, "policy drop;")
+	require.Contains(t, doc, "ip saddr @mgmt_addrs tcp dport 22 accept")
+	require.Contains(t, doc, "elements = { 10.0.0.0/8, 192.168.0.0/16 }")
+	require.Contains(t, doc, "elements = { 4244, 6443, 7472, 10250 }")
+	// ICMP is a static, safe ruleset: full ICMP from mgmt, and from everyone
+	// else the path-health subset (PMTUD + traceroute) plus rate-limited echo.
+	require.Contains(t, doc, "ip saddr @mgmt_addrs icmp type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem } accept")
+	require.Contains(t, doc, "icmp type destination-unreachable accept")
+	require.Contains(t, doc, "icmp type time-exceeded accept")
+	require.Contains(t, doc, "icmp type echo-request limit rate 10/second accept")
+	// Over-budget echo must be dropped explicitly, not left to fall through.
+	require.Contains(t, doc, "icmp type echo-request drop")
+	require.Contains(t, doc, "ip saddr 10.4.0.0/24 tcp dport @in_cluster_ports accept")
+
+	// Ordering is load-bearing: the echo-request rate limit must be evaluated
+	// BEFORE `ct state established,related accept`. netfilter conntrack tracks
+	// ICMP echo flows, so if the established fast-path ran first, every packet
+	// of a sustained ping after the first would bypass the limit.
+	limitIdx := strings.Index(doc, "icmp type echo-request limit rate 10/second accept")
+	dropIdx := strings.Index(doc, "icmp type echo-request drop")
+	// LastIndex: the comment above the rule also references the phrase; the real
+	// rule is the last occurrence.
+	estIdx := strings.LastIndex(doc, "ct state established,related accept")
+	require.Greater(t, dropIdx, limitIdx, "echo drop must follow the echo rate limit")
+	require.Greater(t, estIdx, dropIdx, "established,related accept must come after the ICMP echo rules")
+}
+
+func TestRender_NoMgmtNoPod(t *testing.T) {
+	tbl := NewTable() // no mgmt CIDRs, no pod CIDR
+	doc, err := tbl.Render()
+	require.NoError(t, err)
+
+	// Empty mgmt set renders without an elements clause; no pod CIDR means no
+	// in-cluster rule line.
+	require.Contains(t, doc, "set mgmt_addrs { type ipv4_addr; flags interval; }")
+	require.NotContains(t, doc, "tcp dport @in_cluster_ports accept")
+}
+
+func TestRoundTrip_RenderParseRender(t *testing.T) {
+	cases := map[string]*Table{
+		"full":      sampleTable(),
+		"defaults":  NewTable(),
+		"mgmt-only": {MgmtCIDRs: []string{"10.1.0.0/16"}, SSHPort: 2222},
+		"no-mgmt":   {SSHPort: 22},
+	}
+	for name, tbl := range cases {
+		t.Run(name, func(t *testing.T) {
+			first, err := tbl.Render()
+			require.NoError(t, err)
+
+			parsed, err := Parse(first)
+			require.NoError(t, err)
+
+			second, err := parsed.Render()
+			require.NoError(t, err)
+
+			require.Equal(t, first, second, "render→parse→render must be the identity")
+		})
+	}
+}
+
+func TestRender_RejectsInjection(t *testing.T) {
+	tbl := NewTable()
+	tbl.MgmtCIDRs = []string{"10.0.0.0/8; reboot"}
+	_, err := tbl.Render()
+	require.Error(t, err)
+}
+
+func TestManager_CreateIsCreateIfMissing(t *testing.T) {
+	r := &fakeRunner{}
+	applyCount := 0
+	m, nftPath := newTestManager(t, r, &applyCount)
+	ctx := context.Background()
+
+	// First create writes the file and triggers a service restart.
+	changed, err := m.Create(ctx, sampleTable(), false)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, 1, applyCount)
+	require.FileExists(t, nftPath)
+
+	// The on-disk file uses the delete+recreate prefix so set elements are fully
+	// cleared on every re-apply (flush table only clears chain rules, not sets).
+	data, err := os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "add table inet host")
+	require.Contains(t, string(data), "delete table inet host")
+
+	// Second create without --force is a no-op (table now exists).
+	changed, err = m.Create(ctx, sampleTable(), false)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Equal(t, 1, applyCount)
+
+	// With --force it re-renders and restarts again.
+	changed, err = m.Create(ctx, sampleTable(), true)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, 2, applyCount)
+}
+
+func TestManager_AddRemoveSet(t *testing.T) {
+	r := &fakeRunner{}
+	applyCount := 0
+	m, nftPath := newTestManager(t, r, &applyCount)
+	ctx := context.Background()
+
+	_, err := m.Create(ctx, NewTable(), false)
+	require.NoError(t, err)
+
+	require.NoError(t, m.AddMgmtCIDR(ctx, "10.5.0.0/16"))
+	data, err := os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "10.5.0.0/16")
+
+	require.NoError(t, m.RemoveMgmtCIDR(ctx, "10.5.0.0/16"))
+	data, err = os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "10.5.0.0/16")
+
+	require.NoError(t, m.Set(ctx, []string{"172.16.0.0/12"}, []int{9100}))
+	data, err = os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "172.16.0.0/12")
+	require.Contains(t, string(data), "9100")
+	// Set replaced the port list entirely.
+	require.NotContains(t, string(data), "6443")
+}
+
+func TestManager_AddRejectsBadInput(t *testing.T) {
+	r := &fakeRunner{}
+	applyCount := 0
+	m, _ := newTestManager(t, r, &applyCount)
+	ctx := context.Background()
+	_, err := m.Create(ctx, NewTable(), false)
+	require.NoError(t, err)
+
+	require.Error(t, m.AddMgmtCIDR(ctx, "not-a-cidr"))
+	require.Error(t, m.AddPort(ctx, 70000))
+}
+
+func TestManager_MutateBeforeCreateFails(t *testing.T) {
+	r := &fakeRunner{}
+	applyCount := 0
+	m, _ := newTestManager(t, r, &applyCount)
+	require.Error(t, m.AddMgmtCIDR(context.Background(), "10.0.0.0/8"))
+}
+
+func TestManager_DeleteIsIdempotent(t *testing.T) {
+	r := &fakeRunner{}
+	applyCount := 0
+	m, nftPath := newTestManager(t, r, &applyCount)
+	ctx := context.Background()
+
+	_, err := m.Create(ctx, sampleTable(), false)
+	require.NoError(t, err)
+	require.FileExists(t, nftPath)
+
+	require.NoError(t, m.Delete(ctx))
+	require.True(t, r.deleted)
+	require.NoFileExists(t, nftPath)
+
+	// Deleting again is a no-op, not an error.
+	require.NoError(t, m.Delete(ctx))
+}
+
+func TestManager_ServiceFailureReturnsError(t *testing.T) {
+	r := &fakeRunner{}
+	dir := t.TempDir()
+	m := NewManagerWithConfig(Config{
+		Runner:   r,
+		NftPath:  filepath.Join(dir, "network-host.nft"),
+		LockPath: filepath.Join(dir, ".applying"),
+		ApplyViaService: func(context.Context) error {
+			return context.DeadlineExceeded
+		},
+	})
+	_, err := m.Create(context.Background(), sampleTable(), false)
+	require.Error(t, err)
+}
+
+func TestRender_GoldenStable(t *testing.T) {
+	// Guards against accidental rule reordering/whitespace drift. If the
+	// ruleset legitimately changes, regenerate testdata/network-host.golden.nft
+	// deliberately and review the diff.
+	want, err := os.ReadFile(filepath.Join("testdata", "network-host.golden.nft"))
+	require.NoError(t, err)
+
+	doc, err := sampleTable().Render()
+	require.NoError(t, err)
+	require.Equal(t, strings.TrimSpace(string(want)), strings.TrimSpace(doc))
+}

--- a/internal/network/firewall/manager.go
+++ b/internal/network/firewall/manager.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+)
+
+// Manager implements the `network firewall` verbs against the `inet host`
+// table. Every mutating verb takes the shared apply lock, atomically rewrites
+// the on-disk artifact, and then restarts the systemd service via DBus so the
+// kernel is updated in one consistent operation — no separate nft apply exec.
+type Manager struct {
+	runner          Runner
+	nftPath         string
+	lockPath        string
+	applyViaService func(ctx context.Context) error
+}
+
+// Config customises a Manager. The zero value is not useful; prefer NewManager.
+// Tests inject a fake Runner, temp paths, and a no-op service func so the
+// package builds and runs on any platform.
+type Config struct {
+	Runner          Runner
+	NftPath         string
+	LockPath        string
+	ApplyViaService func(ctx context.Context) error
+}
+
+// NewManager returns a Manager wired to the live kernel and the production
+// paths.
+func NewManager() *Manager {
+	return NewManagerWithConfig(Config{})
+}
+
+// NewManagerWithConfig returns a Manager, filling any unset Config field with
+// its production default.
+func NewManagerWithConfig(cfg Config) *Manager {
+	m := &Manager{
+		runner:          cfg.Runner,
+		nftPath:         cfg.NftPath,
+		lockPath:        cfg.LockPath,
+		applyViaService: cfg.ApplyViaService,
+	}
+	if m.runner == nil {
+		m.runner = NewExecRunner()
+	}
+	if m.nftPath == "" {
+		m.nftPath = HostNftPath
+	}
+	if m.lockPath == "" {
+		m.lockPath = LockPath
+	}
+	if m.applyViaService == nil {
+		m.applyViaService = defaultApplyViaService
+	}
+	return m
+}
+
+// Create is create-if-missing: when the table already exists and force is
+// false, it makes no changes and returns (false, nil). force re-renders the
+// table from the supplied flags and returns (true, nil).
+func (m *Manager) Create(ctx context.Context, t *Table, force bool) (bool, error) {
+	if err := t.Validate(); err != nil {
+		return false, err
+	}
+	var changed bool
+	err := m.withLock(func() error {
+		exists, err := m.runner.Exists(ctx)
+		if err != nil {
+			return err
+		}
+		if exists && !force {
+			logx.As().Warn().Str("table", TableName).Msg("inet host firewall already exists — supplied flags were not applied; pass --force to re-render from the current flags")
+			return nil
+		}
+		changed = true
+		return m.applyAndPersist(ctx, t)
+	})
+	return changed, err
+}
+
+// AddMgmtCIDR adds one CIDR to the management allowlist and re-renders.
+func (m *Manager) AddMgmtCIDR(ctx context.Context, cidr string) error {
+	return m.mutate(ctx, func(t *Table) error { return t.AddMgmtCIDR(cidr) })
+}
+
+// RemoveMgmtCIDR removes one CIDR from the management allowlist and re-renders.
+func (m *Manager) RemoveMgmtCIDR(ctx context.Context, cidr string) error {
+	return m.mutate(ctx, func(t *Table) error { t.RemoveMgmtCIDR(cidr); return nil })
+}
+
+// AddPort adds one in-cluster host-service port and re-renders.
+func (m *Manager) AddPort(ctx context.Context, port int) error {
+	return m.mutate(ctx, func(t *Table) error { return t.AddPort(port) })
+}
+
+// RemovePort removes one in-cluster host-service port and re-renders.
+func (m *Manager) RemovePort(ctx context.Context, port int) error {
+	return m.mutate(ctx, func(t *Table) error { t.RemovePort(port); return nil })
+}
+
+// Set atomically replaces the management CIDR list and/or the in-cluster port
+// list. A nil slice leaves that dimension unchanged; an empty (non-nil) slice
+// clears it.
+func (m *Manager) Set(ctx context.Context, mgmtCIDRs []string, ports []int) error {
+	return m.mutate(ctx, func(t *Table) error {
+		if mgmtCIDRs != nil {
+			if err := t.SetMgmtCIDRs(mgmtCIDRs); err != nil {
+				return err
+			}
+		}
+		if ports != nil {
+			if err := t.SetPorts(ports); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// Show returns the live inet host table. If the table is not active it returns
+// a human-readable message (not an error) so the caller can print it cleanly.
+func (m *Manager) Show(ctx context.Context) (string, error) {
+	exists, err := m.runner.Exists(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		return "No inet host firewall table is currently active.\n" +
+			"Run `solo-provisioner network firewall create` to install one.", nil
+	}
+	return m.runner.List(ctx)
+}
+
+// Delete removes the inet host table and its on-disk artifact. It is
+// idempotent. It deliberately does NOT disable the shared
+// solo-provisioner-network-nft.service (shared with inet weaver) — that is
+// orchestrated by `kube cluster uninstall` (#791).
+func (m *Manager) Delete(ctx context.Context) error {
+	return m.withLock(func() error {
+		exists, err := m.runner.Exists(ctx)
+		if err != nil {
+			return err
+		}
+		if exists {
+			if err := m.runner.Delete(ctx); err != nil {
+				return err
+			}
+		}
+		if err := os.Remove(m.nftPath); err != nil && !os.IsNotExist(err) {
+			return errorx.ExternalError.Wrap(err, "failed to remove %s", m.nftPath)
+		}
+		return nil
+	})
+}
+
+// mutate loads the current table from disk, applies fn, then re-applies and
+// re-persists the full table under the shared lock.
+func (m *Manager) mutate(ctx context.Context, fn func(*Table) error) error {
+	return m.withLock(func() error {
+		t, err := m.load()
+		if err != nil {
+			return err
+		}
+		if err := fn(t); err != nil {
+			return err
+		}
+		return m.applyAndPersist(ctx, t)
+	})
+}
+
+// applyAndPersist atomically rewrites the on-disk artifact and then restarts
+// the systemd service via DBus so the kernel picks up the new rules. The
+// rendered file already contains the idempotent `add table / flush table`
+// prefix, so it is safe for both the boot-time oneshot and live re-applies.
+func (m *Manager) applyAndPersist(ctx context.Context, t *Table) error {
+	block, err := t.Render()
+	if err != nil {
+		return err
+	}
+
+	if err := atomicWriteFile(m.nftPath, block, 0o644); err != nil {
+		return err
+	}
+
+	return m.applyViaService(ctx)
+}
+
+func (m *Manager) load() (*Table, error) {
+	data, err := os.ReadFile(m.nftPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errorx.IllegalState.New("inet host firewall not found at %s; run `solo-provisioner network firewall create` first", m.nftPath)
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read %s", m.nftPath)
+	}
+	return Parse(string(data))
+}
+
+// withLock serialises a mutation behind the shared cross-command flock so a
+// hand-run operator command and the daemon poll loop (#754) cannot interleave
+// nft transactions.
+func (m *Manager) withLock(fn func() error) error {
+	if err := os.MkdirAll(filepath.Dir(m.lockPath), 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create lock directory %s", filepath.Dir(m.lockPath))
+	}
+	f, err := os.OpenFile(m.lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to open lock file %s", m.lockPath)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to acquire lock %s", m.lockPath)
+	}
+	defer func() { _ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }()
+
+	return fn()
+}

--- a/internal/network/firewall/nft.go
+++ b/internal/network/firewall/nft.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// Runner is the seam over the system `nft` binary for read and delete
+// operations. Live rule application is done by writing the on-disk artifact
+// and restarting the systemd service via DBus — so Apply is not part of this
+// interface. Tests substitute a fake so the package builds and unit-tests on
+// any platform (including macOS) without touching the kernel.
+type Runner interface {
+	// List returns the rendered ruleset for the inet host table
+	// (`nft list table inet host`).
+	List(ctx context.Context) (string, error)
+	// Delete removes the inet host table (`nft delete table inet host`).
+	Delete(ctx context.Context) error
+	// Exists reports whether the inet host table is present in the kernel.
+	Exists(ctx context.Context) (bool, error)
+}
+
+// nftBinCandidates are the absolute locations we look for the system nft binary,
+// in order. We never exec a bare "nft" off PATH to avoid picking up a binary
+// from an attacker-controlled directory (see docs/dev/security-model.md).
+var nftBinCandidates = []string{"/usr/sbin/nft", "/sbin/nft", "/usr/bin/nft"}
+
+// tableArgs splits TableName into the argv tokens nft expects for sub-commands
+// that take a family and table name as separate arguments (list, delete).
+// exec.Command does not tokenise arguments on whitespace, so passing TableName
+// as a single arg would send "inet host" as one token instead of two.
+var tableArgs = strings.Fields(TableName) // ["inet", "host"]
+
+// execRunner shells out to the system nft binary.
+type execRunner struct {
+	bin string
+}
+
+// NewExecRunner resolves the nft binary path and returns a Runner that applies
+// changes to the live kernel.
+func NewExecRunner() Runner {
+	bin := nftBinCandidates[0]
+	for _, c := range nftBinCandidates {
+		if _, err := os.Stat(c); err == nil {
+			bin = c
+			break
+		}
+	}
+	return &execRunner{bin: bin}
+}
+
+func (r *execRunner) List(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, r.bin, append([]string{"list", "table"}, tableArgs...)...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", errorx.ExternalError.Wrap(err, "nft list table %s failed: %s", TableName, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+func (r *execRunner) Delete(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, r.bin, append([]string{"delete", "table"}, tableArgs...)...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return errorx.ExternalError.Wrap(err, "nft delete table %s failed: %s", TableName, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+func (r *execRunner) Exists(ctx context.Context) (bool, error) {
+	// `nft list table inet host` exits zero when the table is present and
+	// non-zero (with "No such file or directory" on stderr) when it is absent.
+	// There is no false-positive risk in treating any failure as "absent": the
+	// subsequent Apply will surface a genuine nft/permission error if one exists.
+	cmd := exec.CommandContext(ctx, r.bin, append([]string{"list", "table"}, tableArgs...)...)
+	return cmd.Run() == nil, nil
+}

--- a/internal/network/firewall/parse.go
+++ b/internal/network/firewall/parse.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// Parse reconstructs a Table from the on-disk network-host.nft artifact. It
+// understands only the exact format this package renders (see the embedded
+// template) — it is not a general nft parser. A render→parse→render round-trip
+// is the identity, which is pinned by TestRoundTrip. Element verbs (add/remove/
+// set) use this to load prior state so they don't need the full flag set re-spec.
+func Parse(content string) (*Table, error) {
+	t := &Table{SSHPort: DefaultSSHPort}
+
+	if !strings.Contains(content, "table "+TableName+" {") {
+		return nil, errorx.IllegalFormat.New("not a recognised inet host ruleset")
+	}
+
+	if cidrs, ok := parseElements(content, reMgmtSet); ok {
+		t.MgmtCIDRs = splitElements(cidrs)
+	}
+	if ports, ok := parseElements(content, rePortSet); ok {
+		for _, p := range splitElements(ports) {
+			n, err := strconv.Atoi(p)
+			if err != nil {
+				return nil, errorx.IllegalFormat.Wrap(err, "invalid in-cluster port %q in %s", p, HostNftPath)
+			}
+			t.InClusterPorts = append(t.InClusterPorts, n)
+		}
+	}
+
+	if m := reSSHPort.FindStringSubmatch(content); m != nil {
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			return nil, errorx.IllegalFormat.Wrap(err, "invalid ssh port %q in %s", m[1], HostNftPath)
+		}
+		t.SSHPort = n
+	}
+	if m := rePodCIDR.FindStringSubmatch(content); m != nil {
+		t.PodCIDR = m[1]
+	}
+
+	return t, nil
+}
+
+var (
+	reMgmtSet = regexp.MustCompile(`set mgmt_addrs \{[^}]*elements = \{ ([^}]*) \}`)
+	rePortSet = regexp.MustCompile(`set in_cluster_ports \{[^}]*elements = \{ ([^}]*) \}`)
+	reSSHPort = regexp.MustCompile(`ip saddr @mgmt_addrs tcp dport (\d+) accept`)
+	rePodCIDR = regexp.MustCompile(`ip saddr (\S+) tcp dport @in_cluster_ports accept`)
+)
+
+func parseElements(content string, re *regexp.Regexp) (string, bool) {
+	m := re.FindStringSubmatch(content)
+	if m == nil {
+		return "", false
+	}
+	return strings.TrimSpace(m[1]), true
+}
+
+func splitElements(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if v := strings.TrimSpace(p); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/internal/network/firewall/paths.go
+++ b/internal/network/firewall/paths.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package firewall implements the node-agnostic `solo-provisioner network
+// firewall` scope: the `inet host` nftables table that protects the bare-metal
+// host (SSH/mgmt allowlist, ICMP policy, in-cluster host-service ports).
+//
+// It is a generic primitive — it knows nothing about block/consensus/mirror/
+// relay nodes. Orchestration (wiring create into `kube cluster install`,
+// teardown into `kube cluster uninstall`) is owned by the host/cluster layer
+// (#777 → #778/#791); this package only implements the verbs.
+//
+// The `inet host` table is kept deliberately separate from `inet weaver` (the
+// BN workload plane). The two tables have opposite lifecycles: `inet host` is
+// set once and rarely changes, while `inet weaver` churns continuously as the
+// daemon rewrites set elements.
+package firewall
+
+const (
+	// TableName is the nftables table this package owns.
+	TableName = "inet host"
+
+	// HostNftPath is the on-disk artifact replayed at boot by the shared
+	// solo-provisioner-network-nft.service oneshot (authored by #780). It lives
+	// under /etc (host OS config on the root filesystem) — not /opt/solo/weaver,
+	// which may be a late mount and would leave the firewall unloaded early at
+	// boot.
+	HostNftPath = "/etc/solo-provisioner/network-host.nft"
+
+	// WeaverNftPath is the inet weaver artifact, owned by `block node install`
+	// (TS_2 #743). This package never writes it; it only checks for its presence
+	// to decide whether the shared oneshot may be disabled (teardown is #791).
+	WeaverNftPath = "/etc/solo-provisioner/network-weaver.nft"
+
+	// NetworkNftService is the oneshot unit that loads network-host.nft at boot
+	// and is restarted on every live mutation so the kernel and the on-disk file
+	// are always in sync. This package authors, installs, and enables the unit;
+	// it never disables it — that is orchestrated by `kube cluster uninstall`
+	// (#791). The unit is extended by #780 to also load network-weaver.nft.
+	NetworkNftService = "solo-provisioner-network-nft.service"
+
+	// NetworkNftServiceUnitPath is the absolute path where the unit file is
+	// installed so systemd can discover it.
+	NetworkNftServiceUnitPath = "/usr/lib/systemd/system/" + NetworkNftService
+
+	// networkNftServiceTemplate is the embedded unit file rendered and written on
+	// first mutation.
+	networkNftServiceTemplate = "files/network/solo-provisioner-network-nft.service"
+
+	// NftablesDropInDir is where the nftables.service drop-in is installed.
+	// Drop-ins in /etc/systemd/system/ take precedence and survive package
+	// upgrades of the nftables package itself.
+	NftablesDropInDir = "/etc/systemd/system/nftables.service.d"
+
+	// NftablesDropInPath is the drop-in file that makes nftables.service pull
+	// in solo-provisioner-network-nft.service whenever it activates — so a
+	// mid-run nftables flush (e.g. triggered by kube cluster install's preflight)
+	// is always followed by a re-apply of our inet host rules.
+	NftablesDropInPath = NftablesDropInDir + "/solo-provisioner.conf"
+
+	// nftablesDropInTemplate is the embedded drop-in file content.
+	nftablesDropInTemplate = "files/network/nftables-dropin.conf"
+
+	// LockDir holds the cross-command apply lock. It lives on tmpfs (/run) so it
+	// is auto-cleared on reboot and leaves nothing behind on uninstall.
+	LockDir = "/run/solo-provisioner/network"
+
+	// LockPath is the flock acquired (LOCK_EX) for the duration of any mutating
+	// verb, so a hand-run operator command and the daemon poll loop (#754) can
+	// never interleave nft transactions.
+	LockPath = "/run/solo-provisioner/network/.applying"
+
+	// hostNftTemplate is the embedded template that renders the full `inet host`
+	// table. Lives under internal/templates/files, embedded via that package.
+	hostNftTemplate = "files/network/network-host.nft.tmpl"
+)

--- a/internal/network/firewall/render.go
+++ b/internal/network/firewall/render.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/hashgraph/solo-weaver/internal/templates"
+	"github.com/joomcode/errorx"
+)
+
+// renderData is the flattened view of a Table passed to the nft template.
+// Strings are pre-joined here because templates.Render parses without a FuncMap,
+// so the template itself cannot call join.
+type renderData struct {
+	MgmtElements string
+	PortElements string
+	SSHPort      int
+	PodCIDR      string
+}
+
+// Render produces the full `inet host` nft document for this table. The same
+// output feeds both the kernel apply (`nft -f`) and the on-disk artifact, so
+// the live table and the persisted file can never diverge.
+func (t *Table) Render() (string, error) {
+	if err := t.Validate(); err != nil {
+		return "", err
+	}
+
+	ports := make([]string, len(t.InClusterPorts))
+	for i, p := range t.InClusterPorts {
+		ports[i] = strconv.Itoa(p)
+	}
+
+	data := renderData{
+		MgmtElements: strings.Join(t.MgmtCIDRs, ", "),
+		PortElements: strings.Join(ports, ", "),
+		SSHPort:      t.SSHPort,
+		PodCIDR:      t.PodCIDR,
+	}
+
+	rendered, err := templates.Render(hostNftTemplate, data)
+	if err != nil {
+		return "", errorx.InternalError.Wrap(err, "failed to render inet host table")
+	}
+
+	return rendered, nil
+}
+
+// atomicWriteFile writes content to path via a temp file in the same directory
+// followed by fsync + rename + parent-dir fsync, so a crash mid-write can never
+// leave a torn nft file that the boot oneshot would fail to load.
+func atomicWriteFile(path, content string, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create directory %s", dir)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".network-host-*.nft.tmp")
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create temp file in %s", dir)
+	}
+	tmpName := tmp.Name()
+
+	// Best-effort cleanup if we bail before the rename succeeds.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return errorx.ExternalError.Wrap(err, "failed to write temp file %s", tmpName)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return errorx.ExternalError.Wrap(err, "failed to fsync temp file %s", tmpName)
+	}
+	if err := tmp.Close(); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to close temp file %s", tmpName)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to chmod temp file %s", tmpName)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to rename %s to %s", tmpName, path)
+	}
+	committed = true
+
+	// fsync the parent directory so the rename itself is durable.
+	d, err := os.Open(dir)
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to open directory %s for fsync", dir)
+	}
+	defer func() { _ = d.Close() }()
+	if err := d.Sync(); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to fsync directory %s", dir)
+	}
+
+	return nil
+}

--- a/internal/network/firewall/service_linux.go
+++ b/internal/network/firewall/service_linux.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package firewall
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/templates"
+	soos "github.com/hashgraph/solo-weaver/pkg/os"
+	"github.com/joomcode/errorx"
+)
+
+// defaultApplyViaService installs the network-nft unit file if absent, enables
+// it for boot, and restarts it so the kernel picks up the just-written
+// network-host.nft immediately — all via DBus, no nft exec for the apply path.
+func defaultApplyViaService(ctx context.Context) error {
+	if err := ensureNetworkNftUnit(ctx); err != nil {
+		return err
+	}
+	return soos.RestartService(ctx, NetworkNftService)
+}
+
+// ensureNetworkNftUnit writes the embedded service unit and the nftables
+// drop-in on first call. Both are stat-and-skip independently so a partial
+// install (e.g. upgrading from a version that predates the drop-in) is
+// repaired on the next mutation without a full reinstall.
+func ensureNetworkNftUnit(ctx context.Context) error {
+	_, unitErr := os.Stat(NetworkNftServiceUnitPath)
+	_, dropInErr := os.Stat(NftablesDropInPath)
+	if unitErr == nil && dropInErr == nil {
+		return nil // both already installed — fast path
+	}
+
+	if unitErr != nil {
+		if err := writeEmbedded(networkNftServiceTemplate, NetworkNftServiceUnitPath); err != nil {
+			return err
+		}
+	}
+	if dropInErr != nil {
+		if err := writeEmbedded(nftablesDropInTemplate, NftablesDropInPath); err != nil {
+			return err
+		}
+	}
+
+	if err := soos.DaemonReload(ctx); err != nil {
+		return err
+	}
+	if unitErr != nil {
+		// Only enable at boot on first install; the drop-in alone doesn't need it.
+		if err := soos.EnableService(ctx, NetworkNftService); err != nil {
+			logx.As().Warn().Err(err).Str("service", NetworkNftService).Msg("could not enable service at boot")
+		}
+	}
+	return nil
+}
+
+func writeEmbedded(tmplPath, destPath string) error {
+	content, err := templates.Files.ReadFile(tmplPath)
+	if err != nil {
+		return errorx.InternalError.Wrap(err, "failed to read embedded %s", tmplPath)
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create %s", filepath.Dir(destPath))
+	}
+	if err := os.WriteFile(destPath, content, 0o644); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to write %s", destPath)
+	}
+	return nil
+}

--- a/internal/network/firewall/service_other.go
+++ b/internal/network/firewall/service_other.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package firewall
+
+import (
+	"context"
+
+	"github.com/automa-saga/logx"
+)
+
+// defaultApplyViaService is the non-Linux stub. systemd is Linux-only; on
+// other platforms (e.g. macOS dev/test builds) there is no service to restart,
+// so this only logs.
+func defaultApplyViaService(_ context.Context) error {
+	logx.As().Debug().Str("service", NetworkNftService).Msg("service apply is a no-op on non-Linux builds")
+	return nil
+}

--- a/internal/network/firewall/table.go
+++ b/internal/network/firewall/table.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"net"
+	"sort"
+	"strconv"
+
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
+	"github.com/joomcode/errorx"
+)
+
+// Default flag values per design §8.4.1.
+const (
+	DefaultSSHPort = 22
+)
+
+// DefaultInClusterPorts is the "stack set" of host-service ports opened to the
+// in-cluster (pod) CIDR by default: the kube-apiserver (6443), the Cilium
+// cluster-mesh / health port (4244), the kubelet read-only/metrics port
+// (10250), and the MetalLB metrics/memberlist port (7472). Operators override
+// with --in-cluster-ports.
+var DefaultInClusterPorts = []int{6443, 4244, 7472, 10250}
+
+// Table is the in-memory model of the `inet host` nftables table. It is the
+// single source of truth that both the kernel apply (via `nft -f`) and the
+// on-disk artifact are rendered from, so the two can never diverge.
+type Table struct {
+	// MgmtCIDRs is the management/SSH allowlist (set @mgmt_addrs).
+	MgmtCIDRs []string
+	// InClusterPorts are host-service ports reachable from PodCIDR (set
+	// @in_cluster_ports). Per design there is deliberately no --service-ports:
+	// BN ports live only in `network policy --ports`.
+	InClusterPorts []int
+	// SSHPort is the TCP port accepted from @mgmt_addrs for management access.
+	SSHPort int
+	// PodCIDR is the source range allowed to reach @in_cluster_ports. Empty
+	// means no in-cluster port rule is rendered.
+	PodCIDR string
+}
+
+// NewTable returns a Table populated with the design defaults. Callers override
+// fields from CLI flags before rendering.
+func NewTable() *Table {
+	ports := append([]int(nil), DefaultInClusterPorts...)
+	sort.Ints(ports)
+	return &Table{
+		MgmtCIDRs:      nil,
+		InClusterPorts: ports,
+		SSHPort:        DefaultSSHPort,
+	}
+}
+
+// Validate rejects any field that would be unsafe to render into the nft
+// ruleset. It is the last gate before the renderer; every untrusted value
+// (CIDRs, ports) is checked through pkg/sanity so a malformed token can never
+// break the atomic transaction or smuggle in nft syntax.
+func (t *Table) Validate() error {
+	for _, c := range t.MgmtCIDRs {
+		if err := sanity.ValidateCIDR(c); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --mgmt-cidr %q", c)
+		}
+		if ip, _, _ := net.ParseCIDR(c); ip.To4() == nil {
+			return errorx.IllegalArgument.New(
+				"invalid --mgmt-cidr %q: IPv6 CIDRs are not yet supported; the inet host table uses ipv4_addr sets", c)
+		}
+	}
+
+	if t.PodCIDR != "" {
+		if err := sanity.ValidateCIDR(t.PodCIDR); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --pod-cidr %q", t.PodCIDR)
+		}
+		if ip, _, _ := net.ParseCIDR(t.PodCIDR); ip.To4() == nil {
+			return errorx.IllegalArgument.New(
+				"invalid --pod-cidr %q: IPv6 CIDRs are not yet supported; the inet host table uses ipv4_addr sets", t.PodCIDR)
+		}
+	}
+
+	for _, p := range t.InClusterPorts {
+		if err := sanity.ValidatePort(strconv.Itoa(p)); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --in-cluster-port %d", p)
+		}
+	}
+
+	if err := sanity.ValidatePort(strconv.Itoa(t.SSHPort)); err != nil {
+		return errorx.IllegalArgument.Wrap(err, "invalid --ssh-port %d", t.SSHPort)
+	}
+
+	return nil
+}
+
+// AddMgmtCIDR adds a single CIDR to the management allowlist (idempotent).
+func (t *Table) AddMgmtCIDR(cidr string) error {
+	if err := sanity.ValidateCIDR(cidr); err != nil {
+		return errorx.IllegalArgument.Wrap(err, "invalid --mgmt-cidr %q", cidr)
+	}
+	if sanity.Contains(cidr, t.MgmtCIDRs) {
+		return nil
+	}
+	t.MgmtCIDRs = append(t.MgmtCIDRs, cidr)
+	sort.Strings(t.MgmtCIDRs)
+	return nil
+}
+
+// RemoveMgmtCIDR removes a single CIDR from the management allowlist
+// (idempotent; removing an absent CIDR is a no-op).
+func (t *Table) RemoveMgmtCIDR(cidr string) {
+	out := t.MgmtCIDRs[:0]
+	for _, c := range t.MgmtCIDRs {
+		if c != cidr {
+			out = append(out, c)
+		}
+	}
+	t.MgmtCIDRs = out
+}
+
+// SetMgmtCIDRs atomically replaces the full management allowlist.
+func (t *Table) SetMgmtCIDRs(cidrs []string) error {
+	for _, c := range cidrs {
+		if err := sanity.ValidateCIDR(c); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --mgmt-cidr %q", c)
+		}
+	}
+	dedup := dedupeStrings(cidrs)
+	sort.Strings(dedup)
+	t.MgmtCIDRs = dedup
+	return nil
+}
+
+// AddPort adds a single in-cluster host-service port (idempotent).
+func (t *Table) AddPort(port int) error {
+	if err := sanity.ValidatePort(strconv.Itoa(port)); err != nil {
+		return errorx.IllegalArgument.Wrap(err, "invalid --in-cluster-port %d", port)
+	}
+	for _, p := range t.InClusterPorts {
+		if p == port {
+			return nil
+		}
+	}
+	t.InClusterPorts = append(t.InClusterPorts, port)
+	sort.Ints(t.InClusterPorts)
+	return nil
+}
+
+// RemovePort removes a single in-cluster host-service port (idempotent).
+func (t *Table) RemovePort(port int) {
+	out := t.InClusterPorts[:0]
+	for _, p := range t.InClusterPorts {
+		if p != port {
+			out = append(out, p)
+		}
+	}
+	t.InClusterPorts = out
+}
+
+// SetPorts atomically replaces the full in-cluster host-service port list.
+func (t *Table) SetPorts(ports []int) error {
+	for _, p := range ports {
+		if err := sanity.ValidatePort(strconv.Itoa(p)); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --in-cluster-port %d", p)
+		}
+	}
+	dedup := dedupeInts(ports)
+	sort.Ints(dedup)
+	t.InClusterPorts = dedup
+	return nil
+}
+
+func dedupeStrings(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+func dedupeInts(in []int) []int {
+	seen := make(map[int]struct{}, len(in))
+	out := make([]int, 0, len(in))
+	for _, n := range in {
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}

--- a/internal/network/firewall/testdata/network-host.golden.nft
+++ b/internal/network/firewall/testdata/network-host.golden.nft
@@ -1,0 +1,46 @@
+add table inet host
+delete table inet host
+add table inet host
+table inet host {
+	set mgmt_addrs { type ipv4_addr; flags interval; elements = { 10.0.0.0/8, 192.168.0.0/16 }; }
+	set in_cluster_ports { type inet_service; elements = { 4244, 6443, 7472, 10250 }; }
+
+	chain input {
+		type filter hook input priority 0; policy drop;
+
+		# Drop invalid; admit loopback.
+		ct state invalid drop
+		iif "lo" accept
+
+		# ICMP is evaluated BEFORE the established/related fast-path. netfilter
+		# conntrack DOES track ICMP echo as a flow (keyed on the echo id), so a
+		# sustained ping shares one entry and every packet after the first would
+		# otherwise match `ct state established,related accept` and bypass the
+		# echo-request rate limit. Handling ICMP first keeps the limit effective.
+		# Explicit accepts are still required because the default-drop policy
+		# would otherwise break new-flow ping and path diagnostics (PMTUD,
+		# traceroute), which the established state does not cover for a NEW flow.
+
+		# Full ICMP from management sources (ping, traceroute, diagnostics) — no rate limit.
+		ip saddr @mgmt_addrs icmp type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem } accept
+
+		# From everyone else: always allow the path-health subset (Path MTU
+		# Discovery + traceroute), and rate-limit echo-request to prevent floods.
+		# The trailing drop keeps over-budget echo from being rescued by the
+		# established accept below (a sustained ping is established after the
+		# first reply).
+		icmp type destination-unreachable accept
+		icmp type time-exceeded accept
+		icmp type echo-request limit rate 10/second accept
+		icmp type echo-request drop
+
+		# Conntrack fast-path for TCP/UDP (and solicited ICMP replies).
+		ct state established,related accept
+
+		# SSH / management access from the allowlist only.
+		ip saddr @mgmt_addrs tcp dport 22 accept
+
+		# In-cluster host-service ports, reachable from the pod CIDR only.
+		ip saddr 10.4.0.0/24 tcp dport @in_cluster_ports accept
+	}
+}

--- a/internal/templates/files/network/network-host.nft.tmpl
+++ b/internal/templates/files/network/network-host.nft.tmpl
@@ -1,0 +1,48 @@
+add table inet host
+delete table inet host
+add table inet host
+table inet host {
+	set mgmt_addrs { type ipv4_addr; flags interval;{{if .MgmtElements}} elements = { {{.MgmtElements}} };{{end}} }
+	set in_cluster_ports { type inet_service;{{if .PortElements}} elements = { {{.PortElements}} };{{end}} }
+
+	chain input {
+		type filter hook input priority 0; policy drop;
+
+		# Drop invalid; admit loopback.
+		ct state invalid drop
+		iif "lo" accept
+
+		# ICMP is evaluated BEFORE the established/related fast-path. netfilter
+		# conntrack DOES track ICMP echo as a flow (keyed on the echo id), so a
+		# sustained ping shares one entry and every packet after the first would
+		# otherwise match `ct state established,related accept` and bypass the
+		# echo-request rate limit. Handling ICMP first keeps the limit effective.
+		# Explicit accepts are still required because the default-drop policy
+		# would otherwise break new-flow ping and path diagnostics (PMTUD,
+		# traceroute), which the established state does not cover for a NEW flow.
+
+		# Full ICMP from management sources (ping, traceroute, diagnostics) — no rate limit.
+		ip saddr @mgmt_addrs icmp type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem } accept
+
+		# From everyone else: always allow the path-health subset (Path MTU
+		# Discovery + traceroute), and rate-limit echo-request to prevent floods.
+		# The trailing drop keeps over-budget echo from being rescued by the
+		# established accept below (a sustained ping is established after the
+		# first reply).
+		icmp type destination-unreachable accept
+		icmp type time-exceeded accept
+		icmp type echo-request limit rate 10/second accept
+		icmp type echo-request drop
+
+		# Conntrack fast-path for TCP/UDP (and solicited ICMP replies).
+		ct state established,related accept
+
+		# SSH / management access from the allowlist only.
+		ip saddr @mgmt_addrs tcp dport {{.SSHPort}} accept
+{{- if .PodCIDR}}
+
+		# In-cluster host-service ports, reachable from the pod CIDR only.
+		ip saddr {{.PodCIDR}} tcp dport @in_cluster_ports accept
+{{- end}}
+	}
+}

--- a/internal/templates/files/network/nftables-dropin.conf
+++ b/internal/templates/files/network/nftables-dropin.conf
@@ -1,0 +1,9 @@
+# Installed by solo-provisioner so that whenever Debian's nftables.service
+# runs (at boot or mid-run) and flushes the ruleset, solo-provisioner's own
+# firewall unit is re-applied immediately after.
+#
+# The ordering is enforced by After=nftables.service in
+# solo-provisioner-network-nft.service itself; this Wants= only ensures
+# systemd schedules our unit when nftables.service starts.
+[Unit]
+Wants=solo-provisioner-network-nft.service

--- a/internal/templates/files/network/solo-provisioner-network-nft.service
+++ b/internal/templates/files/network/solo-provisioner-network-nft.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Solo Provisioner Network Host Firewall (nftables)
+Documentation=https://github.com/hashgraph/solo-weaver
+DefaultDependencies=no
+After=nftables.service
+PartOf=nftables.service
+Before=network-pre.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/nft -f /etc/solo-provisioner/network-host.nft
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -3,6 +3,7 @@
 package sanity
 
 import (
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -702,4 +703,49 @@ func Contains[T comparable](item T, slice []T) bool {
 		}
 	}
 	return false
+}
+
+// ValidateCIDR rejects any string that is not a syntactically valid IPv4 or
+// IPv6 CIDR (e.g. "10.0.0.0/8", "2001:db8::/32"). It is the boundary check for
+// management / in-cluster CIDRs that flow into the `inet host` nftables ruleset
+// rendered to disk and applied via `nft -f`; a malformed value must never reach
+// the renderer, where it could break the atomic transaction or smuggle in nft
+// syntax. A bare IP without a prefix length is rejected — callers must be
+// explicit about the mask.
+func ValidateCIDR(s string) error {
+	if s == "" {
+		return errorx.IllegalArgument.New("CIDR cannot be empty")
+	}
+
+	// Defensive: net.ParseCIDR already rejects these, but fail with a specific
+	// message so the operator sees "invalid characters" rather than a parser dump.
+	if shellMetachars.MatchString(s) {
+		return errorx.IllegalArgument.New("CIDR contains invalid characters: %s", s)
+	}
+
+	if _, _, err := net.ParseCIDR(s); err != nil {
+		return errorx.IllegalArgument.New("invalid CIDR: %s", s)
+	}
+
+	return nil
+}
+
+// ValidatePort rejects any string that is not a valid TCP/UDP port number in
+// the range 1–65535. It is the boundary check for `--in-cluster-port` values
+// before they are rendered into the `inet host` nftables ruleset.
+func ValidatePort(s string) error {
+	if s == "" {
+		return errorx.IllegalArgument.New("port cannot be empty")
+	}
+
+	port, err := strconv.Atoi(s)
+	if err != nil {
+		return errorx.IllegalArgument.New("invalid port number: %s", s)
+	}
+
+	if port < 1 || port > 65535 {
+		return errorx.IllegalArgument.New("port must be between 1 and 65535, got %d", port)
+	}
+
+	return nil
 }

--- a/pkg/sanity/sanity_cidr_test.go
+++ b/pkg/sanity/sanity_cidr_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package sanity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanity_ValidateCIDR(t *testing.T) {
+	testCases := []struct {
+		name        string
+		cidr        string
+		expectError bool
+	}{
+		// Valid
+		{name: "ipv4 /8", cidr: "10.0.0.0/8", expectError: false},
+		{name: "ipv4 /24", cidr: "192.168.1.0/24", expectError: false},
+		{name: "ipv4 /32 host", cidr: "203.0.113.5/32", expectError: false},
+		{name: "ipv6 /32", cidr: "2001:db8::/32", expectError: false},
+		{name: "ipv6 /128 host", cidr: "2001:db8::1/128", expectError: false},
+
+		// Invalid
+		{name: "empty", cidr: "", expectError: true},
+		{name: "bare ipv4 no mask", cidr: "10.0.0.0", expectError: true},
+		{name: "bare ipv6 no mask", cidr: "2001:db8::1", expectError: true},
+		{name: "mask out of range", cidr: "10.0.0.0/33", expectError: true},
+		{name: "not an address", cidr: "not-a-cidr", expectError: true},
+		{name: "octet overflow", cidr: "10.0.0.256/24", expectError: true},
+		{name: "shell metachar injection", cidr: "10.0.0.0/8;reboot", expectError: true},
+		{name: "command substitution", cidr: "10.0.0.0/$(id)", expectError: true},
+		{name: "newline", cidr: "10.0.0.0/8\n", expectError: true},
+		{name: "leading space", cidr: " 10.0.0.0/8", expectError: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateCIDR(tc.cidr)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSanity_ValidatePort(t *testing.T) {
+	testCases := []struct {
+		name        string
+		port        string
+		expectError bool
+	}{
+		// Valid
+		{name: "low boundary 1", port: "1", expectError: false},
+		{name: "kubelet 10250", port: "10250", expectError: false},
+		{name: "high boundary 65535", port: "65535", expectError: false},
+
+		// Invalid
+		{name: "empty", port: "", expectError: true},
+		{name: "zero", port: "0", expectError: true},
+		{name: "above range", port: "65536", expectError: true},
+		{name: "negative", port: "-1", expectError: true},
+		{name: "non-numeric", port: "ssh", expectError: true},
+		{name: "trailing junk", port: "443x", expectError: true},
+		{name: "shell metachar", port: "443;reboot", expectError: true},
+		{name: "whitespace", port: " 443", expectError: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePort(tc.port)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Implements #757: the node-agnostic `solo-provisioner network firewall` scope — `create / add / remove / set / show / delete` — managing a dedicated `inet host` nftables table that protects the bare-metal host (SSH/management allowlist, ICMP policy, in-cluster host-service ports). It is a generic primitive that applies to every node type and is kept separate from the `inet weaver` workload plane.

Every mutation atomically rewrites `/etc/solo-provisioner/network-host.nft` from the in-memory model and then restarts the `solo-provisioner-network-nft.service` oneshot via DBus — so the kernel always reflects the file and the two can never diverge. The rendered file uses an `add table / delete table / add table` prefix: `add table` ensures the table exists so `delete table` never fails (idempotent at first boot), `delete table` wipes the table including all sets and their elements (unlike `flush table`, which only clears chain rules and leaves set elements intact), and the final `add table` creates a fresh empty table for the subsequent rules block. The whole file is applied as a single atomic `nft -f` transaction. Mutations are serialised behind a shared `flock` at `/run/solo-provisioner/network/.applying`.

**Orchestration is out of scope** and owned elsewhere: wiring `create` into `kube cluster install` (#778) and teardown into `kube cluster uninstall` (#791). `delete` here removes the table + on-disk file but deliberately does **not** disable `solo-provisioner-network-nft.service`. This PR authors and installs the unit; `delete` does not disable it — that is owned by #791.

### Files changed

| Area | Change |
|---|---|
| `internal/network/firewall/` | New package: table model, embedded nft template + render, atomic temp+rename persistence, Runner interface (List/Delete/Exists only — Apply replaced by service restart), `/run` flock, self-format parser (so add/remove/set load prior state), service install + DBus restart behind build tags. |
| `internal/templates/files/network/network-host.nft.tmpl` | The `inet host` ruleset template. Prefixed with `add table / flush table` for idempotent boot and live re-apply. |
| `internal/templates/files/network/solo-provisioner-network-nft.service` | Embedded oneshot unit file. Written to `/usr/lib/systemd/system/` on first mutation; enabled and restarted via DBus on every apply. |
| `internal/kube/podcidr.go` | `DetectNodePodCIDR`: resolves the local node's `.spec.podCIDR` (hostname match, or sole node) for the `--pod-cidr` auto-detection default. |
| `cmd/cli/commands/network/` | New `network firewall` command family; registered on root. `create` auto-detects `--pod-cidr` when omitted, with a best-effort fallback. |
| `pkg/sanity/` | `ValidateCIDR` / `ValidatePort` domain validators (+ tests). |
| `docs/quickstart.md` | Network firewall command reference. |

### Design notes

- The exact `inet host` ruleset is not specified verbatim in design §8.4.1, so a safe ruleset is rendered (default-drop input, loopback, est/related, ICMP, SSH-from-mgmt, in-cluster ports from the pod CIDR) and pinned by a golden test.
- **ICMP is a fixed, complete ruleset — not flag-driven.** Full ICMP from the mgmt allowlist; from every other source `destination-unreachable` (Path MTU Discovery) and `time-exceeded` (traceroute) are always accepted, with `echo-request` rate-limited to 10/s. This follows the original architecture proposal (v1.9), which §8.4.1 underspecified. The earlier `--icmp-mgmt`/`--icmp-public` accept/drop toggles were removed: they only covered echo-request, and a `drop` setting would silently break PMTUD for legitimate clients (dropping `destination-unreachable`/frag-needed black-holes large TCP over smaller-MTU paths). The explicit accepts are required because `ct established,related` does not cover the NEW packet of a flow.
- **ICMP block sits above the `established,related` fast-path (corrects a v1.9 ordering bug).** Contrary to "ICMP is stateless", netfilter conntrack **does** track ICMP echo as a flow (keyed on echo id). v1.9 placed `ct state established,related accept` first and the echo rate limit after it — so a single-source `ping` flood (one echo id → one conntrack entry, `ESTABLISHED` after the first reply) sails through the established accept and the `limit rate` rule is dead code. This was confirmed empirically (500/500 accepted at 500/s from a non-mgmt source). The fix: render the ICMP rules before the established accept, and add a trailing `icmp type echo-request drop` so over-budget echo from an established flow is dropped rather than rescued. Ordering is pinned by `TestRender_SecurityInvariants` and the golden file.
- add/remove/set reconstruct prior state by parsing this package's own rendered format (round-trip tested), keeping `network-host.nft` as the single artifact (no sidecar).
- `pkg/os` (systemd) is isolated behind `service_{linux,other}.go` build tags so the core package builds and unit-tests on non-Linux dev hosts.
- **`--pod-cidr` defaults to auto-detection**, matching the design §8.4.1 contract (`default: detected`): when omitted, `create` reads the local node's `.spec.podCIDR` from the Kubernetes API (matched by hostname, or the sole node on a single-node host). Detection is **best-effort** — because `network firewall create` is node-agnostic and may run before a cluster exists, an unreachable cluster is not fatal: the command warns and omits the in-cluster-ports rule (equivalent to the prior empty-default behavior). This keeps cluster-less `create` working while honoring the documented auto-detect contract; the detection query lives in `internal/kube` (not the node-agnostic firewall package) and is stubbable in command tests. Selection logic is unit-tested in `internal/kube/podcidr_test.go`.
- The table has an **`input` chain only** (no `forward` chain), so it filters only host-destined traffic. Workload-plane ingress — e.g. a block node on a MetalLB `LoadBalancer` IP — is DNAT'd to the pod and traverses the kernel `forward` path, which this table never touches, so the host firewall cannot break external block-node reachability. This is the mechanism behind the "protects the host, separate from the `inet weaver` workload plane" separation; UAT scenario 7 exercises it end-to-end.

### Review guide

**Code-review checklist**
- `manager.go` `applyAndPersist`: writes the file first, then calls `applyViaService` (DBus restart). If the write fails, the service is never restarted and the kernel is unchanged. If the restart fails, the file reflects the intended state and the boot oneshot will apply it on next reboot — the error is propagated to the caller.
- `service_linux.go` `ensureNetworkNftUnit`: installs the embedded unit file to `/usr/lib/systemd/system/` on first call (stat-and-return on subsequent calls), daemon-reloads, enables. Subsequent mutations skip straight to `RestartService`.
- `nft.go` `Runner`: interface is now List/Delete/Exists only. `Apply` is gone — live rule application is file + DBus, not a second `nft -f` exec.
- `table.go` `Validate` + `pkg/sanity`: every CIDR/port is validated before it can reach the renderer (injection guard). IPv6 CIDRs are rejected explicitly (the sets use `type ipv4_addr`).
- `render.go` `atomicWriteFile`: temp + fsync + rename + parent-dir fsync.
- `nft.go`: nft is resolved from absolute paths only (no `$PATH` lookup), per the security model.
- The on-disk file starts with `add table inet host` / `delete table inet host` / `add table inet host` — idempotent at both boot (table absent → first `add` creates it, `delete` removes it, second `add` recreates it fresh) and live re-apply (table present → first `add` is a no-op, `delete` wipes the table including all set elements — `flush table` only clears chain rules, not sets — and `add` recreates a clean empty table). Both paths are a single atomic `nft -f` transaction.
- `delete` removes the live table via exec + removes the file; it does not disable the service (confirm the comment + `#791` ownership).

**Test commands**
```bash
# Buildable/runnable on macOS dev hosts:
go test -tags='!integration' ./pkg/sanity/ ./internal/network/firewall/
task lint:check

# Requires the UTM VM (see "Testing status" — not run in this PR's authoring env):
task vm:test:unit
task vm:test:integration TEST_NAME='^TestFirewall'
```

**Manual UAT (on a host / VM with `nft`)**

> **Preconditions.** The `network firewall` command itself needs no cluster — but it depends on the `nft` binary and on `systemd` for live applies. On a solo-provisioner host, `nft` is installed by the **System Setup** phase of `kube cluster install` (`nftables` package + service). The realistic path is to run `sudo solo-provisioner kube cluster install` first; that also gives you real listeners on `6443`/`10250`/`4244` and a real pod CIDR, so the in-cluster-port rule can be probed for real. To exercise the command in isolation instead, `sudo apt-get install -y nftables` is enough.
>
> **Bare `nft` may not be on your `$PATH`.** `solo-provisioner` resolves `nft` by absolute path (`/usr/sbin/nft`), so the firewall verbs work even when a non-root shell can't find `nft` (`/usr/sbin` is typically absent from a user `$PATH`). For the raw `nft list ...` verification steps below, run them via `sudo` (whose `secure_path` includes `/usr/sbin`) or use the absolute path `/usr/sbin/nft`.
>
> **You need a second source host** whose IP is *outside* both the mgmt allowlist and the pod CIDR — an allowlist can't be disproven from an allowed box. Set these three variables once; all commands below can then be copy-pasted:
> ```bash
> HOST=<ip-of-the-firewalled-host>          # the machine running solo-provisioner
> MGMT=<ip-of-a-host-inside-mgmt-cidrs>     # box you SSH from; must be in --mgmt-cidrs
> OUTSIDE=<ip-of-a-host-outside-allowlist>  # box NOT in --mgmt-cidrs and NOT in pod CIDR
> ```
>
> **Drops present as timeouts, not "connection refused."** Every negative probe uses a short timeout (`nc -w3`, `ping -W2`) and treats *no response* as the pass condition.

*1. Create and inspect*
```bash
# On $HOST — adjust the CIDR to match the management LAN the operator SSHes from
sudo solo-provisioner network firewall create --mgmt-cidrs 192.168.1.0/24 --ssh-port 22 \
  --pod-cidr 10.4.0.0/24 --in-cluster-ports 6443,4244,10250
sudo solo-provisioner network firewall show      # inet host table: default-drop input, SSH-from-mgmt, in-cluster ports
cat /etc/solo-provisioner/network-host.nft       # on-disk file begins with add table / flush table prefix
systemctl is-enabled solo-provisioner-network-nft.service   # -> enabled (installed by this command)
```

*2. SSH allowlist (`tcp dport 22` from `@mgmt_addrs`)*
```bash
# From $MGMT (inside allowlist) — expect success:
nc -w3 -zv "$HOST" 22                # -> succeeded / open
# From $OUTSIDE (a host NOT on the mgmt LAN) — expect TIMEOUT (dropped, not refused):
nc -w3 -zv "$HOST" 22                # -> timed out  (pass)
```

*3. ICMP (fixed safe ruleset — not flag-driven)*

ICMP is rendered as a static ruleset: full ICMP from the mgmt allowlist; from everyone else, `destination-unreachable` (PMTUD) and `time-exceeded` (traceroute) are always accepted, and `echo-request` (ping) is rate-limited to 10/s. There are no `--icmp-*` flags.

> **The rate limit only bites from a NON-mgmt source, at >10/s.** A normal `ping` sends 1/s — far under the budget — so it always succeeds regardless. And a mgmt-allowlisted source gets full ICMP with no limit. To see the cap you must flood from a source **outside** `--mgmt-cidrs`. The ICMP rules are placed **before** the `ct state established,related accept` fast-path on purpose: netfilter conntrack tracks ICMP echo as a flow, so a single `ping` process (one echo id) is `ESTABLISHED` after the first reply — if the limit ran after the established accept, every subsequent packet would bypass it (this is the v1.9 ordering bug; corrected here).

```bash
# From $MGMT — full ICMP, no limit, expect replies even under flood:
sudo ping -i 0.02 -c100 -W2 "$HOST"      # -> 0% loss (mgmt is exempt)

# From $OUTSIDE (source NOT in --mgmt-cidrs) — normal ping is within budget:
ping -c3 -W2 "$HOST"                      # -> 0% loss (1/s << 10/s)

# From $OUTSIDE — flood past the limit and confirm the cap bites (heavy loss,
# not a full block). 50/s for ~2s over a 10/s + burst-5 budget:
sudo ping -i 0.02 -c100 "$HOST"          # -> ~85-97% loss (only ~5 burst + ~10/s get through)

# PMTUD: inject ICMP fragmentation-needed directly (from $OUTSIDE):
sudo nping --icmp --icmp-type 3 --icmp-code 4 -c1 "$HOST"   # -> RCVD/accepted, not dropped
# (hping3 equivalent: sudo hping3 -1 -C 3 -K 4 -c1 "$HOST")
sudo nft list table inet host | grep destination-unreachable   # rule present

# Verify rule order (ICMP block must precede established,related):
sudo nft list table inet host | grep -nE 'icmp type|established,related'
#   ip saddr @mgmt_addrs icmp type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem } accept
#   icmp type destination-unreachable accept
#   icmp type time-exceeded accept
#   icmp type echo-request limit rate 10/second accept
#   icmp type echo-request drop                    <- excess echo dropped here
#   ct state established,related accept             <- MUST appear AFTER the ICMP block
```

*4. In-cluster host-service ports (from pod CIDR only)*
```bash
# From a source inside the pod CIDR — expect open:
nc -w3 -zv "$HOST" 6443             # -> succeeded
# From $OUTSIDE the pod CIDR — expect timeout:
nc -w3 -zv "$HOST" 10250            # -> timed out  (pass)
```

*4b. `--pod-cidr` auto-detection (with a cluster installed)*
```bash
# Omit --pod-cidr — it should be detected from the local node's .spec.podCIDR:
sudo solo-provisioner network firewall create --mgmt-cidrs 192.168.1.0/24 --force
#   -> log line: auto-detected pod CIDR from the local node  pod_cidr=10.4.0.0/24
sudo nft list table inet host | grep in_cluster_ports    # rule present, scoped to the detected CIDR
kubectl get node "$(hostname)" -o jsonpath='{.spec.podCIDR}'; echo   # matches the logged value

# With no cluster reachable — expect graceful fallback:
sudo solo-provisioner network firewall create --mgmt-cidrs 192.168.1.0/24 --force
#   -> WARN could not auto-detect pod CIDR; the in-cluster host-service ports rule will be omitted
sudo nft list table inet host | grep -c 'dport @in_cluster_ports'   # -> 0  (rule omitted, command still succeeds)
```

*5. Default-drop catch-all*
```bash
# Any port with no explicit allow, from any source — expect timeout:
nc -w3 -zv "$HOST" 8080             # -> timed out  (pass)
```

*6. Mutation lifecycle (each re-applies atomically + rewrites the file)*
```bash
sudo solo-provisioner network firewall add --mgmt-cidr 10.1.0.0/16
sudo nft list table inet host | grep mgmt_addrs        # now includes 10.1.0.0/16

sudo solo-provisioner network firewall set --in-cluster-ports 6443,10250
sudo nft list table inet host | grep in_cluster_ports  # 4244 gone

sudo solo-provisioner network firewall remove --mgmt-cidr 10.1.0.0/16
cat /etc/solo-provisioner/network-host.nft        # disk stays in lock-step with kernel after every mutation
```

*7. Block node stays reachable from outside (workload-plane isolation)*

The `inet host` table has an **`input` chain only** — it filters traffic destined for the host itself. Block-node traffic arrives on a MetalLB **LoadBalancer** IP and is DNAT'd to the pod, so it traverses the kernel **`forward`** path, which this table does not touch.

```bash
sudo solo-provisioner kube cluster install
sudo solo-provisioner block node install
sudo solo-provisioner network firewall create --mgmt-cidrs 192.168.1.0/24 --ssh-port 22 \
  --pod-cidr 10.4.0.0/24 --in-cluster-ports 6443,4244,10250

kubectl get svc -A -o wide | grep LoadBalancer   # note EXTERNAL-IP and PORT
BN_LB=<external-ip>; BN_PORT=<port>

# From $OUTSIDE — expect OPEN (firewall does not block forward-path traffic):
nc -w3 -zv "$BN_LB" "$BN_PORT"    # -> succeeded  (pass)

# Same host still cannot reach $HOST's own SSH (drop policy is live):
nc -w3 -zv "$HOST" 22              # -> timed out  (pass)
```

> If the block node is **unreachable** after `create`, BN ingress is hitting the host `input` path (e.g. hostNetwork/hostPort rather than LoadBalancer/forward) — worth flagging; out of scope for this PR.

*8. Boot replay (rules survive reboot)*

Verifies that the `solo-provisioner-network-nft.service` oneshot correctly replays rules at boot — the core guarantee of the service-restart apply model.

```bash
# Confirm the service is installed and enabled before rebooting:
systemctl is-enabled solo-provisioner-network-nft.service   # -> enabled
cat /usr/lib/systemd/system/solo-provisioner-network-nft.service  # unit file present

sudo reboot

# After reboot — SSH back in from $MGMT and confirm rules loaded:
sudo solo-provisioner network firewall show   # -> table displayed (not "no active table")
sudo nft list table inet host | grep mgmt_addrs   # same CIDRs as before reboot

nc -w3 -zv "$HOST" 22   # from $MGMT     -> succeeded  (pass)
nc -w3 -zv "$HOST" 22   # from $OUTSIDE  -> timed out  (pass)
```

*9. Delete (table + file gone; service untouched)*
```bash
sudo solo-provisioner network firewall delete
sudo nft list table inet host                     # -> No such file or directory
ls /etc/solo-provisioner/network-host.nft         # -> No such file or directory
systemctl is-enabled solo-provisioner-network-nft.service  # still enabled (disable is owned by #791)
```

**Risks / rollback** — Additive (new command, new table, new file); no existing path invokes it yet. The default-drop chain always renders the SSH-from-mgmt allow (golden-pinned) so `create` cannot produce a lock-out ruleset. Rollback = `nft delete table inet host` + `rm /etc/solo-provisioner/network-host.nft`. No cluster prerequisite: the command reads no cluster state and runs on a bare host, but it does depend on the `nft` binary (provisioned by the System Setup phase of `kube cluster install`) and on `systemd` for live applies.

### Testing status

⚠️ **VM-gated tests have not been run in this PR's authoring environment.** Verified here: `pkg/sanity` + `internal/network/firewall` unit tests (macOS), `task lint:check` (0 issues), and linux cross-compile/vet of `./cmd/cli/...`. The CLI structural test and any integration tests need `task vm:test:unit` / `task vm:test:integration` on the UTM VM, and real `nft` apply needs a host — **please run these before merge.**

### Related Issues

* Closes #757

