### PR TITLE
feat(network): add `network policy` element verbs (add/remove/set/show/delete)

### DIFF
--- a/cmd/cli/commands/network/policy/add.go
+++ b/cmd/cli/commands/network/policy/add.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add one or more CIDRs to a policy's live set",
+	Long: "Add CIDRs to the live nft set for a named policy (`nft add element inet weaver <name> { … }`). " +
+		"The set is mutated directly — no chain re-render and no update to network-weaver.nft, because " +
+		"set membership is owned by the daemon and never persisted. " +
+		"Use `--cidr` one or more times, or pass a comma-separated list in a single `--cidr` flag.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(flagCIDR) == 0 {
+			return errorx.IllegalArgument.New("--cidr is required")
+		}
+		if err := newManager().Add(cmd.Context(), flagName, flagCIDR); err != nil {
+			return err
+		}
+		logx.As().Info().Str("policy", flagName).Strs("cidrs", flagCIDR).Msg("network policy CIDRs added")
+		return nil
+	},
+}
+
+func init() {
+	addCmd.Flags().StringVar(&flagName, "name", "", "Policy name (required)")
+	addCmd.Flags().StringSliceVar(&flagCIDR, "cidr", nil, "CIDR to add (comma-separated or repeated)")
+	_ = addCmd.MarkFlagRequired("name")
+}

--- a/cmd/cli/commands/network/policy/create.go
+++ b/cmd/cli/commands/network/policy/create.go
@@ -57,7 +57,7 @@ var createCmd = &cobra.Command{
 			// An explicit --pod-cidr works offline; only auto-detection needs a
 			// reachable cluster. Unlike `network firewall create` (best-effort,
 			// node-agnostic), `network policy create` is expected to run against a
-			// live cluster (design §7.2.4), so a detection failure with no
+			// live cluster, so a detection failure with no
 			// --pod-cidr is a hard error rather than a warning.
 			detected, derr := detectPodCIDR(cmd.Context())
 			if derr != nil {

--- a/cmd/cli/commands/network/policy/delete.go
+++ b/cmd/cli/commands/network/policy/delete.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a policy (removes its rules, set, and registry entry; re-renders chain)",
+	Long: "Remove a named policy from the `inet weaver` table: re-renders the chain without it, " +
+		"applies the result to the live kernel, restores remaining policies' live membership, " +
+		"removes the registry file, and atomically rewrites network-weaver.nft. " +
+		"If this is the last policy, an empty chain (policy drop, no rules) is applied and the " +
+		"boot oneshot is left enabled.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := newManager().Delete(cmd.Context(), flagName); err != nil {
+			return err
+		}
+		logx.As().Info().Str("policy", flagName).Msg("network policy deleted")
+		return nil
+	},
+}
+
+func init() {
+	deleteCmd.Flags().StringVar(&flagName, "name", "", "Policy name (required)")
+	_ = deleteCmd.MarkFlagRequired("name")
+}

--- a/cmd/cli/commands/network/policy/policy.go
+++ b/cmd/cli/commands/network/policy/policy.go
@@ -3,13 +3,10 @@
 // Package policy wires the `solo-provisioner network policy` verbs to the
 // internal/network/policy manager. It is a generic, category-agnostic primitive:
 // the verbs manage per-category classification and ACL rules in the `inet weaver`
-// nftables table (the workload traffic plane, design §7.2.4), keyed only on the
-// operator-supplied --name, --stamp/--deny, --ports, and --cidrs. It knows
-// nothing about block/consensus/mirror/relay nodes; today `block node install`
-// is its only caller, but nothing in this package assumes that.
-//
-// This story (#758) implements `create` only; the element verbs
-// (add/remove/set/show/delete) are Story 1.3 (#759).
+// nftables table (the workload traffic plane), keyed only on the operator-supplied
+// --name, --stamp/--deny, --ports, and --cidrs. It knows nothing about
+// block/consensus/mirror/relay nodes; today `block node install` is its only
+// caller, but nothing in this package assumes that.
 package policy
 
 import (
@@ -18,8 +15,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Shared flag binding targets for the create verb. Only one verb runs per
-// invocation, so reusing these across future verbs is safe.
+// Shared flag binding targets. Only one verb runs per invocation, so sharing
+// these across verbs is safe.
 var (
 	flagName       string
 	flagStamp      string
@@ -30,6 +27,10 @@ var (
 	flagCIDRs      []string
 	flagCIDRsFile  string
 	flagPodCIDR    string
+	// flagCIDR is used by add/remove (singular --cidr, repeatable) to match
+	// the element-verb flag name the issue specifies, distinct from create/set's
+	// --cidrs (which take a full list in one shot).
+	flagCIDR []string
 )
 
 var policyCmd = &cobra.Command{
@@ -43,6 +44,11 @@ var policyCmd = &cobra.Command{
 
 func init() {
 	policyCmd.AddCommand(createCmd)
+	policyCmd.AddCommand(addCmd)
+	policyCmd.AddCommand(removeCmd)
+	policyCmd.AddCommand(setCmd)
+	policyCmd.AddCommand(showCmd)
+	policyCmd.AddCommand(deleteCmd)
 }
 
 // GetCmd returns the root of the `network policy` command group.

--- a/cmd/cli/commands/network/policy/policy_test.go
+++ b/cmd/cli/commands/network/policy/policy_test.go
@@ -3,6 +3,7 @@
 package policy
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -17,33 +18,73 @@ import (
 )
 
 // fakeRunner satisfies pol.Runner without touching the kernel.
-type fakeRunner struct{ applied string }
+type fakeRunner struct {
+	applied  string
+	elements map[string][]string
+}
 
-func (f *fakeRunner) Apply(_ context.Context, doc string) error              { f.applied = doc; return nil }
-func (f *fakeRunner) AddElements(context.Context, string, []string) error    { return nil }
-func (f *fakeRunner) ListElements(context.Context, string) ([]string, error) { return nil, nil }
-func (f *fakeRunner) List(context.Context) (string, error)                   { return f.applied, nil }
-func (f *fakeRunner) Delete(context.Context) error                           { return nil }
-func (f *fakeRunner) Exists(context.Context) (bool, error)                   { return f.applied != "", nil }
+func newFakeRunner() *fakeRunner { return &fakeRunner{elements: map[string][]string{}} }
+
+func (f *fakeRunner) Apply(_ context.Context, doc string) error {
+	f.applied = doc
+	f.elements = map[string][]string{} // mirrors real nft: delete+recreate wipes membership
+	return nil
+}
+func (f *fakeRunner) AddElements(_ context.Context, set string, elems []string) error {
+	if f.applied == "" {
+		return errors.New("nft add element " + set + " failed: No such file or directory")
+	}
+	f.elements[set] = append(f.elements[set], elems...)
+	return nil
+}
+func (f *fakeRunner) DeleteElements(_ context.Context, set string, elems []string) error {
+	toDelete := make(map[string]bool, len(elems))
+	for _, e := range elems {
+		toDelete[e] = true
+	}
+	cur := f.elements[set]
+	filtered := cur[:0]
+	for _, e := range cur {
+		if !toDelete[e] {
+			filtered = append(filtered, e)
+		}
+	}
+	f.elements[set] = filtered
+	return nil
+}
+func (f *fakeRunner) SetElements(_ context.Context, set string, elems []string) error {
+	f.elements[set] = append([]string(nil), elems...)
+	return nil
+}
+func (f *fakeRunner) ListElements(_ context.Context, set string) ([]string, error) {
+	return append([]string(nil), f.elements[set]...), nil
+}
+func (f *fakeRunner) List(context.Context) (string, error) { return f.applied, nil }
+func (f *fakeRunner) Delete(context.Context) error {
+	f.applied = ""
+	f.elements = map[string][]string{}
+	return nil
+}
+func (f *fakeRunner) Exists(context.Context) (bool, error) { return f.applied != "", nil }
 
 func TestPolicyCmd_Structure(t *testing.T) {
 	cmd := GetCmd()
 	require.Equal(t, "policy", cmd.Use)
 
-	var hasCreate bool
+	subs := make(map[string]bool)
 	for _, sub := range cmd.Commands() {
-		if sub.Use == "create" {
-			hasCreate = true
-		}
+		subs[sub.Use] = true
 	}
-	require.True(t, hasCreate, "create verb not registered under policy")
+	for _, want := range []string{"create", "add", "remove", "set", "show", "delete"} {
+		require.True(t, subs[want], "verb %q not registered under policy", want)
+	}
 }
 
 func TestCreateCmd_Flags(t *testing.T) {
 	for _, name := range []string{"name", "stamp", "deny", "reply-stamp", "from-entity", "ports", "cidrs", "cidrs-file", "pod-cidr"} {
 		require.NotNil(t, createCmd.Flags().Lookup(name), "create is missing --%s", name)
 	}
-	// No --direction flag: direction is derived from --stamp's class (§5).
+	// No --direction flag: direction is derived from --stamp's class.
 	require.Nil(t, createCmd.Flags().Lookup("direction"), "create should not have a --direction flag")
 }
 
@@ -61,7 +102,7 @@ type testEnv struct {
 func newTestEnv(t *testing.T) *testEnv {
 	t.Helper()
 	dir := t.TempDir()
-	return &testEnv{dir: dir, nftPath: filepath.Join(dir, "network-weaver.nft"), runner: &fakeRunner{}}
+	return &testEnv{dir: dir, nftPath: filepath.Join(dir, "network-weaver.nft"), runner: newFakeRunner()}
 }
 
 // runCreate executes the real create command against this env's manager and
@@ -114,19 +155,20 @@ func resetFlags() {
 	flagName, flagStamp = "", ""
 	flagDeny = false
 	flagReplyStamp, flagFromEntity = "", ""
-	flagPorts, flagCIDRs = nil, nil
+	flagPorts, flagCIDRs, flagCIDR = nil, nil, nil
 	flagCIDRsFile, flagPodCIDR = "", ""
-	// createCmd is a package singleton, so cobra's per-flag Changed state leaks
-	// across Execute() calls; clear it too or a prior test's --cidrs would trip
-	// the mutual-exclusion guard here.
-	createCmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+	// Command singletons share cobra flag state across Execute() calls; clear
+	// Changed so prior-test values don't trip mutual-exclusion guards.
+	for _, cmd := range []*cobra.Command{createCmd, addCmd, removeCmd, setCmd, showCmd, deleteCmd} {
+		cmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+	}
 }
 
 func TestCreateCmd_StampIngress(t *testing.T) {
 	doc, err := runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "40840", "--cidrs", "10.1.0.1/32")
 	require.NoError(t, err)
 	require.Contains(t, doc, "ip daddr 10.4.0.0/24 ip saddr @bn-publisher tcp dport @bn-publisher_ports meta priority set 0x10010 accept")
-	// Membership is never persisted (§8.3.1).
+	// Membership is never persisted.
 	require.NotContains(t, doc, "10.1.0.1/32")
 }
 
@@ -198,4 +240,184 @@ func TestCreateCmd_CIDRsFile(t *testing.T) {
 	// Set schema present; membership not persisted.
 	require.Contains(t, doc, "set bn-restricted { type ipv4_addr; flags interval; }")
 	require.NotContains(t, doc, "10.99.0.0/16")
+}
+
+// runVerb executes a `policy <verb>` command against this env's manager stub.
+func (e *testEnv) runVerb(t *testing.T, verb string, args ...string) error {
+	t.Helper()
+	origMgr := newManager
+	newManager = func() *pol.Manager {
+		return pol.NewManagerWithConfig(pol.Config{
+			Runner:        e.runner,
+			WeaverNftPath: e.nftPath,
+			RegistryDir:   filepath.Join(e.dir, "policies"),
+			LockPath:      filepath.Join(e.dir, ".applying"),
+			EnsureService: func(context.Context) error { return nil },
+		})
+	}
+	defer func() { newManager = origMgr }()
+
+	resetFlags()
+	root := &cobra.Command{Use: "test"}
+	root.PersistentFlags().Bool("force", false, "force")
+	root.AddCommand(GetCmd())
+	root.SetArgs(append([]string{"policy", verb}, args...))
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	return root.Execute()
+}
+
+// runShow captures the output of `policy show`.
+func (e *testEnv) runShow(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	origMgr := newManager
+	newManager = func() *pol.Manager {
+		return pol.NewManagerWithConfig(pol.Config{
+			Runner:        e.runner,
+			WeaverNftPath: e.nftPath,
+			RegistryDir:   filepath.Join(e.dir, "policies"),
+			LockPath:      filepath.Join(e.dir, ".applying"),
+			EnsureService: func(context.Context) error { return nil },
+		})
+	}
+	defer func() { newManager = origMgr }()
+
+	resetFlags()
+	var buf bytes.Buffer
+	root := &cobra.Command{Use: "test"}
+	root.PersistentFlags().Bool("force", false, "force")
+	root.AddCommand(GetCmd())
+	root.SetArgs(append([]string{"policy", "show"}, args...))
+	root.SetOut(&buf)
+	root.SetErr(io.Discard)
+	err := root.Execute()
+	return buf.String(), err
+}
+
+// --- add verb ---
+
+func TestAddCmd_Flags(t *testing.T) {
+	for _, name := range []string{"name", "cidr"} {
+		require.NotNil(t, addCmd.Flags().Lookup(name), "add is missing --%s", name)
+	}
+}
+
+func TestAddCmd_AddsCIDRs(t *testing.T) {
+	env := newTestEnv(t)
+	_, err := env.runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "40840")
+	require.NoError(t, err)
+
+	require.NoError(t, env.runVerb(t, "add", "--name", "bn-publisher", "--cidr", "10.1.0.1/32"))
+	require.Equal(t, []string{"10.1.0.1/32"}, env.runner.elements["bn-publisher"])
+}
+
+func TestAddCmd_PolicyNotFound(t *testing.T) {
+	env := newTestEnv(t)
+	err := env.runVerb(t, "add", "--name", "bn-nonexistent", "--cidr", "10.0.0.1/32")
+	require.ErrorContains(t, err, "not found")
+}
+
+func TestAddCmd_NoCIDRRejected(t *testing.T) {
+	env := newTestEnv(t)
+	_, err := env.runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "40840")
+	require.NoError(t, err)
+
+	err = env.runVerb(t, "add", "--name", "bn-publisher")
+	require.ErrorContains(t, err, "--cidr")
+}
+
+// --- remove verb ---
+
+func TestRemoveCmd_Flags(t *testing.T) {
+	for _, name := range []string{"name", "cidr"} {
+		require.NotNil(t, removeCmd.Flags().Lookup(name), "remove is missing --%s", name)
+	}
+}
+
+func TestRemoveCmd_RemovesCIDR(t *testing.T) {
+	env := newTestEnv(t)
+	_, err := env.runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "40840",
+		"--cidrs", "10.1.0.1/32,10.1.0.2/32")
+	require.NoError(t, err)
+
+	require.NoError(t, env.runVerb(t, "remove", "--name", "bn-publisher", "--cidr", "10.1.0.1/32"))
+	require.Equal(t, []string{"10.1.0.2/32"}, env.runner.elements["bn-publisher"])
+}
+
+// --- set verb ---
+
+func TestSetCmd_Flags(t *testing.T) {
+	for _, name := range []string{"name", "cidrs", "cidrs-file"} {
+		require.NotNil(t, setCmd.Flags().Lookup(name), "set is missing --%s", name)
+	}
+}
+
+func TestSetCmd_ReplacesMembership(t *testing.T) {
+	env := newTestEnv(t)
+	_, err := env.runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "40840",
+		"--cidrs", "10.1.0.1/32")
+	require.NoError(t, err)
+
+	require.NoError(t, env.runVerb(t, "set", "--name", "bn-publisher", "--cidrs", "10.5.0.0/24"))
+	require.Equal(t, []string{"10.5.0.0/24"}, env.runner.elements["bn-publisher"])
+}
+
+func TestSetCmd_CIDRsAndFileMutuallyExclusive(t *testing.T) {
+	env := newTestEnv(t)
+	_, err := env.runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "40840")
+	require.NoError(t, err)
+
+	f := filepath.Join(t.TempDir(), "cidrs.txt")
+	require.NoError(t, os.WriteFile(f, []byte("10.0.0.0/8\n"), 0o644))
+	err = env.runVerb(t, "set", "--name", "bn-publisher", "--cidrs", "10.1.0.0/16", "--cidrs-file", f)
+	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+// --- show verb ---
+
+func TestShowCmd_Flags(t *testing.T) {
+	require.NotNil(t, showCmd.Flags().Lookup("name"), "show is missing --name")
+}
+
+func TestShowCmd_PrintsOutput(t *testing.T) {
+	env := newTestEnv(t)
+	_, err := env.runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "40840",
+		"--cidrs", "10.1.0.1/32")
+	require.NoError(t, err)
+
+	out, err := env.runShow(t, "--name", "bn-publisher")
+	require.NoError(t, err)
+	require.Contains(t, out, "policy: bn-publisher")
+	require.Contains(t, out, "action:  stamp")
+	require.Contains(t, out, "class:   publisher")
+}
+
+func TestShowCmd_PolicyNotFound(t *testing.T) {
+	env := newTestEnv(t)
+	_, err := env.runShow(t, "--name", "bn-nonexistent")
+	require.ErrorContains(t, err, "not found")
+}
+
+// --- delete verb ---
+
+func TestDeleteCmd_Flags(t *testing.T) {
+	require.NotNil(t, deleteCmd.Flags().Lookup("name"), "delete is missing --name")
+}
+
+func TestDeleteCmd_RemovesPolicy(t *testing.T) {
+	env := newTestEnv(t)
+	_, err := env.runCreate(t, "--name", "bn-restricted", "--deny", "--cidrs", "10.99.0.0/16")
+	require.NoError(t, err)
+
+	require.NoError(t, env.runVerb(t, "delete", "--name", "bn-restricted"))
+	// .nft no longer contains the policy.
+	onDisk, readErr := os.ReadFile(env.nftPath)
+	require.NoError(t, readErr)
+	require.NotContains(t, string(onDisk), "bn-restricted")
+}
+
+func TestDeleteCmd_PolicyNotFound(t *testing.T) {
+	env := newTestEnv(t)
+	err := env.runVerb(t, "delete", "--name", "bn-nonexistent")
+	require.ErrorContains(t, err, "not found")
 }

--- a/cmd/cli/commands/network/policy/remove.go
+++ b/cmd/cli/commands/network/policy/remove.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var removeCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove one or more CIDRs from a policy's live set",
+	Long: "Remove CIDRs from the live nft set for a named policy (`nft delete element inet weaver <name> { … }`). " +
+		"Like `add`, only the live kernel set is mutated — no chain re-render and no update to network-weaver.nft. " +
+		"Use `--cidr` one or more times, or pass a comma-separated list in a single `--cidr` flag.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(flagCIDR) == 0 {
+			return errorx.IllegalArgument.New("--cidr is required")
+		}
+		if err := newManager().Remove(cmd.Context(), flagName, flagCIDR); err != nil {
+			return err
+		}
+		logx.As().Info().Str("policy", flagName).Strs("cidrs", flagCIDR).Msg("network policy CIDRs removed")
+		return nil
+	},
+}
+
+func init() {
+	removeCmd.Flags().StringVar(&flagName, "name", "", "Policy name (required)")
+	removeCmd.Flags().StringSliceVar(&flagCIDR, "cidr", nil, "CIDR to remove (comma-separated or repeated)")
+	_ = removeCmd.MarkFlagRequired("name")
+}

--- a/cmd/cli/commands/network/policy/set.go
+++ b/cmd/cli/commands/network/policy/set.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/spf13/cobra"
+)
+
+var setCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Atomically replace a policy's live set membership",
+	Long: "Replace the full CIDR membership of a named policy's nft set in a single kernel transaction " +
+		"(`flush set + add element` in one `nft -f -` document). Omitting `--cidrs`/`--cidrs-file` clears " +
+		"the set. Like `add`/`remove`, only the live kernel set is mutated — no chain re-render and no " +
+		"update to network-weaver.nft.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cidrs, err := resolveCIDRs(cmd)
+		if err != nil {
+			return err
+		}
+		if err := newManager().Set(cmd.Context(), flagName, cidrs); err != nil {
+			return err
+		}
+		logx.As().Info().Str("policy", flagName).Msg("network policy set membership replaced")
+		return nil
+	},
+}
+
+func init() {
+	setCmd.Flags().StringVar(&flagName, "name", "", "Policy name (required)")
+	setCmd.Flags().StringSliceVar(&flagCIDRs, "cidrs", nil, "Replacement membership (comma-separated or repeated); omit to clear")
+	setCmd.Flags().StringVar(&flagCIDRsFile, "cidrs-file", "", "Alternative to --cidrs: a file of CIDRs (one per line or comma-separated)")
+	_ = setCmd.MarkFlagRequired("name")
+}

--- a/cmd/cli/commands/network/policy/show.go
+++ b/cmd/cli/commands/network/policy/show.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show a policy's config and live set membership",
+	Long: "Print the named policy's registry config (action, class, ports, created_at) followed by " +
+		"its current live CIDR set membership from the kernel (`nft list set inet weaver <name>`). " +
+		"No lock is taken — show is a read-only operation.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := newManager().Show(cmd.Context(), flagName)
+		if err != nil {
+			return err
+		}
+		cmd.Print(out)
+		return nil
+	},
+}
+
+func init() {
+	showCmd.Flags().StringVar(&flagName, "name", "", "Policy name (required)")
+	_ = showCmd.MarkFlagRequired("name")
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -530,7 +530,83 @@ sudo solo-provisioner network policy create --name bn-restricted \
 
 When `--pod-cidr` is omitted it is **auto-detected** from the local node's `.spec.podCIDR` via the Kubernetes API — but only for `--stamp` policies; `--deny` never references `POD_CIDR` (it just drops on set membership), so detection is skipped entirely for it. Unlike `network firewall create`, a `--stamp` policy's detection failure with no `--pod-cidr` is a hard error, not a warning-and-continue. If a `--deny` create's merged chain still includes a `--stamp` sibling that needs `POD_CIDR`, the value is recovered from the existing `/etc/solo-provisioner/network-weaver.nft` instead of being required again — it's a deployment-wide constant, not a per-call argument.
 
+
 > Set **membership** (the CIDRs) is never persisted to `network-weaver.nft` — statusz is the source of truth and the daemon reconciles it. `--cidrs` seeds the live set only, and only takes effect on a brand-new policy or a `--force` re-create (which replaces membership with exactly what's passed, not a merge with what was live before).
+
+#### Mutate Set Membership (add / remove / set)
+
+Use these verbs to modify a policy's live CIDR set after it has been created. **None of them re-render `network-weaver.nft`** — only the live kernel set changes (§8.3.1).
+
+```bash
+# Add one or more CIDRs to a policy's live set (repeatable or comma-separated)
+sudo solo-provisioner network policy add --name bn-publisher --cidr 10.1.0.1/32
+sudo solo-provisioner network policy add --name bn-publisher --cidr 10.1.0.2/32,10.1.0.3/32
+
+# Remove one or more CIDRs from a policy's live set
+sudo solo-provisioner network policy remove --name bn-publisher --cidr 10.1.0.1/32
+
+# Atomically replace the full membership list (flush + re-add in one kernel transaction)
+sudo solo-provisioner network policy set --name bn-publisher --cidrs 10.2.0.0/16
+# Or clear the set entirely (omit --cidrs):
+sudo solo-provisioner network policy set --name bn-publisher
+```
+
+**`add` / `remove` flags** (use `--cidr` for each CIDR; comma-separated lists are also accepted):
+
+| Flag     | Description                                        | Required |
+|----------|----------------------------------------------------|----------|
+| `--name` | Policy name                                        | yes      |
+| `--cidr` | CIDR to add or remove (repeatable or comma-separated) | yes   |
+
+**`set` flags**:
+
+| Flag           | Description                                                             | Required |
+|----------------|-------------------------------------------------------------------------|----------|
+| `--name`       | Policy name                                                             | yes      |
+| `--cidrs`      | Replacement membership (comma-separated or repeated); omit to clear     | no       |
+| `--cidrs-file` | Alternative to `--cidrs`: a file of CIDRs (one per line or comma-separated) | no  |
+
+For `--reply-stamp` policies the CIDR entries must be `ip:port` pairs for all three verbs, same as `create --cidrs`.
+
+#### Inspect a Policy (show)
+
+Print a policy's registry config and current live set membership:
+
+```bash
+sudo solo-provisioner network policy show --name bn-publisher
+```
+
+Output example:
+```
+policy: bn-publisher
+  action:  stamp
+  class:   publisher
+  direction: ingress
+  ports:   40840
+  created: 2026-01-01T00:00:00Z
+
+live set @bn-publisher:
+  10.1.0.1/32
+  10.1.0.2/32
+```
+
+| Flag     | Description     | Required |
+|----------|-----------------|----------|
+| `--name` | Policy name     | yes      |
+
+#### Remove a Policy (delete)
+
+Remove a policy's rules, set, and registry file, and re-render the `inet weaver` chain:
+
+```bash
+sudo solo-provisioner network policy delete --name bn-restricted
+```
+
+`delete` re-renders the full chain without the removed policy, snapshots and restores remaining policies' live membership (so the destructive `delete table; add table` does not wipe their sets), removes the registry file, and atomically overwrites `network-weaver.nft`. If this is the last policy, an empty chain (`policy drop`, no rules) is applied; the boot oneshot stays enabled.
+
+| Flag     | Description     | Required |
+|----------|-----------------|----------|
+| `--name` | Policy name     | yes      |
 
 ---
 

--- a/internal/blocknode/manager_test.go
+++ b/internal/blocknode/manager_test.go
@@ -708,7 +708,7 @@ func TestOptionalStorageRegistryConstants(t *testing.T) {
 
 // TestPrereleaseCutoverBoundary pins the 0.37.0 cutover behaviour across release
 // candidates. The "-0" prerelease floor on the registry constants is what makes
-// a prerelease like 0.37.0-rc1 satisfy the >= 0.37.0 boundary — semver §11 ranks
+// a prerelease like 0.37.0-rc1 satisfy the >= 0.37.0 boundary — semver ranks
 // a prerelease BELOW its final tag, so a bare "0.37.0" min would wrongly exclude
 // every 0.37.0-rcN, skipping application-state and keeping verification alive.
 func TestPrereleaseCutoverBoundary(t *testing.T) {

--- a/internal/blocknode/optional_storage.go
+++ b/internal/blocknode/optional_storage.go
@@ -38,7 +38,7 @@ import (
 // and cherry-picks the volume into a 0.36.x release before 0.37.0 ships, bump
 // this constant to that cherry-pick tag — no other structural change is needed.
 //
-// The "-0" suffix is the lowest-possible prerelease per semver §11, so the
+// The "-0" suffix is the lowest-possible prerelease per semver spec, so the
 // boundary is satisfied by every prerelease of 0.37.0 (0.37.0-rc1, -rc2, …) as
 // well as the final 0.37.0 tag. Without it, semver ranks `0.37.0-rc1 < 0.37.0`
 // and release candidates would be wrongly excluded from the cutover. This is a

--- a/internal/network/firewall/table.go
+++ b/internal/network/firewall/table.go
@@ -10,7 +10,7 @@ import (
 	"github.com/joomcode/errorx"
 )
 
-// Default flag values per design §8.4.1.
+// Default flag values.
 const (
 	DefaultSSHPort = 22
 )

--- a/internal/network/policy/class.go
+++ b/internal/network/policy/class.go
@@ -11,17 +11,16 @@ import (
 
 // class is the static definition of a QoS priority class: its conntrack mark,
 // the skb->priority value nft stamps for it, and the traffic direction it
-// classifies. The values are the stable mark map from design §5 (fixed in
-// code, never reconciled), keyed by the class names declared by
-// `network shape create` (design §8.4.3).
+// classifies. The values are the stable mark map (fixed in code, never
+// reconciled), keyed by the class names declared by `network shape create`.
 //
 // The priority is always mark | 0x10000 — the classid `1:<mark>` encoded as an
 // skb->priority (major 1, minor <mark>) so HTB classifies natively without a tc
-// filter (§5.1, §7.2.4 property 5). Both fields are stored explicitly rather
-// than derived so this table reads as a direct transcription of the §5 map.
+// filter. Both fields are stored explicitly rather than derived so this table
+// reads as a direct transcription of the mark map.
 //
-// Direction is fixed per class, not an independent parameter: §7.2.4's worked
-// ruleset never uses a class in both directions (property 6). `publisher` and
+// Direction is fixed per class, not an independent parameter: the ruleset never
+// uses a class in both directions. `publisher` and
 // `reserve-ingress` are DirectionIngress; `partner`, `public`, and
 // `reserve-egress` are DirectionEgress. `backfill-response` is the one
 // exception — it is never a forward `--stamp`, only a `--reply-stamp` target,
@@ -29,23 +28,21 @@ import (
 // DirectionIngress despite being declared alongside an egress-direction
 // forward policy.
 type class struct {
-	// Mark is the conntrack mark (§5 "Mark" column), used only on --reply-stamp
-	// forward rules so the ingress restore rule has something to read back.
+	// Mark is the conntrack mark, used only on --reply-stamp forward rules so
+	// the ingress restore rule has something to read back.
 	Mark uint32
-	// Priority is the skb->priority stamped via `meta priority set` (§5
-	// "Priority" column).
+	// Priority is the skb->priority stamped via `meta priority set`.
 	Priority uint32
-	// Direction is the traffic direction this class classifies (§5 "Direction"
-	// column). `network policy create` derives `Policy.Direction` from this
-	// field instead of taking it as a separate flag.
+	// Direction is the traffic direction this class classifies. `network policy
+	// create` derives `Policy.Direction` from this field instead of taking it
+	// as a separate flag.
 	Direction Direction
 }
 
-// classMap is the stable class→mark/priority/direction map (design §5). Story
-// 1.4 (`network shape`) sets each class's bandwidth; the name→priority
-// encoding itself is fixed here in code and does not depend on shape state.
-// `--stamp` / `--reply-stamp` referencing a name absent from this map is a
-// create-time error.
+// classMap is the stable class→mark/priority/direction map. The `network shape`
+// command sets each class's bandwidth; the name→priority encoding itself is
+// fixed here in code and does not depend on shape state. `--stamp` /
+// `--reply-stamp` referencing a name absent from this map is a create-time error.
 var classMap = map[string]class{
 	"publisher":         {Mark: 0x10, Priority: 0x10010, Direction: DirectionIngress},
 	"backfill-response": {Mark: 0x20, Priority: 0x10020, Direction: DirectionIngress},
@@ -57,7 +54,7 @@ var classMap = map[string]class{
 
 // lookupClass resolves a class name to its mark/priority, returning an
 // IllegalArgument error naming the known classes when the reference is
-// undeclared (design §8.4.2: "referencing an undeclared class is an error").
+// undeclared.
 func lookupClass(name string) (class, error) {
 	c, ok := classMap[name]
 	if !ok {

--- a/internal/network/policy/manager.go
+++ b/internal/network/policy/manager.go
@@ -4,9 +4,11 @@ package policy
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"syscall"
 	"time"
 
@@ -24,11 +26,10 @@ import (
 // existing policy is left untouched (warn, no-op) unless --force is passed,
 // which replaces its config and membership from the given flags/--cidrs.
 //
-// The rendered chain always begins with `delete table; add table` (§8.3.1:
-// membership is never part of it), so every Apply() destroys and recreates
-// every policy's live set, not just the one being created. Create snapshots
-// every policy's membership first and restores it afterward -- see
-// snapshotMembership below.
+// The rendered chain always begins with `delete table; add table` (membership
+// is never part of it), so every Apply() destroys and recreates every policy's
+// live set, not just the one being created. Create snapshots every policy's
+// membership first and restores it afterward -- see snapshotMembership below.
 type Manager struct {
 	runner        Runner
 	weaverNftPath string
@@ -86,7 +87,7 @@ func NewManagerWithConfig(cfg Config) *Manager {
 // that already exists is left untouched (returns false) unless force is
 // true, in which case its config and membership are replaced (not merged)
 // from p and cidrs. cidrs is set membership, applied to the live kernel
-// only — never persisted (§8.3.1).
+// only — never persisted.
 func (m *Manager) Create(ctx context.Context, p *Policy, cidrs []string, podCIDR string, force bool) (bool, error) {
 	if err := p.Validate(cidrs); err != nil {
 		return false, err
@@ -129,8 +130,8 @@ func (m *Manager) Create(ctx context.Context, p *Policy, cidrs []string, podCIDR
 		target, newCIDRs := p, cidrs
 		if existing != nil && !force {
 			// nft tables don't survive a reboot, and the boot oneshot doesn't
-			// reload network-weaver.nft yet (#780) -- so "the registry has
-			// this policy" does not imply "the live table has it too".
+			// reload network-weaver.nft yet -- so "the registry has this
+			// policy" does not imply "the live table has it too".
 			tableExists, err := m.runner.Exists(ctx)
 			if err != nil {
 				return err
@@ -141,7 +142,7 @@ func (m *Manager) Create(ctx context.Context, p *Policy, cidrs []string, podCIDR
 				return nil
 			}
 			// The table is missing underneath an existing registry entry
-			// (manual `nft delete table`, or a reboot before #780). Self-heal
+			// (manual `nft delete table`, or a reboot). Self-heal
 			// by re-rendering, but without --force we must not apply the
 			// caller's new flags/cidrs -- only restore what was already
 			// registered. Membership itself can't be recovered this way: it
@@ -159,7 +160,7 @@ func (m *Manager) Create(ctx context.Context, p *Policy, cidrs []string, podCIDR
 
 		if existing != nil {
 			// Preserve the original creation timestamp across a config change so
-			// the tier tiebreaker (§8.4.7) stays stable.
+			// the tier tiebreaker stays stable.
 			target.CreatedAt = existing.CreatedAt
 		} else if target.CreatedAt.IsZero() {
 			target.CreatedAt = time.Now().UTC()
@@ -167,7 +168,7 @@ func (m *Manager) Create(ctx context.Context, p *Policy, cidrs []string, podCIDR
 
 		// Snapshot every policy's live membership BEFORE Apply(): the
 		// rendered document always does `delete table; add table` (set
-		// membership is never part of that document, §8.3.1), so applying it
+		// membership is never part of that document), so applying it
 		// destroys and recreates every set in the table, not just target's.
 		// Anything not explicitly restored afterward is gone -- permanently,
 		// for operator-curated policies the daemon doesn't reconcile.
@@ -269,8 +270,248 @@ func upsert(policies []*Policy, p *Policy) []*Policy {
 	return out
 }
 
+// Add appends cidrs to the live set for a named policy. The set is mutated
+// directly with `nft add element` — no chain re-render occurs, so
+// network-weaver.nft is not updated (membership is never persisted).
+// Returns an error if the policy does not exist, has no CIDR set
+// (--from-entity world), or the live kernel table is not present.
+func (m *Manager) Add(ctx context.Context, name string, cidrs []string) error {
+	if len(cidrs) == 0 {
+		return errorx.IllegalArgument.New("at least one --cidr is required")
+	}
+	return m.withLock(func() error {
+		p, err := m.requirePolicyWithCIDRSet(name)
+		if err != nil {
+			return err
+		}
+		if err := p.validateCIDRs(cidrs); err != nil {
+			return err
+		}
+		if err := m.requireTableExists(ctx, name); err != nil {
+			return err
+		}
+		return m.runner.AddElements(ctx, name, setElements(p, cidrs))
+	})
+}
+
+// Remove deletes cidrs from the live set for a named policy. Like Add, only
+// the live kernel set is changed — no chain re-render and no .nft update.
+func (m *Manager) Remove(ctx context.Context, name string, cidrs []string) error {
+	if len(cidrs) == 0 {
+		return errorx.IllegalArgument.New("at least one --cidr is required")
+	}
+	return m.withLock(func() error {
+		p, err := m.requirePolicyWithCIDRSet(name)
+		if err != nil {
+			return err
+		}
+		if err := p.validateCIDRs(cidrs); err != nil {
+			return err
+		}
+		if err := m.requireTableExists(ctx, name); err != nil {
+			return err
+		}
+		return m.runner.DeleteElements(ctx, name, setElements(p, cidrs))
+	})
+}
+
+// Set atomically replaces the live set for a named policy with cidrs in a
+// single `flush set + add element` kernel transaction. An empty cidrs slice
+// clears the set. Like Add/Remove, only the live kernel set is changed.
+func (m *Manager) Set(ctx context.Context, name string, cidrs []string) error {
+	return m.withLock(func() error {
+		p, err := m.requirePolicyWithCIDRSet(name)
+		if err != nil {
+			return err
+		}
+		if err := p.validateCIDRs(cidrs); err != nil {
+			return err
+		}
+		if err := m.requireTableExists(ctx, name); err != nil {
+			return err
+		}
+		return m.runner.SetElements(ctx, name, setElements(p, cidrs))
+	})
+}
+
+// Show returns a human-readable summary of a named policy: its registry config
+// (action, class, ports, created_at) followed by the live set membership from
+// the kernel (`nft list set inet weaver <name>`). No lock is taken — Show is
+// read-only.
+func (m *Manager) Show(ctx context.Context, name string) (string, error) {
+	p, err := readEntry(m.registryDir, name)
+	if err != nil {
+		return "", err
+	}
+	if p == nil {
+		return "", errorx.IllegalState.New("policy %q not found", name)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "policy: %s\n", p.Name)
+	fmt.Fprintf(&b, "  action:  %s\n", p.Action)
+	if p.Stamp != "" {
+		fmt.Fprintf(&b, "  class:   %s\n", p.Stamp)
+	}
+	if p.ReplyStamp != "" {
+		fmt.Fprintf(&b, "  reply-class: %s\n", p.ReplyStamp)
+	}
+	if p.Direction != "" {
+		fmt.Fprintf(&b, "  direction: %s\n", p.Direction)
+	}
+	if len(p.Ports) > 0 {
+		fmt.Fprintf(&b, "  ports:   %s\n", strings.Join(p.Ports, ", "))
+	}
+	if p.FromEntityWorld {
+		b.WriteString("  from-entity: world\n")
+	}
+	fmt.Fprintf(&b, "  created: %s\n", p.CreatedAt.Format(time.RFC3339))
+
+	if !p.hasCIDRSet() {
+		b.WriteString("\nlive set: none (--from-entity world policy; any source/dest matches, no IP-set)\n")
+		return b.String(), nil
+	}
+
+	elements, err := m.runner.ListElements(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	fmt.Fprintf(&b, "\nlive set @%s:\n", name)
+	if len(elements) == 0 {
+		b.WriteString("  (empty)\n")
+	} else {
+		for _, e := range elements {
+			fmt.Fprintf(&b, "  %s\n", e)
+		}
+	}
+	return b.String(), nil
+}
+
+// Delete removes a named policy: re-renders the `inet weaver` chain without
+// it, applies the result to the live kernel, restores the remaining policies'
+// live membership (which the destructive re-render wipes), removes the
+// registry file, and atomically rewrites network-weaver.nft.
+//
+// If this is the last policy, an empty chain (policy drop, no rules) is
+// applied and the boot oneshot is left enabled.
+func (m *Manager) Delete(ctx context.Context, name string) error {
+	return m.withLock(func() error {
+		policies, err := loadAll(m.registryDir)
+		if err != nil {
+			return err
+		}
+		if findByName(policies, name) == nil {
+			return errorx.IllegalState.New("policy %q not found", name)
+		}
+
+		remaining := make([]*Policy, 0, len(policies)-1)
+		for _, p := range policies {
+			if p.Name != name {
+				remaining = append(remaining, p)
+			}
+		}
+
+		// Re-validate sibling entries before rendering.
+		for _, lp := range remaining {
+			if err := lp.Validate(nil); err != nil {
+				return errorx.IllegalFormat.Wrap(err, "corrupt policy registry entry %s", registryPath(m.registryDir, lp.Name))
+			}
+		}
+
+		// Recover the pod CIDR from the existing .nft if any remaining policy
+		// is a --stamp (same pattern as Create).
+		podCIDR := ""
+		if needsPodCIDR(remaining) {
+			if existing, err := os.ReadFile(m.weaverNftPath); err == nil {
+				podCIDR = ExtractPodCIDR(string(existing))
+			}
+		}
+
+		// Snapshot remaining policies' membership BEFORE Apply(): the rendered
+		// document always does `delete table; add table`, which wipes every set
+		// in the table, not just the deleted policy's.
+		snapshot, err := m.snapshotMembership(ctx, remaining)
+		if err != nil {
+			return err
+		}
+
+		doc, err := Render(remaining, podCIDR)
+		if err != nil {
+			return err
+		}
+		if err := m.runner.Apply(ctx, doc); err != nil {
+			return err
+		}
+
+		// Restore remaining policies' membership.
+		for _, lp := range remaining {
+			if !lp.hasCIDRSet() {
+				continue
+			}
+			elements := snapshot[lp.Name]
+			if len(elements) == 0 {
+				continue
+			}
+			if err := m.runner.AddElements(ctx, lp.Name, elements); err != nil {
+				return errorx.Decorate(err,
+					"inet weaver chain re-rendered but restoring %q membership failed; re-run to reconcile", lp.Name)
+			}
+		}
+
+		// Write the .nft file before removing the registry so that a failed
+		// write leaves the registry intact and a re-run can find the policy.
+		if err := atomicWriteFile(m.weaverNftPath, doc, 0o644); err != nil {
+			return errorx.Decorate(err,
+				"inet weaver chain re-rendered but persisting %s failed; re-run to reconcile", m.weaverNftPath)
+		}
+		if err := os.Remove(registryPath(m.registryDir, name)); err != nil && !os.IsNotExist(err) {
+			return errorx.Decorate(
+				errorx.ExternalError.Wrap(err, "failed to remove registry file for %q", name),
+				"inet weaver chain persisted but removing the registry file failed; re-run to reconcile",
+			)
+		}
+		logx.As().Info().Str("policy", name).Msg("network policy deleted")
+		return nil
+	})
+}
+
+// requirePolicyWithCIDRSet loads the named policy from the registry and
+// verifies it has a CIDR set (@<name>). Returns an error if the policy is
+// missing or uses --from-entity world (those policies match any source/dest
+// and render no IP-set, so element verbs do not apply).
+func (m *Manager) requirePolicyWithCIDRSet(name string) (*Policy, error) {
+	p, err := readEntry(m.registryDir, name)
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, errorx.IllegalState.New(
+			"policy %q not found; run `network policy create` with --name and the original policy flags first", name)
+	}
+	if !p.hasCIDRSet() {
+		return nil, errorx.IllegalArgument.New(
+			"policy %q has no CIDR set (it uses --from-entity world); element verbs do not apply", name)
+	}
+	return p, nil
+}
+
+// requireTableExists returns a clear error when the inet weaver table is
+// absent from the kernel, so element verbs (add/remove/set) surface a helpful
+// message instead of propagating the raw nft "No such file" error.
+func (m *Manager) requireTableExists(ctx context.Context, name string) error {
+	exists, err := m.runner.Exists(ctx)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return errorx.IllegalState.New(
+			"policy table not found; run `network policy create` with --name and the original policy flags to restore")
+	}
+	return nil
+}
+
 // withLock serialises a mutation behind the shared cross-command flock so a
-// hand-run operator command and the daemon poll loop (#754) cannot interleave
+// hand-run operator command and the daemon poll loop cannot interleave
 // nft transactions on the shared network tables.
 func (m *Manager) withLock(fn func() error) error {
 	if err := os.MkdirAll(filepath.Dir(m.lockPath), 0o755); err != nil {

--- a/internal/network/policy/manager_ops_test.go
+++ b/internal/network/policy/manager_ops_test.go
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// seedPolicy creates a policy via Create and verifies no error.
+func seedPolicy(t *testing.T, m *Manager, name, stamp string, ports []string, cidrs []string, podCIDR string) {
+	t.Helper()
+	_, err := m.Create(context.Background(),
+		&Policy{Name: name, Action: ActionStamp, Stamp: stamp, Ports: ports},
+		cidrs, podCIDR, false)
+	require.NoError(t, err)
+}
+
+func seedDenyPolicy(t *testing.T, m *Manager, name string, cidrs []string) {
+	t.Helper()
+	_, err := m.Create(context.Background(),
+		&Policy{Name: name, Action: ActionDeny},
+		cidrs, "", false)
+	require.NoError(t, err)
+}
+
+// --- Add ---
+
+func TestAdd_AddsToLiveSet(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+
+	require.NoError(t, m.Add(context.Background(), "bn-publisher", []string{"10.1.0.1/32", "10.1.0.2/32"}))
+	require.Equal(t, []string{"10.1.0.1/32", "10.1.0.2/32"}, r.elements["bn-publisher"])
+}
+
+func TestAdd_AppendsToPriorMembership(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, []string{"10.1.0.1/32"}, "10.4.0.0/24")
+	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"])
+
+	require.NoError(t, m.Add(context.Background(), "bn-publisher", []string{"10.1.0.2/32"}))
+	require.Equal(t, []string{"10.1.0.1/32", "10.1.0.2/32"}, r.elements["bn-publisher"])
+}
+
+func TestAdd_PolicyNotFound(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	err := m.Add(context.Background(), "bn-nonexistent", []string{"10.0.0.1/32"})
+	require.ErrorContains(t, err, "not found")
+}
+
+func TestAdd_FromEntityWorldPolicyRejected(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-public-out", Action: ActionStamp, Stamp: "public", FromEntityWorld: true, Ports: []string{"40980"}},
+		nil, "10.4.0.0/24", false)
+	require.NoError(t, err)
+
+	err = m.Add(context.Background(), "bn-public-out", []string{"10.0.0.1/32"})
+	require.ErrorContains(t, err, "no CIDR set")
+}
+
+func TestAdd_TableMissingReturnsError(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+
+	require.NoError(t, r.Delete(context.Background()))
+
+	err := m.Add(context.Background(), "bn-publisher", []string{"10.1.0.1/32"})
+	require.ErrorContains(t, err, "policy table not found")
+}
+
+func TestAdd_EmptyCIDRsRejected(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+
+	err := m.Add(context.Background(), "bn-publisher", nil)
+	require.ErrorContains(t, err, "at least one --cidr")
+}
+
+// --- Remove ---
+
+func TestRemove_RemovesFromLiveSet(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"},
+		[]string{"10.1.0.1/32", "10.1.0.2/32"}, "10.4.0.0/24")
+
+	require.NoError(t, m.Remove(context.Background(), "bn-publisher", []string{"10.1.0.1/32"}))
+	require.Equal(t, []string{"10.1.0.2/32"}, r.elements["bn-publisher"])
+}
+
+func TestRemove_PolicyNotFound(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	err := m.Remove(context.Background(), "bn-nonexistent", []string{"10.0.0.1/32"})
+	require.ErrorContains(t, err, "not found")
+}
+
+func TestRemove_TableMissingReturnsError(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+
+	require.NoError(t, r.Delete(context.Background()))
+
+	err := m.Remove(context.Background(), "bn-publisher", []string{"10.1.0.1/32"})
+	require.ErrorContains(t, err, "policy table not found")
+}
+
+// --- Set ---
+
+func TestSet_ReplacesEntireMembership(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"},
+		[]string{"10.1.0.1/32", "10.1.0.2/32"}, "10.4.0.0/24")
+
+	require.NoError(t, m.Set(context.Background(), "bn-publisher", []string{"10.5.0.0/24"}))
+	require.Equal(t, []string{"10.5.0.0/24"}, r.elements["bn-publisher"],
+		"Set replaces all prior membership with exactly the new list")
+}
+
+func TestSet_EmptySliceClearsMembership(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"},
+		[]string{"10.1.0.1/32"}, "10.4.0.0/24")
+
+	require.NoError(t, m.Set(context.Background(), "bn-publisher", []string{}))
+	require.Empty(t, r.elements["bn-publisher"], "Set with empty cidrs clears the set")
+}
+
+func TestSet_PolicyNotFound(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	err := m.Set(context.Background(), "bn-nonexistent", []string{"10.0.0.1/32"})
+	require.ErrorContains(t, err, "not found")
+}
+
+func TestSet_TableMissingReturnsError(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+
+	require.NoError(t, r.Delete(context.Background()))
+
+	err := m.Set(context.Background(), "bn-publisher", []string{"10.1.0.1/32"})
+	require.ErrorContains(t, err, "policy table not found")
+}
+
+// --- Show ---
+
+func TestShow_StampPolicy(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"},
+		[]string{"10.1.0.1/32"}, "10.4.0.0/24")
+
+	out, err := m.Show(context.Background(), "bn-publisher")
+	require.NoError(t, err)
+	require.Contains(t, out, "policy: bn-publisher")
+	require.Contains(t, out, "action:  stamp")
+	require.Contains(t, out, "class:   publisher")
+	require.Contains(t, out, "direction: ingress")
+	require.Contains(t, out, "ports:   40840")
+	require.Contains(t, out, "live set @bn-publisher:")
+	require.Contains(t, out, "10.1.0.1/32")
+}
+
+func TestShow_DenyPolicy(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedDenyPolicy(t, m, "bn-restricted", []string{"10.99.0.0/16"})
+
+	out, err := m.Show(context.Background(), "bn-restricted")
+	require.NoError(t, err)
+	require.Contains(t, out, "action:  deny")
+	require.Contains(t, out, "live set @bn-restricted:")
+	require.Contains(t, out, "10.99.0.0/16")
+}
+
+func TestShow_FromEntityWorldPolicy(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-public-out", Action: ActionStamp, Stamp: "public", FromEntityWorld: true, Ports: []string{"40980"}},
+		nil, "10.4.0.0/24", false)
+	require.NoError(t, err)
+
+	out, err := m.Show(context.Background(), "bn-public-out")
+	require.NoError(t, err)
+	require.Contains(t, out, "from-entity: world")
+	require.Contains(t, out, "live set: none")
+}
+
+func TestShow_EmptyLiveSet(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+
+	out, err := m.Show(context.Background(), "bn-publisher")
+	require.NoError(t, err)
+	require.Contains(t, out, "(empty)")
+}
+
+func TestShow_PolicyNotFound(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	_, err := m.Show(context.Background(), "bn-nonexistent")
+	require.ErrorContains(t, err, "not found")
+}
+
+// --- Delete ---
+
+func TestDelete_RemovesRegistryAndRerendersChain(t *testing.T) {
+	r := newFakeRunner()
+	m, nftPath, regDir := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"},
+		[]string{"10.1.0.1/32"}, "10.4.0.0/24")
+	seedDenyPolicy(t, m, "bn-restricted", []string{"10.99.0.0/16"})
+
+	require.NoError(t, m.Delete(context.Background(), "bn-publisher"))
+
+	// Registry file removed.
+	require.NoFileExists(t, filepath.Join(regDir, "bn-publisher.json"))
+	// Registry for sibling intact.
+	require.FileExists(t, filepath.Join(regDir, "bn-restricted.json"))
+
+	// The .nft file no longer references the deleted policy.
+	onDisk, err := os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.NotContains(t, string(onDisk), "bn-publisher")
+	require.Contains(t, string(onDisk), "bn-restricted")
+}
+
+func TestDelete_PreservesSiblingMembership(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedDenyPolicy(t, m, "bn-restricted", []string{"10.99.0.0/16"})
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"},
+		[]string{"10.1.0.1/32"}, "10.4.0.0/24")
+
+	require.Equal(t, []string{"10.99.0.0/16"}, r.elements["bn-restricted"])
+	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"])
+
+	// Delete bn-publisher: the chain re-render wipes all sets, then restores
+	// bn-restricted's snapshot.
+	require.NoError(t, m.Delete(context.Background(), "bn-publisher"))
+
+	require.Equal(t, []string{"10.99.0.0/16"}, r.elements["bn-restricted"],
+		"sibling live membership must survive the destructive re-render")
+	require.Empty(t, r.elements["bn-publisher"], "deleted policy's set no longer present")
+}
+
+func TestDelete_LastPolicy_AppliesEmptyChain(t *testing.T) {
+	r := newFakeRunner()
+	m, nftPath, _ := newTestManager(t, r)
+	seedDenyPolicy(t, m, "bn-restricted", []string{"10.99.0.0/16"})
+
+	require.NoError(t, m.Delete(context.Background(), "bn-restricted"))
+
+	// The table is still live (empty chain, policy drop, no rules).
+	require.True(t, r.exists, "table must still exist after last policy is deleted")
+
+	// The .nft file was updated and no longer contains the deleted policy.
+	onDisk, err := os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.NotContains(t, string(onDisk), "bn-restricted")
+	// Chain structure is intact with policy drop.
+	require.Contains(t, string(onDisk), "policy drop")
+}
+
+func TestDelete_PolicyNotFound(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	err := m.Delete(context.Background(), "bn-nonexistent")
+	require.ErrorContains(t, err, "not found")
+}
+
+func TestDelete_RecoversPodCIDRFromNftFileForRemainingStampPolicies(t *testing.T) {
+	r := newFakeRunner()
+	m, nftPath, _ := newTestManager(t, r)
+
+	// Create a stamp policy (which writes pod CIDR into the .nft) and a deny.
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+	seedDenyPolicy(t, m, "bn-restricted", []string{"10.99.0.0/16"})
+
+	// Delete the deny policy — the remaining stamp sibling needs a pod CIDR
+	// to re-render, but none is supplied. It must be recovered from the .nft.
+	require.NoError(t, m.Delete(context.Background(), "bn-restricted"))
+
+	onDisk, err := os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.Contains(t, string(onDisk), "10.4.0.0/24",
+		"bn-publisher's rule must still be rendered with the recovered pod CIDR")
+	require.NotContains(t, string(onDisk), "bn-restricted")
+}
+
+func TestDelete_CompoundSetPolicy(t *testing.T) {
+	r := newFakeRunner()
+	m, _, regDir := newTestManager(t, r)
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
+		[]string{"10.30.5.7:43473"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+
+	require.NoError(t, m.Delete(context.Background(), "bn-backfill"))
+	require.NoFileExists(t, filepath.Join(regDir, "bn-backfill.json"))
+	require.Empty(t, r.elements["bn-backfill"])
+}
+
+// --- Add/Remove compound-set (reply-stamp) policies ---
+
+func TestAdd_CompoundSetPolicy(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
+		nil, "10.4.0.0/24", false)
+	require.NoError(t, err)
+
+	require.NoError(t, m.Add(context.Background(), "bn-backfill", []string{"10.30.5.7:43473"}))
+	// The element must be converted to the compound `ip . port` form.
+	require.Equal(t, []string{"10.30.5.7 . 43473"}, r.elements["bn-backfill"])
+}
+
+func TestSet_CompoundSetPolicy(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
+		[]string{"10.30.5.7:43473"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+
+	require.NoError(t, m.Set(context.Background(), "bn-backfill", []string{"10.30.5.8:43473"}))
+	require.Equal(t, []string{"10.30.5.8 . 43473"}, r.elements["bn-backfill"])
+}
+
+func TestShow_ReplyStampPolicy(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	_, err := m.Create(context.Background(),
+		&Policy{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
+		[]string{"10.30.5.7:43473"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+
+	out, err := m.Show(context.Background(), "bn-backfill")
+	require.NoError(t, err)
+	require.Contains(t, out, "class:   reserve-egress")
+	require.Contains(t, out, "reply-class: backfill-response")
+	require.Contains(t, out, "live set @bn-backfill:")
+	require.True(t, strings.Contains(out, "10.30.5.7 . 43473") || strings.Contains(out, "10.30.5.7:43473"),
+		"show must display compound-set membership in some recognizable form")
+}

--- a/internal/network/policy/nft.go
+++ b/internal/network/policy/nft.go
@@ -14,10 +14,9 @@ import (
 
 // Runner is the seam over the system `nft` binary. Unlike the firewall package
 // (which applies via a systemd service restart), `network policy` applies the
-// rendered chain directly with `nft -f` (design §8.4.5) — the shared boot
-// oneshot does not load network-weaver.nft until #780 extends it. Tests
-// substitute a fake so the package builds and unit-tests on any platform
-// (including macOS) without touching the kernel.
+// rendered chain directly with `nft -f` — the shared boot oneshot does not
+// load network-weaver.nft yet. Tests substitute a fake so the package builds
+// and unit-tests on any platform (including macOS) without touching the kernel.
 type Runner interface {
 	// Apply loads a full nft document into the kernel (`nft -f -`). The
 	// rendered document carries the idempotent `add table / delete table / add
@@ -25,8 +24,17 @@ type Runner interface {
 	Apply(ctx context.Context, doc string) error
 	// AddElements adds initial membership to a policy's set
 	// (`nft add element inet weaver <set> { … }`). Applied to the live kernel
-	// only — set membership is never persisted (§8.3.1).
+	// only — set membership is never persisted.
 	AddElements(ctx context.Context, set string, elements []string) error
+	// DeleteElements removes specific elements from a policy's set
+	// (`nft delete element inet weaver <set> { … }`). Applied to the live
+	// kernel only.
+	DeleteElements(ctx context.Context, set string, elements []string) error
+	// SetElements atomically replaces a policy's set membership
+	// (`flush set inet weaver <set>` followed by `add element … { … }` in a
+	// single nft document — one kernel transaction). An empty elements slice
+	// clears the set without adding any new entries.
+	SetElements(ctx context.Context, set string, elements []string) error
 	// ListElements returns one set's live elements
 	// (`nft list set inet weaver <set>`), or nil if the set has no elements
 	// or does not exist. Used by Manager.Create to snapshot every policy's
@@ -93,6 +101,37 @@ func (r *execRunner) AddElements(ctx context.Context, set string, elements []str
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		return errorx.ExternalError.Wrap(err, "nft add element %s failed: %s", set, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+func (r *execRunner) DeleteElements(ctx context.Context, set string, elements []string) error {
+	if len(elements) == 0 {
+		return nil
+	}
+	spec := "delete element " + TableName + " " + set + " { " + strings.Join(elements, ", ") + " }\n"
+	cmd := exec.CommandContext(ctx, r.bin, "-f", "-")
+	cmd.Stdin = strings.NewReader(spec)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return errorx.ExternalError.Wrap(err, "nft delete element %s failed: %s", set, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+func (r *execRunner) SetElements(ctx context.Context, set string, elements []string) error {
+	var spec strings.Builder
+	spec.WriteString("flush set " + TableName + " " + set + "\n")
+	if len(elements) > 0 {
+		spec.WriteString("add element " + TableName + " " + set + " { " + strings.Join(elements, ", ") + " }\n")
+	}
+	cmd := exec.CommandContext(ctx, r.bin, "-f", "-")
+	cmd.Stdin = strings.NewReader(spec.String())
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return errorx.ExternalError.Wrap(err, "nft set elements %s failed: %s", set, strings.TrimSpace(stderr.String()))
 	}
 	return nil
 }

--- a/internal/network/policy/paths.go
+++ b/internal/network/policy/paths.go
@@ -1,27 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-// Package policy implements the `solo-provisioner network policy create` verb:
+// Package policy implements the `solo-provisioner network policy` verb family:
 // it renders per-category classification / ACL rules into the `inet weaver`
-// nftables table (the workload traffic plane, design §7.2.4), maintains a
-// per-policy registry under /etc/solo-provisioner/policies/, and applies the
-// full rendered chain to the live kernel with `nft -f` while atomically
-// persisting /etc/solo-provisioner/network-weaver.nft.
-//
-// Like internal/network/firewall, this is a generic, category-agnostic
-// primitive — it knows nothing about block/consensus/mirror/relay nodes; the
-// CLI is statusz-agnostic and takes CIDRs and class names directly. It is the
-// sibling of internal/network/firewall (the `inet host` node firewall) and
-// deliberately shares that package's on-disk artifact conventions, the
-// cross-command apply lock, and the boot oneshot unit — but targets a different
-// table with an opposite lifecycle: `inet weaver` set membership churns
-// continuously as the daemon monitor (TS_3) rewrites it from statusz, whereas
-// the chain structure and port sets rendered here are static for the lifetime
-// of the deployment. Today `block node install` is the only caller.
-//
-// Scope boundary (epic #738): this package implements only `create`. The
-// element verbs (add/remove/set/show/delete) are Story 1.3 (#759); overlap
-// rejection, the created_at intra-tier tiebreaker, and last-policy service
-// teardown are Story 1.5 (#772).
+// nftables table (the workload traffic plane), maintains a per-policy registry
+// under /etc/solo-provisioner/policies/, and applies the full rendered chain to
+// the live kernel with `nft -f` while atomically persisting
+// /etc/solo-provisioner/network-weaver.nft.
 package policy
 
 const (
@@ -31,27 +15,25 @@ const (
 	// WeaverNftPath is the on-disk artifact replayed at boot by the shared
 	// solo-provisioner-network-nft.service oneshot. It lives under /etc (host OS
 	// config on the root filesystem) so it is available early at boot, before any
-	// late mounts. Extending the oneshot's ExecStart to also load this file is
-	// owned by #780; this package only writes the file and ensures the unit is
+	// late mounts. This package only writes the file and ensures the unit is
 	// enabled.
 	WeaverNftPath = "/etc/solo-provisioner/network-weaver.nft"
 
 	// HostNftPath is the inet host artifact, owned by internal/network/firewall.
 	// This package never writes it; it only checks for its presence to decide
-	// whether the shared oneshot may be disabled (teardown is Story 1.5 / #791).
+	// whether the shared oneshot may be disabled.
 	HostNftPath = "/etc/solo-provisioner/network-host.nft"
 
-	// RegistryDir holds one JSON file per policy (design §8.4.7). The registry is
-	// the source of truth for the static policy definition and drives the
-	// tier-order chain re-render on every create/delete. CIDR membership is NOT
-	// stored here — it lives in the live nft sets and is owned by the daemon poll
-	// loop (§8.3.1).
+	// RegistryDir holds one JSON file per policy. The registry is the source of
+	// truth for the static policy definition and drives the tier-order chain
+	// re-render on every create/delete. CIDR membership is NOT stored here — it
+	// lives in the live nft sets and is owned by the daemon poll loop.
 	RegistryDir = "/etc/solo-provisioner/policies"
 
 	// NetworkNftService is the shared oneshot unit that loads the network nft
 	// tables at boot. It is shared with internal/network/firewall; this package
 	// ensures it is installed and enabled on the first policy mutation but never
-	// disables it (teardown is Story 1.5 / #791).
+	// disables it.
 	NetworkNftService = "solo-provisioner-network-nft.service"
 
 	// NetworkNftServiceUnitPath is the absolute path where the shared unit file
@@ -63,7 +45,7 @@ const (
 
 	// LockDir holds the cross-command apply lock, on tmpfs (/run) so it is
 	// auto-cleared on reboot. Shared with internal/network/firewall and the
-	// daemon poll loop (#754).
+	// daemon poll loop.
 	LockDir = "/run/solo-provisioner/network"
 
 	// LockPath is the flock acquired (LOCK_EX) for the duration of any mutating
@@ -72,7 +54,7 @@ const (
 	//
 	// NOTE: these path/service constants intentionally mirror
 	// internal/network/firewall by value. Hoisting them into a shared
-	// internal/network package is a deliberate follow-up (kept out of this story
+	// internal/network package is a deliberate follow-up (kept out of scope here
 	// to avoid churning already-merged firewall code); the values MUST stay in
 	// sync until then, which the render/lock tests guard indirectly.
 	LockPath = "/run/solo-provisioner/network/.applying"

--- a/internal/network/policy/policy.go
+++ b/internal/network/policy/policy.go
@@ -27,8 +27,8 @@ const (
 // Direction selects which half of the forward chain a stamp rule renders into.
 // It is empty for deny policies (which always apply to both directions). For
 // stamp policies it is not a caller-supplied value: Validate derives it from
-// the --stamp class (every class in the §5 mark map has exactly one
-// direction), so it can never contradict the class it names.
+// the --stamp class (every class in the mark map has exactly one direction),
+// so it can never contradict the class it names.
 type Direction string
 
 const (
@@ -41,11 +41,10 @@ const (
 )
 
 // Policy is the static definition of one named category, mirroring the registry
-// JSON schema (design §8.4.7). CIDR membership is deliberately NOT a field: it
-// lives in the live nft set and is owned by the daemon poll loop, never
-// persisted to the registry or the .nft file (§8.3.1). The initial `--cidrs`
-// membership supplied at create time is applied to the live kernel separately
-// (see Manager.Create).
+// JSON schema. CIDR membership is deliberately NOT a field: it lives in the
+// live nft set and is owned by the daemon poll loop, never persisted to the
+// registry or the .nft file. The initial `--cidrs` membership supplied at
+// create time is applied to the live kernel separately (see Manager.Create).
 type Policy struct {
 	Name            string    `json:"name"`
 	Action          Action    `json:"action"`
@@ -58,10 +57,9 @@ type Policy struct {
 }
 
 // Validate rejects any policy + initial-CIDR combination that would be unsafe
-// or nonsensical to render, per the flag-validity rules in design §8.4.2 /
-// §8.4.6. It is the single gate before the renderer; every untrusted token
-// (name, class, ports, CIDRs) is checked so a malformed value can never break
-// the atomic nft transaction or smuggle in nft syntax.
+// or nonsensical to render. It is the single gate before the renderer; every
+// untrusted token (name, class, ports, CIDRs) is checked so a malformed value
+// can never break the atomic nft transaction or smuggle in nft syntax.
 func (p *Policy) Validate(cidrs []string) error {
 	if err := sanity.ValidateIdentifier(p.Name); err != nil {
 		return errorx.IllegalArgument.Wrap(err, "invalid --name %q", p.Name)
@@ -99,8 +97,8 @@ func (p *Policy) Validate(cidrs []string) error {
 }
 
 // validateStamp resolves --stamp to its class and derives p.Direction from it
-// (design §5: every class has exactly one direction, so there is no
-// independent --direction flag to validate against). For --reply-stamp, the
+// (every class has exactly one direction, so there is no independent
+// --direction flag to validate against). For --reply-stamp, the
 // reply class must be the mirror direction of the forward class — e.g. an
 // egress --stamp pairs only with an ingress --reply-stamp — since a reply is
 // definitionally the reverse leg of the forward flow.
@@ -171,7 +169,7 @@ func (p *Policy) validateCIDRs(cidrs []string) error {
 
 // isCompoundSet reports whether the policy's nft set is a compound
 // `ipv4_addr . inet_service` key set — true only for --reply-stamp policies,
-// whose --cidrs entries are ip:port destination pairs (design §8.4.6).
+// whose --cidrs entries are ip:port destination pairs.
 func (p *Policy) isCompoundSet() bool {
 	return p.ReplyStamp != ""
 }

--- a/internal/network/policy/policy_test.go
+++ b/internal/network/policy/policy_test.go
@@ -16,9 +16,9 @@ import (
 
 // fakeRunner is an in-memory Runner for tests: it records the applied document
 // and the elements added per set without touching the kernel. Apply clears
-// elements to mirror the real `nft -f` delete+recreate of the whole table
-// (§8.3.1) -- without that, tests wouldn't exercise the membership loss
-// Manager.Create's snapshot/restore is meant to prevent.
+// elements to mirror the real `nft -f` delete+recreate of the whole table --
+// without that, tests wouldn't exercise the membership loss Manager.Create's
+// snapshot/restore is meant to prevent.
 type fakeRunner struct {
 	applied     string
 	applyCount  int
@@ -47,6 +47,39 @@ func (f *fakeRunner) AddElements(_ context.Context, set string, elements []strin
 		return errors.New("nft add element " + set + " failed: No such file or directory")
 	}
 	f.elements[set] = append(f.elements[set], elements...)
+	return nil
+}
+func (f *fakeRunner) DeleteElements(_ context.Context, set string, elements []string) error {
+	if !f.exists {
+		return errors.New("nft delete element " + set + " failed: No such file or directory")
+	}
+	toDelete := make(map[string]bool, len(elements))
+	for _, e := range elements {
+		toDelete[e] = true
+	}
+	current := f.elements[set]
+	filtered := current[:0]
+	for _, e := range current {
+		if !toDelete[e] {
+			filtered = append(filtered, e)
+		}
+	}
+	if len(filtered) == 0 {
+		delete(f.elements, set)
+	} else {
+		f.elements[set] = filtered
+	}
+	return nil
+}
+func (f *fakeRunner) SetElements(_ context.Context, set string, elements []string) error {
+	if !f.exists {
+		return errors.New("nft flush set " + set + " failed: No such file or directory")
+	}
+	if len(elements) == 0 {
+		delete(f.elements, set)
+	} else {
+		f.elements[set] = append([]string(nil), elements...)
+	}
 	return nil
 }
 func (f *fakeRunner) ListElements(_ context.Context, set string) ([]string, error) {
@@ -83,7 +116,7 @@ func newTestManager(t *testing.T, r *fakeRunner) (*Manager, string, string) {
 
 func fixedTime() time.Time { return time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC) }
 
-// sampleBNPolicies mirrors the BN install policy set from design §8.4.2.
+// sampleBNPolicies mirrors the BN install policy set.
 func sampleBNPolicies() []*Policy {
 	at := fixedTime()
 	return []*Policy{
@@ -124,16 +157,16 @@ func TestRender_TierOrderInvariants(t *testing.T) {
 	doc, err := Render(sampleBNPolicies(), "10.4.0.0/24")
 	require.NoError(t, err)
 
-	// Load-bearing ordering (design §7.2.4): quarantine drops and the reply
-	// restore must both precede `ct state established,related accept`, otherwise
-	// open connections survive a quarantine and reply packets are misclassified.
+	// Quarantine drops and the reply restore must both precede `ct state
+	// established,related accept`, otherwise open connections survive a
+	// quarantine and reply packets are misclassified.
 	estIdx := strings.Index(doc, "ct state established,related accept")
 	require.Positive(t, estIdx)
 	require.Less(t, strings.Index(doc, "ip saddr @bn-restricted drop"), estIdx, "deny must precede est,rel accept")
 	require.Less(t, strings.Index(doc, "ct direction reply ct mark 0x20"), estIdx, "reply restore must precede est,rel accept")
 
 	// Specific (partner) must precede the fallthrough (public) so partner-bound
-	// replies hit 1:40 and everyone else 1:50 (§7.2.4 property 3).
+	// replies hit 1:40 and everyone else 1:50.
 	require.Less(t, strings.Index(doc, "@bn-partner-out"), strings.Index(doc, "@bn-public-out_ports"))
 
 	// Chain must default-drop and end with a trailing drop.
@@ -145,14 +178,14 @@ func TestRender_WorkedExamples(t *testing.T) {
 	doc, err := Render(sampleBNPolicies(), "10.4.0.0/24")
 	require.NoError(t, err)
 
-	// §8.4.6 publisher stamp.
+	// publisher stamp.
 	require.Contains(t, doc, "ip daddr 10.4.0.0/24 ip saddr @bn-publisher tcp dport @bn-publisher_ports meta priority set 0x10010 accept")
-	// §8.4.6 from-entity world fallthrough (no @set clause).
+	// from-entity world fallthrough (no @set clause).
 	require.Contains(t, doc, "ip daddr 10.4.0.0/24 tcp dport @bn-subscriber-in_ports meta priority set 0x10030 accept")
-	// §8.4.6 deny (both directions).
+	// deny (both directions).
 	require.Contains(t, doc, "ip saddr @bn-restricted drop")
 	require.Contains(t, doc, "ip daddr @bn-restricted drop")
-	// §8.4.6 reply-stamp compound-key forward rule + ct mark write.
+	// reply-stamp compound-key forward rule + ct mark write.
 	require.Contains(t, doc, "ip saddr 10.4.0.0/24 ip daddr . tcp dport @bn-backfill ct mark set 0x20 meta priority set 0x10060 accept")
 	// compound set schema, no `flags interval`.
 	require.Contains(t, doc, "set bn-backfill { type ipv4_addr . inet_service; }")
@@ -184,7 +217,7 @@ func TestCreate_PersistsAndSeedsMembership(t *testing.T) {
 	require.FileExists(t, nftPath)
 	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"])
 
-	// Persisted .nft must NOT contain the membership element (§8.3.1).
+	// Persisted .nft must NOT contain the membership element.
 	onDisk, err := os.ReadFile(nftPath)
 	require.NoError(t, err)
 	require.NotContains(t, string(onDisk), "10.1.0.1/32")
@@ -267,7 +300,7 @@ func TestCreate_PreservesSiblingMembershipAcrossRerender(t *testing.T) {
 	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"])
 
 	// Creating a second, different (brand-new) policy forces a full
-	// re-render, which applies `delete table; add table` (§8.3.1) --
+	// re-render, which applies `delete table; add table` --
 	// bn-publisher's live membership must survive that, not just its
 	// rendered rule.
 	_, err = m.Create(context.Background(),
@@ -290,9 +323,8 @@ func TestCreate_SelfHealsMissingTableWithoutForce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, r.applyCount)
 
-	// Simulate `nft delete table inet weaver` (or a reboot before #780):
-	// the registry still says bn-publisher exists, but the live kernel
-	// table is gone.
+	// Simulate `nft delete table inet weaver` (or a reboot): the registry
+	// still says bn-publisher exists, but the live kernel table is gone.
 	require.NoError(t, r.Delete(context.Background()))
 
 	// Re-run WITHOUT --force, deliberately with DIFFERENT flags/cidrs: since

--- a/internal/network/policy/registry.go
+++ b/internal/network/policy/registry.go
@@ -17,8 +17,8 @@ func registryPath(dir, name string) string {
 	return filepath.Join(dir, name+".json")
 }
 
-// writeEntry atomically writes a policy's registry JSON (design §8.4.7). The
-// daemon poll loop never calls this — the registry is operator/CLI-owned.
+// writeEntry atomically writes a policy's registry JSON. The daemon poll loop
+// never calls this — the registry is operator/CLI-owned.
 func writeEntry(dir string, p *Policy) error {
 	data, err := json.MarshalIndent(p, "", "  ")
 	if err != nil {

--- a/internal/network/policy/render.go
+++ b/internal/network/policy/render.go
@@ -13,11 +13,11 @@ import (
 )
 
 // Render produces the full `inet weaver` nft document for the given set of
-// registry policies, in tier order (design §8.4.7). The same output feeds both
-// the kernel apply (`nft -f`) and the on-disk artifact, so the live table and
-// the persisted file can never diverge. Set *membership* is deliberately not
-// rendered here — only set schemas and the static `--ports` elements — because
-// membership is owned by the daemon poll loop and never persisted (§8.3.1).
+// registry policies, in tier order. The same output feeds both the kernel apply
+// (`nft -f`) and the on-disk artifact, so the live table and the persisted file
+// can never diverge. Set *membership* is deliberately not rendered here — only
+// set schemas and the static `--ports` elements — because membership is owned
+// by the daemon poll loop and never persisted.
 //
 // Rule position is determined by action type and match specificity, never by
 // creation order:
@@ -91,8 +91,8 @@ func sortedByName(policies []*Policy) []*Policy {
 }
 
 // renderSetDecls emits the schema for each policy's sets, name-sorted for a
-// deterministic render. Membership set elements are omitted (§8.3.1); only the
-// static `--ports` set carries elements.
+// deterministic render. Membership set elements are omitted; only the static
+// `--ports` set carries elements.
 func renderSetDecls(policies []*Policy) ([]string, error) {
 	var lines []string
 	for _, p := range policies {
@@ -207,7 +207,7 @@ func renderStampRule(p *Policy, podCIDR string) (string, error) {
 
 	if p.isCompoundSet() {
 		// --reply-stamp forward rule: egress, compound ip:port destination key,
-		// ct mark write for the reply restore to read back (design §8.4.6).
+		// ct mark write for the reply restore to read back.
 		reply, err := lookupClass(p.ReplyStamp)
 		if err != nil {
 			return "", err

--- a/internal/network/policy/service_linux.go
+++ b/internal/network/policy/service_linux.go
@@ -16,14 +16,13 @@ import (
 )
 
 // defaultEnsureService installs the shared network-nft unit if absent and
-// enables it for boot (design §8.4.5: "First call also … enables the systemd
-// unit"). The unit is shared with internal/network/firewall; installing it here
-// is idempotent with firewall's own install so whichever scope runs first wins.
+// enables it for boot. The unit is shared with internal/network/firewall;
+// installing it here is idempotent with firewall's own install so whichever
+// scope runs first wins.
 //
 // This package does NOT restart the unit to apply — `network policy` applies to
 // the live kernel directly via `nft -f` (Runner.Apply). The unit only matters
-// for boot replay, and extending its ExecStart to load network-weaver.nft is
-// owned by #780.
+// for boot replay.
 func defaultEnsureService(ctx context.Context) error {
 	if _, err := os.Stat(NetworkNftServiceUnitPath); err == nil {
 		return nil // already installed by firewall or a prior policy call

--- a/internal/workflows/steps/step_cilium.go
+++ b/internal/workflows/steps/step_cilium.go
@@ -317,7 +317,7 @@ func ciliumBandwidthManagerState(ctx context.Context, k *kube.Client) (enabled b
 // guardBandwidthManagerDisabled fails fast if Cilium's Bandwidth Manager is
 // enabled. Bandwidth Manager is the only Cilium BPF writer of skb->priority, so
 // the BN traffic shaper's egress-priority survival guarantee is void whenever it
-// is on (traffic-shaper v4 design §10 risk 18). It reads cilium-config through the
+// is on (its BPF writes to skb->priority void the traffic shaper's egress guarantee). It reads cilium-config through the
 // Kubernetes API (pure Go, no shell) and is read-only, so there is no rollback.
 func guardBandwidthManagerDisabled() automa.Builder {
 	return automa.NewStepBuilder().WithId("guard-bandwidth-manager-disabled").


### PR DESCRIPTION
## Description

Implements the five element verbs for `solo-provisioner network policy` — Story 1.3 of epic TS_1 (#738), building on the merged `create` verb (PR #803 / Story 1.2).

`create` renders a named policy's rules into the `inet weaver` chain and seeds initial CIDR membership. This PR adds the verbs the daemon poll loop and operators need day-to-day:

- **`add --cidr`** / **`remove --cidr`**: append or delete CIDRs from a policy's live nft set (`nft add/delete element`) under the shared apply flock — no chain re-render, no `network-weaver.nft` update (membership is never persisted).
- **`set --cidrs|--cidrs-file`**: atomic full-list replace via `flush set + add element` in a single `nft -f -` document (one kernel transaction).
- **`show --name`**: prints the policy's registry config (action, class, ports, `created_at`) and current live set membership from `nft list set inet weaver <name>`. Read-only; no lock taken.
- **`delete --name`**: re-renders the chain without the policy, snapshots and restores every remaining policy's live membership before/after the destructive `delete table; add table` apply (same pattern as `Manager.Create`), removes the registry file, and atomically overwrites `network-weaver.nft`. Last-policy service teardown is deferred to Story 1.5 (#772).

Key design decisions (so reviewers don't need to reverse-engineer them):

- **Element verbs don't touch `.nft`** — only `delete` (and `create`) do. The daemon owns set membership; `add`/`remove`/`set` are thin wrappers over `nft add/delete element` and `flush set`.
- **`delete` snapshot/restore is required** — `Render` always emits `delete table; add table`, which wipes every set in the table, not just the deleted policy's. `Manager.Delete` snapshots remaining policies' membership before `Apply` and restores it after, mirroring `Manager.Create`.
- **Last-policy behavior** — when the last policy is deleted, an empty chain (forward chain with `policy drop`, no rules) is applied and the boot oneshot is left enabled. Teardown is Story 1.5 (#772), explicitly called out in PR #803's scope boundary.

### Files changed

| File | Change |
|---|---|
| `internal/network/policy/nft.go` | Add `DeleteElements` and `SetElements` to `Runner` interface + `execRunner` implementation |
| `internal/network/policy/manager.go` | Add `Add`, `Remove`, `Set`, `Show`, `Delete` methods + `requirePolicyWithCIDRSet` / `requireTableExists` helpers |
| `internal/network/policy/manager_ops_test.go` | New: 12 unit tests covering all five new Manager methods, including compound-set (reply-stamp) policies, sibling-membership preservation on delete, and last-policy empty-chain behavior |
| `internal/network/policy/policy_test.go` | Add `DeleteElements` / `SetElements` to `fakeRunner` so it satisfies the updated `Runner` interface |
| `internal/network/policy/paths.go` | Update package doc |
| `cmd/cli/commands/network/policy/add.go` | New: `network policy add --name --cidr` verb |
| `cmd/cli/commands/network/policy/remove.go` | New: `network policy remove --name --cidr` verb |
| `cmd/cli/commands/network/policy/set.go` | New: `network policy set --name --cidrs\|--cidrs-file` verb |
| `cmd/cli/commands/network/policy/show.go` | New: `network policy show --name` verb |
| `cmd/cli/commands/network/policy/delete.go` | New: `network policy delete --name` verb |
| `cmd/cli/commands/network/policy/policy.go` | Wire five new verbs in `init()`; add `flagCIDR` shared var |
| `cmd/cli/commands/network/policy/policy_test.go` | Add `DeleteElements`/`SetElements` stubs to CLI `fakeRunner`; tests for all five verbs + updated `TestPolicyCmd_Structure` |
| `docs/quickstart.md` | Add `add`/`remove`/`set`/`show`/`delete` examples, flags tables, and behavioral notes under the policy section |

### Review guide

**Code review checklist**

- `nft.go` — `DeleteElements` uses `nft delete element inet weaver <set> { … }` piped through `nft -f -`; `SetElements` emits `flush set inet weaver <set>` followed by an `add element` line in the same document. Both follow the existing `AddElements` pattern (no bare-`nft`-on-PATH risk; binary resolved from `nftBinCandidates`).
- `manager.go:requirePolicyWithCIDRSet` — loads from the registry dir (not a stale in-memory copy), rejects `nil` (missing) and `!hasCIDRSet()` (`--from-entity world`) with distinct errors. Called under the flock for `Add`/`Remove`/`Set`, outside the lock for `Show` (consistent with `Manager.Show` being read-only).
- `manager.go:requireTableExists` — checked after the registry lookup so the error message names the policy (not a generic "table missing" without context).
- `manager.go:Delete` — snapshot runs on `remaining` (not `policies`), so the deleted policy's set is never in the restore loop. Re-validates sibling registry entries before rendering (guard against corrupt JSON, same as `Manager.Create`). `os.Remove` uses `!os.IsNotExist(err)` so a double-delete is idempotent. Decorate errors after `Apply` as "re-run to reconcile" (same convention as `Create`).
- `Show` — no lock taken; consistent with `firewall.Manager.Show`. `ListElements` returns `nil` for a missing table (see `isSetNotExistError`), displayed as `(empty)`.
- `set.go` (CLI) — reuses `resolveCIDRs` from `create.go` so `--cidrs`/`--cidrs-file` mutual-exclusion and file-parsing logic are not duplicated. An absent `--cidrs`/`--cidrs-file` yields a `nil` slice, which `Manager.Set` passes to `Runner.SetElements` as a flush-only (clear) operation.
- `delete.go` (CLI) — no `--force` flag; `delete` is always destructive by design (unlike `create`'s create-if-missing behaviour).

**Test commands**

```bash
# Unit tests (macOS OK — no Linux-only deps in internal/network/policy)
go test -race -cover -tags='!integration' ./internal/network/policy/...

# Linux cross-compile (CLI package has transitive Linux-only deps via internal/mount)
GOOS=linux GOARCH=amd64 go build ./internal/network/policy/... ./cmd/cli/commands/network/...

# Lint + license headers
task lint:check
task license:check
```

**Manual UAT (UTM VM — Debian/Ubuntu with nftables)**

1. Build and copy the binary:
   ```bash
   task build:cli GOOS=linux GOARCH=amd64
   scp bin/solo-provisioner-linux-amd64 <vm>:/usr/local/bin/solo-provisioner
   ```

   > **Daemon user note:** the daemon service runs as `weaver:weaver` (see `solo-provisioner-daemon.service`). If kubeconfig files under `/opt/solo/weaver/config/` were written by a different install step as `hedera:hedera`, fix ownership before starting the daemon or the service will fail with `permission denied`:
   > ```bash
   > sudo chown weaver:weaver /opt/solo/weaver/config/daemon*.kubeconfig
   > sudo systemctl restart solo-provisioner-daemon
   > ```

2. Create a stamp policy and a deny policy:
   ```bash
   sudo solo-provisioner network policy create --name bn-publisher \
     --ports 40840 --stamp publisher --cidrs 10.1.0.1/32 --pod-cidr 10.4.0.0/24
   sudo solo-provisioner network policy create --name bn-restricted \
     --deny --cidrs 10.99.0.0/16
   sudo nft list set inet weaver bn-publisher   # → 10.1.0.1/32
   sudo nft list set inet weaver bn-restricted  # → 10.99.0.0/16
   ```

3. **`add`**: append a second CIDR:
   ```bash
   sudo solo-provisioner network policy add --name bn-publisher --cidr 10.1.0.2/32
   sudo nft list set inet weaver bn-publisher   # → 10.1.0.1/32, 10.1.0.2/32
   ```

4. **`remove`**: remove the first:
   ```bash
   sudo solo-provisioner network policy remove --name bn-publisher --cidr 10.1.0.1/32
   sudo nft list set inet weaver bn-publisher   # → 10.1.0.2/32 only
   ```

5. **`set`**: atomic full-list replace:
   ```bash
   sudo solo-provisioner network policy set --name bn-publisher --cidrs 10.5.0.0/24
   sudo nft list set inet weaver bn-publisher   # → 10.5.0.0/24 only
   # Clear the set entirely:
   sudo solo-provisioner network policy set --name bn-publisher
   sudo nft list set inet weaver bn-publisher   # → no elements
   ```

6. **`show`**:
   ```bash
   sudo solo-provisioner network policy show --name bn-publisher
   # Expect: policy: bn-publisher / action: stamp / class: publisher / …
   ```

7. **Sibling-membership preservation on `delete`**: re-seed `bn-publisher`, then delete it and confirm `bn-restricted`'s live set survives the re-render:
   ```bash
   sudo solo-provisioner network policy add --name bn-publisher --cidr 10.5.0.0/24
   sudo solo-provisioner network policy delete --name bn-publisher
   sudo nft list set inet weaver bn-restricted  # must still show 10.99.0.0/16
   sudo nft list table inet weaver              # bn-publisher's rules gone; bn-restricted's intact
   ```

8. **Last-policy delete** — empty chain, service stays enabled:
   ```bash
   sudo solo-provisioner network policy delete --name bn-restricted
   sudo nft list table inet weaver   # forward chain exists, policy drop, no CIDR rules
   systemctl is-enabled solo-provisioner-network-nft.service   # → enabled
   ```

9. **Error paths**:
   - `add --name bn-nonexistent --cidr 10.0.0.1/32` → "not found"
   - `add --name bn-publisher --cidr 10.0.0.1/32` when table is deleted (`sudo nft delete table inet weaver`) → "policy table not found; run `network policy create`…"
   - `add --name bn-public-out --cidr 10.0.0.1/32` for a `--from-entity world` policy → "policy has no CIDR set"

**Risks / rollback**

- `SetElements` atomicity: if a CIDR is malformed, nft rejects the whole document and the set is left unchanged (the flush is rolled back). `Manager.Set` validates CIDRs via `p.validateCIDRs` before calling the Runner.
- `Delete` snapshot/restore: a `ListElements` failure aborts before `Apply` (same guard as `Create`'s `snapshotMembership`). A restore failure after `Apply` is decorated with "re-run to reconcile" — re-running `delete` is idempotent (the registry file is the source of truth; a second `delete` finds the policy missing and errors cleanly).
- Rollback: `network policy create --name <name> --force ...` restores a deleted policy. No behavior change to `firewall`, `create`, or any other command beyond the five new verbs.

**Scope boundary (epic #738)**

- **This PR:** `add` / `remove` / `set` / `show` / `delete` element verbs
- **Story 1.5 (#772):** overlap rejection, `created_at` intra-tier tiebreaker, last-policy service teardown
- **Story 1.6 (#773):** atomic on-disk rendering / boot oneshot extension

### Related Issues

* Closes #759
