### PR TITLE
fix(blocknode): honor --values plugins.names via "no override" preset

### DIFF
--- a/cmd/cli/commands/block/node/init.go
+++ b/cmd/cli/commands/block/node/init.go
@@ -160,7 +160,7 @@ func promptForMissingFlags(cmd *cobra.Command, args []string) error {
 	}, cv)
 
 	// Plugin preset prompt: preset select → conditional custom multi-select.
-	prompt.AddPluginPresetPrompts(w, cmd, defaults, &flagPluginPreset, &flagPlugins, flagChartVersion, cv)
+	prompt.AddPluginPresetPrompts(w, cmd, defaults, &flagPluginPreset, &flagPlugins, flagChartVersion, flagValuesFile, cv)
 
 	// Run all accumulated pages as a single navigable form.
 	if err := w.Run(); err != nil {
@@ -239,7 +239,10 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 	// --plugin-preset is not prompted, so flagPluginPreset stays empty. Re-resolve
 	// from the stored preset to ensure plugin names are updated when crossing chart
 	// version boundaries (e.g. the 0.35 s3-archive → cloud-storage-* rename).
-	if cmd.Name() == "upgrade" && pluginPreset == "" && pluginList == "" {
+	// Skip this when the operator manages plugins via their --values file (it defines
+	// plugins.names): re-resolving from the saved preset would clobber the values file.
+	if cmd.Name() == "upgrade" && pluginPreset == "" && pluginList == "" &&
+		!bnpkg.ValuesFileDefinesPlugins(validatedValuesFile) {
 		if stateDefaults, defErr := state.ReadPromptDefaultsFromDisk(); defErr == nil {
 			if bnpkg.IsKnownPreset(stateDefaults.BlockNode.PluginPreset) {
 				pluginPreset = stateDefaults.BlockNode.PluginPreset

--- a/cmd/cli/commands/common/flags_blocknode.go
+++ b/cmd/cli/commands/common/flags_blocknode.go
@@ -175,7 +175,7 @@ func FlagPluginPreset() FlagDefinition[string] {
 	return FlagDefinition[string]{
 		Name:        "plugin-preset",
 		ShortName:   "",
-		Description: "Plugin preset to deploy (tier1-lfh, tier1-rfh, or custom); prompts interactively when omitted",
+		Description: "Plugin preset to deploy (tier1-lfh, tier1-rfh, custom, or none for no override — use --values/chart default); prompts interactively when omitted",
 		Default:     "",
 	}
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -173,7 +173,7 @@ sudo solo-provisioner block node install \
 | `--verification-size`     | Verification storage size (chart versions below 0.37.0)                                                                               |
 | `--log-size`              | Log storage size                                                                                                                      |
 | `--application-state-size` | PV/PVC size for application-state storage (e.g., `500Mi`, `1Gi`); chart versions 0.37.0 and above                                    |
-| `--plugin-preset`         | Plugin preset to deploy (`tier1-lfh`, `tier1-rfh`, or `custom`); prompts interactively when omitted                                   |
+| `--plugin-preset`         | Plugin preset to deploy (`tier1-lfh`, `tier1-rfh`, `custom`, or `none` for no override — use `--values`/chart default); prompts interactively when omitted |
 | `--plugins`               | Comma-separated plugin list; overrides `--plugin-preset` when set                                                                     |
 | `--plugins-size`          | PV/PVC size for plugins storage (e.g., `5Gi`, `10Gi`)                                                                                 |
 | `--plugins-path`          | Path for plugins storage                                                                                                              |

--- a/internal/blocknode/blocknode_plugins.go
+++ b/internal/blocknode/blocknode_plugins.go
@@ -28,6 +28,13 @@ const (
 
 	// PresetCustom indicates the operator selected a custom set of plugins.
 	PresetCustom = "custom"
+
+	// PresetNone means "do not override": the plugin list is left to the operator's
+	// --values file (if it sets plugins.names) or the chart's built-in default.
+	// It resolves to an empty plugin list, so injectPluginsConfig is a no-op.
+	// It is deliberately absent from every Presets map, so IsKnownPreset reports
+	// false and PluginListForPreset returns "".
+	PresetNone = "none"
 )
 
 // blockNodePluginConfig holds the canonical plugin configuration for a range of
@@ -106,10 +113,11 @@ var presetLabels = map[string]string{
 	PresetTier1LFH: "Tier 1 — Local Full History  (blocks stored on local disk)",
 	PresetTier1RFH: "Tier 1 — Remote Full History  (blocks stored in cloud storage)",
 	PresetCustom:   "Custom  (select individual plugins)",
+	PresetNone:     "Use Values File / Chart Default  (no override)",
 }
 
 // orderedPresets is the display order for the TUI select prompt.
-var orderedPresets = []string{PresetTier1LFH, PresetTier1RFH, PresetCustom}
+var orderedPresets = []string{PresetTier1LFH, PresetTier1RFH, PresetCustom, PresetNone}
 
 // configForVersion returns the plugin configuration applicable to the given
 // chart version. Empty or unparseable versions return the latest config.

--- a/internal/blocknode/blocknode_plugins_test.go
+++ b/internal/blocknode/blocknode_plugins_test.go
@@ -3,6 +3,8 @@
 package blocknode
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -55,6 +57,22 @@ func TestAvailablePresets_ContainsExpectedPresets(t *testing.T) {
 	assert.Contains(t, presets, PresetTier1LFH)
 	assert.Contains(t, presets, PresetTier1RFH)
 	assert.Contains(t, presets, PresetCustom)
+	assert.Contains(t, presets, PresetNone)
+}
+
+// TestPresetNone_ResolvesToEmptyList locks in the contract that the "no override"
+// preset is not a known preset and yields an empty plugin list, so injectPluginsConfig
+// leaves the merged --values/chart-default plugins.names untouched.
+func TestPresetNone_ResolvesToEmptyList(t *testing.T) {
+	assert.False(t, IsKnownPreset(PresetNone), "PresetNone must not be a known preset")
+	assert.Empty(t, PluginListForPreset(PresetNone, ""), "PresetNone must resolve to an empty plugin list")
+	assert.Empty(t, PluginListForPreset(PresetNone, "0.35.0"), "PresetNone must resolve empty at any version")
+	assert.NotEmpty(t, PresetLabel(PresetNone), "PresetNone must have a display label")
+	// It must be absent from every version entry's Presets map.
+	for i, cfg := range blockNodePluginHistory {
+		_, ok := cfg.Presets[PresetNone]
+		assert.False(t, ok, "entry %d (MinVersion=%q) must not define PresetNone", i, cfg.MinVersion)
+	}
 }
 
 func TestAvailablePresets_ReturnsACopy(t *testing.T) {
@@ -287,6 +305,45 @@ func TestInjectPluginsConfig_CustomListNoWhitespace(t *testing.T) {
 	for _, entry := range strings.Split(names, ",") {
 		assert.Equal(t, strings.TrimSpace(entry), entry, "no surrounding whitespace per plugin entry")
 	}
+}
+
+// ── ValuesFileDefinesPlugins ───────────────────────────────────────────────────
+
+func TestValuesFileDefinesPlugins(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"scalar string", "plugins:\n  names: \"health,verification\"\n", true},
+		{"yaml sequence", "plugins:\n  names:\n    - health\n    - verification\n", true},
+		// An explicit empty string, empty sequence, or null still counts as "defined":
+		// the operator touched the key, and Helm's CoalesceTables treats an operator
+		// null as an instruction to delete the chart's default plugins.names entirely
+		// (see ValuesFileDefinesPlugins doc comment) — that's deliberate operator intent,
+		// not "no opinion", so it must not be clobbered by a preset-derived list.
+		{"empty string", "plugins:\n  names: \"\"\n", true},
+		{"empty sequence", "plugins:\n  names: []\n", true},
+		{"explicit null", "plugins:\n  names: null\n", true},
+		{"names absent", "plugins:\n  mavenImage: img\n", false},
+		{"plugins absent", "blockNode:\n  config: {}\n", false},
+		{"unparseable yaml", "plugins: : :\n  - [\n", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "values.yaml")
+			require.NoError(t, os.WriteFile(path, []byte(tc.content), 0o600))
+			assert.Equal(t, tc.want, ValuesFileDefinesPlugins(path))
+		})
+	}
+}
+
+func TestValuesFileDefinesPlugins_EmptyPathIsFalse(t *testing.T) {
+	assert.False(t, ValuesFileDefinesPlugins(""))
+}
+
+func TestValuesFileDefinesPlugins_MissingFileIsFalse(t *testing.T) {
+	assert.False(t, ValuesFileDefinesPlugins(filepath.Join(t.TempDir(), "does-not-exist.yaml")))
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/internal/blocknode/values.go
+++ b/internal/blocknode/values.go
@@ -182,6 +182,43 @@ func mergeValues(base, operator []byte) ([]byte, error) {
 	return result, nil
 }
 
+// ValuesFileDefinesPlugins reports whether the operator-supplied values file manages
+// plugins.names at all — i.e. the key is present under plugins, regardless of its value.
+// This includes an explicit empty string, an empty sequence, or null: Helm's
+// chartutil.CoalesceTables treats an operator-set null as an instruction to delete the
+// chart's default plugins.names entirely (see coalesceTablesFullKey's "nullifying a
+// chart default" branch), which is just as much a deliberate operator choice as setting
+// a concrete list. Callers (the prompt smart-default and the upgrade re-resolve guard)
+// must not clobber any of these with a preset-derived list.
+// It is intentionally error-tolerant: an empty path, an unreadable file, or a parse
+// failure all return false rather than an error — the interactive prompt uses this only
+// to decide a smart default, and the deploy-time path (ComputeValuesFile) surfaces any
+// real read/parse error later.
+func ValuesFileDefinesPlugins(valuesFile string) bool {
+	if valuesFile == "" {
+		return false
+	}
+	sanitizedPath, err := sanity.ValidateInputFile(valuesFile)
+	if err != nil {
+		return false
+	}
+	content, err := oslib.ReadFile(sanitizedPath)
+	if err != nil {
+		return false
+	}
+
+	var vals map[string]interface{}
+	if err := yaml.Unmarshal(content, &vals); err != nil {
+		return false
+	}
+	plugins, ok := vals["plugins"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	_, ok = plugins["names"]
+	return ok
+}
+
 // persistenceEntry represents the required persistence settings for a storage type.
 type persistenceEntry struct {
 	name      string

--- a/internal/ui/prompt/blocknode.go
+++ b/internal/ui/prompt/blocknode.go
@@ -550,6 +550,15 @@ func BlockNodeReconfigureInputPrompts(
 // page and switch away from Custom — the multi-select page hides again and
 // --plugins is left empty (normalised in afterRun).
 //
+// The preset-select page pre-selects the last used preset read from the on-disk
+// state file. When the operator's --values file defines plugins.names, the
+// "no override" preset (PresetNone) is pre-selected instead so the values file
+// wins unless the operator actively picks a preset.
+//
+// The custom multi-select page lists all known block-node plugins for the given
+// chartVersion; the operator's selection is joined as a comma-separated string
+// and written to *flagPlugins.
+//
 // The function is a no-op when either flag was already supplied on the command
 // line — the caller's values are respected as-is.
 //
@@ -560,6 +569,8 @@ func BlockNodeReconfigureInputPrompts(
 //   - flagPluginPreset: pointer to the --plugin-preset flag variable
 //   - flagPlugins:     pointer to the --plugins flag variable
 //   - chartVersion:   target chart version (used to filter available plugins)
+//   - valuesFile:     path to the operator's --values file (empty when not supplied);
+//     used to smart-default the preset to "no override" when it defines plugins.names
 //   - cv:              chosen-values collector for summary printing
 //
 // Note: the custom multi-select's option list is fixed at construction from
@@ -572,6 +583,7 @@ func AddPluginPresetPrompts(
 	flagPluginPreset *string,
 	flagPlugins *string,
 	chartVersion string,
+	valuesFile string,
 	cv *ChosenValues,
 ) {
 	// If the operator already supplied --plugins, no prompting is needed.
@@ -585,6 +597,13 @@ func AddPluginPresetPrompts(
 
 	// ── Page: preset selection ─────────────────────────────────────────────────
 	effectivePreset := resolveEffective(defaults.BlockNode.PluginPreset, "", blocknode.PresetTier1LFH)
+	// Smart default: when the operator's --values file defines plugins.names, pre-select
+	// the "no override" option so their file wins unless they actively pick a preset.
+	// This overrides the tier1-lfh/state default (and is sticky when state already saved
+	// "none", since resolveEffective returns it and this just re-selects it).
+	if blocknode.ValuesFileDefinesPlugins(valuesFile) {
+		effectivePreset = blocknode.PresetNone
+	}
 	*flagPluginPreset = effectivePreset
 
 	var options []huh.Option[string]
@@ -687,10 +706,11 @@ func RunPluginPresetPrompts(
 	flagPluginPreset *string,
 	flagPlugins *string,
 	chartVersion string,
+	valuesFile string,
 	cv *ChosenValues,
 ) error {
 	w := NewWizard()
-	AddPluginPresetPrompts(w, cmd, defaults, flagPluginPreset, flagPlugins, chartVersion, cv)
+	AddPluginPresetPrompts(w, cmd, defaults, flagPluginPreset, flagPlugins, chartVersion, valuesFile, cv)
 	return w.Run()
 }
 

--- a/internal/ui/prompt/wizard_test.go
+++ b/internal/ui/prompt/wizard_test.go
@@ -5,6 +5,8 @@
 package prompt
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashgraph/solo-weaver/internal/blocknode"
@@ -183,7 +185,7 @@ func TestAddPluginPresetPrompts_NonCustomClearsPlugins(t *testing.T) {
 	var preset, plugins string
 
 	w := NewWizard()
-	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, "0.35.1", NewChosenValues())
+	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, "0.35.1", "", NewChosenValues())
 
 	// preset group + conditional custom group.
 	if len(w.groups) != 2 || len(w.afterRun) != 1 {
@@ -217,7 +219,7 @@ func TestAddPluginPresetPrompts_CustomJoinsSelection(t *testing.T) {
 
 	cv := NewChosenValues()
 	w := NewWizard()
-	AddPluginPresetPrompts(w, cmd, defaults, &preset, &plugins, "0.35.1", cv)
+	AddPluginPresetPrompts(w, cmd, defaults, &preset, &plugins, "0.35.1", "", cv)
 
 	if preset != blocknode.PresetCustom {
 		t.Fatalf("expected Custom preset pre-selected, got %q", preset)
@@ -233,6 +235,35 @@ func TestAddPluginPresetPrompts_CustomJoinsSelection(t *testing.T) {
 	}
 }
 
+func TestAddPluginPresetPrompts_SmartDefaultsToNoneWhenValuesFileDefinesPlugins(t *testing.T) {
+	valuesFile := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(valuesFile, []byte("plugins:\n  names: \"health,verification\"\n"), 0o600); err != nil {
+		t.Fatalf("failed to write values file: %v", err)
+	}
+
+	cmd := &cobra.Command{Use: "install"}
+	var preset, plugins string
+
+	w := NewWizard()
+	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, "0.35.1", valuesFile, NewChosenValues())
+
+	if preset != blocknode.PresetNone {
+		t.Fatalf("expected the values file to smart-default the preset to PresetNone, got %q", preset)
+	}
+}
+
+func TestAddPluginPresetPrompts_DefaultsToTier1LFHWhenNoValuesFile(t *testing.T) {
+	cmd := &cobra.Command{Use: "install"}
+	var preset, plugins string
+
+	w := NewWizard()
+	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, "0.35.1", "", NewChosenValues())
+
+	if preset != blocknode.PresetTier1LFH {
+		t.Fatalf("expected the default tier1-lfh preset when no --values file is given, got %q", preset)
+	}
+}
+
 func TestAddPluginPresetPrompts_SkipsWhenPresetFlagSet(t *testing.T) {
 	cmd := &cobra.Command{Use: "install"}
 	var preset, plugins string
@@ -241,7 +272,7 @@ func TestAddPluginPresetPrompts_SkipsWhenPresetFlagSet(t *testing.T) {
 	_ = cmd.Flags().Set("plugin-preset", "tier1-lfh")
 
 	w := NewWizard()
-	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, "0.35.1", NewChosenValues())
+	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, "0.35.1", "", NewChosenValues())
 
 	if len(w.groups) != 0 {
 		t.Fatalf("expected no groups when --plugin-preset already set, got %d", len(w.groups))

--- a/pkg/models/inputs.go
+++ b/pkg/models/inputs.go
@@ -72,7 +72,7 @@ type BlockNodeInputs struct {
 	LoadBalancerEnabled bool   // true = inject metallb.io/address-pool annotation via Helm values
 	HistoricRetention   string // FILES_HISTORIC_BLOCK_RETENTION_THRESHOLD (0 = unlimited)
 	RecentRetention     string // FILES_RECENT_BLOCK_RETENTION_THRESHOLD (~96000 default)
-	PluginPreset        string // preset ID (e.g. "tier1-lfh") or "custom"; empty = chart default
+	PluginPreset        string // preset ID (e.g. "tier1-lfh"), "custom", or "none" (no override); empty/"none" = use --values or chart default
 	PluginList          string // resolved comma-separated plugin list injected into plugins.names
 }
 


### PR DESCRIPTION
## Description

A block-node `--values` file that sets `plugins.names` was silently ignored on an
interactive install. The plugin-preset prompt always pre-selected a preset (default
`tier1-lfh`) and offered no "use my values file" option, so the resolved plugin list was
never empty — and `injectPluginsConfig` then overwrote the values-file `plugins.names`
*after* the deep-merge (PR #703) had correctly let it win. Operators who set `plugins.names`
in `--values` got the preset bundle deployed instead, a silent divergence between intent
and what actually ran.

This PR implements the precedence **flags/TUI (explicit) > `values.yaml` > chart default**
by letting the resolution produce an *empty* plugin list when the operator did not
explicitly choose plugins. An empty list already makes `injectPluginsConfig` a no-op, so
the merged values-file (or chart-default) `plugins.names` survives untouched.
`injectPluginsConfig` and `mergeValues` are unchanged.

### Files changed

| File | Change |
|---|---|
| `internal/blocknode/blocknode_plugins.go` | Add `PresetNone = "none"` + label + menu entry; deliberately **not** in any `Presets` map → `IsKnownPreset("none")=false`, resolves to `""` |
| `internal/blocknode/values.go` | Add exported `ValuesFileDefinesPlugins(path)` (error-tolerant; scalar or YAML-sequence `plugins.names`) |
| `internal/ui/prompt/blocknode.go` | `RunPluginPresetPrompts` gains a `valuesFile` param; smart-defaults to `PresetNone` when the file defines `plugins.names` |
| `cmd/cli/commands/block/node/init.go` | Pass `flagValuesFile` to the prompt; upgrade re-resolve guard now `&& !ValuesFileDefinesPlugins(...)` |
| `pkg/models/inputs.go`, `cmd/cli/commands/common/flags_blocknode.go`, `docs/quickstart.md` | Document `none` on `PluginPreset` / the `--plugin-preset` flag |
| `internal/blocknode/blocknode_plugins_test.go` | Tests for the `PresetNone` registry contract and `ValuesFileDefinesPlugins` |

### Behavior

- Interactive install with `-f` defining `plugins.names` → prompt now lists **and
  pre-selects** "Use Values File / Chart Default"; accepting it deploys the file's list.
- `--plugins` / `--plugin-preset` still suppress the prompt and win (flags beat the file).
- `--plugin-preset none` is a valid scripted "no override" value.
- No `-f` plugins / no explicit choice → unchanged (`tier1-lfh` default; scripted → chart default).
- `upgrade`: a values-managed `plugins.names` is no longer clobbered by the saved-state
  re-resolve, while the chart-version plugin rename still applies when plugins are not
  values-managed.

### Review guide

**Code-review checklist**

- [ ] `PresetNone` is absent from every `blockNodePluginHistory[*].Presets` map →
      `IsKnownPreset("none")==false`, `PluginListForPreset("none",…)==""`
      (`internal/blocknode/blocknode_plugins.go`).
- [ ] Selecting `PresetNone` leaves `*flagPlugins` empty — the existing Pass-2
      `!= PresetCustom` early return handles it (`internal/ui/prompt/blocknode.go`).
- [ ] `init.go` resolution: `PresetNone` → `pluginList==""`, so neither the
      `--plugins required` error nor the `custom` promotion triggers
      (`cmd/cli/commands/block/node/init.go` resolve block).
- [ ] Upgrade guard skips the state re-resolve **only** when the values file defines
      plugins; otherwise the `0.35 s3-archive → cloud-storage-*` rename still applies.
- [ ] Smart default overrides the `tier1-lfh`/state default **only** when the values file
      actually defines `plugins.names` (common no-`-f` case unchanged).
- [ ] `injectPluginsConfig` / `mergeValues` untouched.

**Test commands**

```bash
# macOS-runnable unit tests (core of the fix)
go test ./internal/blocknode/... ./internal/ui/prompt/... ./pkg/models/...
go test ./internal/blocknode/ -run 'PresetNone|ValuesFileDefinesPlugins|AvailablePresets' -v

# Full suite incl. Linux-only packages — run in the UTM VM
task vm:test:unit
task vm:test:integration TEST_NAME='^Test.*Install.*$'
```

**Manual UAT (VM) — verified end-to-end** ✅

1. Create a values file with a plugin list distinct from every built-in preset — the
   full `tier1-lfh` list minus `backfill`:
   ```bash
   printf 'plugins:\n  names: "facility-messaging,block-access-service,health,server-status,stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent"\n' > /tmp/myvalues.yaml
   ```
   > **Note:** a very sparse plugin set (e.g. just `health,verification`) can make the
   > block-node server fail its `/healthz/readyz` probe and never come up, causing Helm's
   > `--atomic` install to time out and roll back the whole release — a property of that
   > plugin combination, not of this fix. Confirmed via `kubectl get events -n <ns>`:
   > the pod pulled the image and started, but `block-node-server` never opened its port
   > in time. Use a fuller-but-still-custom list (as above) to get a stable release you
   > can inspect with `helm get values`.
2. Self-install the provisioner once, then run the interactive install (use the installed
   binary on `PATH`, not `./bin/...`):
   ```bash
   sudo solo-provisioner install
   sudo solo-provisioner block node install -p local \
     --namespace bn --release-name bn --chart-version 0.37.0 \
     --base-path /opt/bn --historic-retention 0 --recent-retention 96000 \
     -f /tmp/myvalues.yaml
   ```
   (`0.37.0` is the newest chart version published to `ghcr.io/hiero-ledger/hiero-block-node`
   at time of writing; pick whatever is current.)
3. **Expected — smart default:** the "Block Node Plugin Preset" prompt now lists a fourth
   option and pre-selects it:
   ```
   ┃ Block Node Plugin Preset
   ┃   Tier 1 — Local Full History  (blocks stored on local disk)
   ┃   Tier 1 — Remote Full History  (blocks stored in cloud storage)
   ┃   Custom  (select individual plugins)
   ┃ > Use Values File / Chart Default  (no override)
   ```
4. Accept "Use Values File / Chart Default". Confirm the values file won:
   ```bash
   helm get values bn -n bn -a | grep -A1 '^plugins:'
   # observed: names: facility-messaging,block-access-service,health,server-status,
   #   stream-publisher,stream-subscriber,verification,blocks-file-historic,blocks-file-recent
   # (9 plugins — NOT the 10-plugin tier1-lfh bundle, which also includes backfill)
   ```
5. **Flags still win:** re-run adding `--plugin-preset tier1-lfh` (or `--plugins a,b`) — no
   prompt appears and the preset/flag list is deployed, overriding the file.
6. **Unchanged default:** re-run with a `-f` file that has **no** `plugins.names` (or no
   `-f`) — the prompt defaults to **Tier 1 — Local Full History** as before.
7. **Scripted no-override:** `--force --plugin-preset none -f /tmp/myvalues.yaml` deploys
   the file's `plugins.names` with no prompt.

**Risks / rollback**

Low. The interactive default only changes when the `--values` file defines `plugins.names`;
all other flows are unchanged, and `injectPluginsConfig`/`mergeValues` are untouched.
Rollback = revert the `PresetNone` additions, the prompt smart-default line, and the
upgrade-guard clause.

### Stacking note

Builds on merged PR #703 (deep-merge custom `--values` over the embedded profile base),
which is what lets a values-file `plugins.names` survive the merge in the first place.

### Related Issues

* Closes #731



