### PR TITLE
fix(daemon): harden daemon concurrency

### DIFF
--- a/internal/daemon/consensus/migration_monitor.go
+++ b/internal/daemon/consensus/migration_monitor.go
@@ -81,6 +81,9 @@ type MigrationMonitor struct {
 	// quiescence before returning.
 	soakWg sync.WaitGroup
 
+	// soakLifecycleMu serializes soakWg.Add (Run/resumeIfNeeded) against soakWg.Wait (TryStop)
+	soakLifecycleMu sync.Mutex
+
 	// soakCancel cancels the per-watcher context. Set atomically when a watcher
 	// goroutine starts; cleared when it exits. Used by TryStop.
 	soakCancel atomic.Pointer[context.CancelFunc]
@@ -281,7 +284,10 @@ func (mm *MigrationMonitor) TryStop(deleteState bool) bool {
 		return false
 	}
 	(*cancelPtr)()
+	// Serialize against the Add sites so Wait never overlaps a 0->1 Add
+	mm.soakLifecycleMu.Lock()
 	mm.soakWg.Wait()
+	mm.soakLifecycleMu.Unlock()
 	if deleteState && mm.stateFilePath != "" {
 		if err := os.Remove(mm.stateFilePath); err != nil && !os.IsNotExist(err) {
 			logx.As().Warn().Err(err).
@@ -315,9 +321,10 @@ func (mm *MigrationMonitor) Run(ctx context.Context) error {
 	for {
 		select {
 		case req := <-mm.soakStartCh:
-			// soakWg.Add before goroutine start so the deferred soakWg.Wait()
-			// above accounts for it.
+			// Add before spawn (accounted by the deferred Wait), locked so it can't race TryStop's Wait
+			mm.soakLifecycleMu.Lock()
 			mm.soakWg.Add(1)
+			mm.soakLifecycleMu.Unlock()
 			go mm.run(ctx, req, false)
 		case <-ctx.Done():
 			// Intentional: if soakStartCh has a buffered item at the same time
@@ -629,6 +636,9 @@ func (mm *MigrationMonitor) resumeIfNeeded(ctx context.Context) {
 	reqCopy := req
 	mm.soakStatus.Store(&SoakStatusResponse{Active: true, Request: &reqCopy})
 	mm.soakActive.Store(true)
+	// Locked so a concurrent startup TryStop can't race this 0->1 Add
+	mm.soakLifecycleMu.Lock()
 	mm.soakWg.Add(1)
+	mm.soakLifecycleMu.Unlock()
 	go mm.run(ctx, req, true)
 }

--- a/internal/daemon/consensus/migration_monitor_test.go
+++ b/internal/daemon/consensus/migration_monitor_test.go
@@ -408,3 +408,37 @@ func Test_SoakDuration_FalseWhenNotElapsed(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok)
 }
+
+// Test_MigrationMonitor_ConcurrentStartStop hammers TryEnqueue/TryStop from two
+// goroutines to race soakWg.Add against soakWg.Wait - panics pre-#697, clean after (run under -race).
+func Test_MigrationMonitor_ConcurrentStartStop(t *testing.T) {
+	mm := newMonitor(t, nil, &mockDecommissioner{}, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	go func() { _ = mm.Run(ctx); close(runDone) }()
+
+	const iterations = 2000
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			mm.TryEnqueue(testRequest(-time.Hour))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			mm.TryStop(true)
+		}
+	}()
+	wg.Wait()
+
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -365,8 +365,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error { return d.server.Start(ctx) })
 	eg.Go(func() error { return d.componentSupervisor(ctx) })
-
-	go d.runComponentProbes(ctx)
+	// Tracked in the errgroup so Run awaits it (nil return never cancels the group)
+	eg.Go(func() error {
+		d.runComponentProbes(ctx)
+		return nil
+	})
 
 	return eg.Wait()
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -320,6 +321,61 @@ func TestNewFromConfig_ConsensusNodeWiring(t *testing.T) {
 	assert.NotNil(t, comp.tracker)
 	assert.NotNil(t, comp.probe, "the upgrade monitor declares an RBAC prerequisite, so the component probe must be built")
 	assert.Equal(t, "consensus-node", comp.probe.ComponentName())
+}
+
+// gateProbe closes entered on first Probe, then blocks until release is closed —
+// pins runComponentProbes mid-cycle so a test can check Run awaits it (#697).
+type gateProbe struct {
+	name      string
+	entered   chan struct{}
+	release   chan struct{}
+	enterOnce sync.Once
+}
+
+func (p *gateProbe) ComponentName() string { return p.name }
+func (p *gateProbe) Probe(_ context.Context) error {
+	p.enterOnce.Do(func() { close(p.entered) })
+	<-p.release
+	return nil
+}
+
+// TestRun_AwaitsProbeGoroutine verifies Daemon.Run does not return while the
+// component-probe loop is still in-flight (#697).
+func TestRun_AwaitsProbeGoroutine(t *testing.T) {
+	dir := t.TempDir()
+	d, err := NewFromConfig(models.WeaverPaths{DaemonSockPath: filepath.Join(dir, "d.sock")}, DaemonConfig{})
+	require.NoError(t, err)
+
+	// No monitors: the supervisor returns nil at once, so only the probe keeps Run alive after cancel.
+	probe := &gateProbe{name: "slow", entered: make(chan struct{}), release: make(chan struct{})}
+	d.components = []component{{name: "slow", probe: probe}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runDone := make(chan struct{})
+	go func() { _ = d.Run(ctx); close(runDone) }()
+
+	select {
+	case <-probe.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probe goroutine never started")
+	}
+
+	// Cancel: server + supervisor unwind, but the probe is still blocked.
+	cancel()
+	select {
+	case <-runDone:
+		t.Fatal("Run returned while the probe goroutine was still in-flight")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// Release the probe; Run must now observe quiescence and return.
+	close(probe.release)
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after the probe goroutine finished")
+	}
 }
 
 const minimalKubeconfig = `apiVersion: v1


### PR DESCRIPTION
## Description

- Adds a soakLifecycleMu mutex to MigrationMonitor that serializes soakWg.Add (in Run/resumeIfNeeded) against soakWg.Wait (in TryStop), fixing a WaitGroup data race where a 0→1 Add could overlap a concurrent Wait.
- Moves runComponentProbes from a detached go statement into the Daemon.Run errgroup (returning nil so it never cancels the group), so Run no longer returns while the component-probe loop is still in-flight.
- Adds Test_MigrationMonitor_ConcurrentStartStop, which hammers TryEnqueue/TryStop from two goroutines to exercise the Add/Wait race under -race.
- Adds TestRun_AwaitsProbeGoroutine, which uses a gate-blocked probe to prove Run waits for the probe loop to finish before returning.

### Related Issues

- Closes #697

