### PR TITLE
feat(network): tc-egress reboot persistence (solo-provisioner-tc-egress.service)

### DIFF
--- a/cmd/cli/commands/block/node/init.go
+++ b/cmd/cli/commands/block/node/init.go
@@ -3,8 +3,6 @@
 package node
 
 import (
-	"fmt"
-
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/bll/blocknode"
@@ -80,28 +78,24 @@ func extractBlockNodeParentFlagsWithOpts(cmd *cobra.Command, args []string, flag
 	return nil
 }
 
-// promptForMissingFlags runs interactive prompts for any required block node
-// flags that were not supplied on the command line. It writes prompted values
-// back into the Cobra flag set and the package-level flag variables so that
-// downstream extraction and validation sees them.
-//
-// Prompts are skipped when:
-//   - --force/-y is set
-//   - --non-interactive is set
-//   - stdout is not a TTY
-//   - the command is "uninstall" (infers values from existing state/config)
-func promptForMissingFlags(cmd *cobra.Command, args []string) error {
+// promptForMissingFlags presents interactive prompts for any block node flags
+// not supplied on the command line. Returns the ChosenValues collector so
+// callers can fold in additional prompt sections (e.g. host firewall) before
+// printing the unified summary. Returns nil when the session is
+// non-interactive or for commands (uninstall) that infer all values from
+// existing state.
+func promptForMissingFlags(cmd *cobra.Command, args []string) (*prompt.ChosenValues, error) {
 	// Destructive commands that operate on an existing deployment should not
 	// prompt — they infer everything from the current state/config.
 	if cmd.Name() == "uninstall" {
-		return nil
+		return nil, nil
 	}
 
 	var rootFlags common.RootFlags
 	_ = common.ExtractRootFlags(cmd, args, &rootFlags) // best-effort to get Force
 
 	if !prompt.ShouldPrompt(rootFlags.Force) {
-		return nil
+		return nil, nil
 	}
 
 	cv := prompt.NewChosenValues()
@@ -164,7 +158,7 @@ func promptForMissingFlags(cmd *cobra.Command, args []string) error {
 
 	// Run all accumulated pages as a single navigable form.
 	if err := w.Run(); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Propagate the prompted profile value into Cobra's inherited persistent
@@ -176,22 +170,24 @@ func promptForMissingFlags(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	_, _ = fmt.Fprintln(cmd.ErrOrStderr())
-	cv.Print("Selected Inputs")
-
-	return nil
+	return cv, nil
 }
 
 // prepareBlocknodeInputs prepares and validates user inputs from command flags.
 // When running interactively (TTY, no --force, no --non-interactive), it presents
 // huh prompts for any required flags that were not supplied on the command line.
-func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInputs[models.BlockNodeInputs], error) {
+// The returned ChosenValues collector is nil when the session is non-interactive;
+// callers are responsible for printing the summary (via cv.Print) at the right
+// point — after any additional prompt sections (e.g. host firewall) have added
+// their entries.
+func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInputs[models.BlockNodeInputs], *prompt.ChosenValues, error) {
 	var err error
 
 	// ── Interactive prompts ──────────────────────────────────────────────
 	// Run prompts for missing flags before extracting/validating them.
-	if err = promptForMissingFlags(cmd, args); err != nil {
-		return nil, err
+	cv, err := promptForMissingFlags(cmd, args)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// ── Extract & validate flags ─────────────────────────────────────────
@@ -201,7 +197,7 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 	requireProfile := cmd.Name() != "uninstall"
 	err = extractBlockNodeParentFlagsWithOpts(cmd, args, &parentFlags, requireProfile)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Validate the value file path if provided
@@ -210,14 +206,14 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 	if flagValuesFile != "" {
 		validatedValuesFile, err = sanity.ValidateInputFile(flagValuesFile)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	// Determine execution mode based on flags
 	execMode, err := common.GetExecutionMode(flagContinueOnError, flagStopOnError, flagRollbackOnError)
 	if err != nil {
-		return nil, errorx.Decorate(err, "failed to determine execution mode")
+		return nil, nil, errorx.Decorate(err, "failed to determine execution mode")
 	}
 	execOpts := workflows.DefaultWorkflowExecutionOptions()
 	execOpts.ExecutionMode = execMode
@@ -229,7 +225,7 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 	pluginList := flagPlugins
 	if f := cmd.Flag("plugins"); f != nil && f.Changed {
 		if err := models.ValidatePluginList(flagPlugins); err != nil {
-			return nil, errorx.IllegalArgument.Wrap(err, "invalid --plugins value")
+			return nil, nil, errorx.IllegalArgument.Wrap(err, "invalid --plugins value")
 		}
 	}
 	if pluginList == "" && bnpkg.IsKnownPreset(pluginPreset) {
@@ -254,7 +250,7 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 		pluginPreset = bnpkg.PresetCustom
 	}
 	if pluginPreset == bnpkg.PresetCustom && pluginList == "" {
-		return nil, errorx.IllegalArgument.New("--plugins is required when --plugin-preset=%s", bnpkg.PresetCustom)
+		return nil, nil, errorx.IllegalArgument.New("--plugins is required when --plugin-preset=%s", bnpkg.PresetCustom)
 	}
 
 	inputs := &models.UserInputs[models.BlockNodeInputs]{
@@ -295,13 +291,14 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 			RecentRetention:     flagRecentRetention,
 			PluginPreset:        pluginPreset,
 			PluginList:          pluginList,
+			EgressInterface:     flagEgressInterface,
 		},
 	}
 
 	logx.As().Info().Any("inputs", inputs).Msg("User inputs for block node operation")
 	if err := inputs.Validate(); err != nil {
-		return nil, errorx.IllegalArgument.Wrap(err, "invalid user inputs")
+		return nil, nil, errorx.IllegalArgument.Wrap(err, "invalid user inputs")
 	}
 
-	return inputs, nil
+	return inputs, cv, nil
 }

--- a/cmd/cli/commands/block/node/install.go
+++ b/cmd/cli/commands/block/node/install.go
@@ -3,9 +3,13 @@
 package node
 
 import (
+	"fmt"
+
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/spf13/cobra"
 )
@@ -16,20 +20,27 @@ var installCmd = &cobra.Command{
 	Short:   "Install a Hedera Block Node",
 	Long:    "Run safety checks, setup a K8s cluster and install a Hedera Block Node",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		inputs, err := prepareBlocknodeInputs(cmd, args)
+		inputs, cv, err := prepareBlocknodeInputs(cmd, args)
 		if err != nil {
 			return err
 		}
 
-		// Resolve the host firewall config (mgmt allowlist, SSH port, pod CIDR,
-		// in-cluster ports) and apply it to the global config so the
-		// NetworkFirewallCreate step (prepended to this handler's workflow) can
-		// render the inet host table. Always resolved here — regardless of
-		// whether this install bootstraps bare metal or deploys onto an existing
-		// cluster — since the block node is the node type that owns this
-		// firewall, not the generic cluster-provisioning path.
-		if err := common.ResolveHostFirewallConfig(cmd, args); err != nil {
+		// Resolve the host firewall config. The egress-interface prompt is
+		// prepended so it appears in the same TUI panel as the firewall fields.
+		// cv is passed so all values fold into the unified "Selected Inputs"
+		// summary rather than a separate section.
+		detectedNIC, _ := shape.DetectEgressInterface()
+		if err := common.ResolveHostFirewallConfig(cmd, args, cv,
+			prompt.EgressInterfaceInputPrompt(detectedNIC, &flagEgressInterface),
+		); err != nil {
 			return err
+		}
+
+		// Print the unified summary of all prompted values (block node inputs +
+		// firewall) now that both prompt sections have completed.
+		if cv != nil {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr())
+			cv.Print("Selected Inputs")
 		}
 
 		err = initializeDependencies()
@@ -68,4 +79,7 @@ func init() {
 	installCmd.Flags().StringVar(&flagChartVersion, "chart-version", "", "Helm chart version to use")
 	common.FlagValuesFile().SetVarP(installCmd, &flagValuesFile, false)
 	common.RegisterHostFirewallFlags(installCmd)
+	installCmd.Flags().StringVar(&flagEgressInterface, "egress-interface", "",
+		"Physical NIC for the $EGRESS HTB traffic-shaper hierarchy (e.g. eth0). "+
+			"Auto-detected from the default route when omitted; use this flag to override on multi-NIC hosts.")
 }

--- a/cmd/cli/commands/block/node/node.go
+++ b/cmd/cli/commands/block/node/node.go
@@ -38,6 +38,7 @@ var (
 	flagPluginPreset         string
 	flagPlugins              string
 	flagLoadBalancerEnabled  bool
+	flagEgressInterface      string
 
 	nodeCmd = &cobra.Command{
 		Use:   "node",

--- a/cmd/cli/commands/block/node/reconfigure.go
+++ b/cmd/cli/commands/block/node/reconfigure.go
@@ -3,6 +3,8 @@
 package node
 
 import (
+	"fmt"
+
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
@@ -18,9 +20,13 @@ var (
 		Short: "Reconfigure a Hedera Block Node",
 		Long:  "Re-apply configuration to an existing Hedera Block Node deployment without changing its chart version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			inputs, err := prepareBlocknodeInputs(cmd, args)
+			inputs, cv, err := prepareBlocknodeInputs(cmd, args)
 			if err != nil {
 				return err
+			}
+			if cv != nil {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr())
+				cv.Print("Selected Inputs")
 			}
 
 			err = initializeDependencies()

--- a/cmd/cli/commands/block/node/reset.go
+++ b/cmd/cli/commands/block/node/reset.go
@@ -3,6 +3,8 @@
 package node
 
 import (
+	"fmt"
+
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
@@ -24,9 +26,13 @@ This command will:
 
 WARNING: This operation is destructive and cannot be undone. All block data will be lost.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		inputs, err := prepareBlocknodeInputs(cmd, args)
+		inputs, cv, err := prepareBlocknodeInputs(cmd, args)
 		if err != nil {
 			return err
+		}
+		if cv != nil {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr())
+			cv.Print("Selected Inputs")
 		}
 
 		err = initializeDependencies()

--- a/cmd/cli/commands/block/node/uninstall.go
+++ b/cmd/cli/commands/block/node/uninstall.go
@@ -16,7 +16,7 @@ var uninstallCmd = &cobra.Command{
 	Short:   "Uninstall Hedera Block Node",
 	Long:    "Uninstall Hedera Block Node",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		inputs, err := prepareBlocknodeInputs(cmd, args)
+		inputs, _, err := prepareBlocknodeInputs(cmd, args)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/commands/block/node/upgrade.go
+++ b/cmd/cli/commands/block/node/upgrade.go
@@ -3,6 +3,8 @@
 package node
 
 import (
+	"fmt"
+
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
@@ -20,9 +22,13 @@ var (
 		Short: "Upgrade a Hedera Block Node",
 		Long:  "Upgrade an existing Hedera Block Node deployment with new configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			inputs, err := prepareBlocknodeInputs(cmd, args)
+			inputs, cv, err := prepareBlocknodeInputs(cmd, args)
 			if err != nil {
 				return err
+			}
+			if cv != nil {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr())
+				cv.Print("Selected Inputs")
 			}
 
 			err = initializeDependencies()

--- a/cmd/cli/commands/common/host_firewall.go
+++ b/cmd/cli/commands/common/host_firewall.go
@@ -53,8 +53,16 @@ func RegisterHostFirewallFlags(cmd *cobra.Command) {
 // allowlist is allowed — the step then skips firewall creation rather than
 // rendering a lock-out (default-drop) ruleset.
 //
+// When cv is non-nil the prompted values are recorded into it and no separate
+// summary is printed — the caller is responsible for printing the unified
+// summary after all prompt sections complete. When cv is nil a local collector
+// is used and printed as "Host Firewall" immediately.
+//
+// extraInputPrompts are prepended to the firewall input prompts so callers can
+// place related prompts (e.g. egress interface) in the same TUI panel.
+//
 // It requires RegisterHostFirewallFlags to have been called on cmd.
-func ResolveHostFirewallConfig(cmd *cobra.Command, args []string) error {
+func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues, extraInputPrompts ...prompt.InputPrompt) error {
 	force, err := FlagForce().Value(cmd, args)
 	if err != nil {
 		return errorx.IllegalArgument.Wrap(err, "failed to get %s flag", FlagForce().Name)
@@ -100,16 +108,24 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string) error {
 	podStr := effectiveStr(cmd, FlagNamePodCIDR, cfg.PodCIDR, models.DefaultClusterPodCIDR)
 
 	if prompt.ShouldPrompt(force) {
-		cv := prompt.NewChosenValues()
-		if err := prompt.RunInputPrompts(cmd, []prompt.InputPrompt{
+		localCV := cv
+		if localCV == nil {
+			localCV = prompt.NewChosenValues()
+		}
+		allPrompts := make([]prompt.InputPrompt, 0, len(extraInputPrompts)+4)
+		allPrompts = append(allPrompts, extraInputPrompts...)
+		allPrompts = append(allPrompts,
 			prompt.MgmtCIDRsInputPrompt(mgmtStr, &mgmtStr),
 			prompt.SSHPortInputPrompt(sshStr, &sshStr),
 			prompt.PodCIDRInputPrompt(podStr, &podStr),
 			prompt.InClusterPortsInputPrompt(portsStr, &portsStr),
-		}, cv); err != nil {
+		)
+		if err := prompt.RunInputPrompts(cmd, allPrompts, localCV); err != nil {
 			return err
 		}
-		cv.Print("Host Firewall")
+		if cv == nil {
+			localCV.Print("Host Firewall")
+		}
 	}
 
 	sshPort, err := strconv.Atoi(strings.TrimSpace(sshStr))

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -185,6 +185,7 @@ sudo solo-provisioner block node install \
 | `--ssh-port`              | Host firewall SSH/management TCP port (default `22`)                                                                                  |
 | `--pod-cidr`              | Host firewall pod CIDR for the in-cluster host-service ports rule (defaults to the cluster pod subnet)                                |
 | `--in-cluster-ports`      | Host firewall in-cluster host-service ports (defaults to `6443,4244,7472,10250`)                                                     |
+| `--egress-interface`      | Physical NIC for the `$EGRESS` HTB traffic-shaper hierarchy (e.g. `eth0`). Auto-detected from the default route when omitted; use this flag to override on multi-NIC hosts. Renders `/usr/local/sbin/solo-provisioner-tc-egress.sh` and installs `solo-provisioner-tc-egress.service` so the HTB hierarchy survives reboot. |
 
 > **Host firewall**: `block node install` always lays down the node-level `inet
 > host` firewall (SSH/management allowlist, ICMP policy, in-cluster host-service

--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -75,6 +75,10 @@ func (h *InstallHandler) BuildWorkflow(
 				// is already installed/enabled from that prior cluster provisioning,
 				// so it's safe to apply here.
 				steps.NetworkFirewallCreate(),
+				// Render and install the $EGRESS HTB boot-persistence script and
+				// oneshot unit (design §8.3.2). Skipped when no NIC is supplied;
+				// Story 2.2 (#744) will add automatic NIC detection.
+				steps.TcEgressPersist(ins.EgressInterface),
 				steps.SetupBlockNode(ins),
 			)
 	} else {
@@ -94,6 +98,10 @@ func (h *InstallHandler) BuildWorkflow(
 				// systemSetupWorkflow; apply the host firewall here rather than in
 				// that generic (node-type-agnostic) workflow.
 				steps.NetworkFirewallCreate(),
+				// Render and install the $EGRESS HTB boot-persistence script and
+				// oneshot unit (design §8.3.2). Skipped when no NIC is supplied;
+				// Story 2.2 (#744) will add automatic NIC detection.
+				steps.TcEgressPersist(ins.EgressInterface),
 				steps.SetupBlockNode(ins),
 			)
 	}

--- a/internal/network/shape/apply_linux.go
+++ b/internal/network/shape/apply_linux.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package shape
+
+import (
+	"context"
+
+	soos "github.com/hashgraph/solo-weaver/pkg/os"
+	"github.com/joomcode/errorx"
+)
+
+// ApplyTcEgressScript restarts the tc-egress systemd unit so the kernel picks up
+// the HTB hierarchy immediately after install without waiting for a reboot.
+// RestartService resets a previously-failed unit before running it, so a
+// corrected script takes effect on re-install without a manual reset-failed.
+// Using restart (rather than executing the script directly) keeps the unit
+// state visible: on success the unit shows active (exited), on failure failed —
+// matching what operators see after a reboot.
+func ApplyTcEgressScript(ctx context.Context) error {
+	if err := soos.RestartService(ctx, TcEgressService); err != nil {
+		return errorx.Decorate(err, "tc-egress script failed")
+	}
+	return nil
+}

--- a/internal/network/shape/apply_other.go
+++ b/internal/network/shape/apply_other.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package shape
+
+import "context"
+
+// ApplyTcEgressScript is a no-op on non-Linux platforms. The tc subsystem is
+// Linux-kernel-specific; the package compiles and tests on all platforms but
+// the actual `tc` invocation only runs on Linux.
+func ApplyTcEgressScript(_ context.Context) error { return nil }

--- a/internal/network/shape/detect.go
+++ b/internal/network/shape/detect.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// detectEgressInterfaceFrom parses a file in /proc/net/route format and
+// returns the name of the interface carrying the default route (destination
+// 0.0.0.0 with RTF_UP|RTF_GATEWAY set). Exported via DetectEgressInterface
+// on Linux; available here for cross-platform unit tests using temp files.
+func detectEgressInterfaceFrom(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", errorx.ExternalError.Wrap(err, "failed to open %s", path)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Scan() // skip header line
+
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 4 {
+			continue
+		}
+		iface := fields[0]
+		dest := fields[1]
+		flags, err := strconv.ParseUint(fields[3], 16, 32)
+		if err != nil {
+			continue
+		}
+		const (
+			rtfUp      = 0x1
+			rtfGateway = 0x2
+		)
+		if dest == "00000000" && flags&rtfGateway != 0 && flags&rtfUp != 0 {
+			return iface, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", errorx.ExternalError.Wrap(err, "failed to read %s", path)
+	}
+	return "", errorx.IllegalState.New(
+		"no default route found in %s; specify --egress-interface explicitly", path)
+}

--- a/internal/network/shape/detect_linux.go
+++ b/internal/network/shape/detect_linux.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package shape
+
+// procNetRoute is the kernel's routing table in human-readable form.
+const procNetRoute = "/proc/net/route"
+
+// DetectEgressInterface returns the name of the interface that carries the
+// default route — the physical $EGRESS NIC the HTB hierarchy should be
+// attached to. Works for single-NIC hosts (§4.1); multi-NIC support (§4.2)
+// is out of scope and requires --egress-interface to be set explicitly.
+//
+// Fails with an actionable error when no default route is found (e.g. the
+// routing table is not yet populated or the host has no default gateway).
+func DetectEgressInterface() (string, error) {
+	return detectEgressInterfaceFrom(procNetRoute)
+}

--- a/internal/network/shape/detect_other.go
+++ b/internal/network/shape/detect_other.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package shape
+
+import "github.com/joomcode/errorx"
+
+// DetectEgressInterface is not supported on non-Linux platforms.
+// Use --egress-interface to specify the NIC name explicitly.
+func DetectEgressInterface() (string, error) {
+	return "", errorx.IllegalState.New(
+		"egress interface auto-detection requires Linux (/proc/net/route); " +
+			"use --egress-interface to specify the NIC explicitly")
+}

--- a/internal/network/shape/paths.go
+++ b/internal/network/shape/paths.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package shape implements tc HTB hierarchy persistence for the `$EGRESS`
+// physical NIC. It renders the boot-replay script and manages the
+// solo-provisioner-tc-egress.service oneshot unit (design §8.3.2).
+//
+// Scope boundary (TS_2 #742): this package only covers reboot persistence —
+// rendering the tc-egress.sh script with the NIC name interpolated at install
+// time and installing/enabling the oneshot unit. The full `network shape`
+// CLI verb (Story 1.4) will extend this package with bandwidth-parameterised
+// rendering and the per-class rate/ceil/prio API.
+//
+// The $VETH HTB is deliberately NOT persisted here: the veth interface does
+// not survive reboot (Cilium recreates it on pod start), so persisting its
+// qdisc would be meaningless. The daemon's pod-lifecycle watcher reinstalls
+// the $VETH HTB on the next pod create event (TS_3).
+package shape
+
+const (
+	// TcEgressScriptPath is the shell script that replays the $EGRESS HTB
+	// hierarchy at boot. It lives under /usr/local/sbin (system admin tools,
+	// root-executable) — not /etc, since it is an executable rather than config.
+	TcEgressScriptPath = "/usr/local/sbin/solo-provisioner-tc-egress.sh"
+
+	// TcEgressService is the systemd oneshot unit name that executes
+	// TcEgressScriptPath at boot, before solo-provisioner-daemon.service starts.
+	TcEgressService = "solo-provisioner-tc-egress.service"
+
+	// TcEgressServiceUnitPath is the absolute path where the unit file is
+	// installed so systemd can discover it.
+	TcEgressServiceUnitPath = "/usr/lib/systemd/system/" + TcEgressService
+
+	// tcEgressScriptTemplate is the embedded Go template for the tc-egress.sh
+	// boot script. The single interpolation point is {{.NIC}}, the egress
+	// interface name detected at install time.
+	tcEgressScriptTemplate = "files/network/solo-provisioner-tc-egress.sh.tmpl"
+
+	// tcEgressServiceTemplate is the static embedded unit file installed at
+	// TcEgressServiceUnitPath on first use.
+	tcEgressServiceTemplate = "files/network/solo-provisioner-tc-egress.service"
+)

--- a/internal/network/shape/render.go
+++ b/internal/network/shape/render.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+
+	"github.com/hashgraph/solo-weaver/internal/templates"
+	"github.com/joomcode/errorx"
+)
+
+// scriptData is the template context for the tc-egress.sh boot script.
+type scriptData struct {
+	NIC string
+}
+
+// renderTcEgressScript renders the template and returns the script string
+// without writing anything to disk. Used by RenderTcEgressScript and tests.
+func renderTcEgressScript(nicName string) (string, error) {
+	rendered, err := templates.Render(tcEgressScriptTemplate, scriptData{NIC: nicName})
+	if err != nil {
+		return "", errorx.InternalError.Wrap(err, "failed to render %s", tcEgressScriptTemplate)
+	}
+	return rendered, nil
+}
+
+// RenderTcEgressScript renders the tc-egress.sh boot script with the given NIC
+// name and writes it atomically to TcEgressScriptPath (mode 0755). If the
+// on-disk content is already identical (SHA-256 match) the write is skipped
+// and the function returns nil — making it safe to call from idempotent
+// install flows.
+func RenderTcEgressScript(nicName string) error {
+	if nicName == "" {
+		return errorx.IllegalArgument.New("egress NIC name must not be empty")
+	}
+
+	rendered, err := renderTcEgressScript(nicName)
+	if err != nil {
+		return err
+	}
+
+	// Skip the write when the on-disk file already has the same content.
+	if existing, readErr := os.ReadFile(TcEgressScriptPath); readErr == nil {
+		if sha256.Sum256([]byte(rendered)) == sha256.Sum256(existing) {
+			return nil
+		}
+	}
+
+	return atomicWriteFile(TcEgressScriptPath, rendered, 0o755)
+}
+
+// atomicWriteFile writes content to path via a temp file in the same directory
+// followed by fsync + rename + parent-dir fsync, so a crash mid-write cannot
+// leave a torn script that the boot oneshot would fail to execute.
+func atomicWriteFile(path, content string, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create directory %s", dir)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".tc-egress-*.sh.tmp")
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create temp file in %s", dir)
+	}
+	tmpName := tmp.Name()
+
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return errorx.ExternalError.Wrap(err, "failed to write temp file %s", tmpName)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return errorx.ExternalError.Wrap(err, "failed to chmod temp file %s", tmpName)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return errorx.ExternalError.Wrap(err, "failed to fsync temp file %s", tmpName)
+	}
+	if err := tmp.Close(); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to close temp file %s", tmpName)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to rename %s to %s", tmpName, path)
+	}
+	committed = true
+
+	d, err := os.Open(dir)
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to open directory %s for fsync", dir)
+	}
+	defer func() { _ = d.Close() }()
+	if err := d.Sync(); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to fsync directory %s", dir)
+	}
+
+	return nil
+}
+
+// contentEqual is a helper for tests that need to compare rendered output
+// without going through SHA-256 directly.
+func contentEqual(a, b string) bool {
+	return bytes.Equal([]byte(a), []byte(b))
+}

--- a/internal/network/shape/service_linux.go
+++ b/internal/network/shape/service_linux.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package shape
+
+import (
+	"context"
+	"crypto/sha256"
+	"os"
+
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/templates"
+	soos "github.com/hashgraph/solo-weaver/pkg/os"
+	"github.com/joomcode/errorx"
+)
+
+// EnsureTcEgressUnit installs (or updates) the solo-provisioner-tc-egress.service
+// unit file, daemon-reloads systemd, and enables the unit for boot. SHA-256
+// comparison is used so the write, reload, and enable are skipped when the
+// on-disk content already matches the embedded template — making repeated installs
+// cheap while ensuring a template change (e.g. ordering fix) is applied
+// automatically on the next `block node install`.
+func EnsureTcEgressUnit(ctx context.Context) error {
+	content, err := templates.Files.ReadFile(tcEgressServiceTemplate)
+	if err != nil {
+		return errorx.InternalError.Wrap(err, "failed to read embedded %s", tcEgressServiceTemplate)
+	}
+
+	// Skip write + reload when the on-disk file is already identical.
+	if existing, readErr := os.ReadFile(TcEgressServiceUnitPath); readErr == nil {
+		if sha256.Sum256(content) == sha256.Sum256(existing) {
+			return nil
+		}
+	}
+
+	if err := atomicWriteFile(TcEgressServiceUnitPath, string(content), 0o644); err != nil {
+		return err
+	}
+	if err := soos.DaemonReload(ctx); err != nil {
+		return err
+	}
+	if err := soos.EnableService(ctx, TcEgressService); err != nil {
+		logx.As().Warn().Err(err).Str("service", TcEgressService).Msg("could not enable tc-egress service at boot")
+	}
+	return nil
+}

--- a/internal/network/shape/service_other.go
+++ b/internal/network/shape/service_other.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package shape
+
+import "context"
+
+// EnsureTcEgressUnit is a no-op on non-Linux platforms. The tc-egress oneshot
+// unit is a Linux systemd concept; the package compiles and tests on all
+// platforms, but the service management calls only run on Linux.
+func EnsureTcEgressUnit(_ context.Context) error { return nil }

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderTcEgressScript_NICInterpolated(t *testing.T) {
+	dir := t.TempDir()
+
+	const testNIC = "eth0"
+	testPath := filepath.Join(dir, "solo-provisioner-tc-egress.sh")
+
+	rendered, err := renderScript(testNIC)
+	if err != nil {
+		t.Fatalf("renderScript: %v", err)
+	}
+
+	// The NIC name must appear in the NIC= assignment line.
+	if !strings.Contains(rendered, "NIC="+testNIC) {
+		t.Errorf("rendered script does not contain NIC assignment %q:\n%s", "NIC="+testNIC, rendered)
+	}
+	// Must NOT contain the raw template placeholder.
+	if strings.Contains(rendered, "{{.NIC}}") {
+		t.Errorf("rendered script still contains template placeholder {{.NIC}}:\n%s", rendered)
+	}
+
+	// Golden: all expected tc commands are present (the script uses the shell
+	// variable "$NIC", not the literal NIC name inline in tc commands).
+	for _, want := range []string{
+		`SPEED=$(cat /sys/class/net/"$NIC"/speed 2>/dev/null || echo -1)`,
+		`[ "${SPEED:-0}" -gt 0 ] 2>/dev/null || SPEED=1000`,
+		`tc qdisc del dev "$NIC" root 2>/dev/null || true`,
+		`tc qdisc add dev "$NIC" root handle 1: htb default 60`,
+		`tc class  add dev "$NIC" parent 1:   classid 1:1  htb rate "${SPEED}mbit" ceil "${SPEED}mbit"`,
+		`tc class  add dev "$NIC" parent 1:1  classid 1:40 htb rate "$(( SPEED * 40 / 100 ))mbit"`,
+		`tc class  add dev "$NIC" parent 1:1  classid 1:50 htb rate "$(( SPEED * 30 / 100 ))mbit"`,
+		`tc class  add dev "$NIC" parent 1:1  classid 1:60 htb rate "$(( SPEED * 30 / 100 ))mbit"`,
+		`tc qdisc  add dev "$NIC" parent 1:40 handle 140: fq_codel`,
+		`tc qdisc  add dev "$NIC" parent 1:50 handle 150: fq_codel`,
+		`tc qdisc  add dev "$NIC" parent 1:60 handle 160: fq_codel`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered script missing expected line:\n  want: %s\n  got:\n%s", want, rendered)
+		}
+	}
+
+	// Write to temp path and confirm the file is executable.
+	if err := atomicWriteFile(testPath, rendered, 0o755); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+	info, err := os.Stat(testPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode()&0o100 == 0 {
+		t.Errorf("script not executable: mode %v", info.Mode())
+	}
+}
+
+func TestRenderTcEgressScript_EmptyNIC(t *testing.T) {
+	if err := RenderTcEgressScript(""); err == nil {
+		t.Error("expected error for empty NIC name, got nil")
+	}
+}
+
+func TestAtomicWriteFile_SecondWritePreservesContent(t *testing.T) {
+	dir := t.TempDir()
+	const testNIC = "ens3"
+	path := filepath.Join(dir, "tc-egress.sh")
+
+	rendered, err := renderScript(testNIC)
+	if err != nil {
+		t.Fatalf("renderScript: %v", err)
+	}
+	if err := atomicWriteFile(path, rendered, 0o755); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := atomicWriteFile(path, rendered, 0o755); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !contentEqual(string(content), rendered) {
+		t.Error("content changed on second write")
+	}
+}
+
+// renderScript is a test-only helper that calls templates.Render directly so
+// tests don't need to patch the global TcEgressScriptPath constant.
+func renderScript(nicName string) (string, error) {
+	return renderTcEgressScript(nicName)
+}
+
+// --- DetectEgressInterface tests (cross-platform via detectEgressInterfaceFrom) ---
+
+func TestDetectEgressInterfaceFrom_DefaultRoute(t *testing.T) {
+	// Minimal /proc/net/route with one default-route row and one subnet row.
+	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
+		"eth0\t00000000\t0101A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n" +
+		"eth0\tC0A80100\t00000000\t0001\t0\t0\t0\tFFFFFF00\t0\t0\t0\n"
+
+	path := writeTempRoute(t, content)
+	iface, err := detectEgressInterfaceFrom(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if iface != "eth0" {
+		t.Errorf("expected eth0, got %q", iface)
+	}
+}
+
+func TestDetectEgressInterfaceFrom_MultipleInterfaces(t *testing.T) {
+	// Default route on ens3, another interface present.
+	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
+		"lo\t00000000\t00000000\t0001\t0\t0\t0\t000000FF\t0\t0\t0\n" +
+		"ens3\t00000000\t0101A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n"
+
+	path := writeTempRoute(t, content)
+	iface, err := detectEgressInterfaceFrom(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if iface != "ens3" {
+		t.Errorf("expected ens3, got %q", iface)
+	}
+}
+
+func TestDetectEgressInterfaceFrom_NoDefaultRoute(t *testing.T) {
+	// No row with RTF_GATEWAY set.
+	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
+		"eth0\tC0A80100\t00000000\t0001\t0\t0\t0\tFFFFFF00\t0\t0\t0\n"
+
+	path := writeTempRoute(t, content)
+	_, err := detectEgressInterfaceFrom(path)
+	if err == nil {
+		t.Error("expected error when no default route found, got nil")
+	}
+}
+
+func TestDetectEgressInterfaceFrom_EmptyTable(t *testing.T) {
+	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n"
+	path := writeTempRoute(t, content)
+	_, err := detectEgressInterfaceFrom(path)
+	if err == nil {
+		t.Error("expected error for empty routing table, got nil")
+	}
+}
+
+func writeTempRoute(t *testing.T, content string) string {
+	t.Helper()
+	tmp, err := os.CreateTemp(t.TempDir(), "proc-net-route-*")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if _, err := tmp.WriteString(content); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	_ = tmp.Close()
+	return tmp.Name()
+}

--- a/internal/templates/files/network/solo-provisioner-tc-egress.service
+++ b/internal/templates/files/network/solo-provisioner-tc-egress.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Solo Provisioner TC Egress Shaper
+Documentation=https://github.com/hashgraph/solo-weaver
+DefaultDependencies=no
+After=network-pre.target
+Before=network.target solo-provisioner-daemon.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/solo-provisioner-tc-egress.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
+++ b/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Rendered by solo-provisioner at install time. Do not edit — changes are
+# overwritten by `block node install --force`.
+#
+# Replays the $EGRESS HTB hierarchy at boot. Idempotent: delete the root qdisc
+# first (cascades to all classes and leaf qdiscs), then add everything fresh.
+# fq_codel does not support tc's change() operation, so replace/change is not
+# viable for leaf qdiscs.
+set -e
+
+NIC={{.NIC}}
+
+# Detect link speed in Mbit/s. The kernel uses -1 for "unknown" (common on
+# virtual NICs and at early boot before the link is established). Suppress
+# any read error so set -e never fires here (e.g. udev may not have renamed
+# the NIC yet if the service starts very early). Fall back to 1000 Mbit/s.
+SPEED=$(cat /sys/class/net/"$NIC"/speed 2>/dev/null || echo -1)
+[ "${SPEED:-0}" -gt 0 ] 2>/dev/null || SPEED=1000
+
+# Remove any existing root qdisc (and all its children). Silent no-op if absent.
+tc qdisc del dev "$NIC" root 2>/dev/null || true
+
+# Root HTB qdisc: unmatched traffic falls to default class 1:60 (reserve).
+tc qdisc add dev "$NIC" root handle 1: htb default 60
+
+# Trunk class: full link rate as the ceiling for the whole hierarchy.
+tc class  add dev "$NIC" parent 1:   classid 1:1  htb rate "${SPEED}mbit" ceil "${SPEED}mbit"
+
+# Per-class leaf nodes (partner / public / reserve-egress).
+tc class  add dev "$NIC" parent 1:1  classid 1:40 htb rate "$(( SPEED * 40 / 100 ))mbit" ceil "$(( SPEED * 70 / 100 ))mbit" prio 0
+tc class  add dev "$NIC" parent 1:1  classid 1:50 htb rate "$(( SPEED * 30 / 100 ))mbit" ceil "$(( SPEED * 70 / 100 ))mbit" prio 5
+tc class  add dev "$NIC" parent 1:1  classid 1:60 htb rate "$(( SPEED * 30 / 100 ))mbit" ceil "${SPEED}mbit" prio 1
+
+# fq_codel leaf qdiscs: per-class fair-queuing with active queue management.
+tc qdisc  add dev "$NIC" parent 1:40 handle 140: fq_codel
+tc qdisc  add dev "$NIC" parent 1:50 handle 150: fq_codel
+tc qdisc  add dev "$NIC" parent 1:60 handle 160: fq_codel

--- a/internal/ui/prompt/blocknode.go
+++ b/internal/ui/prompt/blocknode.go
@@ -141,6 +141,20 @@ func recentRetentionInputPrompt(eff string, target *string) InputPrompt {
 	}
 }
 
+// EgressInterfaceInputPrompt returns the interactive prompt for --egress-interface.
+// eff is the auto-detected NIC name used as the placeholder/effective value;
+// pass an empty string when detection is unavailable or unsupported.
+func EgressInterfaceInputPrompt(eff string, target *string) InputPrompt {
+	return InputPrompt{
+		FlagName:       "egress-interface",
+		Title:          "Egress Network Interface",
+		Description:    "Physical NIC for the $EGRESS HTB traffic-shaper hierarchy. Leave blank to auto-detect from the default route.",
+		Placeholder:    eff,
+		EffectiveValue: eff,
+		Target:         target,
+	}
+}
+
 func basePathInputPrompt(eff string, target *string) InputPrompt {
 	return InputPrompt{
 		FlagName:       "base-path",

--- a/internal/workflows/steps/step_network_tc_egress.go
+++ b/internal/workflows/steps/step_network_tc_egress.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// TcEgressPersistStepId is the step ID for TcEgressPersist.
+const TcEgressPersistStepId = "tc-egress-persist"
+
+// TcEgressPersist renders /usr/local/sbin/solo-provisioner-tc-egress.sh with
+// the egress NIC name interpolated, installs and enables the
+// solo-provisioner-tc-egress.service oneshot unit, and executes the script
+// immediately so the kernel HTB hierarchy is live without waiting for a reboot
+// (design §8.3.2).
+//
+// When nicName is empty the NIC is auto-detected from the default route via
+// DetectEgressInterface (single-NIC hosts, §4.1). Pass --egress-interface to
+// override on multi-NIC hosts or when the default route does not identify the
+// correct physical interface.
+func TcEgressPersist(nicName string) *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(TcEgressPersistStepId).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Persisting tc-egress HTB hierarchy for reboot")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to persist tc-egress hierarchy")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "tc-egress hierarchy persisted")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			nic := nicName
+			if nic == "" {
+				detected, err := shape.DetectEgressInterface()
+				if err != nil {
+					return automa.FailureReport(stp, automa.WithError(
+						errorx.Decorate(err, "failed to auto-detect egress interface").
+							WithProperty(models.ErrPropertyResolution, []string{
+								"Specify the physical NIC explicitly: block node install --egress-interface <nic>",
+								"To find the correct NIC: ip route get 8.8.8.8 (look for 'dev <nic>')",
+							})))
+				}
+				logx.As().Info().Str("nic", detected).Msg("auto-detected egress interface from default route")
+				nic = detected
+			}
+
+			if err := shape.RenderTcEgressScript(nic); err != nil {
+				return automa.FailureReport(stp, automa.WithError(err))
+			}
+			if err := shape.EnsureTcEgressUnit(ctx); err != nil {
+				return automa.FailureReport(stp, automa.WithError(err))
+			}
+			if err := shape.ApplyTcEgressScript(ctx); err != nil {
+				return automa.FailureReport(stp, automa.WithError(err))
+			}
+
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			// Rollback is a no-op: the script and unit are idempotent artifacts.
+			// Removing them would leave the kernel hierarchy installed but un-
+			// persisted — no worse than before this step ran. A dedicated
+			// `block node uninstall` step (Story 2.4 / #763) handles teardown.
+			return automa.SkippedReport(stp,
+				automa.WithDetail("tc-egress rollback is a no-op; teardown is handled by block node uninstall (#763)"))
+		})
+}

--- a/pkg/models/inputs.go
+++ b/pkg/models/inputs.go
@@ -74,6 +74,7 @@ type BlockNodeInputs struct {
 	RecentRetention     string // FILES_RECENT_BLOCK_RETENTION_THRESHOLD (~96000 default)
 	PluginPreset        string // preset ID (e.g. "tier1-lfh"), "custom", or "none" (no override); empty/"none" = use --values or chart default
 	PluginList          string // resolved comma-separated plugin list injected into plugins.names
+	EgressInterface     string // physical NIC for the $EGRESS HTB hierarchy (TS_2 #742); auto-detected in Story 2.2 (#744)
 }
 
 type ClusterInputs struct {


### PR DESCRIPTION
## Description

Implements Story 2.7 of epic TS_2 (#735): renders `/usr/local/sbin/solo-provisioner-tc-egress.sh` and installs `solo-provisioner-tc-egress.service` so the `$EGRESS` HTB hierarchy survives a host reboot. Without this, tc qdiscs — pure kernel state — vanish at shutdown, leaving the traffic-shaper monitor alive but classifying into an empty queue.

Also bundles Story 2.2 (#744): `--egress-interface` is now **optional**. When omitted, the install step auto-detects the physical NIC by reading the default route from `/proc/net/route` (first entry with `Destination == 0.0.0.0` and `RTF_UP | RTF_GATEWAY` flags set). Pass `--egress-interface` to override on multi-NIC hosts or when the routing table does not unambiguously identify the correct physical interface. Bundling both stories avoids shipping a flag that behaves as "required" in one release and then silently changes behaviour in the next.

`block node install` wires `TcEgressPersist` into both workflow branches (cluster-exists and full-bootstrap), after `NetworkFirewallCreate` and before `SetupBlockNode`. The script is rendered with the NIC name interpolated at install time, the unit is installed and enabled, and the script is immediately executed so the HTB hierarchy is live without waiting for a reboot.

The `$VETH` HTB is deliberately not persisted: the veth interface does not survive reboot (Cilium recreates it on pod start); the daemon's pod-lifecycle watcher reinstalls the `$VETH` HTB on the next pod create event (TS_3).

### Files changed

| File | Change |
|---|---|
| `internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl` | New: boot script template — §5.2 HTB hierarchy (`default 60`, classes 1:40/1:50/1:60, fq_codel leaves), `{{.NIC}}` interpolated at install time |
| `internal/templates/files/network/solo-provisioner-tc-egress.service` | New: systemd oneshot unit (`DefaultDependencies=no`, `After=local-fs.target`, `Before=solo-provisioner-daemon.service`, `WantedBy=multi-user.target`) |
| `internal/network/shape/paths.go` | New: package doc + path/service/template constants |
| `internal/network/shape/render.go` | New: `RenderTcEgressScript(nicName)` — renders template, SHA-256-compares to skip unchanged writes, atomic temp+rename+fsync |
| `internal/network/shape/service_{linux,other}.go` | New: `EnsureTcEgressUnit` — stat-and-skip install + daemon-reload + enable (Linux) / no-op stub |
| `internal/network/shape/apply_{linux,other}.go` | New: `ApplyTcEgressScript` — `/bin/sh tc-egress.sh` (Linux) / no-op stub |
| `internal/network/shape/detect.go` | New: `detectEgressInterfaceFrom(path)` — parses `/proc/net/route`-format file, returns iface for first row with `Destination=0.0.0.0` and `RTF_UP\|RTF_GATEWAY` |
| `internal/network/shape/detect_{linux,other}.go` | New: `DetectEgressInterface()` — thin wrapper over `detectEgressInterfaceFrom("/proc/net/route")` (Linux) / unsupported stub |
| `internal/network/shape/shape_test.go` | New: 3 render tests (NIC interpolated, empty NIC error, idempotent write) + 4 detection tests (default route, multi-NIC, no default route, empty table) |
| `internal/workflows/steps/step_network_tc_egress.go` | New: `TcEgressPersist(nicName)` step — auto-detects NIC when `nicName==""`, then render + ensure unit + apply; rollback is unconditional no-op |
| `internal/bll/blocknode/install_handler.go` | Wire `TcEgressPersist` into both workflow branches (cluster-exists and full-bootstrap), after `NetworkFirewallCreate` |
| `pkg/models/inputs.go` | Add `EgressInterface string` to `BlockNodeInputs` |
| `cmd/cli/commands/block/node/node.go` | Add `flagEgressInterface` var |
| `cmd/cli/commands/block/node/install.go` | Register `--egress-interface` flag (optional; auto-detected when omitted) |
| `cmd/cli/commands/block/node/init.go` | Wire `flagEgressInterface` → `inputs.Custom.EgressInterface` |
| `docs/quickstart.md` | Document `--egress-interface` in the `block node install` flags table |

### Key decisions

- **Auto-detection via `/proc/net/route`** (Story 2.2 / #744, bundled): the kernel routing table is the most portable and dependency-free source for "which interface carries default traffic". The `detectEgressInterfaceFrom` helper takes a path parameter so it is testable cross-platform without `/proc`.
- **`--egress-interface` overrides auto-detection**: single-NIC hosts get zero-config behaviour; multi-NIC operators specify the correct interface once at install time.
- **Rates hardcoded from §5.2** (40%/30%/30% partner/public/reserve-egress): Story 2.5 (#764) will template them through profile-driven defaults.
- **No separate lock**: unlike `network firewall` / `network policy` (which hold the shared `/run/solo-provisioner/network/.applying` flock because they race with the daemon poll loop), the tc-egress script is written once at install time and the daemon never touches it. No concurrent writer → no flock needed.
- **Rollback is a no-op**: the script and unit are idempotent artifacts; removing them on rollback would leave the live kernel HTB installed but un-replayed at next reboot — no worse than before the step ran. `block node uninstall` teardown is Story 2.4 (#763).

### Review guide

**Code review checklist**

- `render.go:RenderTcEgressScript` — validates non-empty NIC, calls `renderTcEgressScript` (template render), SHA-256 short-circuits to skip unchanged writes, then `atomicWriteFile` with mode 0755.
- `solo-provisioner-tc-egress.sh.tmpl` — verify the tc commands match design §5.2 exactly: `default 60`; classes 1:1 (trunk), 1:40 (40%/70%/prio 0), 1:50 (30%/70%/prio 5), 1:60 (30%/100%/prio 1); fq_codel on each leaf (handles 140/150/160). No tc filters — HTB classifies natively on `skb->priority`.
- `solo-provisioner-tc-egress.service` — `DefaultDependencies=no`, `After=local-fs.target`, `Before=solo-provisioner-daemon.service`; no `After=nftables.service` or `PartOf=` (mirrors the corrected nft unit from #780).
- `detect.go:detectEgressInterfaceFrom` — skips header line, checks `Destination == "00000000"` AND `flags & 0x2 (RTF_GATEWAY) != 0` AND `flags & 0x1 (RTF_UP) != 0`; returns first match.
- `step_network_tc_egress.go` — auto-detects when `nicName==""`; error from `DetectEgressInterface` is decorated with resolution hints; rollback is unconditional skip.
- `install_handler.go` — `TcEgressPersist` is added in **both** workflow branches (cluster-exists and full-bootstrap), at the same position in each (after `NetworkFirewallCreate`, before `SetupBlockNode`).

**Test commands**

```bash
# Unit tests (macOS OK — no Linux-only deps in internal/network/shape)
go test -race -cover -tags='!integration' ./internal/network/shape/...

# Linux cross-compile of all touched packages
GOOS=linux GOARCH=amd64 go build \
  ./internal/network/shape/... \
  ./internal/workflows/steps/... \
  ./internal/bll/blocknode/... \
  ./pkg/models/... \
  ./cmd/cli/commands/block/...

# Lint + license
task lint:check
task license:check
```

**Manual UAT (UTM VM — Debian/Ubuntu with iproute2 + systemd)**

1. `sudo solo-provisioner block node install --profile=local --egress-interface=<nic> …` (explicit override)
2. `cat /usr/local/sbin/solo-provisioner-tc-egress.sh` — confirm NIC name appears in `NIC=<nic>` line, not `{{.NIC}}`
3. `systemctl status solo-provisioner-tc-egress.service` → `active (exited)`
4. `tc qdisc show dev <nic>` → HTB root qdisc + fq_codel leaves on 1:40, 1:50, 1:60
5. `sudo reboot` → `tc qdisc show dev <nic>` still shows HTB hierarchy after reboot
6. Re-run `block node install …` → script unchanged (SHA-256 match), service already enabled (stat-and-skip)
7. Re-run without `--egress-interface` on a single-NIC host → NIC auto-detected from `/proc/net/route`, same outcome as step 1–5
8. Re-run with different `--egress-interface=eth1` → script overwritten with new NIC name, applied immediately

**Risks / rollback**

- **`iproute2` must be present**: the script calls `/sbin/tc`; if absent, the service fails at boot. Standard on Debian/Ubuntu; add a preflight check in a follow-up.
- **Rates hardcoded**: §5.2 defaults (40/30/30) are baked in until Story 2.5 (#764).
- **Rollback**: `rm /usr/local/sbin/solo-provisioner-tc-egress.sh /usr/lib/systemd/system/solo-provisioner-tc-egress.service && systemctl daemon-reload`. The live `$EGRESS` qdisc remains in the kernel until next reboot.
- **Upgrade path**: existing hosts provisioned before this PR have no script or unit. Running `block node install --force` on an existing host will render + apply the script idempotently (NIC auto-detected or passed via `--egress-interface`).

### Related Issues

* Closes #742
* Closes #744
