### PR TITLE
feat(network): add `network policy create` (--stamp/--deny/--reply-stamp)

### DIFF
--- a/cmd/cli/commands/network/network.go
+++ b/cmd/cli/commands/network/network.go
@@ -5,6 +5,7 @@ package network
 import (
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/network/firewall"
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/network/policy"
 	"github.com/spf13/cobra"
 )
 
@@ -12,12 +13,15 @@ var networkCmd = &cobra.Command{
 	Use:   "network",
 	Short: "Manage node-level network state (firewall, policy, shaping, load balancing)",
 	Long: "Manage node-level network state behind the solo-provisioner traffic shaper. " +
-		"The firewall scope manages the node-agnostic `inet host` nftables table.",
+		"The firewall scope manages the node-agnostic `inet host` nftables table; the policy scope " +
+		"manages per-category traffic rules in the `inet weaver` table. Both are generic primitives " +
+		"driven by CIDRs and class names, not tied to any specific node type.",
 	RunE: common.DefaultRunE, // runnable group; sub-commands inherit parent/root flags
 }
 
 func init() {
 	networkCmd.AddCommand(firewall.GetCmd())
+	networkCmd.AddCommand(policy.GetCmd())
 }
 
 // GetCmd returns the root of the `network` command group.

--- a/cmd/cli/commands/network/policy/create.go
+++ b/cmd/cli/commands/network/policy/create.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/internal/kube"
+	pol "github.com/hashgraph/solo-weaver/internal/network/policy"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+// detectPodCIDR resolves the local node's pod CIDR from the cluster. It is
+// indirected through a var so command tests can stub cluster access.
+var detectPodCIDR = func(ctx context.Context) (string, error) {
+	c, err := kube.NewClient()
+	if err != nil {
+		return "", err
+	}
+	return c.DetectNodePodCIDR(ctx)
+}
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a policy: render its rule(s) into the `inet weaver` chain",
+	Long: "Render one named category's classification/ACL rule(s) into the `inet weaver` forward chain and " +
+		"ensure its nft set exists. Specify exactly one action: --stamp <class> (classify into an HTB priority " +
+		"class), or --deny (drop the CIDRs both directions). There is no --direction flag: --stamp's class fixes " +
+		"the direction. --reply-stamp adds an asymmetric conntrack reply rule to an egress-direction --stamp " +
+		"policy; the reply class must be the mirror (ingress) direction. create-if-missing: an existing policy " +
+		"is left untouched unless --force is passed, which replaces its config and membership from the given " +
+		"flags/--cidrs.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		p, err := policyFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		cidrs, err := resolveCIDRs(cmd)
+		if err != nil {
+			return err
+		}
+
+		podCIDR := flagPodCIDR
+		if podCIDR == "" && p.Action != pol.ActionDeny {
+			// A --deny rule never references POD_CIDR (see Render), so skip
+			// resolving it entirely for --deny -- no point requiring a
+			// reachable cluster (or --pod-cidr) for a quarantine-only policy.
+			// If a sibling --stamp policy in the registry still needs it,
+			// Manager.Create's Render call below surfaces that clearly.
+			//
+			// An explicit --pod-cidr works offline; only auto-detection needs a
+			// reachable cluster. Unlike `network firewall create` (best-effort,
+			// node-agnostic), `network policy create` is expected to run against a
+			// live cluster (design §7.2.4), so a detection failure with no
+			// --pod-cidr is a hard error rather than a warning.
+			detected, derr := detectPodCIDR(cmd.Context())
+			if derr != nil {
+				return errorx.IllegalState.Wrap(derr,
+					"could not auto-detect the pod CIDR; pass --pod-cidr explicitly")
+			}
+			podCIDR = detected
+			logx.As().Info().Str("pod_cidr", podCIDR).Msg("auto-detected pod CIDR from the local node")
+		}
+
+		force, err := common.FlagForce().Value(cmd, args)
+		if err != nil {
+			return err
+		}
+
+		changed, err := newManager().Create(cmd.Context(), p, cidrs, podCIDR, force)
+		if err != nil {
+			return err
+		}
+		if changed {
+			logx.As().Info().Str("policy", p.Name).Msg("network policy created")
+		}
+		return nil
+	},
+}
+
+// policyFromFlags assembles a Policy from the create flags, resolving the action
+// (exactly one of --stamp / --deny) and --from-entity. Deeper validity checks
+// (class references, flag combinations) are enforced by Policy.Validate.
+func policyFromFlags(cmd *cobra.Command) (*pol.Policy, error) {
+	if flagDeny && flagStamp != "" {
+		return nil, errorx.IllegalArgument.New("--deny is mutually exclusive with --stamp")
+	}
+
+	p := &pol.Policy{
+		Name:       flagName,
+		Stamp:      flagStamp,
+		ReplyStamp: flagReplyStamp,
+		Ports:      flagPorts,
+	}
+	switch {
+	case flagDeny:
+		p.Action = pol.ActionDeny
+	case flagStamp != "":
+		p.Action = pol.ActionStamp
+	default:
+		return nil, errorx.IllegalArgument.New("policy must specify exactly one of --stamp or --deny")
+	}
+
+	if flagFromEntity != "" {
+		if flagFromEntity != "world" {
+			return nil, errorx.IllegalArgument.New("--from-entity accepts only \"world\", got %q", flagFromEntity)
+		}
+		p.FromEntityWorld = true
+	}
+	return p, nil
+}
+
+// resolveCIDRs returns the initial set membership from --cidrs or --cidrs-file
+// (mutually exclusive). Either may be omitted (the set is created empty).
+func resolveCIDRs(cmd *cobra.Command) ([]string, error) {
+	if cmd.Flags().Changed("cidrs") && cmd.Flags().Changed("cidrs-file") {
+		return nil, errorx.IllegalArgument.New("--cidrs and --cidrs-file are mutually exclusive")
+	}
+	if flagCIDRsFile != "" {
+		return readCIDRsFile(flagCIDRsFile)
+	}
+	return flagCIDRs, nil
+}
+
+// readCIDRsFile reads a newline- and/or comma-separated CIDR list from a file,
+// skipping blank lines and `#` comments. Per-entry syntax is validated
+// downstream by Policy.Validate.
+func readCIDRsFile(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errorx.ExternalError.Wrap(err, "failed to read --cidrs-file %s", path)
+	}
+	var out []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		for _, tok := range strings.Split(line, ",") {
+			if v := strings.TrimSpace(tok); v != "" {
+				out = append(out, v)
+			}
+		}
+	}
+	return out, nil
+}
+
+func init() {
+	createCmd.Flags().StringVar(&flagName, "name", "", "Policy name; also the nft set name `@<name>` (required)")
+	createCmd.Flags().StringVar(&flagStamp, "stamp", "", "HTB class to classify matching packets into; also fixes the policy's direction (mutually exclusive with --deny)")
+	createCmd.Flags().BoolVar(&flagDeny, "deny", false, "Drop the --cidrs both directions (mutually exclusive with --stamp)")
+	createCmd.Flags().StringVar(&flagReplyStamp, "reply-stamp", "", "Reply class for an asymmetric conntrack reply (requires --stamp to resolve to an egress class; --reply-stamp must resolve to the mirror ingress class)")
+	createCmd.Flags().StringVar(&flagFromEntity, "from-entity", "", "Match any source/dest with no IP-set clause (only value: world; mutually exclusive with --cidrs)")
+	createCmd.Flags().StringSliceVar(&flagPorts, "ports", nil, "Workload listener ports for the match key (comma-separated or repeated)")
+	createCmd.Flags().StringSliceVar(&flagCIDRs, "cidrs", nil, "Initial set membership (comma-separated or repeated); ip:port entries for --reply-stamp")
+	createCmd.Flags().StringVar(&flagCIDRsFile, "cidrs-file", "", "Alternative to --cidrs: a file of CIDRs (one per line or comma-separated)")
+	createCmd.Flags().StringVar(&flagPodCIDR, "pod-cidr", "", "Pod CIDR to scope classification to (default: auto-detected from the local node's .spec.podCIDR)")
+	_ = createCmd.MarkFlagRequired("name")
+}

--- a/cmd/cli/commands/network/policy/policy.go
+++ b/cmd/cli/commands/network/policy/policy.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package policy wires the `solo-provisioner network policy` verbs to the
+// internal/network/policy manager. It is a generic, category-agnostic primitive:
+// the verbs manage per-category classification and ACL rules in the `inet weaver`
+// nftables table (the workload traffic plane, design §7.2.4), keyed only on the
+// operator-supplied --name, --stamp/--deny, --ports, and --cidrs. It knows
+// nothing about block/consensus/mirror/relay nodes; today `block node install`
+// is its only caller, but nothing in this package assumes that.
+//
+// This story (#758) implements `create` only; the element verbs
+// (add/remove/set/show/delete) are Story 1.3 (#759).
+package policy
+
+import (
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	pol "github.com/hashgraph/solo-weaver/internal/network/policy"
+	"github.com/spf13/cobra"
+)
+
+// Shared flag binding targets for the create verb. Only one verb runs per
+// invocation, so reusing these across future verbs is safe.
+var (
+	flagName       string
+	flagStamp      string
+	flagDeny       bool
+	flagReplyStamp string
+	flagFromEntity string
+	flagPorts      []string
+	flagCIDRs      []string
+	flagCIDRsFile  string
+	flagPodCIDR    string
+)
+
+var policyCmd = &cobra.Command{
+	Use:   "policy",
+	Short: "Manage per-category traffic policies (`inet weaver` nftables table)",
+	Long: "Manage the workload traffic plane: named policies in the `inet weaver` nftables table that " +
+		"map source CIDRs (or any source) to an HTB priority class on a set of ports, or quarantine a set " +
+		"of CIDRs. This table is separate from the `inet host` node firewall.",
+	RunE: common.DefaultRunE,
+}
+
+func init() {
+	policyCmd.AddCommand(createCmd)
+}
+
+// GetCmd returns the root of the `network policy` command group.
+func GetCmd() *cobra.Command {
+	return policyCmd
+}
+
+// newManager constructs the production manager (live nft kernel apply + systemd
+// service enable). Indirected through a var so command tests can stub it.
+var newManager = func() *pol.Manager { return pol.NewManager() }

--- a/cmd/cli/commands/network/policy/policy_test.go
+++ b/cmd/cli/commands/network/policy/policy_test.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	pol "github.com/hashgraph/solo-weaver/internal/network/policy"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRunner satisfies pol.Runner without touching the kernel.
+type fakeRunner struct{ applied string }
+
+func (f *fakeRunner) Apply(_ context.Context, doc string) error              { f.applied = doc; return nil }
+func (f *fakeRunner) AddElements(context.Context, string, []string) error    { return nil }
+func (f *fakeRunner) ListElements(context.Context, string) ([]string, error) { return nil, nil }
+func (f *fakeRunner) List(context.Context) (string, error)                   { return f.applied, nil }
+func (f *fakeRunner) Delete(context.Context) error                           { return nil }
+func (f *fakeRunner) Exists(context.Context) (bool, error)                   { return f.applied != "", nil }
+
+func TestPolicyCmd_Structure(t *testing.T) {
+	cmd := GetCmd()
+	require.Equal(t, "policy", cmd.Use)
+
+	var hasCreate bool
+	for _, sub := range cmd.Commands() {
+		if sub.Use == "create" {
+			hasCreate = true
+		}
+	}
+	require.True(t, hasCreate, "create verb not registered under policy")
+}
+
+func TestCreateCmd_Flags(t *testing.T) {
+	for _, name := range []string{"name", "stamp", "deny", "reply-stamp", "from-entity", "ports", "cidrs", "cidrs-file", "pod-cidr"} {
+		require.NotNil(t, createCmd.Flags().Lookup(name), "create is missing --%s", name)
+	}
+	// No --direction flag: direction is derived from --stamp's class (§5).
+	require.Nil(t, createCmd.Flags().Lookup("direction"), "create should not have a --direction flag")
+}
+
+// testEnv holds the state a sequence of create invocations shares: the same
+// fakeRunner and on-disk paths, so a second runCreate call can see what a
+// first one did (e.g. to exercise create-if-missing / --force behavior).
+// detect, if set, overrides the default always-succeeds pod-CIDR stub.
+type testEnv struct {
+	dir     string
+	nftPath string
+	runner  *fakeRunner
+	detect  func(context.Context) (string, error)
+}
+
+func newTestEnv(t *testing.T) *testEnv {
+	t.Helper()
+	dir := t.TempDir()
+	return &testEnv{dir: dir, nftPath: filepath.Join(dir, "network-weaver.nft"), runner: &fakeRunner{}}
+}
+
+// runCreate executes the real create command against this env's manager and
+// stubbed pod-CIDR detection, returning the persisted network-weaver.nft.
+func (e *testEnv) runCreate(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	origMgr, origDetect := newManager, detectPodCIDR
+	newManager = func() *pol.Manager {
+		return pol.NewManagerWithConfig(pol.Config{
+			Runner:        e.runner,
+			WeaverNftPath: e.nftPath,
+			RegistryDir:   filepath.Join(e.dir, "policies"),
+			LockPath:      filepath.Join(e.dir, ".applying"),
+			EnsureService: func(context.Context) error { return nil },
+		})
+	}
+	if e.detect != nil {
+		detectPodCIDR = e.detect
+	} else {
+		detectPodCIDR = func(context.Context) (string, error) { return "10.4.0.0/24", nil }
+	}
+	defer func() { newManager, detectPodCIDR = origMgr, origDetect }()
+
+	// Reset shared flag vars between invocations so state doesn't leak.
+	resetFlags()
+
+	root := &cobra.Command{Use: "test"}
+	// --force is a persistent flag on the real root (cmd/cli/commands/root.go);
+	// this synthetic root needs its own copy for common.FlagForce().Value to
+	// find it.
+	root.PersistentFlags().Bool("force", false, "force")
+	root.AddCommand(GetCmd())
+	root.SetArgs(append([]string{"policy", "create"}, args...))
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	if err := root.Execute(); err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(e.nftPath)
+	return string(data), err
+}
+
+// runCreate is the single-invocation convenience wrapper most tests use: a
+// fresh, isolated env per call.
+func runCreate(t *testing.T, args ...string) (string, error) {
+	return newTestEnv(t).runCreate(t, args...)
+}
+
+func resetFlags() {
+	flagName, flagStamp = "", ""
+	flagDeny = false
+	flagReplyStamp, flagFromEntity = "", ""
+	flagPorts, flagCIDRs = nil, nil
+	flagCIDRsFile, flagPodCIDR = "", ""
+	// createCmd is a package singleton, so cobra's per-flag Changed state leaks
+	// across Execute() calls; clear it too or a prior test's --cidrs would trip
+	// the mutual-exclusion guard here.
+	createCmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+}
+
+func TestCreateCmd_StampIngress(t *testing.T) {
+	doc, err := runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "40840", "--cidrs", "10.1.0.1/32")
+	require.NoError(t, err)
+	require.Contains(t, doc, "ip daddr 10.4.0.0/24 ip saddr @bn-publisher tcp dport @bn-publisher_ports meta priority set 0x10010 accept")
+	// Membership is never persisted (§8.3.1).
+	require.NotContains(t, doc, "10.1.0.1/32")
+}
+
+func TestCreateCmd_Deny(t *testing.T) {
+	doc, err := runCreate(t, "--name", "bn-restricted", "--deny", "--cidrs", "10.99.0.0/16")
+	require.NoError(t, err)
+	require.Contains(t, doc, "ip saddr @bn-restricted drop")
+	require.Contains(t, doc, "ip daddr @bn-restricted drop")
+}
+
+func TestCreateCmd_DenySkipsPodCIDRDetection(t *testing.T) {
+	env := newTestEnv(t)
+	called := false
+	env.detect = func(context.Context) (string, error) {
+		called = true
+		return "", errors.New("no cluster reachable")
+	}
+
+	doc, err := env.runCreate(t, "--name", "bn-restricted", "--deny", "--cidrs", "10.99.0.0/16")
+	require.NoError(t, err, "--deny must not need pod-CIDR detection at all")
+	require.False(t, called, "detectPodCIDR must not be invoked for --deny")
+	require.Contains(t, doc, "ip saddr @bn-restricted drop")
+}
+
+func TestCreateCmd_StampAndDenyMutuallyExclusive(t *testing.T) {
+	_, err := runCreate(t, "--name", "x", "--stamp", "publisher", "--deny")
+	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+func TestCreateCmd_FromEntityInvalidValue(t *testing.T) {
+	_, err := runCreate(t, "--name", "x", "--stamp", "public", "--from-entity", "internet")
+	require.ErrorContains(t, err, "only")
+}
+
+func TestCreateCmd_CIDRsAndFileMutuallyExclusive(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "cidrs.txt")
+	require.NoError(t, os.WriteFile(f, []byte("10.0.0.0/8\n"), 0o644))
+	_, err := runCreate(t, "--name", "x", "--deny", "--cidrs", "10.1.0.0/16", "--cidrs-file", f)
+	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+func TestCreateCmd_ExistingWithoutForceIsNoOp(t *testing.T) {
+	env := newTestEnv(t)
+	doc1, err := env.runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "40840")
+	require.NoError(t, err)
+	require.Contains(t, doc1, "40840")
+
+	doc2, err := env.runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "50000")
+	require.NoError(t, err)
+	require.Equal(t, doc1, doc2, "an existing policy without --force must not change")
+}
+
+func TestCreateCmd_ForceReplacesExisting(t *testing.T) {
+	env := newTestEnv(t)
+	_, err := env.runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "40840")
+	require.NoError(t, err)
+
+	doc, err := env.runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "50000", "--force")
+	require.NoError(t, err)
+	require.Contains(t, doc, "50000")
+	require.NotContains(t, doc, "40840", "--force replaces the config, it doesn't merge with the old one")
+}
+
+func TestCreateCmd_CIDRsFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "cidrs.txt")
+	require.NoError(t, os.WriteFile(f, []byte("# quarantine\n10.99.0.0/16, 10.98.0.0/16\n"), 0o644))
+	doc, err := runCreate(t, "--name", "bn-restricted", "--deny", "--cidrs-file", f)
+	require.NoError(t, err)
+	// Set schema present; membership not persisted.
+	require.Contains(t, doc, "set bn-restricted { type ipv4_addr; flags interval; }")
+	require.NotContains(t, doc, "10.99.0.0/16")
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -462,6 +462,58 @@ sudo solo-provisioner network firewall delete
 
 > `delete` removes the table and `/etc/solo-provisioner/network-host.nft` but does not disable the shared `solo-provisioner-network-nft.service` (shared with `inet weaver`); disable it manually if you need it off.
 
+#### Create a Traffic Policy
+
+The `policy` scope is a generic, category-agnostic primitive that manages the `inet weaver` workload traffic plane: named per-category rules that classify traffic into an HTB priority class, or quarantine a set of CIDRs. It is not tied to any specific node type — the CLI takes CIDRs and class names directly (statusz-agnostic); the examples below use the block-node categories because `block node install` is the only caller today. Each `create` renders the rule(s) into the `inet weaver` forward chain, ensures the policy's nft set `@<name>` exists, writes a per-policy registry file under `/etc/solo-provisioner/policies/`, applies the full chain to the live kernel with `nft -f`, and atomically rewrites `/etc/solo-provisioner/network-weaver.nft`.
+
+`create` is create-if-missing, mirroring `network firewall create`: a policy that already exists is left untouched unless `--force` is passed, in which case its config and membership are **replaced** (not merged) from the given flags/`--cidrs`. Without `--force`, an existing policy warns and makes no changes — even if the flags/`--cidrs` given this time differ from before.
+
+Specify **exactly one** action: `--stamp <class>` (classify into an HTB priority class) or `--deny` (drop the CIDRs both directions). There is no `--direction` flag — every class has exactly one direction (see the class list below), so `--stamp <class>` determines it.
+
+```bash
+# Publisher: highest-priority ingress class on the publisher listener port
+sudo solo-provisioner network policy create --name bn-publisher \
+  --ports 40840 --stamp publisher
+
+# Subscriber ingress from any source (no IP-set clause): reserve class
+sudo solo-provisioner network policy create --name bn-subscriber-in \
+  --ports 40980,40981 --stamp reserve-ingress --from-entity world
+
+# Partner egress (specific destinations), curated CIDR list
+sudo solo-provisioner network policy create --name bn-partner-out \
+  --ports 40980,40981 --stamp partner --cidrs 10.20.0.0/16
+
+# Backfill egress with an asymmetric reply class (conntrack reply gets higher priority)
+sudo solo-provisioner network policy create --name bn-backfill \
+  --stamp reserve-egress --reply-stamp backfill-response \
+  --cidrs 10.30.5.7:43473
+
+# Quarantine: drop all traffic to/from a set of CIDRs, both directions
+sudo solo-provisioner network policy create --name bn-restricted \
+  --deny --cidrs 10.99.0.0/16
+```
+
+**Flags**:
+
+| Flag            | Description                                                                                          | Default       |
+|-----------------|------------------------------------------------------------------------------------------------------|---------------|
+| `--name`        | Policy name; also the nft set name `@<name>` (**required**)                                          | (none)        |
+| `--stamp`       | HTB class to classify matching packets into; also fixes the policy's direction (mutually exclusive with `--deny`) | (none) |
+| `--deny`        | Drop the `--cidrs` in both directions (mutually exclusive with `--stamp`)                            | `false`       |
+| `--reply-stamp` | Reply class for an asymmetric conntrack reply (requires `--stamp` to resolve to an egress class; `--reply-stamp` must resolve to the mirror ingress class) | (none) |
+| `--from-entity` | `world` — match any source/dest with no IP-set clause (mutually exclusive with `--cidrs`)            | (none)        |
+| `--ports`       | Workload listener ports for the match key (comma-separated or repeated)                              | (none)        |
+| `--cidrs`       | Initial set membership (comma-separated or repeated); `ip:port` entries for `--reply-stamp` policies | (none)        |
+| `--cidrs-file`  | Alternative to `--cidrs`: a file of CIDRs (one per line or comma-separated)                          | (none)        |
+| `--pod-cidr`    | Pod CIDR to scope classification to                                                                  | auto-detected |
+| `--force`       | Replace an existing policy's config and membership (root flag, `-y`); without it, an existing policy is left untouched | `false` |
+
+`--stamp` references a QoS class name — `publisher`, `reserve-ingress` (ingress); `partner`, `public`, `reserve-egress` (egress); `backfill-response` (ingress, `--reply-stamp` only) — referencing an unknown class is an error. Rule position in the chain is determined by action type and match specificity (deny → reply-restore → specific stamp → fallthrough stamp), never by creation order.
+
+When `--pod-cidr` is omitted it is **auto-detected** from the local node's `.spec.podCIDR` via the Kubernetes API — but only for `--stamp` policies; `--deny` never references `POD_CIDR` (it just drops on set membership), so detection is skipped entirely for it. Unlike `network firewall create`, a `--stamp` policy's detection failure with no `--pod-cidr` is a hard error, not a warning-and-continue. If a `--deny` create's merged chain still includes a `--stamp` sibling that needs `POD_CIDR`, the value is recovered from the existing `/etc/solo-provisioner/network-weaver.nft` instead of being required again — it's a deployment-wide constant, not a per-call argument.
+
+> Set **membership** (the CIDRs) is never persisted to `network-weaver.nft` — statusz is the source of truth and the daemon reconciles it. `--cidrs` seeds the live set only, and only takes effect on a brand-new policy or a `--force` re-create (which replaces membership with exactly what's passed, not a merge with what was live before).
+
 ---
 
 ### Teleport Commands

--- a/internal/network/policy/class.go
+++ b/internal/network/policy/class.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// class is the static definition of a QoS priority class: its conntrack mark,
+// the skb->priority value nft stamps for it, and the traffic direction it
+// classifies. The values are the stable mark map from design §5 (fixed in
+// code, never reconciled), keyed by the class names declared by
+// `network shape create` (design §8.4.3).
+//
+// The priority is always mark | 0x10000 — the classid `1:<mark>` encoded as an
+// skb->priority (major 1, minor <mark>) so HTB classifies natively without a tc
+// filter (§5.1, §7.2.4 property 5). Both fields are stored explicitly rather
+// than derived so this table reads as a direct transcription of the §5 map.
+//
+// Direction is fixed per class, not an independent parameter: §7.2.4's worked
+// ruleset never uses a class in both directions (property 6). `publisher` and
+// `reserve-ingress` are DirectionIngress; `partner`, `public`, and
+// `reserve-egress` are DirectionEgress. `backfill-response` is the one
+// exception — it is never a forward `--stamp`, only a `--reply-stamp` target,
+// and its priority is applied on the ingress leg (the reply), so it is also
+// DirectionIngress despite being declared alongside an egress-direction
+// forward policy.
+type class struct {
+	// Mark is the conntrack mark (§5 "Mark" column), used only on --reply-stamp
+	// forward rules so the ingress restore rule has something to read back.
+	Mark uint32
+	// Priority is the skb->priority stamped via `meta priority set` (§5
+	// "Priority" column).
+	Priority uint32
+	// Direction is the traffic direction this class classifies (§5 "Direction"
+	// column). `network policy create` derives `Policy.Direction` from this
+	// field instead of taking it as a separate flag.
+	Direction Direction
+}
+
+// classMap is the stable class→mark/priority/direction map (design §5). Story
+// 1.4 (`network shape`) sets each class's bandwidth; the name→priority
+// encoding itself is fixed here in code and does not depend on shape state.
+// `--stamp` / `--reply-stamp` referencing a name absent from this map is a
+// create-time error.
+var classMap = map[string]class{
+	"publisher":         {Mark: 0x10, Priority: 0x10010, Direction: DirectionIngress},
+	"backfill-response": {Mark: 0x20, Priority: 0x10020, Direction: DirectionIngress},
+	"reserve-ingress":   {Mark: 0x30, Priority: 0x10030, Direction: DirectionIngress},
+	"partner":           {Mark: 0x40, Priority: 0x10040, Direction: DirectionEgress},
+	"public":            {Mark: 0x50, Priority: 0x10050, Direction: DirectionEgress},
+	"reserve-egress":    {Mark: 0x60, Priority: 0x10060, Direction: DirectionEgress},
+}
+
+// lookupClass resolves a class name to its mark/priority, returning an
+// IllegalArgument error naming the known classes when the reference is
+// undeclared (design §8.4.2: "referencing an undeclared class is an error").
+func lookupClass(name string) (class, error) {
+	c, ok := classMap[name]
+	if !ok {
+		return class{}, errorx.IllegalArgument.New(
+			"unknown class %q: must be one of %s", name, strings.Join(knownClasses(), ", "))
+	}
+	return c, nil
+}
+
+// knownClasses returns the declared class names in sorted order for stable
+// error messages.
+func knownClasses() []string {
+	names := make([]string, 0, len(classMap))
+	for n := range classMap {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/network/policy/manager.go
+++ b/internal/network/policy/manager.go
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"syscall"
+	"time"
+
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+)
+
+// Manager implements `network policy create` against the `inet weaver` table.
+// create takes the shared apply lock, writes the policy's registry file,
+// re-renders the full chain from the registry in tier order, applies it to the
+// live kernel with `nft -f`, atomically rewrites network-weaver.nft, and ensures
+// the shared boot oneshot is enabled.
+//
+// create is create-if-missing, mirroring internal/network/firewall: an
+// existing policy is left untouched (warn, no-op) unless --force is passed,
+// which replaces its config and membership from the given flags/--cidrs.
+//
+// The rendered chain always begins with `delete table; add table` (§8.3.1:
+// membership is never part of it), so every Apply() destroys and recreates
+// every policy's live set, not just the one being created. Create snapshots
+// every policy's membership first and restores it afterward -- see
+// snapshotMembership below.
+type Manager struct {
+	runner        Runner
+	weaverNftPath string
+	registryDir   string
+	lockPath      string
+	ensureService func(ctx context.Context) error
+}
+
+// Config customises a Manager. The zero value is not useful; prefer NewManager.
+// Tests inject a fake Runner, temp paths, and a no-op service func so the
+// package builds and runs on any platform.
+type Config struct {
+	Runner        Runner
+	WeaverNftPath string
+	RegistryDir   string
+	LockPath      string
+	EnsureService func(ctx context.Context) error
+}
+
+// NewManager returns a Manager wired to the live kernel and the production paths.
+func NewManager() *Manager {
+	return NewManagerWithConfig(Config{})
+}
+
+// NewManagerWithConfig returns a Manager, filling any unset Config field with
+// its production default.
+func NewManagerWithConfig(cfg Config) *Manager {
+	m := &Manager{
+		runner:        cfg.Runner,
+		weaverNftPath: cfg.WeaverNftPath,
+		registryDir:   cfg.RegistryDir,
+		lockPath:      cfg.LockPath,
+		ensureService: cfg.EnsureService,
+	}
+	if m.runner == nil {
+		m.runner = NewExecRunner()
+	}
+	if m.weaverNftPath == "" {
+		m.weaverNftPath = WeaverNftPath
+	}
+	if m.registryDir == "" {
+		m.registryDir = RegistryDir
+	}
+	if m.lockPath == "" {
+		m.lockPath = LockPath
+	}
+	if m.ensureService == nil {
+		m.ensureService = defaultEnsureService
+	}
+	return m
+}
+
+// Create adds a policy, or replaces an existing one when force is set.
+// create-if-missing: a policy that doesn't exist is always created. A policy
+// that already exists is left untouched (returns false) unless force is
+// true, in which case its config and membership are replaced (not merged)
+// from p and cidrs. cidrs is set membership, applied to the live kernel
+// only — never persisted (§8.3.1).
+func (m *Manager) Create(ctx context.Context, p *Policy, cidrs []string, podCIDR string, force bool) (bool, error) {
+	if err := p.Validate(cidrs); err != nil {
+		return false, err
+	}
+	// No blanket podCIDR requirement here: Render (below) only requires it
+	// when the merged policy set actually contains a --stamp policy -- a
+	// --deny-only chain never references POD_CIDR. When the caller doesn't
+	// supply one (as --deny never does), recover the value last used to
+	// render network-weaver.nft -- it's a deployment-wide constant, not a
+	// per-call argument, so an unrelated --deny create shouldn't need it
+	// re-supplied just to correctly re-render an unchanged --stamp sibling.
+	if podCIDR == "" {
+		if existing, err := os.ReadFile(m.weaverNftPath); err == nil {
+			podCIDR = ExtractPodCIDR(string(existing))
+		}
+	}
+
+	var changed bool
+	err := m.withLock(func() error {
+		policies, err := loadAll(m.registryDir)
+		if err != nil {
+			return err
+		}
+
+		// Re-validate sibling registry entries before rendering: a corrupt or
+		// hand-edited /etc/solo-provisioner/policies/*.json would otherwise flow
+		// straight into Render and could emit invalid nft or wrong semantics.
+		// The entry matching p.Name is skipped — it is replaced by the freshly
+		// validated p, so a re-create can heal a corrupt file for the same name.
+		for _, lp := range policies {
+			if lp.Name == p.Name {
+				continue
+			}
+			if err := lp.Validate(nil); err != nil {
+				return errorx.IllegalFormat.Wrap(err, "corrupt policy registry entry %s", registryPath(m.registryDir, lp.Name))
+			}
+		}
+
+		existing := findByName(policies, p.Name)
+		target, newCIDRs := p, cidrs
+		if existing != nil && !force {
+			// nft tables don't survive a reboot, and the boot oneshot doesn't
+			// reload network-weaver.nft yet (#780) -- so "the registry has
+			// this policy" does not imply "the live table has it too".
+			tableExists, err := m.runner.Exists(ctx)
+			if err != nil {
+				return err
+			}
+			if tableExists {
+				logx.As().Warn().Str("policy", p.Name).Msg(
+					"network policy already exists — supplied flags/cidrs were not applied; pass --force to replace")
+				return nil
+			}
+			// The table is missing underneath an existing registry entry
+			// (manual `nft delete table`, or a reboot before #780). Self-heal
+			// by re-rendering, but without --force we must not apply the
+			// caller's new flags/cidrs -- only restore what was already
+			// registered. Membership itself can't be recovered this way: it
+			// was never persisted, so it comes back empty until --force
+			// re-seeds it or the daemon's poll loop catches up.
+			if len(cidrs) > 0 {
+				logx.As().Warn().Str("policy", p.Name).Msg(
+					"network policy's live table was missing; restoring its already-registered config, not the new flags/cidrs just supplied — pass --force to apply those")
+			}
+			if err := existing.Validate(nil); err != nil {
+				return errorx.IllegalFormat.Wrap(err, "corrupt policy registry entry %s", registryPath(m.registryDir, p.Name))
+			}
+			target, newCIDRs = existing, nil
+		}
+
+		if existing != nil {
+			// Preserve the original creation timestamp across a config change so
+			// the tier tiebreaker (§8.4.7) stays stable.
+			target.CreatedAt = existing.CreatedAt
+		} else if target.CreatedAt.IsZero() {
+			target.CreatedAt = time.Now().UTC()
+		}
+
+		// Snapshot every policy's live membership BEFORE Apply(): the
+		// rendered document always does `delete table; add table` (set
+		// membership is never part of that document, §8.3.1), so applying it
+		// destroys and recreates every set in the table, not just target's.
+		// Anything not explicitly restored afterward is gone -- permanently,
+		// for operator-curated policies the daemon doesn't reconcile.
+		snapshot, err := m.snapshotMembership(ctx, policies)
+		if err != nil {
+			return err
+		}
+
+		// Render the prospective full chain BEFORE touching disk so a render or
+		// kernel-apply failure leaves the registry untouched.
+		merged := upsert(policies, target)
+		doc, err := Render(merged, podCIDR)
+		if err != nil {
+			return err
+		}
+		if err := m.runner.Apply(ctx, doc); err != nil {
+			return err
+		}
+		// The table is now live in the kernel, emptied of all membership.
+		// Restore every sibling's snapshot as-is; target's membership is
+		// replaced with exactly newCIDRs, not merged with what was live
+		// before (force means "this is the new desired state"). Any failure
+		// from here leaves the kernel ahead of disk; decorate so the caller
+		// reads it as "re-run to reconcile" (create is idempotent) rather
+		// than "nothing happened".
+		for _, lp := range merged {
+			if !lp.hasCIDRSet() {
+				continue
+			}
+			elements := snapshot[lp.Name]
+			if lp.Name == target.Name {
+				elements = setElements(target, newCIDRs)
+			}
+			if len(elements) == 0 {
+				continue
+			}
+			if err := m.runner.AddElements(ctx, lp.Name, elements); err != nil {
+				return errorx.Decorate(err, "inet weaver chain applied to the kernel but restoring %q membership failed; re-run to reconcile", lp.Name)
+			}
+		}
+		if err := writeEntry(m.registryDir, target); err != nil {
+			return errorx.Decorate(err, "inet weaver chain applied to the kernel but persisting the policy registry failed; re-run to reconcile")
+		}
+		if err := atomicWriteFile(m.weaverNftPath, doc, 0o644); err != nil {
+			return errorx.Decorate(err, "inet weaver chain applied to the kernel but persisting %s failed; re-run to reconcile", m.weaverNftPath)
+		}
+		if err := m.ensureService(ctx); err != nil {
+			return errorx.Decorate(err, "inet weaver chain applied and persisted but enabling %s failed", NetworkNftService)
+		}
+		changed = true
+		return nil
+	})
+	return changed, err
+}
+
+// snapshotMembership captures the live membership of every policy that
+// carries a CIDR set, before the caller runs a destructive Apply() that would
+// otherwise wipe it. A ListElements failure aborts immediately (returned to
+// the caller) rather than silently proceeding with a partial snapshot into a
+// destructive apply.
+func (m *Manager) snapshotMembership(ctx context.Context, policies []*Policy) (map[string][]string, error) {
+	snapshot := make(map[string][]string, len(policies))
+	for _, lp := range policies {
+		if !lp.hasCIDRSet() {
+			continue
+		}
+		elements, err := m.runner.ListElements(ctx, lp.Name)
+		if err != nil {
+			return nil, errorx.Decorate(err, "failed to snapshot live membership for policy %q before re-render", lp.Name)
+		}
+		if len(elements) > 0 {
+			snapshot[lp.Name] = elements
+		}
+	}
+	return snapshot, nil
+}
+
+// findByName returns the policy with the given name, or nil.
+func findByName(policies []*Policy, name string) *Policy {
+	for _, p := range policies {
+		if p.Name == name {
+			return p
+		}
+	}
+	return nil
+}
+
+// upsert returns policies with p inserted or replaced by name, name-sorted for
+// a deterministic render.
+func upsert(policies []*Policy, p *Policy) []*Policy {
+	out := make([]*Policy, 0, len(policies)+1)
+	for _, existing := range policies {
+		if existing.Name != p.Name {
+			out = append(out, existing)
+		}
+	}
+	out = append(out, p)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// withLock serialises a mutation behind the shared cross-command flock so a
+// hand-run operator command and the daemon poll loop (#754) cannot interleave
+// nft transactions on the shared network tables.
+func (m *Manager) withLock(fn func() error) error {
+	if err := os.MkdirAll(filepath.Dir(m.lockPath), 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create lock directory %s", filepath.Dir(m.lockPath))
+	}
+	f, err := os.OpenFile(m.lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to open lock file %s", m.lockPath)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to acquire lock %s", m.lockPath)
+	}
+	defer func() { _ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }()
+
+	return fn()
+}

--- a/internal/network/policy/nft.go
+++ b/internal/network/policy/nft.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// Runner is the seam over the system `nft` binary. Unlike the firewall package
+// (which applies via a systemd service restart), `network policy` applies the
+// rendered chain directly with `nft -f` (design §8.4.5) — the shared boot
+// oneshot does not load network-weaver.nft until #780 extends it. Tests
+// substitute a fake so the package builds and unit-tests on any platform
+// (including macOS) without touching the kernel.
+type Runner interface {
+	// Apply loads a full nft document into the kernel (`nft -f -`). The
+	// rendered document carries the idempotent `add table / delete table / add
+	// table` prefix, so a re-apply atomically replaces the inet weaver table.
+	Apply(ctx context.Context, doc string) error
+	// AddElements adds initial membership to a policy's set
+	// (`nft add element inet weaver <set> { … }`). Applied to the live kernel
+	// only — set membership is never persisted (§8.3.1).
+	AddElements(ctx context.Context, set string, elements []string) error
+	// ListElements returns one set's live elements
+	// (`nft list set inet weaver <set>`), or nil if the set has no elements
+	// or does not exist. Used by Manager.Create to snapshot every policy's
+	// membership before the destructive delete/recreate Apply() performs, so
+	// it can be restored afterward (see Manager.Create for why).
+	ListElements(ctx context.Context, set string) ([]string, error)
+	// List returns the rendered inet weaver table (`nft list table inet weaver`).
+	List(ctx context.Context) (string, error)
+	// Delete removes the inet weaver table (`nft delete table inet weaver`).
+	Delete(ctx context.Context) error
+	// Exists reports whether the inet weaver table is present in the kernel.
+	Exists(ctx context.Context) (bool, error)
+}
+
+// nftBinCandidates are the absolute locations we look for the system nft binary,
+// in order. We never exec a bare "nft" off PATH to avoid picking up a binary
+// from an attacker-controlled directory (see docs/dev/security-model.md).
+var nftBinCandidates = []string{"/usr/sbin/nft", "/sbin/nft", "/usr/bin/nft"}
+
+// tableArgs splits TableName into the argv tokens nft expects for sub-commands
+// that take a family and table name as separate arguments (list, delete).
+var tableArgs = strings.Fields(TableName) // ["inet", "weaver"]
+
+// execRunner shells out to the system nft binary.
+type execRunner struct {
+	bin string
+}
+
+// NewExecRunner resolves the nft binary path and returns a Runner that applies
+// changes to the live kernel.
+func NewExecRunner() Runner {
+	bin := nftBinCandidates[0]
+	for _, c := range nftBinCandidates {
+		if _, err := os.Stat(c); err == nil {
+			bin = c
+			break
+		}
+	}
+	return &execRunner{bin: bin}
+}
+
+func (r *execRunner) Apply(ctx context.Context, doc string) error {
+	cmd := exec.CommandContext(ctx, r.bin, "-f", "-")
+	cmd.Stdin = strings.NewReader(doc)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return errorx.ExternalError.Wrap(err, "nft -f failed: %s", strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+func (r *execRunner) AddElements(ctx context.Context, set string, elements []string) error {
+	if len(elements) == 0 {
+		return nil
+	}
+	// Fed through `nft -f -` rather than as argv tokens: element values contain
+	// spaces (compound `<ip> . <port>` keys) and exec.Command does not tokenise
+	// arguments on whitespace, so a single-string spec would be mis-parsed.
+	spec := "add element " + TableName + " " + set + " { " + strings.Join(elements, ", ") + " }\n"
+	cmd := exec.CommandContext(ctx, r.bin, "-f", "-")
+	cmd.Stdin = strings.NewReader(spec)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return errorx.ExternalError.Wrap(err, "nft add element %s failed: %s", set, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+func (r *execRunner) ListElements(ctx context.Context, set string) ([]string, error) {
+	args := append([]string{"list", "set"}, tableArgs...)
+	args = append(args, set)
+	cmd := exec.CommandContext(ctx, r.bin, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		// A missing set/table ("No such file or directory") is expected --
+		// snapshotMembership calls this for every registry entry, including
+		// ones never yet applied to the kernel, so treating that one
+		// failure as "no elements" is safe (same reasoning as Exists()).
+		// Any OTHER failure (permission denied, missing nft binary, a
+		// syntax/version issue) must NOT be swallowed the same way:
+		// Manager.Create's membership snapshot/restore safety net depends
+		// on a real ListElements failure surfacing and aborting before the
+		// destructive Apply() runs, not masquerading as "nothing to
+		// preserve" and silently losing live membership.
+		if isSetNotExistError(stderr.String()) {
+			return nil, nil
+		}
+		return nil, errorx.ExternalError.Wrap(err, "nft list set %s failed: %s", set, strings.TrimSpace(stderr.String()))
+	}
+	return parseElementsLine(stdout.String()), nil
+}
+
+// isSetNotExistError reports whether nft's stderr indicates the set (or its
+// table) doesn't exist -- the one ListElements failure mode that's safe to
+// treat as "no elements" rather than propagating.
+func isSetNotExistError(stderr string) bool {
+	return strings.Contains(stderr, "No such file or directory")
+}
+
+// parseElementsLine extracts a set's live elements from `nft list set`
+// output. nft omits the `elements = { … }` line entirely when a set has no
+// elements, rather than printing an empty one, so absence of the marker
+// means "no elements", not a parse failure.
+func parseElementsLine(output string) []string {
+	const marker = "elements = {"
+	start := strings.Index(output, marker)
+	if start == -1 {
+		return nil
+	}
+	rest := output[start+len(marker):]
+	end := strings.Index(rest, "}")
+	if end == -1 {
+		return nil
+	}
+	inner := strings.TrimSpace(rest[:end])
+	if inner == "" {
+		return nil
+	}
+	parts := strings.Split(inner, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if v := strings.TrimSpace(part); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func (r *execRunner) List(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, r.bin, append([]string{"list", "table"}, tableArgs...)...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", errorx.ExternalError.Wrap(err, "nft list table %s failed: %s", TableName, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+func (r *execRunner) Delete(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, r.bin, append([]string{"delete", "table"}, tableArgs...)...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return errorx.ExternalError.Wrap(err, "nft delete table %s failed: %s", TableName, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+func (r *execRunner) Exists(ctx context.Context) (bool, error) {
+	// `nft list table inet weaver` exits zero when the table is present and
+	// non-zero when absent. Treating any failure as "absent" is safe: a genuine
+	// nft/permission error surfaces on the subsequent Apply.
+	cmd := exec.CommandContext(ctx, r.bin, append([]string{"list", "table"}, tableArgs...)...)
+	return cmd.Run() == nil, nil
+}

--- a/internal/network/policy/nft_test.go
+++ b/internal/network/policy/nft_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSetNotExistError(t *testing.T) {
+	require.True(t, isSetNotExistError("/dev/stdin:1:18-23: Error: No such file or directory\nlist set inet weaver bn-publisher\n"))
+	require.False(t, isSetNotExistError("Error: Operation not permitted"))
+	require.False(t, isSetNotExistError(""))
+}

--- a/internal/network/policy/parse.go
+++ b/internal/network/policy/parse.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import "regexp"
+
+// rePodCIDR matches the literal CIDR every rendered --stamp rule starts with
+// (`ip daddr <PODCIDR> ...` ingress, `ip saddr <PODCIDR> ...` egress/reply-stamp
+// forward -- see renderStampRule). A `\d+\.\d+\.\d+\.\d+/\d+` literal never
+// matches a deny rule's `ip saddr/daddr @<name> drop`, which references a set
+// by name, not an inline CIDR.
+var rePodCIDR = regexp.MustCompile(`ip (?:daddr|saddr) (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{1,2})\b`)
+
+// ExtractPodCIDR recovers the pod CIDR last used to render network-weaver.nft.
+// Mirrors internal/network/firewall's Parse(): it understands only the exact
+// format Render produces, not a general nft parser, and exists so a caller
+// that doesn't supply --pod-cidr (as --deny never does) can still correctly
+// re-render unchanged --stamp siblings using the value they were already
+// rendered with, instead of requiring every call to re-supply or re-detect a
+// value that's effectively a deployment-wide constant. Returns "" if none is
+// found (e.g. a deny-only chain, or the file doesn't exist yet).
+func ExtractPodCIDR(content string) string {
+	if m := rePodCIDR.FindStringSubmatch(content); m != nil {
+		return m[1]
+	}
+	return ""
+}

--- a/internal/network/policy/parse_test.go
+++ b/internal/network/policy/parse_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractPodCIDR(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		want string
+	}{
+		{
+			name: "ingress rule",
+			doc:  "ip daddr 10.4.0.0/24 ip saddr @bn-publisher tcp dport @bn-publisher_ports meta priority set 0x10010 accept",
+			want: "10.4.0.0/24",
+		},
+		{
+			name: "egress rule",
+			doc:  "ip saddr 10.4.0.0/24 ip daddr @bn-partner-out tcp sport @bn-partner-out_ports meta priority set 0x10040 accept",
+			want: "10.4.0.0/24",
+		},
+		{
+			name: "compound reply-stamp forward rule",
+			doc:  "ip saddr 10.4.0.0/24 ip daddr . tcp dport @bn-backfill ct mark set 0x20 meta priority set 0x10060 accept",
+			want: "10.4.0.0/24",
+		},
+		{
+			name: "deny-only chain has no literal CIDR to recover",
+			doc:  "ip saddr @bn-restricted drop\nip daddr @bn-restricted drop",
+			want: "",
+		},
+		{
+			name: "empty document",
+			doc:  "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ExtractPodCIDR(tt.doc))
+		})
+	}
+}
+
+func TestExtractPodCIDR_FromGoldenFile(t *testing.T) {
+	// The real render output must round-trip: whatever Render/renderStampRule
+	// wrote for the sample BN install set must be recoverable byte-for-byte.
+	doc, err := Render(sampleBNPolicies(), "10.4.0.0/24")
+	require.NoError(t, err)
+	require.Equal(t, "10.4.0.0/24", ExtractPodCIDR(doc))
+}

--- a/internal/network/policy/paths.go
+++ b/internal/network/policy/paths.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package policy implements the `solo-provisioner network policy create` verb:
+// it renders per-category classification / ACL rules into the `inet weaver`
+// nftables table (the workload traffic plane, design §7.2.4), maintains a
+// per-policy registry under /etc/solo-provisioner/policies/, and applies the
+// full rendered chain to the live kernel with `nft -f` while atomically
+// persisting /etc/solo-provisioner/network-weaver.nft.
+//
+// Like internal/network/firewall, this is a generic, category-agnostic
+// primitive — it knows nothing about block/consensus/mirror/relay nodes; the
+// CLI is statusz-agnostic and takes CIDRs and class names directly. It is the
+// sibling of internal/network/firewall (the `inet host` node firewall) and
+// deliberately shares that package's on-disk artifact conventions, the
+// cross-command apply lock, and the boot oneshot unit — but targets a different
+// table with an opposite lifecycle: `inet weaver` set membership churns
+// continuously as the daemon monitor (TS_3) rewrites it from statusz, whereas
+// the chain structure and port sets rendered here are static for the lifetime
+// of the deployment. Today `block node install` is the only caller.
+//
+// Scope boundary (epic #738): this package implements only `create`. The
+// element verbs (add/remove/set/show/delete) are Story 1.3 (#759); overlap
+// rejection, the created_at intra-tier tiebreaker, and last-policy service
+// teardown are Story 1.5 (#772).
+package policy
+
+const (
+	// TableName is the nftables table this package owns.
+	TableName = "inet weaver"
+
+	// WeaverNftPath is the on-disk artifact replayed at boot by the shared
+	// solo-provisioner-network-nft.service oneshot. It lives under /etc (host OS
+	// config on the root filesystem) so it is available early at boot, before any
+	// late mounts. Extending the oneshot's ExecStart to also load this file is
+	// owned by #780; this package only writes the file and ensures the unit is
+	// enabled.
+	WeaverNftPath = "/etc/solo-provisioner/network-weaver.nft"
+
+	// HostNftPath is the inet host artifact, owned by internal/network/firewall.
+	// This package never writes it; it only checks for its presence to decide
+	// whether the shared oneshot may be disabled (teardown is Story 1.5 / #791).
+	HostNftPath = "/etc/solo-provisioner/network-host.nft"
+
+	// RegistryDir holds one JSON file per policy (design §8.4.7). The registry is
+	// the source of truth for the static policy definition and drives the
+	// tier-order chain re-render on every create/delete. CIDR membership is NOT
+	// stored here — it lives in the live nft sets and is owned by the daemon poll
+	// loop (§8.3.1).
+	RegistryDir = "/etc/solo-provisioner/policies"
+
+	// NetworkNftService is the shared oneshot unit that loads the network nft
+	// tables at boot. It is shared with internal/network/firewall; this package
+	// ensures it is installed and enabled on the first policy mutation but never
+	// disables it (teardown is Story 1.5 / #791).
+	NetworkNftService = "solo-provisioner-network-nft.service"
+
+	// NetworkNftServiceUnitPath is the absolute path where the shared unit file
+	// is installed so systemd can discover it.
+	NetworkNftServiceUnitPath = "/usr/lib/systemd/system/" + NetworkNftService
+
+	// networkNftServiceTemplate is the embedded unit file, shared with firewall.
+	networkNftServiceTemplate = "files/network/solo-provisioner-network-nft.service"
+
+	// LockDir holds the cross-command apply lock, on tmpfs (/run) so it is
+	// auto-cleared on reboot. Shared with internal/network/firewall and the
+	// daemon poll loop (#754).
+	LockDir = "/run/solo-provisioner/network"
+
+	// LockPath is the flock acquired (LOCK_EX) for the duration of any mutating
+	// verb, so a hand-run operator command and the daemon poll loop can never
+	// interleave nft transactions on the shared network tables.
+	//
+	// NOTE: these path/service constants intentionally mirror
+	// internal/network/firewall by value. Hoisting them into a shared
+	// internal/network package is a deliberate follow-up (kept out of this story
+	// to avoid churning already-merged firewall code); the values MUST stay in
+	// sync until then, which the render/lock tests guard indirectly.
+	LockPath = "/run/solo-provisioner/network/.applying"
+)

--- a/internal/network/policy/policy.go
+++ b/internal/network/policy/policy.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"net"
+	"strings"
+	"time"
+
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
+	"github.com/joomcode/errorx"
+)
+
+// Action is the nft verdict a policy renders: classify-and-accept (stamp) or
+// drop (deny). Every policy is exactly one of the two.
+type Action string
+
+const (
+	// ActionStamp classifies matching packets into an HTB priority class
+	// (`meta priority set <value> accept`).
+	ActionStamp Action = "stamp"
+	// ActionDeny drops matching packets in both directions, before the
+	// established/related fast-path.
+	ActionDeny Action = "deny"
+)
+
+// Direction selects which half of the forward chain a stamp rule renders into.
+// It is empty for deny policies (which always apply to both directions). For
+// stamp policies it is not a caller-supplied value: Validate derives it from
+// the --stamp class (every class in the §5 mark map has exactly one
+// direction), so it can never contradict the class it names.
+type Direction string
+
+const (
+	// DirectionIngress renders into the peer→pod block (`ip daddr POD_CIDR …
+	// tcp dport`).
+	DirectionIngress Direction = "ingress"
+	// DirectionEgress renders into the pod→peer block (`ip saddr POD_CIDR …
+	// tcp sport`).
+	DirectionEgress Direction = "egress"
+)
+
+// Policy is the static definition of one named category, mirroring the registry
+// JSON schema (design §8.4.7). CIDR membership is deliberately NOT a field: it
+// lives in the live nft set and is owned by the daemon poll loop, never
+// persisted to the registry or the .nft file (§8.3.1). The initial `--cidrs`
+// membership supplied at create time is applied to the live kernel separately
+// (see Manager.Create).
+type Policy struct {
+	Name            string    `json:"name"`
+	Action          Action    `json:"action"`
+	Stamp           string    `json:"stamp"`             // HTB class (from --stamp); "" for deny
+	ReplyStamp      string    `json:"reply_stamp"`       // reply class (from --reply-stamp); "" if unset
+	Direction       Direction `json:"direction"`         // derived from Stamp's class by Validate; "" for deny
+	Ports           []string  `json:"ports"`             // workload listener ports (from --ports); nil if none
+	FromEntityWorld bool      `json:"from_entity_world"` // true if --from-entity world (no IP-set clause)
+	CreatedAt       time.Time `json:"created_at"`        // tiebreaker within a tier, preserved across a --force replace
+}
+
+// Validate rejects any policy + initial-CIDR combination that would be unsafe
+// or nonsensical to render, per the flag-validity rules in design §8.4.2 /
+// §8.4.6. It is the single gate before the renderer; every untrusted token
+// (name, class, ports, CIDRs) is checked so a malformed value can never break
+// the atomic nft transaction or smuggle in nft syntax.
+func (p *Policy) Validate(cidrs []string) error {
+	if err := sanity.ValidateIdentifier(p.Name); err != nil {
+		return errorx.IllegalArgument.Wrap(err, "invalid --name %q", p.Name)
+	}
+
+	switch p.Action {
+	case ActionStamp:
+		if err := p.validateStamp(); err != nil {
+			return err
+		}
+	case ActionDeny:
+		if err := p.validateDeny(); err != nil {
+			return err
+		}
+	default:
+		return errorx.IllegalArgument.New("policy must specify exactly one of --stamp or --deny")
+	}
+
+	if p.FromEntityWorld {
+		if p.Action != ActionStamp {
+			return errorx.IllegalArgument.New("--from-entity world is only valid with --stamp")
+		}
+		if len(cidrs) > 0 {
+			return errorx.IllegalArgument.New("--from-entity world is mutually exclusive with --cidrs")
+		}
+	}
+
+	for _, port := range p.Ports {
+		if err := sanity.ValidatePort(port); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --ports entry %q", port)
+		}
+	}
+
+	return p.validateCIDRs(cidrs)
+}
+
+// validateStamp resolves --stamp to its class and derives p.Direction from it
+// (design §5: every class has exactly one direction, so there is no
+// independent --direction flag to validate against). For --reply-stamp, the
+// reply class must be the mirror direction of the forward class — e.g. an
+// egress --stamp pairs only with an ingress --reply-stamp — since a reply is
+// definitionally the reverse leg of the forward flow.
+func (p *Policy) validateStamp() error {
+	if p.Stamp == "" {
+		return errorx.IllegalArgument.New("--stamp requires a class name")
+	}
+	c, err := lookupClass(p.Stamp)
+	if err != nil {
+		return err
+	}
+	p.Direction = c.Direction
+
+	if p.ReplyStamp != "" {
+		rc, err := lookupClass(p.ReplyStamp)
+		if err != nil {
+			return err
+		}
+		if c.Direction != DirectionEgress {
+			return errorx.IllegalArgument.New(
+				"--reply-stamp is only valid when --stamp resolves to an egress class (got %q)", p.Stamp)
+		}
+		if rc.Direction != DirectionIngress {
+			return errorx.IllegalArgument.New(
+				"--reply-stamp class %q must resolve to an ingress class (the mirror of --stamp %q)", p.ReplyStamp, p.Stamp)
+		}
+	}
+	return nil
+}
+
+func (p *Policy) validateDeny() error {
+	if p.Stamp != "" || p.ReplyStamp != "" {
+		return errorx.IllegalArgument.New("--deny is mutually exclusive with --stamp and --reply-stamp")
+	}
+	if p.Direction != "" {
+		return errorx.IllegalArgument.New("--direction does not apply to --deny (it drops both directions)")
+	}
+	if len(p.Ports) > 0 {
+		return errorx.IllegalArgument.New("--ports does not apply to --deny")
+	}
+	if p.FromEntityWorld {
+		return errorx.IllegalArgument.New("--from-entity world does not apply to --deny")
+	}
+	return nil
+}
+
+// validateCIDRs checks the initial membership entries against the set type the
+// policy renders: compound ip:port keys for a --reply-stamp policy (matching a
+// `ipv4_addr . inet_service` set), plain IPv4 CIDRs otherwise.
+func (p *Policy) validateCIDRs(cidrs []string) error {
+	for _, c := range cidrs {
+		if p.isCompoundSet() {
+			if err := validateIPPort(c); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := sanity.ValidateCIDR(c); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --cidrs entry %q", c)
+		}
+		if ip, _, _ := net.ParseCIDR(c); ip.To4() == nil {
+			return errorx.IllegalArgument.New(
+				"invalid --cidrs entry %q: IPv6 is not yet supported; the inet weaver sets use ipv4_addr", c)
+		}
+	}
+	return nil
+}
+
+// isCompoundSet reports whether the policy's nft set is a compound
+// `ipv4_addr . inet_service` key set — true only for --reply-stamp policies,
+// whose --cidrs entries are ip:port destination pairs (design §8.4.6).
+func (p *Policy) isCompoundSet() bool {
+	return p.ReplyStamp != ""
+}
+
+// hasCIDRSet reports whether the policy renders a named `@<name>` membership
+// set. A --from-entity world stamp policy matches any source/dest and so
+// renders no set.
+func (p *Policy) hasCIDRSet() bool {
+	return !p.FromEntityWorld
+}
+
+func validateIPPort(s string) error {
+	host, port, err := net.SplitHostPort(s)
+	if err != nil {
+		return errorx.IllegalArgument.New("invalid --cidrs entry %q: --reply-stamp policies require ip:port pairs", s)
+	}
+	if ip := net.ParseIP(host); ip == nil || ip.To4() == nil {
+		return errorx.IllegalArgument.New("invalid --cidrs entry %q: %q is not an IPv4 address", s, host)
+	}
+	if err := sanity.ValidatePort(port); err != nil {
+		return errorx.IllegalArgument.Wrap(err, "invalid --cidrs entry %q", s)
+	}
+	return nil
+}
+
+// setElements converts initial --cidrs entries into nft element tokens for the
+// policy's set: `<ip> . <port>` compound keys for --reply-stamp policies, plain
+// CIDRs otherwise. The input is assumed already validated.
+func setElements(p *Policy, cidrs []string) []string {
+	if !p.isCompoundSet() {
+		return cidrs
+	}
+	out := make([]string, 0, len(cidrs))
+	for _, c := range cidrs {
+		host, port, _ := net.SplitHostPort(c)
+		out = append(out, host+" . "+port)
+	}
+	return out
+}
+
+// portElements returns the --ports values joined for an nft `elements = { … }`
+// clause.
+func portElements(ports []string) string {
+	return strings.Join(ports, ", ")
+}

--- a/internal/network/policy/policy_test.go
+++ b/internal/network/policy/policy_test.go
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRunner is an in-memory Runner for tests: it records the applied document
+// and the elements added per set without touching the kernel. Apply clears
+// elements to mirror the real `nft -f` delete+recreate of the whole table
+// (§8.3.1) -- without that, tests wouldn't exercise the membership loss
+// Manager.Create's snapshot/restore is meant to prevent.
+type fakeRunner struct {
+	applied     string
+	applyCount  int
+	elements    map[string][]string
+	exists      bool
+	applyErr    error
+	listElemErr error
+}
+
+func newFakeRunner() *fakeRunner { return &fakeRunner{elements: map[string][]string{}} }
+
+func (f *fakeRunner) Apply(_ context.Context, doc string) error {
+	if f.applyErr != nil {
+		return f.applyErr
+	}
+	f.applied = doc
+	f.applyCount++
+	f.exists = true
+	f.elements = map[string][]string{}
+	return nil
+}
+func (f *fakeRunner) AddElements(_ context.Context, set string, elements []string) error {
+	if !f.exists {
+		// Mirrors the real `nft add element` against a missing table:
+		// "No such file or directory", not a silent success.
+		return errors.New("nft add element " + set + " failed: No such file or directory")
+	}
+	f.elements[set] = append(f.elements[set], elements...)
+	return nil
+}
+func (f *fakeRunner) ListElements(_ context.Context, set string) ([]string, error) {
+	if f.listElemErr != nil {
+		return nil, f.listElemErr
+	}
+	return append([]string(nil), f.elements[set]...), nil
+}
+func (f *fakeRunner) List(context.Context) (string, error) { return f.applied, nil }
+func (f *fakeRunner) Delete(context.Context) error {
+	// Mirrors `nft delete table`: the table and every set in it are gone.
+	f.exists = false
+	f.elements = map[string][]string{}
+	return nil
+}
+func (f *fakeRunner) Exists(context.Context) (bool, error) { return f.exists, nil }
+
+// newTestManager wires a Manager with a fakeRunner, temp paths, and a no-op
+// service func so the package runs on any platform without touching systemd.
+func newTestManager(t *testing.T, r *fakeRunner) (*Manager, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	nftPath := filepath.Join(dir, "network-weaver.nft")
+	regDir := filepath.Join(dir, "policies")
+	m := NewManagerWithConfig(Config{
+		Runner:        r,
+		WeaverNftPath: nftPath,
+		RegistryDir:   regDir,
+		LockPath:      filepath.Join(dir, ".applying"),
+		EnsureService: func(context.Context) error { return nil },
+	})
+	return m, nftPath, regDir
+}
+
+func fixedTime() time.Time { return time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC) }
+
+// sampleBNPolicies mirrors the BN install policy set from design §8.4.2.
+func sampleBNPolicies() []*Policy {
+	at := fixedTime()
+	return []*Policy{
+		{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response", Direction: DirectionEgress, CreatedAt: at},
+		{Name: "bn-partner-out", Action: ActionStamp, Stamp: "partner", Direction: DirectionEgress, Ports: []string{"40980", "40981"}, CreatedAt: at},
+		{Name: "bn-public-out", Action: ActionStamp, Stamp: "public", Direction: DirectionEgress, FromEntityWorld: true, Ports: []string{"40980", "40981"}, CreatedAt: at},
+		{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Direction: DirectionIngress, Ports: []string{"40840"}, CreatedAt: at},
+		{Name: "bn-restricted", Action: ActionDeny, CreatedAt: at},
+		{Name: "bn-subscriber-in", Action: ActionStamp, Stamp: "reserve-ingress", Direction: DirectionIngress, FromEntityWorld: true, Ports: []string{"40980", "40981"}, CreatedAt: at},
+	}
+}
+
+func TestRender_GoldenMatchesBNInstallSet(t *testing.T) {
+	doc, err := Render(sampleBNPolicies(), "10.4.0.0/24")
+	require.NoError(t, err)
+
+	want, err := os.ReadFile("testdata/network-weaver.golden.nft")
+	require.NoError(t, err)
+	require.Equal(t, string(want), doc, "render drifted from golden; if intentional, regenerate testdata/network-weaver.golden.nft")
+}
+
+func TestRender_DeterministicRegardlessOfInputOrder(t *testing.T) {
+	sorted := sampleBNPolicies()
+	reversed := make([]*Policy, len(sorted))
+	for i, p := range sorted {
+		reversed[len(sorted)-1-i] = p
+	}
+	require.NotEqual(t, sorted, reversed, "test fixture must not already be a palindrome")
+
+	want, err := Render(sorted, "10.4.0.0/24")
+	require.NoError(t, err)
+	got, err := Render(reversed, "10.4.0.0/24")
+	require.NoError(t, err)
+	require.Equal(t, want, got, "Render must sort internally, not rely on the caller's order")
+}
+
+func TestRender_TierOrderInvariants(t *testing.T) {
+	doc, err := Render(sampleBNPolicies(), "10.4.0.0/24")
+	require.NoError(t, err)
+
+	// Load-bearing ordering (design §7.2.4): quarantine drops and the reply
+	// restore must both precede `ct state established,related accept`, otherwise
+	// open connections survive a quarantine and reply packets are misclassified.
+	estIdx := strings.Index(doc, "ct state established,related accept")
+	require.Positive(t, estIdx)
+	require.Less(t, strings.Index(doc, "ip saddr @bn-restricted drop"), estIdx, "deny must precede est,rel accept")
+	require.Less(t, strings.Index(doc, "ct direction reply ct mark 0x20"), estIdx, "reply restore must precede est,rel accept")
+
+	// Specific (partner) must precede the fallthrough (public) so partner-bound
+	// replies hit 1:40 and everyone else 1:50 (§7.2.4 property 3).
+	require.Less(t, strings.Index(doc, "@bn-partner-out"), strings.Index(doc, "@bn-public-out_ports"))
+
+	// Chain must default-drop and end with a trailing drop.
+	require.Contains(t, doc, "policy drop;")
+	require.True(t, strings.HasSuffix(strings.TrimSpace(doc), "}\n}") || strings.Contains(doc, "\n\t\tdrop\n"))
+}
+
+func TestRender_WorkedExamples(t *testing.T) {
+	doc, err := Render(sampleBNPolicies(), "10.4.0.0/24")
+	require.NoError(t, err)
+
+	// §8.4.6 publisher stamp.
+	require.Contains(t, doc, "ip daddr 10.4.0.0/24 ip saddr @bn-publisher tcp dport @bn-publisher_ports meta priority set 0x10010 accept")
+	// §8.4.6 from-entity world fallthrough (no @set clause).
+	require.Contains(t, doc, "ip daddr 10.4.0.0/24 tcp dport @bn-subscriber-in_ports meta priority set 0x10030 accept")
+	// §8.4.6 deny (both directions).
+	require.Contains(t, doc, "ip saddr @bn-restricted drop")
+	require.Contains(t, doc, "ip daddr @bn-restricted drop")
+	// §8.4.6 reply-stamp compound-key forward rule + ct mark write.
+	require.Contains(t, doc, "ip saddr 10.4.0.0/24 ip daddr . tcp dport @bn-backfill ct mark set 0x20 meta priority set 0x10060 accept")
+	// compound set schema, no `flags interval`.
+	require.Contains(t, doc, "set bn-backfill { type ipv4_addr . inet_service; }")
+}
+
+func TestRender_RequiresPodCIDR(t *testing.T) {
+	_, err := Render(sampleBNPolicies(), "")
+	require.Error(t, err)
+}
+
+func TestRender_DenyOnlyDoesNotRequirePodCIDR(t *testing.T) {
+	deny := []*Policy{{Name: "bn-restricted", Action: ActionDeny, CreatedAt: fixedTime()}}
+	doc, err := Render(deny, "")
+	require.NoError(t, err, "a deny-only chain never references POD_CIDR")
+	require.Contains(t, doc, "ip saddr @bn-restricted drop")
+}
+
+func TestCreate_PersistsAndSeedsMembership(t *testing.T) {
+	r := newFakeRunner()
+	m, nftPath, regDir := newTestManager(t, r)
+	p := &Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}}
+
+	changed, err := m.Create(context.Background(), p, []string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	// Registry file written; .nft persisted; initial membership applied live.
+	require.FileExists(t, filepath.Join(regDir, "bn-publisher.json"))
+	require.FileExists(t, nftPath)
+	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"])
+
+	// Persisted .nft must NOT contain the membership element (§8.3.1).
+	onDisk, err := os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.NotContains(t, string(onDisk), "10.1.0.1/32")
+}
+
+func TestCreate_ExistingWithoutForceIsNoOp(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
+		[]string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+	require.Equal(t, 1, r.applyCount)
+
+	// Different ports AND new cidrs, but no --force: must be a pure no-op,
+	// matching internal/network/firewall's create-if-missing convention.
+	changed, err := m.Create(context.Background(),
+		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840", "50000"}},
+		[]string{"10.1.0.2/32"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+	require.False(t, changed, "an existing policy without --force must not change")
+	require.Equal(t, 1, r.applyCount, "no --force on an existing policy must never re-render")
+	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"], "membership must be untouched")
+}
+
+func TestCreate_ForceReplacesConfigAndMembership(t *testing.T) {
+	r := newFakeRunner()
+	m, nftPath, regDir := newTestManager(t, r)
+
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-mgmt-in", Action: ActionStamp, Stamp: "reserve-ingress", Ports: []string{"40983"}, CreatedAt: fixedTime()},
+		[]string{"10.0.0.0/8"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+
+	// --force with a changed port set and a different --cidrs: re-renders,
+	// replaces (not merges) membership, and keeps the original created_at.
+	changed, err := m.Create(context.Background(),
+		&Policy{Name: "bn-mgmt-in", Action: ActionStamp, Stamp: "reserve-ingress", Ports: []string{"40983", "40984"}},
+		[]string{"192.168.0.0/16"}, "10.4.0.0/24", true)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	got, err := readEntry(regDir, "bn-mgmt-in")
+	require.NoError(t, err)
+	require.Equal(t, fixedTime(), got.CreatedAt)
+	require.Equal(t, []string{"40983", "40984"}, got.Ports)
+
+	doc, err := os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.Contains(t, string(doc), "40984")
+	require.Equal(t, []string{"192.168.0.0/16"}, r.elements["bn-mgmt-in"],
+		"--force replaces membership with exactly what's passed, not a merge with what was live before")
+}
+
+func TestCreate_ForceWithoutCIDRsClearsMembership(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
+		[]string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+
+	_, err = m.Create(context.Background(),
+		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
+		nil, "10.4.0.0/24", true)
+	require.NoError(t, err)
+	require.Empty(t, r.elements["bn-publisher"], "--force without --cidrs replaces membership with nothing")
+}
+
+func TestCreate_PreservesSiblingMembershipAcrossRerender(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
+		[]string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"])
+
+	// Creating a second, different (brand-new) policy forces a full
+	// re-render, which applies `delete table; add table` (§8.3.1) --
+	// bn-publisher's live membership must survive that, not just its
+	// rendered rule.
+	_, err = m.Create(context.Background(),
+		&Policy{Name: "bn-partner-out", Action: ActionStamp, Stamp: "partner", Ports: []string{"40980"}},
+		[]string{"10.20.0.0/16"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"],
+		"a sibling create must not wipe bn-publisher's live membership")
+	require.Equal(t, []string{"10.20.0.0/16"}, r.elements["bn-partner-out"])
+}
+
+func TestCreate_SelfHealsMissingTableWithoutForce(t *testing.T) {
+	r := newFakeRunner()
+	m, nftPath, _ := newTestManager(t, r)
+
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
+		[]string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+	require.Equal(t, 1, r.applyCount)
+
+	// Simulate `nft delete table inet weaver` (or a reboot before #780):
+	// the registry still says bn-publisher exists, but the live kernel
+	// table is gone.
+	require.NoError(t, r.Delete(context.Background()))
+
+	// Re-run WITHOUT --force, deliberately with DIFFERENT flags/cidrs: since
+	// no --force was given, those must be ignored -- only the
+	// already-registered config is restored (self-heal, not a config
+	// change). Membership can't be recovered this way (it was never
+	// persisted), so it comes back empty.
+	changed, err := m.Create(context.Background(),
+		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840", "50000"}},
+		[]string{"10.1.0.99/32"}, "10.4.0.0/24", false)
+	require.NoError(t, err, "a missing table must be restored, not error")
+	require.True(t, changed)
+	require.Equal(t, 2, r.applyCount, "the table must be re-rendered when the kernel table is missing")
+
+	doc, err := os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.Contains(t, string(doc), "40840")
+	require.NotContains(t, string(doc), "50000", "without --force, new flags must not be applied, even to self-heal a missing table")
+	require.Empty(t, r.elements["bn-publisher"], "membership already lost from the kernel can't be recovered without --force")
+}
+
+func TestCreate_SnapshotFailureAbortsBeforeApply(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
+		[]string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+	require.Equal(t, 1, r.applyCount)
+
+	r.listElemErr = errors.New("nft: permission denied")
+	_, err = m.Create(context.Background(),
+		&Policy{Name: "bn-partner-out", Action: ActionStamp, Stamp: "partner", Ports: []string{"40980"}},
+		nil, "10.4.0.0/24", false)
+	require.ErrorContains(t, err, "failed to snapshot live membership")
+	require.Equal(t, 1, r.applyCount, "a snapshot failure must abort before the kernel is touched")
+}
+
+func TestCreate_DenyDoesNotRequirePodCIDR(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	changed, err := m.Create(context.Background(),
+		&Policy{Name: "bn-restricted", Action: ActionDeny}, []string{"10.99.0.0/16"}, "", false)
+	require.NoError(t, err, "a deny-only policy must not require a pod CIDR")
+	require.True(t, changed)
+	require.Equal(t, []string{"10.99.0.0/16"}, r.elements["bn-restricted"])
+}
+
+func TestCreate_DenyRecoversPodCIDRFromExistingNftFile(t *testing.T) {
+	r := newFakeRunner()
+	m, nftPath, _ := newTestManager(t, r)
+
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
+		nil, "10.4.0.0/24", false)
+	require.NoError(t, err)
+
+	// bn-restricted's own --deny rule never needs a pod CIDR, but the merged
+	// chain still includes bn-publisher's rule, which does. No --pod-cidr is
+	// passed here: it must be recovered from network-weaver.nft instead of
+	// erroring, mirroring internal/network/firewall's Parse().
+	changed, err := m.Create(context.Background(),
+		&Policy{Name: "bn-restricted", Action: ActionDeny}, []string{"10.99.0.0/16"}, "", false)
+	require.NoError(t, err, "must recover the pod CIDR from the existing network-weaver.nft artifact")
+	require.True(t, changed)
+
+	doc, err := os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.Contains(t, string(doc), "10.4.0.0/24", "bn-publisher's rule must still be rendered with the recovered pod CIDR")
+}
+
+func TestCreate_StampSiblingStillRequiresPodCIDRWhenNftFileMissing(t *testing.T) {
+	r := newFakeRunner()
+	m, _, regDir := newTestManager(t, r)
+
+	// A stamp policy already in the registry, but network-weaver.nft was
+	// never written (e.g. deleted independently of the JSON registry) --
+	// there is nothing to recover a pod CIDR from.
+	require.NoError(t, writeEntry(regDir, &Policy{
+		Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}, CreatedAt: fixedTime(),
+	}))
+
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-restricted", Action: ActionDeny}, []string{"10.99.0.0/16"}, "", false)
+	require.ErrorContains(t, err, "pod CIDR is required")
+}
+
+func TestCreate_UnknownClassRejected(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	_, err := m.Create(context.Background(), &Policy{Name: "bad", Action: ActionStamp, Stamp: "nonexistent"}, nil, "10.4.0.0/24", false)
+	require.ErrorContains(t, err, "unknown class")
+	require.Empty(t, r.applied, "invalid policy must never reach the kernel")
+}
+
+func TestCreate_CorruptSiblingRegistryRejected(t *testing.T) {
+	r := newFakeRunner()
+	m, _, regDir := newTestManager(t, r)
+	require.NoError(t, os.MkdirAll(regDir, 0o755))
+
+	// A hand-edited sibling entry that is invalid (references a class that no
+	// longer exists in classMap).
+	bad := `{"name":"bn-bad","action":"stamp","stamp":"retired-class","direction":"","ports":null,"from_entity_world":false}`
+	require.NoError(t, os.WriteFile(filepath.Join(regDir, "bn-bad.json"), []byte(bad), 0o644))
+
+	_, err := m.Create(context.Background(), &Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}}, nil, "10.4.0.0/24", false)
+	require.ErrorContains(t, err, "corrupt policy registry entry")
+	require.Empty(t, r.applied, "a corrupt sibling entry must fail before the kernel is touched")
+}
+
+func TestRegistry_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	p := &Policy{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response", Direction: DirectionEgress, CreatedAt: fixedTime()}
+	require.NoError(t, writeEntry(dir, p))
+
+	got, err := readEntry(dir, "bn-backfill")
+	require.NoError(t, err)
+	require.Equal(t, p, got)
+
+	all, err := loadAll(dir)
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	require.Equal(t, "bn-backfill", all[0].Name)
+}

--- a/internal/network/policy/registry.go
+++ b/internal/network/policy/registry.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// registryPath returns the on-disk path of a policy's registry file.
+func registryPath(dir, name string) string {
+	return filepath.Join(dir, name+".json")
+}
+
+// writeEntry atomically writes a policy's registry JSON (design §8.4.7). The
+// daemon poll loop never calls this — the registry is operator/CLI-owned.
+func writeEntry(dir string, p *Policy) error {
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return errorx.InternalError.Wrap(err, "failed to marshal policy %q", p.Name)
+	}
+	// json.MarshalIndent omits the trailing newline; add one so the file is a
+	// well-formed text file and round-trips cleanly through editors/diffs.
+	return atomicWriteFile(registryPath(dir, p.Name), string(data)+"\n", 0o644)
+}
+
+// readEntry loads a single policy from its registry file.
+func readEntry(dir, name string) (*Policy, error) {
+	data, err := os.ReadFile(registryPath(dir, name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // not an error: caller distinguishes create vs re-render
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read policy registry %s", registryPath(dir, name))
+	}
+	var p Policy
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse policy registry %s", registryPath(dir, name))
+	}
+	return &p, nil
+}
+
+// loadAll reads every policy registry file in dir, sorted by name for a
+// deterministic render. A missing directory yields an empty slice (the first
+// create renders from a single in-memory entry before the dir exists).
+func loadAll(dir string) ([]*Policy, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read policy registry dir %s", dir)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(e.Name(), ".json"))
+	}
+	sort.Strings(names)
+
+	policies := make([]*Policy, 0, len(names))
+	for _, n := range names {
+		p, err := readEntry(dir, n)
+		if err != nil {
+			return nil, err
+		}
+		if p != nil {
+			policies = append(policies, p)
+		}
+	}
+	return policies, nil
+}

--- a/internal/network/policy/render.go
+++ b/internal/network/policy/render.go
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// Render produces the full `inet weaver` nft document for the given set of
+// registry policies, in tier order (design §8.4.7). The same output feeds both
+// the kernel apply (`nft -f`) and the on-disk artifact, so the live table and
+// the persisted file can never diverge. Set *membership* is deliberately not
+// rendered here — only set schemas and the static `--ports` elements — because
+// membership is owned by the daemon poll loop and never persisted (§8.3.1).
+//
+// Rule position is determined by action type and match specificity, never by
+// creation order:
+//
+//  1. deny drops (both directions)
+//  2. asymmetric reply-stamp restore
+//  3. stamp classification — specific (has an IP-set match)
+//  4. stamp classification — fallthrough (--from-entity world)
+//  5. ct state established,related accept   (structural)
+//  6. drop                                   (structural)
+func Render(policies []*Policy, podCIDR string) (string, error) {
+	if podCIDR == "" && needsPodCIDR(policies) {
+		return "", errorx.IllegalArgument.New("pod CIDR is required to render a --stamp policy in the inet weaver chain")
+	}
+
+	// renderSetDecls's own doc comment promises name-sorted output; sort
+	// here (a copy, so the caller's slice is untouched) rather than relying
+	// on every caller to pre-sort -- Manager.Create's upsert already does,
+	// but Render is exported and callers other than Create (tests, a future
+	// show/reconcile path) shouldn't have to replicate that to get a
+	// deterministic render.
+	policies = sortedByName(policies)
+
+	setLines, err := renderSetDecls(policies)
+	if err != nil {
+		return "", err
+	}
+	chainLines, err := renderChain(policies, podCIDR)
+	if err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+	// The idempotent prefix makes a re-apply atomically replace the table (same
+	// convention as internal/network/firewall) so this document is safe for both
+	// the boot oneshot and live re-applies.
+	b.WriteString("add table " + TableName + "\n")
+	b.WriteString("delete table " + TableName + "\n")
+	b.WriteString("add table " + TableName + "\n")
+	b.WriteString("table " + TableName + " {\n")
+	if len(setLines) > 0 {
+		b.WriteString(strings.Join(setLines, "\n"))
+		b.WriteString("\n\n")
+	}
+	b.WriteString("\tchain forward {\n")
+	b.WriteString(strings.Join(chainLines, "\n"))
+	b.WriteString("\n\t}\n")
+	b.WriteString("}\n")
+	return b.String(), nil
+}
+
+// needsPodCIDR reports whether any policy in the set is a --stamp policy.
+// POD_CIDR is only ever read by renderStampRule; a deny-only chain never
+// references it, so it shouldn't be required to render one.
+func needsPodCIDR(policies []*Policy) bool {
+	for _, p := range policies {
+		if p.Action == ActionStamp {
+			return true
+		}
+	}
+	return false
+}
+
+// sortedByName returns a name-sorted copy of policies, leaving the input
+// slice untouched.
+func sortedByName(policies []*Policy) []*Policy {
+	out := make([]*Policy, len(policies))
+	copy(out, policies)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// renderSetDecls emits the schema for each policy's sets, name-sorted for a
+// deterministic render. Membership set elements are omitted (§8.3.1); only the
+// static `--ports` set carries elements.
+func renderSetDecls(policies []*Policy) ([]string, error) {
+	var lines []string
+	for _, p := range policies {
+		if p.hasCIDRSet() {
+			if p.isCompoundSet() {
+				// Compound ip:port key for --reply-stamp destinations.
+				lines = append(lines, fmt.Sprintf("\tset %s { type ipv4_addr . inet_service; }", p.Name))
+			} else {
+				lines = append(lines, fmt.Sprintf("\tset %s { type ipv4_addr; flags interval; }", p.Name))
+			}
+		}
+		if len(p.Ports) > 0 {
+			lines = append(lines, fmt.Sprintf("\tset %s_ports { type inet_service; elements = { %s }; }",
+				p.Name, portElements(p.Ports)))
+		}
+	}
+	return lines, nil
+}
+
+// renderChain builds the forward chain body lines (indented two tabs), grouped
+// into the six tiers above.
+func renderChain(policies []*Policy, podCIDR string) ([]string, error) {
+	lines := []string{
+		"\t\ttype filter hook forward priority 0; policy drop;",
+		"\t\tct state invalid drop",
+	}
+
+	// Tier 1: quarantine drops.
+	var deny []string
+	for _, p := range policies {
+		if p.Action == ActionDeny {
+			deny = append(deny,
+				fmt.Sprintf("\t\tip saddr @%s drop", p.Name),
+				fmt.Sprintf("\t\tip daddr @%s drop", p.Name))
+		}
+	}
+	if len(deny) > 0 {
+		lines = append(lines, "",
+			"\t\t# Quarantine (deny), both directions. Runs before est,rel accept",
+			"\t\t# so already-open connections are also killed.")
+		lines = append(lines, deny...)
+	}
+
+	// Tier 2: asymmetric reply-stamp restore.
+	var restore []string
+	for _, p := range policies {
+		if p.Action == ActionStamp && p.ReplyStamp != "" {
+			rule, err := renderReplyRestoreRule(p)
+			if err != nil {
+				return nil, err
+			}
+			restore = append(restore, rule)
+		}
+	}
+	if len(restore) > 0 {
+		lines = append(lines, "",
+			"\t\t# Asymmetric reply restore. Must precede est,rel accept so every",
+			"\t\t# reply packet is reclassified, not just the SYN.")
+		lines = append(lines, restore...)
+	}
+
+	// Tiers 3 and 4: stamp classification, specific before fallthrough.
+	var specific, fallthr []string
+	for _, p := range policies {
+		if p.Action != ActionStamp {
+			continue
+		}
+		rule, err := renderStampRule(p, podCIDR)
+		if err != nil {
+			return nil, err
+		}
+		if p.FromEntityWorld {
+			fallthr = append(fallthr, rule)
+		} else {
+			specific = append(specific, rule)
+		}
+	}
+	if len(specific) > 0 {
+		lines = append(lines, "", "\t\t# Classification — specific matches.")
+		lines = append(lines, specific...)
+	}
+	if len(fallthr) > 0 {
+		lines = append(lines, "", "\t\t# Classification — fallthrough (any source/dest).")
+		lines = append(lines, fallthr...)
+	}
+
+	lines = append(lines, "",
+		"\t\tct state established,related accept",
+		"\t\tdrop")
+	return lines, nil
+}
+
+// renderReplyRestoreRule renders the ingress restore rule for a --reply-stamp
+// policy: on the conntrack reply, restamp with the reply class's priority.
+func renderReplyRestoreRule(p *Policy) (string, error) {
+	reply, err := lookupClass(p.ReplyStamp)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("\t\tct direction reply ct mark %s meta priority set %s accept",
+		hex(reply.Mark), hex(reply.Priority)), nil
+}
+
+// renderStampRule renders a single stamp policy's classification rule for its
+// direction, honoring --from-entity world (no IP-set clause) and --reply-stamp
+// (compound-key egress forward rule with a ct mark write).
+func renderStampRule(p *Policy, podCIDR string) (string, error) {
+	fwd, err := lookupClass(p.Stamp)
+	if err != nil {
+		return "", err
+	}
+
+	if p.isCompoundSet() {
+		// --reply-stamp forward rule: egress, compound ip:port destination key,
+		// ct mark write for the reply restore to read back (design §8.4.6).
+		reply, err := lookupClass(p.ReplyStamp)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("\t\tip saddr %s ip daddr . tcp dport @%s ct mark set %s meta priority set %s accept",
+			podCIDR, p.Name, hex(reply.Mark), hex(fwd.Priority)), nil
+	}
+
+	var b strings.Builder
+	b.WriteString("\t\t")
+	switch p.Direction {
+	case DirectionIngress:
+		b.WriteString("ip daddr " + podCIDR)
+		if p.hasCIDRSet() {
+			b.WriteString(" ip saddr @" + p.Name)
+		}
+		if len(p.Ports) > 0 {
+			b.WriteString(" tcp dport @" + p.Name + "_ports")
+		}
+	case DirectionEgress:
+		b.WriteString("ip saddr " + podCIDR)
+		if p.hasCIDRSet() {
+			b.WriteString(" ip daddr @" + p.Name)
+		}
+		if len(p.Ports) > 0 {
+			b.WriteString(" tcp sport @" + p.Name + "_ports")
+		}
+	default:
+		return "", errorx.AssertionFailed.New("stamp policy %q has no direction", p.Name)
+	}
+	b.WriteString(fmt.Sprintf(" meta priority set %s accept", hex(fwd.Priority)))
+	return b.String(), nil
+}
+
+// hex formats an nft numeric literal as lowercase hex (e.g. 0x10010). This is
+// what we write and what the golden file pins. `nft list table` reformats a
+// `meta priority` value that decodes as a valid tc classid into its
+// `major:minor` display form on read-back (e.g. 0x10010 -> "1:10") -- that's
+// nft's own listing behavior, not a discrepancy in the rendered document.
+func hex(v uint32) string { return fmt.Sprintf("0x%x", v) }
+
+// atomicWriteFile writes content to path via a temp file in the same directory
+// followed by fsync + rename + parent-dir fsync, so a crash mid-write can never
+// leave a torn file that the boot oneshot would fail to load. Mirrors the
+// firewall package's writer (a shared helper is a follow-up refactor).
+func atomicWriteFile(path, content string, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create directory %s", dir)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".network-weaver-*.tmp")
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create temp file in %s", dir)
+	}
+	tmpName := tmp.Name()
+
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return errorx.ExternalError.Wrap(err, "failed to write temp file %s", tmpName)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return errorx.ExternalError.Wrap(err, "failed to fsync temp file %s", tmpName)
+	}
+	if err := tmp.Close(); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to close temp file %s", tmpName)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to chmod temp file %s", tmpName)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to rename %s to %s", tmpName, path)
+	}
+	committed = true
+
+	d, err := os.Open(dir)
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to open directory %s for fsync", dir)
+	}
+	defer func() { _ = d.Close() }()
+	if err := d.Sync(); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to fsync directory %s", dir)
+	}
+	return nil
+}

--- a/internal/network/policy/service_linux.go
+++ b/internal/network/policy/service_linux.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package policy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/templates"
+	soos "github.com/hashgraph/solo-weaver/pkg/os"
+	"github.com/joomcode/errorx"
+)
+
+// defaultEnsureService installs the shared network-nft unit if absent and
+// enables it for boot (design §8.4.5: "First call also … enables the systemd
+// unit"). The unit is shared with internal/network/firewall; installing it here
+// is idempotent with firewall's own install so whichever scope runs first wins.
+//
+// This package does NOT restart the unit to apply — `network policy` applies to
+// the live kernel directly via `nft -f` (Runner.Apply). The unit only matters
+// for boot replay, and extending its ExecStart to load network-weaver.nft is
+// owned by #780.
+func defaultEnsureService(ctx context.Context) error {
+	if _, err := os.Stat(NetworkNftServiceUnitPath); err == nil {
+		return nil // already installed by firewall or a prior policy call
+	}
+
+	content, err := templates.Files.ReadFile(networkNftServiceTemplate)
+	if err != nil {
+		return errorx.InternalError.Wrap(err, "failed to read embedded %s", networkNftServiceTemplate)
+	}
+	if err := os.MkdirAll(filepath.Dir(NetworkNftServiceUnitPath), 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create %s", filepath.Dir(NetworkNftServiceUnitPath))
+	}
+	if err := os.WriteFile(NetworkNftServiceUnitPath, content, 0o644); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to write %s", NetworkNftServiceUnitPath)
+	}
+
+	if err := soos.DaemonReload(ctx); err != nil {
+		return err
+	}
+	if err := soos.EnableService(ctx, NetworkNftService); err != nil {
+		logx.As().Warn().Err(err).Str("service", NetworkNftService).Msg("could not enable service at boot")
+	}
+	return nil
+}

--- a/internal/network/policy/service_other.go
+++ b/internal/network/policy/service_other.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package policy
+
+import "context"
+
+// defaultEnsureService is a no-op on non-Linux platforms so the package builds
+// and unit-tests on macOS/CI. Enabling the systemd oneshot only makes sense on
+// the Linux host where solo-provisioner runs.
+func defaultEnsureService(_ context.Context) error { return nil }

--- a/internal/network/policy/testdata/network-weaver.golden.nft
+++ b/internal/network/policy/testdata/network-weaver.golden.nft
@@ -1,0 +1,39 @@
+add table inet weaver
+delete table inet weaver
+add table inet weaver
+table inet weaver {
+	set bn-backfill { type ipv4_addr . inet_service; }
+	set bn-partner-out { type ipv4_addr; flags interval; }
+	set bn-partner-out_ports { type inet_service; elements = { 40980, 40981 }; }
+	set bn-public-out_ports { type inet_service; elements = { 40980, 40981 }; }
+	set bn-publisher { type ipv4_addr; flags interval; }
+	set bn-publisher_ports { type inet_service; elements = { 40840 }; }
+	set bn-restricted { type ipv4_addr; flags interval; }
+	set bn-subscriber-in_ports { type inet_service; elements = { 40980, 40981 }; }
+
+	chain forward {
+		type filter hook forward priority 0; policy drop;
+		ct state invalid drop
+
+		# Quarantine (deny), both directions. Runs before est,rel accept
+		# so already-open connections are also killed.
+		ip saddr @bn-restricted drop
+		ip daddr @bn-restricted drop
+
+		# Asymmetric reply restore. Must precede est,rel accept so every
+		# reply packet is reclassified, not just the SYN.
+		ct direction reply ct mark 0x20 meta priority set 0x10020 accept
+
+		# Classification — specific matches.
+		ip saddr 10.4.0.0/24 ip daddr . tcp dport @bn-backfill ct mark set 0x20 meta priority set 0x10060 accept
+		ip saddr 10.4.0.0/24 ip daddr @bn-partner-out tcp sport @bn-partner-out_ports meta priority set 0x10040 accept
+		ip daddr 10.4.0.0/24 ip saddr @bn-publisher tcp dport @bn-publisher_ports meta priority set 0x10010 accept
+
+		# Classification — fallthrough (any source/dest).
+		ip saddr 10.4.0.0/24 tcp sport @bn-public-out_ports meta priority set 0x10050 accept
+		ip daddr 10.4.0.0/24 tcp dport @bn-subscriber-in_ports meta priority set 0x10030 accept
+
+		ct state established,related accept
+		drop
+	}
+}

--- a/internal/network/policy/validate_test.go
+++ b/internal/network/policy/validate_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  *Policy
+		cidrs   []string
+		wantErr string // "" means valid
+	}{
+		{
+			name:   "valid stamp ingress",
+			policy: &Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
+			cidrs:  []string{"10.1.0.1/32"},
+		},
+		{
+			name:   "valid deny",
+			policy: &Policy{Name: "bn-restricted", Action: ActionDeny},
+			cidrs:  []string{"10.99.0.0/16"},
+		},
+		{
+			name:   "valid reply-stamp egress with ip:port cidrs",
+			policy: &Policy{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
+			cidrs:  []string{"10.30.5.7:43473"},
+		},
+		{
+			name:   "valid from-entity world fallthrough",
+			policy: &Policy{Name: "bn-public-out", Action: ActionStamp, Stamp: "public", FromEntityWorld: true, Ports: []string{"40980"}},
+		},
+		{
+			name:    "empty name",
+			policy:  &Policy{Action: ActionStamp, Stamp: "publisher"},
+			wantErr: "invalid --name",
+		},
+		{
+			name:    "no action",
+			policy:  &Policy{Name: "x"},
+			wantErr: "exactly one of --stamp or --deny",
+		},
+		{
+			name:    "stamp unknown class",
+			policy:  &Policy{Name: "x", Action: ActionStamp, Stamp: "bogus"},
+			wantErr: "unknown class",
+		},
+		{
+			name:    "reply-stamp on ingress-class stamp rejected",
+			policy:  &Policy{Name: "x", Action: ActionStamp, Stamp: "publisher", ReplyStamp: "backfill-response"},
+			wantErr: "only valid when --stamp resolves to an egress class",
+		},
+		{
+			name:    "reply-stamp same-direction class rejected",
+			policy:  &Policy{Name: "x", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "partner"},
+			wantErr: "must resolve to an ingress class",
+		},
+		{
+			name:    "deny with stamp rejected",
+			policy:  &Policy{Name: "x", Action: ActionDeny, Stamp: "publisher"},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "deny with direction rejected",
+			policy:  &Policy{Name: "x", Action: ActionDeny, Direction: DirectionIngress},
+			wantErr: "--direction does not apply to --deny",
+		},
+		{
+			name:    "deny with ports rejected",
+			policy:  &Policy{Name: "x", Action: ActionDeny, Ports: []string{"40840"}},
+			wantErr: "--ports does not apply to --deny",
+		},
+		{
+			name:    "from-entity world with cidrs rejected",
+			policy:  &Policy{Name: "x", Action: ActionStamp, Stamp: "public", FromEntityWorld: true},
+			cidrs:   []string{"10.0.0.0/8"},
+			wantErr: "mutually exclusive with --cidrs",
+		},
+		{
+			name:    "from-entity world on deny rejected",
+			policy:  &Policy{Name: "x", Action: ActionDeny, FromEntityWorld: true},
+			wantErr: "--from-entity world does not apply to --deny",
+		},
+		{
+			name:    "invalid port",
+			policy:  &Policy{Name: "x", Action: ActionStamp, Stamp: "publisher", Ports: []string{"70000"}},
+			wantErr: "invalid --ports entry",
+		},
+		{
+			name:    "invalid cidr",
+			policy:  &Policy{Name: "x", Action: ActionStamp, Stamp: "publisher"},
+			cidrs:   []string{"not-a-cidr"},
+			wantErr: "invalid --cidrs entry",
+		},
+		{
+			name:    "ipv6 cidr rejected",
+			policy:  &Policy{Name: "x", Action: ActionStamp, Stamp: "publisher"},
+			cidrs:   []string{"2001:db8::/32"},
+			wantErr: "IPv6 is not yet supported",
+		},
+		{
+			name:    "reply-stamp cidr without port rejected",
+			policy:  &Policy{Name: "x", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
+			cidrs:   []string{"10.30.5.7"},
+			wantErr: "require ip:port pairs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.policy.Validate(tt.cidrs)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestValidate_DerivesDirectionFromStamp(t *testing.T) {
+	p := &Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}}
+	require.NoError(t, p.Validate(nil))
+	require.Equal(t, DirectionIngress, p.Direction)
+
+	p = &Policy{Name: "bn-partner-out", Action: ActionStamp, Stamp: "partner", Ports: []string{"40980"}}
+	require.NoError(t, p.Validate(nil))
+	require.Equal(t, DirectionEgress, p.Direction)
+}
+
+func TestLookupClass(t *testing.T) {
+	c, err := lookupClass("publisher")
+	require.NoError(t, err)
+	require.Equal(t, uint32(0x10010), c.Priority)
+	require.Equal(t, uint32(0x10), c.Mark)
+
+	_, err = lookupClass("nope")
+	require.ErrorContains(t, err, "unknown class")
+}


### PR DESCRIPTION
## Description

Implements `solo-provisioner network policy create` — Story 1.2 of epic TS_1 (#738), the second scope in the `network` command family after `network firewall` (#757). This is the command-driven authoring surface for the `inet weaver` classification/ACL plane (design §7.2.4, §8.4.2, §8.4.6).

`create` renders one named category's rule(s) into the `inet weaver` forward chain, ensures its nft set `@<name>` exists, writes a per-policy registry JSON under `/etc/solo-provisioner/policies/`, applies the full chain to the live kernel with `nft -f`, and atomically rewrites `/etc/solo-provisioner/network-weaver.nft`. The new `internal/network/policy` package mirrors the merged `internal/network/firewall` package (Manager, atomic temp+rename write, shared apply flock, shared boot oneshot) but targets the `inet weaver` table, which has the opposite lifecycle — its set membership churns continuously as the daemon reconciles it from statusz.

Key design decisions (so reviewers don't reverse-engineer them):

- **`--stamp` priority lookup is in-code.** The 6 stable QoS classes (`publisher` … `reserve-egress`) map to fixed skb->priority / ct-mark values from design §5, baked into `class.go`. Referencing an unknown class is a create-time error. This means Story 1.2 has **no runtime dependency on Story 1.4** (`network shape`) — the name→priority encoding is static; shape only sets each class's bandwidth.
- **No `--direction` flag.** Every class in the §5 map has exactly one direction (§7.2.4's worked ruleset never mixes a class across both), so `Validate` derives `Policy.Direction` from `--stamp`'s class instead of taking it as a separate flag that could contradict it. `--reply-stamp` is checked as the mirror direction of the forward `--stamp` class (egress forward → ingress reply) rather than requiring a matching `--direction` value. Design doc (§5, §8.4.2, §8.4.3) and issues #738/#758/#771 updated to match.
- **Full chain rendered in tier order** (deny → reply-restore → specific stamp → fallthrough stamp → est/rel accept → drop), never creation order. A mis-ordered deny would let already-open connections survive a quarantine, so ordering is a correctness invariant, pinned by a golden file. This is the boundary the epic owner and I agreed on for 1.2; see "Scope boundary" below for what's deferred to #772.
- **Set membership is never persisted** to `network-weaver.nft` (§8.3.1) — statusz is the source of truth and the daemon reconciles it. `--cidrs` seeds the *live* set only, via a separate `nft add element`.
- **Kernel apply is direct `nft -f`**, not a service restart (the shared boot oneshot does not load `network-weaver.nft` until #780 extends it). `create` still enables the shared unit for boot readiness.
- **`--pod-cidr` is no longer required (or auto-detected) for `--deny`.** `POD_CIDR` is only ever read by `renderStampRule`; a deny rule (`ip saddr/daddr @<name> drop`) never references it. `Render` now only requires it when the merged policy set has at least one `--stamp` policy (`needsPodCIDR`), and the CLI skips cluster-based auto-detection entirely for `--deny`. Caught by manually testing `--deny` in isolation — quarantining a CIDR shouldn't need a reachable cluster.
- **When `--deny`'s merged chain *does* need a pod CIDR (a `--stamp` sibling exists) and none was supplied, `Create` recovers it from the existing `network-weaver.nft` instead of erroring** — `ExtractPodCIDR` (new, `parse.go`) regex-extracts the literal CIDR any rendered `--stamp` rule starts with. This mirrors `internal/network/firewall`'s `Parse()`, which exists for the same reason ("element verbs use this to load prior state so they don't need the full flag set re-spec") — `podCIDR` is a deployment-wide constant, not a per-call argument, so an unrelated `--deny` create shouldn't need it re-supplied just to correctly re-render an unchanged `--stamp` sibling. No CLI change: `--stamp`'s own auto-detect-or-hard-error path is untouched, since that policy's *own* correctness still depends on a fresh value, not a cached one. `network-weaver.nft` genuinely missing (not just the kernel table) still errors clearly.
- **`create` is create-if-missing, mirroring `network firewall create` — not additive.** An existing policy is left untouched (warn, no changes) unless `--force` is passed, which **replaces** (not merges) its config and membership from the given flags/`--cidrs`. This is a deliberate divergence from an earlier iteration of this PR that made `create` diff-and-reapply automatically; matching firewall's already-established convention is simpler and more predictable.
- **Two related correctness issues surfaced during manual UAT while landing the above** (neither was caught by the original unit tests — the original fake `Runner` didn't model `Apply()`'s destructive wipe, so it couldn't have; it does now):
  1. The rendered document always starts with `delete table; add table` (§8.3.1: membership is never part of it), so every `Apply()` destroys and recreates *every* set in the table, not just the policy being created — any other policy's live membership (permanently so, for operator-curated policies like `bn-mgmt-in`, which the daemon never touches) was lost on every subsequent `create`. Fixed by snapshotting every policy's live membership (`Runner.ListElements`, new) before `Apply()` and restoring it afterward (`TestCreate_PreservesSiblingMembershipAcrossRerender`).
  2. A policy's registry entry can outlive the live kernel table: nft tables don't survive a reboot, and the boot oneshot doesn't reload `network-weaver.nft` yet (#780) — so "the registry has this policy" doesn't imply "the live table has it". Without `--force`, `create` now checks `Runner.Exists` and self-heals a missing table from the *already-registered* config — never the caller's just-typed flags/`--cidrs`, since applying those requires `--force` (`TestCreate_SelfHealsMissingTableWithoutForce`). Membership itself can't be recovered this way (it was never persisted); it comes back empty until `--force` re-seeds it or the daemon's poll loop catches up.

### Files changed

| File | Change |
|---|---|
| `internal/network/policy/paths.go` | Package doc + `inet weaver` path/service/lock constants |
| `internal/network/policy/class.go` | Static §5 class→mark/priority map + `lookupClass` |
| `internal/network/policy/policy.go` | `Policy` registry model + `Validate` (all flag-combination rules) |
| `internal/network/policy/render.go` | Tier-order full-chain renderer + `atomicWriteFile` |
| `internal/network/policy/parse.go` | `ExtractPodCIDR` — recovers the pod CIDR from an existing `network-weaver.nft` (mirrors `firewall.Parse`) |
| `internal/network/policy/registry.go` | Per-policy registry JSON read/write/load-all |
| `internal/network/policy/manager.go` | `Manager.Create` (flock, idempotent, apply+persist) |
| `internal/network/policy/nft.go` | Exec `nft` Runner (`Apply`/`AddElements`/`ListElements`/`List`/`Delete`/`Exists`) |
| `internal/network/policy/service_{linux,other}.go` | Shared oneshot enable (Linux) / no-op (other) |
| `internal/network/policy/*_test.go` + `testdata/network-weaver.golden.nft` | Render golden, tier-order, validation, idempotency, registry tests |
| `cmd/cli/commands/network/policy/{policy,create}.go` | `network policy create` verb + flags |
| `cmd/cli/commands/network/policy/policy_test.go` | Command structure, flag, and execution tests |
| `cmd/cli/commands/network/network.go` | Wire `policy.GetCmd()` into the `network` group |
| `docs/quickstart.md` | `Create a Traffic Policy` section (examples + flags table) |

### Review guide

**Code review checklist**

- `class.go` — the 6 class priorities/marks match design §5 exactly (`publisher` 0x10/0x10010 … `reserve-egress` 0x60/0x10060); reply ct-mark = the reply class's mark.
- `policy.go:Validate` — `--stamp`⊕`--deny`; `--stamp` derives `Direction` from its class; `--reply-stamp` requires `--stamp` to resolve to an egress class and itself resolve to the mirror ingress class; `--from-entity world` ⊕ `--cidrs` and stamp-only; `--reply-stamp` CIDRs are `ip:port`; IPv6 rejected (ipv4_addr sets).
- `render.go` — tier order (deny → reply-restore → specific → fallthrough → est/rel → drop); membership set schemas carry **no** elements, only `_ports` sets do; compound `ipv4_addr . inet_service` set for reply-stamp; `ip daddr .` compound match on the egress forward rule; `needsPodCIDR` only requires `podCIDR` when the merged set has a `--stamp` policy, since only `renderStampRule` reads it.
- `manager.go:Create` — create-if-missing: an existing policy is a no-op without `--force`, regardless of whether the given flags/`--cidrs` differ; `--force` re-renders and replaces (not merges) config and membership. Render happens **before** any disk write (a failed apply leaves the registry untouched); `created_at` preserved across a `--force` replace; whole op under the shared flock. `snapshotMembership` runs before `Apply()` and its restore loop runs after, so siblings' membership survives the destructive re-render — a snapshot failure aborts before the kernel is touched. Without `--force`, a missing live table for an existing policy self-heals from the registry, ignoring the caller's new flags/`--cidrs`. An empty `podCIDR` is recovered from the existing `network-weaver.nft` via `ExtractPodCIDR` before falling through to `Render`'s `needsPodCIDR` check.
- **Port-set naming** (`@<policy-name>_ports`) — the design examples are internally inconsistent (`@bn_ports_publisher` by class vs `@bn_ports_subscriber` shared across policies). I chose a mechanical per-policy set. Flag if you want shared class-grouped port sets instead.
- `network-weaver.golden.nft` — read it top-to-bottom against §7.2.4; it is the behavioral contract.

**Scope boundary (epic #738)** — this PR is `create` only. Deferred:
- `add`/`remove`/`set`/`show`/`delete` element verbs → #759 (Story 1.3)
- overlap rejection, the `created_at` intra-tier tiebreaker, `delete` + last-policy service teardown → #772 (Story 1.5)
- extending the boot oneshot to load `network-weaver.nft` → #780
- `network shape` class declaration → #771 (Story 1.4)

**Test commands**

```bash
# Unit tests (macOS OK — internal/network/policy has no Linux-only deps)
go test -race -cover -tags='!integration' ./internal/network/policy/...

# CLI command package (Linux only — pulls in internal/mount; run in the VM)
task vm:test:unit

# Linux cross-compile of the touched packages
GOOS=linux GOARCH=amd64 go build ./internal/network/policy/... ./cmd/cli/commands/network/...

# Lint (errorx/forbidigo) + license headers
task lint:check
task license:check
```

**Manual UAT (UTM VM — Debian/Ubuntu with nftables + systemd)**

1. Build and copy the binary to the VM:
   ```bash
   task build:cli GOOS=linux GOARCH=amd64
   scp bin/solo-provisioner-linux-amd64 <vm>:/usr/local/bin/solo-provisioner
   ```
2. Create a stamp policy (pod CIDR passed explicitly so no cluster is needed):
   ```bash
   sudo solo-provisioner network policy create --name bn-publisher \
     --ports 40840 --stamp publisher \
     --cidrs 10.1.0.1/32 --pod-cidr 10.4.0.0/24
   ```
   Verify the live chain:
   ```bash
   sudo nft list table inet weaver
   ```
   Expect a `chain forward` with `policy drop`, the set `bn-publisher` (`type ipv4_addr; flags interval`), the port set `bn-publisher_ports` with `elements = { 40840 }`, and the rule:
   ```
   ip daddr 10.4.0.0/24 ip saddr @bn-publisher tcp dport @bn-publisher_ports meta priority set 1:10 accept
   ```
   (`nft list table` reformats `meta priority` values that decode as a valid tc classid into `major:minor` notation — `0x10010` → `1:10`. This is nft's own display choice on read-back, not what we write: `network-weaver.nft` and the golden test both correctly show the literal `0x10010` we author.)
   The live `@bn-publisher` set should contain `10.1.0.1/32`, but the **on-disk file must not**:
   ```bash
   sudo nft list set inet weaver bn-publisher        # shows 10.1.0.1/32 (live)
   grep 10.1.0.1 /etc/solo-provisioner/network-weaver.nft   # no match (membership not persisted)
   cat /etc/solo-provisioner/policies/bn-publisher.json     # registry entry present
   ```
3. Add a quarantine (deny) policy and confirm the drops render **above** `ct state established,related accept`. Deliberately **omit `--pod-cidr`** here — `--deny` never references `POD_CIDR` itself, so it must not try to auto-detect it. Note that the merged chain *does* still include `bn-publisher` (a `--stamp` policy, from step 2) — this call succeeding with no `--pod-cidr` and no cluster reachable demonstrates the recovery path: the CIDR is pulled back out of the existing `network-weaver.nft` (`10.4.0.0/24`, from step 2), not re-detected or required:
   ```bash
   sudo solo-provisioner network policy create --name bn-restricted \
     --deny --cidrs 10.99.0.0/16
   sudo nft -a list table inet weaver | grep -nE 'drop|established|10.4.0.0'
   ```
   Expect `ip saddr @bn-restricted drop` / `ip daddr @bn-restricted drop` to appear before the `ct state established,related accept` line, no pod-CIDR detection log line, no failure even if this VM has no cluster configured, and `bn-publisher`'s rule still correctly showing `ip daddr 10.4.0.0/24 ...` (recovered, not lost).
4. Add a backfill reply-stamp policy and confirm the compound set + auto-rendered restore rule:
   ```bash
   sudo solo-provisioner network policy create --name bn-backfill \
     --stamp reserve-egress --reply-stamp backfill-response \
     --cidrs 10.30.5.7:43473 --pod-cidr 10.4.0.0/24
   sudo nft list table inet weaver | grep -E 'ct direction reply|ct mark set 0x20|bn-backfill'
   ```
   Expect the set `bn-backfill { type ipv4_addr . inet_service; }`, the egress forward rule with `ct mark set 0x20 meta priority set 1:60`, and the ingress restore `ct direction reply ct mark 0x20 meta priority set 1:20 accept`. (`ct mark` stays raw hex on read-back; only `meta priority` gets the classid reformat — see the note in step 2.)
5. Create-if-missing and `--force`:
   - Re-run step 2 verbatim → warns `network policy already exists — supplied flags/cidrs were not applied; pass --force to replace`; `nft list set inet weaver bn-publisher` still shows exactly `10.1.0.1/32`.
   - Re-run step 2 with a **different** `--ports` and a **different** `--cidrs`, still without `--force` → same warning, same no-op. Differing flags don't matter without `--force`.
   - Re-run with `--force`:
     ```bash
     sudo solo-provisioner network policy create --name bn-publisher \
       --ports 40840,40841 --stamp publisher \
       --cidrs 10.1.0.2/32 --pod-cidr 10.4.0.0/24 --force
     ```
     Expect the port set to now show `{ 40840, 40841 }`, and `nft list set inet weaver bn-publisher` to show **only** `10.1.0.2/32` — `--force` replaces membership, it does not merge with `10.1.0.1/32`.
6. Missing-table self-heal without `--force` (this is what actually surfaced the bugs above). **Note**: `nft delete table` only deletes the *kernel* table — it does **not** touch `/etc/solo-provisioner/policies/*.json` (the registry). If you want a true clean-slate reset for testing (not this step, which specifically wants the registry to still think the policy exists), delete both: `sudo nft delete table inet weaver && sudo rm -f /etc/solo-provisioner/policies/*.json`.
   ```bash
   sudo nft delete table inet weaver
   sudo solo-provisioner network policy create --name bn-publisher \
     --ports 40840,40841 --stamp publisher \
     --cidrs 10.1.0.99/32 --pod-cidr 10.4.0.0/24
   ```
   No `--force`, and deliberately yet another different `--cidrs`. The registry still says `bn-publisher` is configured, but the kernel table is gone — this is also what a reboot looks like before #780 extends the boot oneshot. Expect success (not `nft add element ... failed: No such file or directory`): the table is recreated from the **last registered** config (ports `40840,40841`, from step 5's `--force` call), but `10.1.0.99/32` must not appear anywhere and `nft list set inet weaver bn-publisher` comes back **empty** — membership was never persisted, so it can't be recovered without `--force` re-seeding it.

   Re-seed known membership with `--force` (the table exists again now, so this is a normal replace) so the next step has something to verify:
   ```bash
   sudo solo-provisioner network policy create --name bn-publisher \
     --ports 40840,40841 --stamp publisher \
     --cidrs 10.1.0.1/32 --pod-cidr 10.4.0.0/24 --force
   ```
7. `--from-entity world` fallthrough, and creation-order independence. Create the **fallthrough** policy first, then the **specific** one that shares its direction and ports, and confirm the chain still orders specific-before-fallthrough despite the reverse creation order:
   ```bash
   sudo solo-provisioner network policy create --name bn-public-out \
     --stamp public --from-entity world --ports 40980,40981 --pod-cidr 10.4.0.0/24
   sudo solo-provisioner network policy create --name bn-partner-out \
     --stamp partner --ports 40980,40981 --cidrs 10.20.0.0/16 --pod-cidr 10.4.0.0/24
   sudo solo-provisioner network policy create --name bn-subscriber-in \
     --stamp reserve-ingress --from-entity world --ports 40980,40981 --pod-cidr 10.4.0.0/24
   sudo nft list table inet weaver | grep -nE 'bn-partner-out|bn_ports_subscriber|meta priority set 1:(4|5|3)0'
   ```
   Expect, in this order: the `bn-partner-out` rule (`ip saddr @bn-partner-out ... meta priority set 1:40`) **before** the `bn-public-out` rule (`... meta priority set 1:50`, no `ip daddr @set` clause — `--from-entity world` suppresses it) — even though `bn-public-out` was created first. `bn-subscriber-in`'s rule (`ip daddr 10.4.0.0/24 tcp dport ... meta priority set 1:30`, no `ip saddr @set`) confirms the same on the ingress side.
8. Confirm `bn-publisher`'s membership (re-seeded at the end of step 6) survived the three brand-new-policy re-renders just triggered in step 7:
   ```bash
   sudo nft list set inet weaver bn-publisher
   ```
   Must still show exactly `10.1.0.1/32` — this is the sibling-membership bug fixed above: each `create` in step 7 forces a full chain re-render (`delete table; add table`), which previously wiped every other policy's live membership.
9. Error paths:
   - `--stamp bogus` exits non-zero with `unknown class "bogus": must be one of …` and leaves the table unchanged.
   - `--stamp publisher --reply-stamp backfill-response` (an ingress class with a reply-stamp) → `--reply-stamp is only valid when --stamp resolves to an egress class`.
   - `--stamp reserve-egress --reply-stamp partner` (both egress — `partner` is not the mirror ingress class) → `--reply-stamp class "partner" must resolve to an ingress class`.
   - **Recovery genuinely has nothing to recover from**: `sudo rm /etc/solo-provisioner/network-weaver.nft` (the file itself, independent of the kernel table or the JSON registry), then re-run the step-3 `--deny` command again. `bn-publisher`'s registry entry is still there, so the merged chain still needs a pod CIDR, and there's no `network-weaver.nft` left to recover it from → expect the same `pod CIDR is required to render a --stamp policy` error, not a silent/incorrect success.
10. `--pod-cidr` hard-error path (no cluster reachable from this VM): omit `--pod-cidr` entirely, for a **new** policy name so create-if-missing doesn't short-circuit first —
    ```bash
    sudo solo-provisioner network policy create --name bn-test --stamp publisher --ports 40840
    ```
    Expect a hard error ("could not auto-detect the pod CIDR; pass --pod-cidr explicitly"), not a warning-and-continue. This is the deliberate difference from `network firewall create`, which falls back best-effort when no cluster is reachable — `network policy create` always requires a resolvable pod CIDR.
11. Boot readiness: `systemctl is-enabled solo-provisioner-network-nft.service` → `enabled`.

**Risks / rollback**

- Wrong rule order = security/QoS bug; mitigated by the golden-file test pinning tier order.
- Membership snapshot/restore adds one `nft list set` per existing policy before every re-render; bounded by the shared flock (no concurrent mutator, including the future daemon poll loop, can interleave with it), so the snapshot can't go stale mid-`Create`.
- Shared coupling with `firewall`: the boot unit (#780) and the apply lock (#759) are shared; path/service constants are duplicated by value with a matching-values note (hoisting to a shared package is a follow-up).
- The verb is create-if-missing (`--force` to replace an existing policy). Rollback: `nft delete table inet weaver` + remove `/etc/solo-provisioner/policies/` and `/etc/solo-provisioner/network-weaver.nft`. No behavior change to `firewall` or existing commands beyond the one `AddCommand` line.

### Related Issues

* Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)







