### PR TITLE
refactor(cli): drop --profile and --node-type from kube cluster install

### DIFF
--- a/cmd/cli/commands/kube/cluster/cluster.go
+++ b/cmd/cli/commands/kube/cluster/cluster.go
@@ -8,6 +8,9 @@ import (
 )
 
 var (
+	// flagNodeType backs the deprecated --node-type flag on `kube cluster install`.
+	// Cluster install is workload-agnostic now, so the value is ignored; the flag is
+	// kept hidden for backward compatibility.
 	flagNodeType        string
 	flagStopOnError     bool
 	flagRollbackOnError bool

--- a/cmd/cli/commands/kube/cluster/install.go
+++ b/cmd/cli/commands/kube/cluster/install.go
@@ -7,9 +7,6 @@ import (
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/rsl"
 	"github.com/hashgraph/solo-weaver/internal/workflows"
-	"github.com/hashgraph/solo-weaver/pkg/config"
-	"github.com/hashgraph/solo-weaver/pkg/hardware"
-	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/joomcode/errorx"
 	"github.com/spf13/cobra"
 )
@@ -19,28 +16,18 @@ var installCmd = &cobra.Command{
 	Short: "Install a Kubernetes Cluster",
 	Long:  "Run safety checks, setup a K8s cluster",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		flagProfile, err := common.FlagProfile().Value(cmd, args)
-		if err != nil {
-			return errorx.IllegalArgument.Wrap(err, "failed to get profile flag")
+		// Cluster install is workload-agnostic: it validates only the Kubernetes
+		// substrate hardware floor, so no --profile or --node-type is required.
+		// Both flags are deprecated: still accepted (hidden) for backward compatibility
+		// but ignored. Tell the operator if either was explicitly provided.
+		if cmd.Flags().Changed(common.FlagProfile().Name) {
+			logx.As().Warn().Msgf("--%s is deprecated and ignored for 'kube cluster install': it validates only the Kubernetes substrate floor. Profile-based sizing applies to 'block node' commands.",
+				common.FlagProfile().Name)
 		}
-
-		if flagProfile == "" {
-			return errorx.IllegalArgument.New("profile flag is required")
+		if cmd.Flags().Changed(common.FlagNodeType().Name) {
+			logx.As().Warn().Msgf("--%s is deprecated and ignored for 'kube cluster install': it validates only the Kubernetes substrate floor.",
+				common.FlagNodeType().Name)
 		}
-
-		// Validate node type and profile early for better error messages
-		if !hardware.IsValidNodeType(flagNodeType) {
-			return errorx.IllegalArgument.New("unsupported node type: %q. Supported types: %v",
-				flagNodeType, hardware.SupportedNodeTypes())
-		}
-
-		if !hardware.IsValidProfile(flagProfile) {
-			return errorx.IllegalArgument.New("unsupported profile: %q. Supported profiles: %v",
-				flagProfile, models.SupportedProfiles())
-		}
-
-		// Set the profile in the global config so other components can access it
-		config.SetProfile(flagProfile)
 
 		execMode, err := common.GetExecutionMode(flagContinueOnError, flagStopOnError, flagRollbackOnError)
 		if err != nil {
@@ -70,7 +57,7 @@ var installCmd = &cobra.Command{
 			return errorx.IllegalArgument.New("expected MachineRuntime to be *rsl.MachineRuntimeResolver but got %T", sr.Runtime.MachineRuntime)
 		}
 
-		wb := workflows.WithWorkflowExecutionMode(workflows.InstallClusterWorkflow(flagNodeType, flagProfile, "", skipHardwareChecks, mr), opts)
+		wb := workflows.WithWorkflowExecutionMode(workflows.InstallClusterWorkflow(skipHardwareChecks, mr), opts)
 		if err := common.RunWorkflowBuilder(cmd.Context(), wb); err != nil {
 			return err
 		}
@@ -81,7 +68,9 @@ var installCmd = &cobra.Command{
 }
 
 func init() {
-	common.FlagNodeType().SetVarP(installCmd, &flagNodeType, true)
+	// Deprecated: --node-type no longer affects cluster install (substrate-only floor).
+	// Kept hidden for backward compatibility; the value is ignored (see RunE notice).
+	common.FlagNodeType().SetVarPHidden(installCmd, &flagNodeType, false)
 	common.FlagStopOnError().SetVarP(installCmd, &flagStopOnError, false)
 	common.FlagRollbackOnError().SetVarP(installCmd, &flagRollbackOnError, false)
 	common.FlagContinueOnError().SetVarP(installCmd, &flagContinueOnError, false)

--- a/cmd/cli/commands/kube/kube.go
+++ b/cmd/cli/commands/kube/kube.go
@@ -9,6 +9,10 @@ import (
 )
 
 var (
+	// flagProfile backs the deprecated --profile flag. Cluster install is now
+	// workload-agnostic (it validates only the Kubernetes substrate floor), so the
+	// value is ignored. The flag is kept hidden for backward compatibility so that
+	// existing invocations/scripts do not break; see install.go for the ignore notice.
 	flagProfile string
 
 	kubeCmd = &cobra.Command{
@@ -20,7 +24,10 @@ var (
 )
 
 func init() {
-	common.FlagProfile().SetVarP(kubeCmd, &flagProfile, false)
+	// Deprecated: --profile no longer affects cluster install (substrate-only floor).
+	// Kept hidden + persistent for backward compatibility; per-workload sizing lives
+	// on the block node commands.
+	common.FlagProfile().SetVarPHidden(kubeCmd, &flagProfile, false)
 	kubeCmd.AddCommand(cluster.GetCmd())
 }
 

--- a/cmd/cli/commands/kube/kube_test.go
+++ b/cmd/cli/commands/kube/kube_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeprecatedClusterInstallFlagsHiddenButAccepted pins the deprecation contract
+// for #685: `--profile` and `--node-type` must remain registered (so existing scripts
+// do not break with "unknown flag") but hidden from --help.
+func TestDeprecatedClusterInstallFlagsHiddenButAccepted(t *testing.T) {
+	root := GetCmd()
+
+	// --profile is retained (hidden, persistent) on the kube command for backward
+	// compatibility; cluster install ignores its value.
+	profile := root.PersistentFlags().Lookup("profile")
+	require.NotNil(t, profile, "--profile must remain registered for backward compatibility")
+	require.True(t, profile.Hidden, "--profile must be hidden from --help")
+
+	install := findSubcommand(t, findSubcommand(t, root, "cluster"), "install")
+
+	// --node-type is retained (hidden) on cluster install; its value is ignored.
+	nodeType := install.PersistentFlags().Lookup("node-type")
+	require.NotNil(t, nodeType, "--node-type must remain registered for backward compatibility")
+	require.True(t, nodeType.Hidden, "--node-type must be hidden from --help")
+}
+
+func findSubcommand(t *testing.T, parent *cobra.Command, name string) *cobra.Command {
+	t.Helper()
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	require.Failf(t, "subcommand not found", "%q under %q", name, parent.Name())
+	return nil
+}

--- a/docs/dev/daemon/daemon-testing-guide.md
+++ b/docs/dev/daemon/daemon-testing-guide.md
@@ -63,10 +63,7 @@ chmod +x /tmp/solo-provisioner-new
 sudo /tmp/solo-provisioner-new install --non-interactive
 
 # ── 3. Bootstrap a single-node Kubernetes cluster ─────────────────────────
-sudo solo-provisioner kube cluster install \
-  --profile local \
-  --node-type block \
-  --non-interactive
+sudo solo-provisioner kube cluster install --non-interactive
 
 # Verify:
 sudo kubectl get nodes

--- a/docs/dev/functionality-test-suite.md
+++ b/docs/dev/functionality-test-suite.md
@@ -94,9 +94,9 @@
 
 ### 3.1 Cluster Install
 
-- [ ] **TC-CL-INS-001** — As a node operator, when I run `kube cluster install`, the cluster is set up with the specified profile and node type.
+- [ ] **TC-CL-INS-001** — As a node operator, when I run `kube cluster install`, the cluster is set up after validating only the Kubernetes substrate hardware floor (no `--profile` / `--node-type` required).
 - [ ] **TC-CL-INS-002** — As a node operator, when I run `kube cluster install` and the cluster is already created (`ClusterState.Created = true`), the command should detect the existing setup and error if it is already installed.
-- [ ] **TC-CL-INS-003** — Invalid profile or node type is rejected with a clear error message.
+- [ ] **TC-CL-INS-003** — A host below the substrate floor (CPU/memory/disk/OS) is rejected with a clear error; a host that meets the substrate floor but not a later workload floor still installs the cluster.
 - [ ] **TC-CL-INS-004** — State manager is initialised, refreshed, and passed into the workflow correctly.
 
 ### 3.2 Cluster Uninstall

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -348,24 +348,31 @@ Sets up a complete single-node Kubernetes environment with all required componen
 - **k9s**: Terminal-based Kubernetes UI
 - **Metrics Server**: Resource metrics for pods and nodes
 
+Cluster install is **workload-agnostic**: it validates only the Kubernetes substrate
+hardware floor (what Kubernetes itself needs to run), not any per-workload sizing. It
+therefore takes **no `--profile` or `--node-type`**. Workload-sized hardware validation
+happens later, at `block node check` / `block node install`, where the deployment
+profile and plugin preset are known.
+
 ```bash
-# Install full Kubernetes stack for block nodes
-sudo solo-provisioner kube cluster install \
-  --profile=local \
-  --node-type=block
+# Install the full Kubernetes stack
+sudo solo-provisioner kube cluster install
 
 # With error handling
-sudo solo-provisioner kube cluster install \
-  --profile=mainnet \
-  --node-type=block \
-  --rollback-on-error
+sudo solo-provisioner kube cluster install --rollback-on-error
 ```
 
 **Flags**:
 
-| Flag          | Short | Description                             | Required |
-|---------------|-------|-----------------------------------------|----------|
-| `--node-type` | `-n`  | Type of node (block\|consensus\|mirror) | Yes      |
+| Flag                 | Short | Description                                                        | Required |
+|----------------------|-------|-------------------------------------------------------------------|----------|
+| `--rollback-on-error`| —     | Roll back completed steps if a later step fails                   | No       |
+| `--stop-on-error`    | —     | Stop at the first failing step (default)                          | No       |
+| `--continue-on-error`| —     | Continue past failing steps                                       | No       |
+
+> **Deprecated:** `--profile` and `--node-type` are no longer used by `kube cluster install`.
+> They are still accepted (hidden) so existing scripts do not break, but their values are
+> **ignored** and a notice is printed if you pass them. Remove them from your invocations.
 
 #### Uninstall Kubernetes Cluster
 
@@ -1114,7 +1121,7 @@ sudo solo-provisioner block node reset       --profile=<profile>
 sudo solo-provisioner block node uninstall   --profile=<profile> [--with-reset]
 
 # KUBERNETES
-sudo solo-provisioner kube cluster install   --profile=<profile> --node-type=block
+sudo solo-provisioner kube cluster install
 sudo solo-provisioner kube cluster uninstall
 
 # TELEPORT

--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -76,10 +76,15 @@ func (h *InstallHandler) BuildWorkflow(
 		wb = automa.NewWorkflowBuilder().WithId("block-node-install").
 			Steps(
 				// Same backwards-compat guard as above: ensure weaver:2500 exists
-				// before InstallClusterWorkflow's preflight check validates it.
-				// Older binaries did not create this account during self-install.
+				// before the preflight check validates it. Older binaries did not
+				// create this account during self-install.
 				steps.EnsureWeaverOwnerStep(),
-				workflows.InstallClusterWorkflow(models.NodeTypeBlock, ins.Profile, ins.PluginPreset, ins.SkipHardwareChecks, h.mr),
+				// Block node install owns its workload-sized preflight (block provider,
+				// profile, plugin preset) plus system setup, then stands up Kubernetes.
+				// InstallClusterWorkflow is intentionally not reused here: it validates
+				// only the substrate floor, which is weaker than the block-node floor.
+				workflows.NodeSetupWorkflow(models.NodeTypeBlock, ins.Profile, ins.PluginPreset, ins.SkipHardwareChecks),
+				workflows.KubernetesSetupWorkflow(h.mr),
 				steps.SetupBlockNode(ins),
 			)
 	}

--- a/internal/workflows/cluster.go
+++ b/internal/workflows/cluster.go
@@ -22,18 +22,25 @@ func DefaultWorkflowExecutionOptions() *models.WorkflowExecutionOptions {
 }
 
 // InstallClusterWorkflow creates a workflow to set up a kubernetes cluster.
-func InstallClusterWorkflow(nodeType string, profile string, pluginPreset string, skipHardwareChecks bool, mr software.MachineRuntime) *automa.WorkflowBuilder {
+//
+// It is workload-agnostic: it validates only the Kubernetes substrate hardware floor
+// (what Kubernetes itself needs), not any per-workload sizing. Per-workload preflight
+// belongs to the node install commands (e.g. block node install), which run
+// NodeSetupWorkflow before composing KubernetesSetupWorkflow themselves.
+func InstallClusterWorkflow(skipHardwareChecks bool, mr software.MachineRuntime) *automa.WorkflowBuilder {
 	return automa.NewWorkflowBuilder().
 		WithId("setup-kubernetes").
 		Steps(
-			NodeSetupWorkflow(nodeType, profile, pluginPreset, skipHardwareChecks),
-			kubernetesSetupWorkflow(mr),
+			SubstrateSetupWorkflow(skipHardwareChecks),
+			KubernetesSetupWorkflow(mr),
 		)
 }
 
-// kubernetesSetupWorkflow installs and configures Kubernetes components.
-// Rendered as the "Kubernetes Setup" phase in the TUI.
-func kubernetesSetupWorkflow(mr software.MachineRuntime) *automa.WorkflowBuilder {
+// KubernetesSetupWorkflow installs and configures Kubernetes components.
+// Rendered as the "Kubernetes Setup" phase in the TUI. It is node-type-agnostic and is
+// composed both by InstallClusterWorkflow (cluster install) and by node install handlers
+// (e.g. block node install) after their own workload preflight + system setup.
+func KubernetesSetupWorkflow(mr software.MachineRuntime) *automa.WorkflowBuilder {
 	wfSteps := []automa.Builder{
 		// setup env for k8s
 		steps.DisableSwap(),

--- a/internal/workflows/cluster_it_test.go
+++ b/internal/workflows/cluster_it_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/hashgraph/solo-weaver/internal/testutil"
 	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
-	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,7 +45,7 @@ import (
 func Test_ClusterSetup(t *testing.T) {
 	testutil.Reset(t)
 
-	installWf, err := InstallClusterWorkflow(models.NodeTypeBlock, models.ProfileLocal, "", false, nil).
+	installWf, err := InstallClusterWorkflow(false, nil).
 		WithExecutionMode(automa.StopOnError).
 		Build()
 	require.NoError(t, err)

--- a/internal/workflows/preflight.go
+++ b/internal/workflows/preflight.go
@@ -414,3 +414,104 @@ func NewNodeSafetyCheckWorkflow(spec hardware.DeploymentSpec, skipHardwareChecks
 			notify.As().PhaseCompletion(ctx, stp, rpt, "Preflight Checks")
 		})
 }
+
+// CheckSubstrateHardwareStep validates the Kubernetes substrate hardware floor
+// (OS, CPU, memory, storage) in a single step, independent of any workload node
+// type or profile. It resolves requirements from the "k8s-substrate" provider via
+// hardware.CreateSubstrateSpec, which bypasses the node-type/profile validation gates.
+func CheckSubstrateHardwareStep() automa.Builder {
+	return automa.NewStepBuilder().WithId("validate-substrate-hardware").
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			hostProfile := hardware.GetHostProfile()
+			substrateSpec, err := hardware.CreateSubstrateSpec(hostProfile)
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to resolve Kubernetes substrate requirements").
+						WithProperty(doctor.ErrPropertyResolution, []string{
+							"This is an internal error: verify the \"k8s-substrate\" requirements provider is registered.",
+						})))
+			}
+
+			reqs := substrateSpec.GetBaselineRequirements()
+			logx.As().Info().Msgf("substrate floor — required: %d cores, %d GB RAM, %d GB disk, OS %v",
+				reqs.MinCpuCores, reqs.MinMemoryGB, reqs.MinStorageGB, reqs.MinSupportedOS)
+
+			// Resolve the why-map once for operator-facing attribution on failure.
+			whyMap := map[string]string{}
+			if p, ok := hardware.Providers()[hardware.NodeTypeSubstrate]; ok {
+				if _, w, e := p.ComputeWithWhy(hardware.DeploymentSpec{NodeType: hardware.NodeTypeSubstrate}); e == nil {
+					whyMap = w
+				}
+			}
+
+			resolution := []string{
+				fmt.Sprintf("Provision a host that meets the Kubernetes control-plane minimum: %d CPU cores, %d GB RAM, %d GB free disk.",
+					reqs.MinCpuCores, reqs.MinMemoryGB, reqs.MinStorageGB),
+				"Re-run with --skip-hardware-checks to bypass substrate validation (not recommended).",
+			}
+
+			checks := []struct {
+				validate func() error
+				why      string
+				what     string
+			}{
+				{substrateSpec.ValidateOS, "", "OS"},
+				{substrateSpec.ValidateCPU, whyMap["cpu"], "CPU"},
+				{substrateSpec.ValidateMemory, whyMap["memory"], "memory"},
+				{substrateSpec.ValidateStorage, whyMap["storage"], "storage"},
+			}
+			for _, c := range checks {
+				if err := c.validate(); err != nil {
+					baseErr := errorx.IllegalState.Wrap(err, "%s validation failed for Kubernetes substrate", c.what).
+						WithProperty(doctor.ErrPropertyResolution, resolution)
+					if c.why != "" {
+						baseErr = baseErr.WithProperty(models.ErrPropertyWhyFloor, c.why)
+					}
+					return automa.FailureReport(stp, automa.WithError(baseErr))
+				}
+			}
+			return automa.SuccessReport(stp)
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Validating Kubernetes substrate hardware")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Validating Kubernetes substrate hardware")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Validating Kubernetes substrate hardware")
+		})
+}
+
+// NewSubstrateSafetyCheckWorkflow creates a safety check workflow for the Kubernetes
+// substrate — the hardware floor Kubernetes itself needs, independent of any workload
+// node type or profile. Unlike NewNodeSafetyCheckWorkflow it omits CheckHostProfileStep
+// (there is no node type / profile to validate) and validates hardware via the single
+// CheckSubstrateHardwareStep. If skipHardwareChecks is true, hardware validation is excluded.
+func NewSubstrateSafetyCheckWorkflow(skipHardwareChecks bool) *automa.WorkflowBuilder {
+	preflightSteps := []automa.Builder{
+		CheckPrivilegesStep(),
+		CheckWeaverUserStep(),
+	}
+
+	if skipHardwareChecks {
+		logx.As().Warn().Msg("Substrate hardware validation (OS, CPU, memory, storage) will be skipped due to --skip-hardware-checks flag")
+	} else {
+		preflightSteps = append(preflightSteps, CheckSubstrateHardwareStep())
+	}
+
+	return automa.NewWorkflowBuilder().
+		WithId("substrate-preflight").
+		Steps(preflightSteps...).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().PhaseStart(ctx, stp, "Preflight Checks")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().PhaseFailure(ctx, stp, rpt, "Preflight Checks")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().PhaseCompletion(ctx, stp, rpt, "Preflight Checks")
+		})
+}

--- a/internal/workflows/preflight.go
+++ b/internal/workflows/preflight.go
@@ -20,8 +20,14 @@ import (
 	"github.com/joomcode/errorx"
 )
 
-// createNodeSpec creates the appropriate node spec based on a DeploymentSpec and host profile
+// createNodeSpec creates the appropriate node spec based on a DeploymentSpec and host profile.
+// The Kubernetes substrate is resolved via CreateSubstrateSpec, which bypasses the
+// node-type/profile validation gates (the substrate is not a user-facing node type and
+// carries no profile); everything else goes through the standard CreateNodeSpec path.
 func createNodeSpec(spec hardware.DeploymentSpec, hostProfile hardware.HostProfile) (hardware.Spec, error) {
+	if spec.NodeType == hardware.NodeTypeSubstrate {
+		return hardware.CreateSubstrateSpec(hostProfile)
+	}
 	return hardware.CreateNodeSpec(spec, hostProfile)
 }
 
@@ -253,7 +259,11 @@ func CheckOSStep(spec hardware.DeploymentSpec) automa.Builder {
 
 			if err := nodeSpec.ValidateOS(); err != nil {
 				return automa.FailureReport(stp,
-					automa.WithError(errorx.IllegalState.Wrap(err, "OS validation failed")))
+					automa.WithError(errorx.IllegalState.Wrap(err, "OS validation failed").
+						WithProperty(doctor.ErrPropertyResolution, []string{
+							fmt.Sprintf("Install or upgrade to a supported OS: %v.", reqs.MinSupportedOS),
+							"Or re-run with --skip-hardware-checks to bypass hardware validation (not recommended).",
+						})))
 			}
 			return automa.SuccessReport(stp)
 		}).
@@ -283,7 +293,11 @@ func CheckCPUStep(spec hardware.DeploymentSpec) automa.Builder {
 			logx.As().Info().Msgf("detected: %d cores, required: %d cores", hostProfile.GetCPUCores(), reqs.MinCpuCores)
 
 			if err := nodeSpec.ValidateCPU(); err != nil {
-				baseErr := automa.StepExecutionError.Wrap(err, "CPU validation failed")
+				baseErr := automa.StepExecutionError.Wrap(err, "CPU validation failed").
+					WithProperty(doctor.ErrPropertyResolution, []string{
+						fmt.Sprintf("Provision a host with at least %d CPU cores.", reqs.MinCpuCores),
+						"Or re-run with --skip-hardware-checks to bypass hardware validation (not recommended).",
+					})
 				if p, ok := hardware.Providers()[spec.NodeType]; ok {
 					if _, whyMap, e := p.ComputeWithWhy(spec); e == nil && whyMap["cpu"] != "" {
 						baseErr = baseErr.WithProperty(models.ErrPropertyWhyFloor, whyMap["cpu"])
@@ -320,7 +334,11 @@ func CheckMemoryStep(spec hardware.DeploymentSpec) automa.Builder {
 			logx.As().Info().Msgf("detected: %d GB, required: %d GB", hostProfile.GetTotalMemoryGB(), reqs.MinMemoryGB)
 
 			if err := nodeSpec.ValidateMemory(); err != nil {
-				baseErr := errorx.IllegalState.Wrap(err, "memory validation failed")
+				baseErr := errorx.IllegalState.Wrap(err, "memory validation failed").
+					WithProperty(doctor.ErrPropertyResolution, []string{
+						fmt.Sprintf("Provision a host with at least %d GB of RAM.", reqs.MinMemoryGB),
+						"Or re-run with --skip-hardware-checks to bypass hardware validation (not recommended).",
+					})
 				if p, ok := hardware.Providers()[spec.NodeType]; ok {
 					if _, whyMap, e := p.ComputeWithWhy(spec); e == nil && whyMap["memory"] != "" {
 						baseErr = baseErr.WithProperty(models.ErrPropertyWhyFloor, whyMap["memory"])
@@ -358,7 +376,11 @@ func CheckStorageStep(spec hardware.DeploymentSpec) automa.Builder {
 				hostProfile.GetTotalStorageGB(), hostProfile.GetSSDStorageGB(), hostProfile.GetHDDStorageGB(), reqs.MinStorageGB)
 
 			if err := nodeSpec.ValidateStorage(); err != nil {
-				baseErr := errorx.IllegalState.Wrap(err, "storage validation failed")
+				baseErr := errorx.IllegalState.Wrap(err, "storage validation failed").
+					WithProperty(doctor.ErrPropertyResolution, []string{
+						fmt.Sprintf("Provision a host with at least %d GB of total disk capacity.", reqs.MinStorageGB),
+						"Or re-run with --skip-hardware-checks to bypass hardware validation (not recommended).",
+					})
 				if p, ok := hardware.Providers()[spec.NodeType]; ok {
 					if _, whyMap, e := p.ComputeWithWhy(spec); e == nil && whyMap["storage"] != "" {
 						baseErr = baseErr.WithProperty(models.ErrPropertyWhyFloor, whyMap["storage"])
@@ -415,81 +437,17 @@ func NewNodeSafetyCheckWorkflow(spec hardware.DeploymentSpec, skipHardwareChecks
 		})
 }
 
-// CheckSubstrateHardwareStep validates the Kubernetes substrate hardware floor
-// (OS, CPU, memory, storage) in a single step, independent of any workload node
-// type or profile. It resolves requirements from the "k8s-substrate" provider via
-// hardware.CreateSubstrateSpec, which bypasses the node-type/profile validation gates.
-func CheckSubstrateHardwareStep() automa.Builder {
-	return automa.NewStepBuilder().WithId("validate-substrate-hardware").
-		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
-			hostProfile := hardware.GetHostProfile()
-			substrateSpec, err := hardware.CreateSubstrateSpec(hostProfile)
-			if err != nil {
-				return automa.FailureReport(stp, automa.WithError(
-					errorx.Decorate(err, "failed to resolve Kubernetes substrate requirements").
-						WithProperty(doctor.ErrPropertyResolution, []string{
-							"This is an internal error: verify the \"k8s-substrate\" requirements provider is registered.",
-						})))
-			}
-
-			reqs := substrateSpec.GetBaselineRequirements()
-			logx.As().Info().Msgf("substrate floor — required: %d cores, %d GB RAM, %d GB disk, OS %v",
-				reqs.MinCpuCores, reqs.MinMemoryGB, reqs.MinStorageGB, reqs.MinSupportedOS)
-
-			// Resolve the why-map once for operator-facing attribution on failure.
-			whyMap := map[string]string{}
-			if p, ok := hardware.Providers()[hardware.NodeTypeSubstrate]; ok {
-				if _, w, e := p.ComputeWithWhy(hardware.DeploymentSpec{NodeType: hardware.NodeTypeSubstrate}); e == nil {
-					whyMap = w
-				}
-			}
-
-			resolution := []string{
-				fmt.Sprintf("Provision a host that meets the Kubernetes control-plane minimum: %d CPU cores, %d GB RAM, %d GB free disk.",
-					reqs.MinCpuCores, reqs.MinMemoryGB, reqs.MinStorageGB),
-				"Re-run with --skip-hardware-checks to bypass substrate validation (not recommended).",
-			}
-
-			checks := []struct {
-				validate func() error
-				why      string
-				what     string
-			}{
-				{substrateSpec.ValidateOS, "", "OS"},
-				{substrateSpec.ValidateCPU, whyMap["cpu"], "CPU"},
-				{substrateSpec.ValidateMemory, whyMap["memory"], "memory"},
-				{substrateSpec.ValidateStorage, whyMap["storage"], "storage"},
-			}
-			for _, c := range checks {
-				if err := c.validate(); err != nil {
-					baseErr := errorx.IllegalState.Wrap(err, "%s validation failed for Kubernetes substrate", c.what).
-						WithProperty(doctor.ErrPropertyResolution, resolution)
-					if c.why != "" {
-						baseErr = baseErr.WithProperty(models.ErrPropertyWhyFloor, c.why)
-					}
-					return automa.FailureReport(stp, automa.WithError(baseErr))
-				}
-			}
-			return automa.SuccessReport(stp)
-		}).
-		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
-			notify.As().StepStart(ctx, stp, "Validating Kubernetes substrate hardware")
-			return ctx, nil
-		}).
-		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepFailure(ctx, stp, rpt, "Validating Kubernetes substrate hardware")
-		}).
-		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepCompletion(ctx, stp, rpt, "Validating Kubernetes substrate hardware")
-		})
-}
-
 // NewSubstrateSafetyCheckWorkflow creates a safety check workflow for the Kubernetes
 // substrate — the hardware floor Kubernetes itself needs, independent of any workload
-// node type or profile. Unlike NewNodeSafetyCheckWorkflow it omits CheckHostProfileStep
-// (there is no node type / profile to validate) and validates hardware via the single
-// CheckSubstrateHardwareStep. If skipHardwareChecks is true, hardware validation is excluded.
+// node type or profile. It reuses the same per-resource hardware steps as the node
+// preflight (CheckOSStep, CheckCPUStep, CheckMemoryStep, CheckStorageStep) so each
+// resource gets its own TUI entry and failure report; it only omits CheckHostProfileStep
+// (there is no node type / profile to validate). The steps resolve the substrate floor
+// via createNodeSpec -> CreateSubstrateSpec. If skipHardwareChecks is true, the hardware
+// validation steps are excluded.
 func NewSubstrateSafetyCheckWorkflow(skipHardwareChecks bool) *automa.WorkflowBuilder {
+	spec := hardware.DeploymentSpec{NodeType: hardware.NodeTypeSubstrate}
+
 	preflightSteps := []automa.Builder{
 		CheckPrivilegesStep(),
 		CheckWeaverUserStep(),
@@ -498,7 +456,12 @@ func NewSubstrateSafetyCheckWorkflow(skipHardwareChecks bool) *automa.WorkflowBu
 	if skipHardwareChecks {
 		logx.As().Warn().Msg("Substrate hardware validation (OS, CPU, memory, storage) will be skipped due to --skip-hardware-checks flag")
 	} else {
-		preflightSteps = append(preflightSteps, CheckSubstrateHardwareStep())
+		preflightSteps = append(preflightSteps,
+			CheckOSStep(spec),
+			CheckCPUStep(spec),
+			CheckMemoryStep(spec),
+			CheckStorageStep(spec),
+		)
 	}
 
 	return automa.NewWorkflowBuilder().

--- a/internal/workflows/preflight_test.go
+++ b/internal/workflows/preflight_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package workflows
+
+import (
+	"testing"
+
+	"github.com/automa-saga/automa"
+	"github.com/stretchr/testify/require"
+)
+
+// substrateStepIDs builds the substrate safety-check workflow and returns the
+// ordered IDs of its immediate child steps.
+func substrateStepIDs(t *testing.T, skipHardwareChecks bool) []string {
+	t.Helper()
+	built, err := NewSubstrateSafetyCheckWorkflow(skipHardwareChecks).Build()
+	require.NoError(t, err)
+
+	wf, ok := built.(automa.Workflow)
+	require.True(t, ok, "expected built substrate preflight to be an automa.Workflow")
+
+	ids := make([]string, 0, len(wf.Steps()))
+	for _, s := range wf.Steps() {
+		ids = append(ids, s.Id())
+	}
+	return ids
+}
+
+// TestNewSubstrateSafetyCheckWorkflow_OmitsHostProfileStep verifies the substrate
+// preflight runs privilege + weaver-user + the single substrate hardware step, and
+// deliberately omits the node-type/profile host-profile validation.
+func TestNewSubstrateSafetyCheckWorkflow_OmitsHostProfileStep(t *testing.T) {
+	ids := substrateStepIDs(t, false)
+
+	require.Contains(t, ids, "validate-privileges")
+	require.Contains(t, ids, "validate-weaver-user")
+	require.Contains(t, ids, "validate-substrate-hardware")
+	require.NotContains(t, ids, "validate-host-profile",
+		"substrate preflight must not validate node type / profile")
+}
+
+// TestNewSubstrateSafetyCheckWorkflow_SkipsHardwareWhenRequested verifies that
+// --skip-hardware-checks excludes the substrate hardware step while keeping the
+// non-hardware safety checks.
+func TestNewSubstrateSafetyCheckWorkflow_SkipsHardwareWhenRequested(t *testing.T) {
+	ids := substrateStepIDs(t, true)
+
+	require.Contains(t, ids, "validate-privileges")
+	require.Contains(t, ids, "validate-weaver-user")
+	require.NotContains(t, ids, "validate-substrate-hardware",
+		"hardware step must be excluded when skipHardwareChecks is true")
+}

--- a/internal/workflows/preflight_test.go
+++ b/internal/workflows/preflight_test.go
@@ -27,26 +27,32 @@ func substrateStepIDs(t *testing.T, skipHardwareChecks bool) []string {
 }
 
 // TestNewSubstrateSafetyCheckWorkflow_OmitsHostProfileStep verifies the substrate
-// preflight runs privilege + weaver-user + the single substrate hardware step, and
-// deliberately omits the node-type/profile host-profile validation.
+// preflight runs privilege + weaver-user + the same four per-resource hardware steps as
+// the node preflight, and deliberately omits the node-type/profile host-profile validation.
 func TestNewSubstrateSafetyCheckWorkflow_OmitsHostProfileStep(t *testing.T) {
 	ids := substrateStepIDs(t, false)
 
 	require.Contains(t, ids, "validate-privileges")
 	require.Contains(t, ids, "validate-weaver-user")
-	require.Contains(t, ids, "validate-substrate-hardware")
+	// Per-resource hardware steps, each surfacing independently (matches node preflight).
+	require.Contains(t, ids, "validate-os")
+	require.Contains(t, ids, "validate-cpu")
+	require.Contains(t, ids, "validate-memory")
+	require.Contains(t, ids, "validate-storage")
 	require.NotContains(t, ids, "validate-host-profile",
 		"substrate preflight must not validate node type / profile")
 }
 
 // TestNewSubstrateSafetyCheckWorkflow_SkipsHardwareWhenRequested verifies that
-// --skip-hardware-checks excludes the substrate hardware step while keeping the
+// --skip-hardware-checks excludes the per-resource hardware steps while keeping the
 // non-hardware safety checks.
 func TestNewSubstrateSafetyCheckWorkflow_SkipsHardwareWhenRequested(t *testing.T) {
 	ids := substrateStepIDs(t, true)
 
 	require.Contains(t, ids, "validate-privileges")
 	require.Contains(t, ids, "validate-weaver-user")
-	require.NotContains(t, ids, "validate-substrate-hardware",
-		"hardware step must be excluded when skipHardwareChecks is true")
+	for _, hw := range []string{"validate-os", "validate-cpu", "validate-memory", "validate-storage"} {
+		require.NotContains(t, ids, hw,
+			"hardware steps must be excluded when skipHardwareChecks is true")
+	}
 }

--- a/internal/workflows/setup.go
+++ b/internal/workflows/setup.go
@@ -35,6 +35,21 @@ func NodeSetupWorkflow(nodeType string, profile string, pluginPreset string, ski
 		)
 }
 
+// SubstrateSetupWorkflow creates a setup workflow for the Kubernetes substrate —
+// workload-agnostic preflight (substrate-only hardware floor) followed by the same
+// system setup used by node setups. Used by cluster install, which no longer knows a
+// node type or profile.
+func SubstrateSetupWorkflow(skipHardwareChecks bool) *automa.WorkflowBuilder {
+	return automa.NewWorkflowBuilder().
+		WithId("substrate-node-setup").
+		Steps(
+			// Substrate-only preflight: no node type / profile involved.
+			NewSubstrateSafetyCheckWorkflow(skipHardwareChecks),
+			// Then perform the actual system setup (packages, kernel modules, etc.)
+			systemSetupWorkflow("substrate"),
+		)
+}
+
 // systemSetupWorkflow installs system-level dependencies, kernel modules, and
 // services required before Kubernetes can be set up. Rendered as the
 // "System Setup" phase in the TUI.

--- a/pkg/hardware/factory.go
+++ b/pkg/hardware/factory.go
@@ -67,3 +67,20 @@ func CreateNodeSpec(spec DeploymentSpec, hostProfile HostProfile) (Spec, error) 
 
 	return nodeSpec, nil
 }
+
+// CreateSubstrateSpec creates a spec for the Kubernetes substrate floor.
+//
+// Unlike CreateNodeSpec, it deliberately bypasses the IsValidNodeType / IsValidProfile
+// gates: the substrate is not a user-facing node type and carries no profile. It resolves
+// requirements straight from the "k8s-substrate" provider via NewNodeSpec, which only
+// consults the provider registry. The substrate provider ignores profile and options.
+func CreateSubstrateSpec(hostProfile HostProfile) (Spec, error) {
+	spec := DeploymentSpec{NodeType: NodeTypeSubstrate}
+
+	nodeSpec, err := NewNodeSpec(spec, hostProfile)
+	if err != nil {
+		return nil, errorx.IllegalArgument.Wrap(err, "failed to create substrate spec")
+	}
+
+	return nodeSpec, nil
+}

--- a/pkg/hardware/node_spec.go
+++ b/pkg/hardware/node_spec.go
@@ -49,6 +49,11 @@ func NewNodeSpec(spec DeploymentSpec, hostProfile HostProfile) (Spec, error) {
 // formatDisplayName creates a human-readable display name
 func formatDisplayName(nodeType, profile string) string {
 	caser := cases.Title(language.Und)
+	// The substrate spec carries no profile; omit the empty parentheses so
+	// operator-facing errors read "K8s-Substrate Node" rather than "K8s-Substrate Node ()".
+	if profile == "" {
+		return fmt.Sprintf("%s Node", caser.String(nodeType))
+	}
 	return fmt.Sprintf("%s Node (%s)", caser.String(nodeType), caser.String(profile))
 }
 

--- a/pkg/hardware/provider_substrate.go
+++ b/pkg/hardware/provider_substrate.go
@@ -2,8 +2,14 @@
 
 package hardware
 
+// NodeTypeSubstrate is the provider key for the Kubernetes substrate floor —
+// the hardware Kubernetes itself needs to run, independent of any workload.
+// It is intentionally not part of SupportedNodeTypes(): it is never a user-facing
+// --node-type, only an internal provider key used by the cluster-install preflight.
+const NodeTypeSubstrate = "k8s-substrate"
+
 func init() {
-	registerProvider("k8s-substrate", &substrateProvider{})
+	registerProvider(NodeTypeSubstrate, &substrateProvider{})
 }
 
 type substrateProvider struct{}

--- a/pkg/hardware/provider_substrate_test.go
+++ b/pkg/hardware/provider_substrate_test.go
@@ -3,6 +3,7 @@
 package hardware
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -79,6 +80,12 @@ func TestCreateSubstrateSpec_BypassesProfileAndNodeTypeGates(t *testing.T) {
 	}
 	if err := spec.ValidateStorage(); err != nil {
 		t.Errorf("expected storage validation to pass on a 500 GB host: %v", err)
+	}
+
+	// The substrate spec has no profile; its display name must not render empty
+	// parentheses (e.g. "K8s-Substrate Node ()") in operator-facing errors.
+	if name := spec.GetNodeType(); strings.Contains(name, "()") {
+		t.Errorf("substrate display name should omit empty profile parentheses, got %q", name)
 	}
 
 	// Sanity: the same host through CreateNodeSpec with the substrate key + empty

--- a/pkg/hardware/provider_substrate_test.go
+++ b/pkg/hardware/provider_substrate_test.go
@@ -58,6 +58,36 @@ func TestSubstrateProvider_IgnoresSpec(t *testing.T) {
 	}
 }
 
+func TestCreateSubstrateSpec_BypassesProfileAndNodeTypeGates(t *testing.T) {
+	// A host that clears the substrate floor (2/2/20) but carries no profile and
+	// a node type that is NOT in SupportedNodeTypes. CreateNodeSpec would reject it;
+	// CreateSubstrateSpec must not.
+	host := NewMockHostProfile("ubuntu", "20.04", 8, 16, 500)
+
+	spec, err := CreateSubstrateSpec(host)
+	if err != nil {
+		t.Fatalf("CreateSubstrateSpec returned error: %v", err)
+	}
+
+	reqs := spec.GetBaselineRequirements()
+	if reqs.MinCpuCores != 2 || reqs.MinMemoryGB != 2 || reqs.MinStorageGB != 20 {
+		t.Errorf("expected substrate floor 2/2/20, got %d/%d/%d",
+			reqs.MinCpuCores, reqs.MinMemoryGB, reqs.MinStorageGB)
+	}
+	if err := spec.ValidateCPU(); err != nil {
+		t.Errorf("expected CPU validation to pass on an 8-core host: %v", err)
+	}
+	if err := spec.ValidateStorage(); err != nil {
+		t.Errorf("expected storage validation to pass on a 500 GB host: %v", err)
+	}
+
+	// Sanity: the same host through CreateNodeSpec with the substrate key + empty
+	// profile must be rejected — proving the substrate helper is doing the bypass.
+	if _, err := CreateNodeSpec(DeploymentSpec{NodeType: NodeTypeSubstrate}, host); err == nil {
+		t.Error("expected CreateNodeSpec to reject the substrate node type / empty profile")
+	}
+}
+
 func TestSubstrateProvider_RegistryEntry(t *testing.T) {
 	providers := Providers()
 	p, ok := providers["k8s-substrate"]


### PR DESCRIPTION
## Summary

Makes `kube cluster install` workload-agnostic. It now validates only the **Kubernetes substrate hardware floor** (2 CPU / 2 GB / 20 GB) via the `k8s-substrate` provider added in #684, instead of a block-node workload-sized preflight (16 CPU / 64 GB / 5 TB). The `--profile` and `--node-type` flags are **deprecated** — hidden from `--help` and ignored, but still accepted so existing scripts do not break.

Per-workload hardware validation stays where the full `DeploymentSpec` is known — `block node check` / `block node install` — so a small host intended for a Tier-1 RFH block node can stand up the cluster without `--skip-hardware-checks`; the workload mismatch surfaces later at `block node check`.

Closes #685. Depends on #684 (merged).

## Problem

`--profile` / `--node-type` existed on `kube cluster install` only to drive a workload-sized preflight at cluster-install time, coupling "stand up Kubernetes" to per-workload knowledge it should not own. Every new sizing axis (plugin presets, TPS/retention) would otherwise have to thread through the cluster command's flags.

## Design notes

- **`InstallClusterWorkflow(skipHardwareChecks, mr)`** is now substrate-only: `SubstrateSetupWorkflow` + `KubernetesSetupWorkflow`. Used solely by `kube cluster install`.
- **`block node install` no longer calls `InstallClusterWorkflow`.** Its bootstrap branch composes `NodeSetupWorkflow(block, profile, preset, skip)` + `KubernetesSetupWorkflow(mr)` directly, preserving the workload-sized preflight byte-for-byte. `kubernetesSetupWorkflow` was exported to enable this.
- **Substrate preflight reuses the node preflight's per-resource steps.** `NewSubstrateSafetyCheckWorkflow` runs privileges + weaver-user + the same four steps (`CheckOSStep`/`CheckCPUStep`/`CheckMemoryStep`/`CheckStorageStep`) with a substrate spec, and omits `CheckHostProfileStep`. Those steps route through `hardware.CreateNodeSpec`, which rejects node type `k8s-substrate` and an empty profile, so the preflight `createNodeSpec` wrapper sends the substrate type to `hardware.CreateSubstrateSpec` instead (resolves the floor via `NewNodeSpec` — registry-only, no IsValid gate). Each resource keeps its own TUI entry, failure report, and resolution hint (the shared steps previously carried only `WhyFloor`). Like the node preflight, it stops at the first failing hardware step — see UAT-3b.
- `SupportedNodeTypes()` / `SupportedProfiles()` are intentionally **not** polluted with substrate/empty entries.
- **Flag deprecation over hard removal.** `--profile`/`--node-type` are kept registered but hidden (`SetVarPHidden`, the same mechanism `alloy cluster` uses to retire flags) and their values are ignored; `install.go` warns via `cmd.Flags().Changed(...)` when either is explicitly passed. This keeps existing invocations working while `--help` shows the clean new surface.

## Changed files

| File | Change |
|------|--------|
| `pkg/hardware/provider_substrate.go` | Add `NodeTypeSubstrate` const; replace bare `"k8s-substrate"` literals |
| `pkg/hardware/factory.go` | New `CreateSubstrateSpec(host)` — bypasses node-type/profile IsValid gates |
| `internal/workflows/preflight.go` | New `NewSubstrateSafetyCheckWorkflow` reusing the four per-resource steps; `createNodeSpec` routes substrate to `CreateSubstrateSpec`; resolution hints added to the hardware steps |
| `internal/workflows/setup.go` | New `SubstrateSetupWorkflow` (substrate preflight + shared system setup) |
| `internal/workflows/cluster.go` | `InstallClusterWorkflow` substrate-only; export `KubernetesSetupWorkflow` |
| `internal/bll/blocknode/install_handler.go` | Bootstrap branch recomposed; workload preflight preserved |
| `cmd/cli/commands/kube/cluster/install.go` | Drop profile/node-type validation + `SetProfile`; simplify workflow call; register `--node-type` hidden + warn when deprecated flags are passed |
| `cmd/cli/commands/kube/cluster/cluster.go` | `flagNodeType` retained to back the hidden deprecated flag |
| `cmd/cli/commands/kube/kube.go` | `--profile` kept hidden/persistent (deprecated, ignored) instead of removed |
| `internal/workflows/cluster_it_test.go` | Update `InstallClusterWorkflow(false, nil)` call |
| `pkg/hardware/provider_substrate_test.go` | Test `CreateSubstrateSpec` bypass + floor |
| `internal/workflows/preflight_test.go` (new) | Assert substrate preflight composition (omits host-profile step) |
| `docs/quickstart.md`, `docs/dev/daemon/daemon-testing-guide.md`, `docs/dev/functionality-test-suite.md` | Docs for the new command shape |

## Review checklist

- [ ] `kube cluster install` runs substrate-only preflight; no `--profile`/`--node-type` on `--help`.
- [ ] Deprecated `--profile`/`--node-type` are still accepted (no `unknown flag`), ignored, and warn when passed.
- [ ] `block node install` bootstrap still runs the block-node workload preflight before Kubernetes setup, in that order.
- [ ] `CreateSubstrateSpec` bypasses `IsValidNodeType`/`IsValidProfile` while `CreateNodeSpec` still rejects them.
- [ ] `NewSubstrateSafetyCheckWorkflow` omits `CheckHostProfileStep`; the hardware step attaches resolution hints.
- [ ] No non-test consumer of `config.Get().Profile` runs in the substrate-only cluster-install path.
- [ ] `--skip-hardware-checks` still bypasses the substrate floor at cluster install.

## Tests run

```bash
task lint                       # 0 issues
go test ./pkg/hardware/...      # 95 passed (incl. new substrate-bypass test)
GOOS=linux go build ./...       # changed pkgs compile
```

Full unit + integration suites run in the UTM VM (Linux-only `internal/mount`):

```bash
task vm:test:unit
task vm:test:integration TEST_NAME='^Test_ClusterSetup$'
```

## Manual UAT

Run inside the UTM VM (Ubuntu), as a freshly-provisioned host.

### UAT-1 — Cluster install needs no profile/node-type

```bash
sudo ./bin/solo-provisioner-linux-amd64 kube cluster install --non-interactive
```

Expected: install proceeds through **Preflight Checks** (privileges, weaver user, then the four per-resource hardware steps — "Validating OS/CPU/memory/storage requirements"), **System Setup**, then **Kubernetes Setup**, ending:

```
Successfully installed Kubernetes Cluster
```

```bash
sudo kubectl get nodes    # node reports Ready
```

### UAT-2 — Flags hidden from help

```bash
./bin/solo-provisioner-linux-amd64 kube cluster install --help
```

Expected: **no** `--profile` / `-p` and **no** `--node-type` / `-n` in the flag list; only the error-control flags (`--stop-on-error`, `--rollback-on-error`, `--continue-on-error`) and inherited persistent flags.

### UAT-2b — Deprecated flags still accepted but ignored (backward compatibility)

The flags are retired the same way this CLI retires others (hidden + still parseable), so existing scripts do not break. Passing them must not error, must not change behavior, and must print a notice.

```bash
sudo ./bin/solo-provisioner-linux-amd64 kube cluster install --profile testnet --node-type block --non-interactive
```

Expected:
- Does **not** error (no `unknown flag`).
- Prints a WARN notice for each provided flag, e.g. `--profile is deprecated and ignored for 'kube cluster install': it validates only the Kubernetes substrate floor. ...`
- Runs the **same** substrate-only preflight as UAT-1 (the `testnet` value does **not** raise the floor to the block-node testnet floor) and completes with `Successfully installed Kubernetes Cluster`.

```bash
# Inherited --profile is likewise accepted (and silently ignored, as before) on uninstall:
sudo ./bin/solo-provisioner-linux-amd64 kube cluster uninstall --profile testnet
```

Expected: no `unknown flag` error; teardown proceeds normally.

### UAT-3 — Substrate floor still enforced

On a host below the substrate floor, set in UTM VM settings — easiest is **1 vCPU** (< 2 cores) or **1 GB RAM** (< 2 GB). Note the disk check reads *total physical capacity*, not free space, so a 64 GiB dev VM always clears the 20 GB floor regardless of usage.

```bash
sudo ./bin/solo-provisioner-linux-amd64 kube cluster install --non-interactive
```

Expected: fails at the matching per-resource step (e.g. "Validating CPU requirements") with the shortfall, `Set by: Kubernetes control-plane minimum`, and a resolution hint naming the minimum (e.g. "at least 2 CPU cores") plus the `--skip-hardware-checks` escape hatch.

### UAT-3b — Substrate preflight is four independent per-resource steps

Verifies the review change: substrate preflight reuses the node preflight's four per-resource steps rather than one combined step, so each resource has its own TUI entry, failure report, and resolution hint.

1. In UTM, set the VM below a single floor — e.g. **1 vCPU** (keep RAM at 2 GB+ so only CPU is short):

```bash
sudo ./bin/solo-provisioner-linux-amd64 kube cluster install --non-interactive
```

Expected:
- Preflight runs as **distinct per-resource steps** in order — `Validating OS requirements` (success), then `Validating CPU requirements` (failed) — not a single opaque "substrate hardware" step.
- The CPU failure carries its own message (`CPU does not meet K8s-Substrate Node requirements (minimum 2 cores)`), `Set by: Kubernetes control-plane minimum`, and a CPU-specific resolution hint.

2. To confirm each resource is reported independently, make a *different* single resource short — restore **2 vCPU** and set **1 GB RAM** — and re-run. Now `Validating CPU requirements` passes and `Validating memory requirements` fails with its own message and hint.

**Note on multiple simultaneous shortfalls:** the preflight stops at the **first** failing hardware step (e.g. CPU), so a host short on both CPU and memory surfaces only the CPU failure — matching the existing node preflight. This holds even with `--continue-on-error`: that flag only applies at the outer workflow level (letting it proceed into System Setup after the preflight fails); the nested preflight itself runs stop-on-error, because automa propagates execution mode only one level deep. Reporting all hardware shortfalls in a single run would be a separate, framework-level enhancement affecting every preflight.

### UAT-4 — Responsibility boundary moved (the point of the change)

On a host that meets the substrate floor but **not** the block-node testnet floor (e.g. 4 CPU / 8 GB / 100 GB disk):

```bash
# 1. Cluster install now succeeds (previously rejected on storage):
sudo ./bin/solo-provisioner-linux-amd64 kube cluster install --non-interactive
# -> Successfully installed Kubernetes Cluster

# 2. Workload validation still catches the mismatch, attributed to the workload:
sudo ./bin/solo-provisioner-linux-amd64 block node check --profile testnet
# -> fails on CPU/memory/storage with the block-node testnet floor and a
#    'Set by: block node testnet ...' attribution
```

### UAT-5 — block node install unchanged

On a host that meets the block-node testnet floor, with no existing cluster:

```bash
sudo ./bin/solo-provisioner-linux-amd64 block node install --profile testnet --non-interactive
```

Expected: runs the block-node **Preflight Checks** (workload-sized) → **System Setup** → **Kubernetes Setup** → block-node deployment, in that order — identical to before this PR.

## Risks

- `config.SetProfile` is no longer called at cluster install. Re-grep confirms the only `config.Get().Profile` readers (block-node prompt, alloy steps) do not run in the substrate-only `KubernetesSetupWorkflow` path.
- `block node install` recomposition is the main behavioral risk surface; `NodeSetupWorkflow` is unchanged and only the Kubernetes step was relocated, keeping ordering identical. Covered by the `Test_ClusterSetup` integration test and UAT-5.
- No embedded-template or install-time-config changes; no upgrade/migration path is touched.
