### PR TITLE
feat(alloy): add workflow phases, error-control flags, and cluster gate to alloy cluster

### DIFF
--- a/cmd/cli/commands/alloy/cluster/cluster.go
+++ b/cmd/cli/commands/alloy/cluster/cluster.go
@@ -8,6 +8,11 @@ import (
 )
 
 var (
+	// Error-control flags (persistent → apply to both install and uninstall)
+	flagStopOnError     bool
+	flagRollbackOnError bool
+	flagContinueOnError bool
+
 	// Alloy configuration flags
 	flagMonitorBlockNode   bool
 	flagClusterName        string
@@ -32,6 +37,17 @@ var (
 )
 
 func init() {
+	// Error-control flags (persistent on the cluster command, so both install and
+	// uninstall inherit them — mirrors the block node pattern in block/node/node.go).
+	common.FlagStopOnError().SetVarP(clusterCmd, &flagStopOnError, false)
+	common.FlagRollbackOnError().SetVarP(clusterCmd, &flagRollbackOnError, false)
+	common.FlagContinueOnError().SetVarP(clusterCmd, &flagContinueOnError, false)
+	clusterCmd.MarkFlagsMutuallyExclusive(
+		common.FlagStopOnError().Name,
+		common.FlagContinueOnError().Name,
+		common.FlagRollbackOnError().Name,
+	)
+
 	// Core configuration flags
 	common.FlagClusterName().SetVarP(clusterCmd, &flagClusterName, false)
 	common.FlagMonitorBlockNode().SetVarP(clusterCmd, &flagMonitorBlockNode, false)

--- a/cmd/cli/commands/alloy/cluster/install.go
+++ b/cmd/cli/commands/alloy/cluster/install.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/workflows"
-	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
 	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 )
@@ -100,7 +99,14 @@ Examples:
 			l.Warn().Msg("--prometheus-url, --prometheus-username, --loki-url, and --loki-username flags are deprecated; please use --add-prometheus-remote and --add-loki-remote instead")
 		}
 
-		wb := workflows.NewAlloyInstallWorkflow()
+		execMode, err := common.GetExecutionMode(flagContinueOnError, flagStopOnError, flagRollbackOnError)
+		if err != nil {
+			return err
+		}
+		opts := workflows.DefaultWorkflowExecutionOptions()
+		opts.ExecutionMode = execMode
+
+		wb := workflows.WithWorkflowExecutionMode(workflows.NewAlloyInstallWorkflow(), opts)
 
 		if err := common.RunWorkflowBuilder(cmd.Context(), wb); err != nil {
 			return err
@@ -110,6 +116,3 @@ Examples:
 		return nil
 	},
 }
-
-// Verify that the required step functions are accessible
-var _ = steps.SetupAlloyStack

--- a/cmd/cli/commands/alloy/cluster/uninstall.go
+++ b/cmd/cli/commands/alloy/cluster/uninstall.go
@@ -18,7 +18,14 @@ var uninstallCmd = &cobra.Command{
 			Strs("args", args).
 			Msg("Uninstalling Alloy observability stack")
 
-		wb := workflows.NewAlloyUninstallWorkflow()
+		execMode, err := common.GetExecutionMode(flagContinueOnError, flagStopOnError, flagRollbackOnError)
+		if err != nil {
+			return err
+		}
+		opts := workflows.DefaultWorkflowExecutionOptions()
+		opts.ExecutionMode = execMode
+
+		wb := workflows.WithWorkflowExecutionMode(workflows.NewAlloyUninstallWorkflow(), opts)
 
 		if err := common.RunWorkflowBuilder(cmd.Context(), wb); err != nil {
 			return err

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -660,6 +660,14 @@ sudo solo-provisioner alloy cluster install \
 | `--prometheus-username`   | Prometheus authentication username *(deprecated)*                                                                                 |
 | `--loki-url`              | Loki remote write URL *(deprecated: use `--add-loki-remote`)*                                                                     |
 | `--loki-username`         | Loki authentication username *(deprecated)*                                                                                       |
+| `--stop-on-error`         | Stop execution on first error (default behaviour when no execution-mode flag is set)                                             |
+| `--rollback-on-error`     | Rollback executed steps on error                                                                                                 |
+| `--continue-on-error`     | Continue executing steps even if some steps fail                                                                                 |
+
+> **Note**: `--stop-on-error`, `--rollback-on-error`, and `--continue-on-error` are mutually exclusive and apply to
+> both `alloy cluster install` and `alloy cluster uninstall`. When Alloy fails to install because the Kubernetes
+> cluster is not reachable, install the cluster first with `solo-provisioner kube cluster install` — Alloy deploys
+> into an existing cluster and does not create one.
 
 > **Note**: Passwords must be pre-created in a K8s Secret named `grafana-alloy-secrets` in the `grafana-alloy`
 > namespace. The secret can be created manually, via ESO, Terraform, or any other mechanism.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -660,7 +660,7 @@ sudo solo-provisioner alloy cluster install \
 | `--prometheus-username`   | Prometheus authentication username *(deprecated)*                                                                                 |
 | `--loki-url`              | Loki remote write URL *(deprecated: use `--add-loki-remote`)*                                                                     |
 | `--loki-username`         | Loki authentication username *(deprecated)*                                                                                       |
-| `--stop-on-error`         | Stop execution on first error (default behaviour when no execution-mode flag is set)                                             |
+| `--stop-on-error`         | Stop execution on first error (default behavior when no execution-mode flag is set)                                             |
 | `--rollback-on-error`     | Rollback executed steps on error                                                                                                 |
 | `--continue-on-error`     | Continue executing steps even if some steps fail                                                                                 |
 

--- a/internal/workflows/steps/step_alloy.go
+++ b/internal/workflows/steps/step_alloy.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	SetupAlloyStepId                = "setup-alloy"
+	PreflightAlloyPhaseId           = "preflight-alloy"
 	PreCheckAlloyStepId             = "precheck-alloy"
 	InstallAlloyStepId              = "install-alloy"
 	InstallNodeExporterStepId       = "install-node-exporter"
@@ -40,22 +41,16 @@ const (
 // This includes Prometheus Operator CRDs and Grafana Alloy.
 // K8s secrets containing passwords for remote endpoints must be pre-created before running this.
 // Secrets can be created manually, via ESO/Vault, Terraform, or any other mechanism.
+//
+// It is a bare container that composes three top-level phases, each of which emits
+// phase-level TUI progress (see PreflightAlloy, SetupPrometheusOperatorCRDs, SetupAlloy).
+// Mirrors InstallClusterWorkflow in internal/workflows/cluster.go.
 func SetupAlloyStack() *automa.WorkflowBuilder {
 	return automa.NewWorkflowBuilder().WithId("setup-alloy-stack").Steps(
-		preCheckAlloy(),               // Verify prerequisites (K8s secrets, remote endpoints)
-		SetupPrometheusOperatorCRDs(), // Install CRDs for ServiceMonitor/PodMonitor
-		SetupAlloy(),                  // Install Alloy with Node Exporter
-	).
-		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
-			notify.As().StepStart(ctx, stp, "Setting up Alloy observability stack")
-			return ctx, nil
-		}).
-		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepFailure(ctx, stp, rpt, "Failed to setup Alloy observability stack")
-		}).
-		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepCompletion(ctx, stp, rpt, "Alloy observability stack setup successfully")
-		})
+		PreflightAlloy(),              // Phase 1: verify prerequisites (cluster reachable, K8s secrets, remotes)
+		SetupPrometheusOperatorCRDs(), // Phase 2: install CRDs for ServiceMonitor/PodMonitor
+		SetupAlloy(),                  // Phase 3: install Alloy with Node Exporter
+	)
 }
 
 // TeardownAlloyStack returns a workflow builder that tears down the complete Alloy observability stack.
@@ -78,8 +73,28 @@ func TeardownAlloyStack() *automa.WorkflowBuilder {
 		})
 }
 
+// PreflightAlloy returns the preflight phase for the Alloy install workflow.
+// It wraps the preCheckAlloy prerequisite check as a top-level, phase-level builder so
+// the TUI renders it as a named phase boundary (mirrors SetupBlockNode's phase pattern).
+func PreflightAlloy() *automa.WorkflowBuilder {
+	return automa.NewWorkflowBuilder().WithId(PreflightAlloyPhaseId).Steps(
+		preCheckAlloy(),
+	).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().PhaseStart(ctx, stp, "Preflight Checks")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().PhaseFailure(ctx, stp, rpt, "Preflight Checks")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().PhaseCompletion(ctx, stp, rpt, "Preflight Checks")
+		})
+}
+
 // preCheckAlloy verifies that all prerequisites are in place before installing Alloy.
-// This includes verifying that required K8s secrets exist and that remote endpoints are reachable.
+// This includes verifying that the Kubernetes cluster is reachable, that required K8s
+// secrets exist, and that remote endpoints are reachable.
 func preCheckAlloy() automa.Builder {
 	spec := chartSpec("alloy")
 	return automa.NewStepBuilder().WithId(PreCheckAlloyStepId).
@@ -88,6 +103,31 @@ func preCheckAlloy() automa.Builder {
 			l := logx.As()
 
 			meta := map[string]string{}
+
+			// Fail fast if the Kubernetes cluster is not reachable. Alloy is a
+			// deploy-into-existing-cluster command (like teleport cluster) — it does not
+			// bootstrap the cluster. Without this gate a missing/unreachable cluster only
+			// surfaces later as a cryptic Helm "Kubernetes cluster unreachable" error.
+			clusterExists, err := kube.ClusterExists()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(
+					errorx.ExternalError.Wrap(err, "failed to probe Kubernetes cluster reachability").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Ensure the cluster is installed and its API server is reachable:",
+							"  solo-provisioner kube cluster install",
+							"  kubectl cluster-info",
+						})))
+			}
+			if !clusterExists {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(
+					errorx.IllegalState.New("Kubernetes cluster is not reachable").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Install/verify the cluster before installing Alloy:",
+							"  solo-provisioner kube cluster install",
+							"Confirm the API server is reachable:",
+							"  kubectl cluster-info",
+						})))
+			}
 
 			// Check if any remotes are configured
 			hasRemotes := len(cfg.PrometheusRemotes) > 0 || len(cfg.LokiRemotes) > 0 ||
@@ -212,14 +252,14 @@ func SetupAlloy() *automa.WorkflowBuilder {
 		isAlloyPodsReady(),
 	).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
-			notify.As().StepStart(ctx, stp, "Setting up Grafana Alloy")
+			notify.As().PhaseStart(ctx, stp, "Alloy Deployment")
 			return ctx, nil
 		}).
 		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepFailure(ctx, stp, rpt, "Failed to setup Grafana Alloy")
+			notify.As().PhaseFailure(ctx, stp, rpt, "Alloy Deployment")
 		}).
 		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepCompletion(ctx, stp, rpt, "Grafana Alloy setup successfully")
+			notify.As().PhaseCompletion(ctx, stp, rpt, "Alloy Deployment")
 		})
 }
 

--- a/internal/workflows/steps/step_prometheus_operator_crds.go
+++ b/internal/workflows/steps/step_prometheus_operator_crds.go
@@ -28,14 +28,14 @@ func SetupPrometheusOperatorCRDs() *automa.WorkflowBuilder {
 		isPrometheusOperatorCRDsReady(),
 	).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
-			notify.As().StepStart(ctx, stp, "Setting up Prometheus Operator CRDs")
+			notify.As().PhaseStart(ctx, stp, "Prometheus Operator CRDs")
 			return ctx, nil
 		}).
 		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepFailure(ctx, stp, rpt, "Failed to setup Prometheus Operator CRDs")
+			notify.As().PhaseFailure(ctx, stp, rpt, "Prometheus Operator CRDs")
 		}).
 		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepCompletion(ctx, stp, rpt, "Prometheus Operator CRDs setup successfully")
+			notify.As().PhaseCompletion(ctx, stp, rpt, "Prometheus Operator CRDs")
 		})
 }
 


### PR DESCRIPTION
## Summary

Brings `alloy cluster install` / `uninstall` in line with the workflow conventions already used by `block node` and `teleport cluster`. Three things change:

1. The install workflow is restructured into three **named, phase-level** builders so the TUI renders phase boundaries: **Preflight Checks → Prometheus Operator CRDs → Alloy Deployment**.
2. Standard error-control flags — `--stop-on-error` / `--rollback-on-error` / `--continue-on-error` — are added as **persistent** flags on `alloy cluster` (inherited by both `install` and `uninstall`, mutually exclusive) and wired into the workflow execution mode.
3. A **fail-fast cluster-reachability gate** is added to the preflight phase, so a missing/unreachable cluster fails early with an actionable resolution instead of a cryptic Helm error deep in the run.

Alloy remains a deploy-into-existing-cluster command (like `teleport cluster`); it deliberately does **not** bootstrap the cluster — only `block node` / `kube cluster` do that.

Closes #445.

## Problem

`alloy cluster install`/`uninstall` called `common.RunWorkflowBuilder` on a flat, unphased builder. Operators had no way to control error handling, the TUI showed no phase boundaries, and — most visibly — running `install` with no cluster present failed late inside the Prometheus-CRD Helm step with an error that gave no actionable next step:

```
✗ Setting up Prometheus Operator CRDs
✗ Installing Prometheus Operator CRDs
    common.internal_error: failed to get release status, cause: Kubernetes cluster unreachable: Get "http://localhost:8080/version": dial tcp [::1]:8080: connect: connection refused

Error: common.internal_error: failed to get release status, cause: Kubernetes cluster unreachable: ...
  Resolution:
    1. Check error message for details or contact support
```

The prerequisite check (`preCheckAlloy`) only touched the cluster when remotes were configured, so an install with no remotes did zero cluster verification and sailed straight into the failing Helm step.

## Design notes

- **Three phase-level builders.** `PreflightAlloy()` (new), `SetupPrometheusOperatorCRDs()`, and `SetupAlloy()` now emit `PhaseStart`/`PhaseFailure`/`PhaseCompletion` (previously step-level `StepStart`). Their leaf steps keep emitting `StepStart`, giving the phase→step nesting the TUI renders — the same pattern as `SetupBlockNode` and `KubernetesSetupWorkflow`.
- **`SetupAlloyStack()` is now a bare container** composing the three phases, with no `WithPrepare`/`WithOnFailure`/`WithOnCompletion` wrapper of its own (mirrors `InstallClusterWorkflow`). This avoids a spurious step line wrapping the phases.
- **`PreflightAlloy()` wraps the existing `preCheckAlloy` leaf** as a phase, so the single check step gets a named phase boundary without duplicating its logic.
- **Fail-fast gate uses `kube.ClusterExists()`** (kubeconfig presence + a 3s API probe; already used by `uninstallTeleportKubeAgent`) at the **top** of `preCheckAlloy`, *before* the `hasRemotes` branch, so it runs even with zero remotes. `ClusterExists()` returns `(false, nil)` on unreachable, so the `!clusterExists` branch is the gate. Both failure paths attach `models.ErrPropertyResolution` hints per the repo convention.
- **Execution mode wiring reuses the shared helpers.** Both commands call `common.GetExecutionMode(continue, stop, rollback)` and wrap the workflow with `workflows.WithWorkflowExecutionMode(...)` — the same path `teleport cluster install` uses.
- **Flags are persistent on the `cluster` command** (via `SetVarP`, which registers on `PersistentFlags()`), so both subcommands inherit them, and `MarkFlagsMutuallyExclusive` enforces exactly-one — matching `block node`.
- **Uninstall keeps step-level output** (not restructured into phases): the issue's phase diagram is install-only, and only the flags are required on uninstall.

## Changed files

| File | Change |
|------|--------|
| `internal/workflows/steps/step_alloy.go` | New `PreflightAlloy()` phase builder + `PreflightAlloyPhaseId`; fail-fast `kube.ClusterExists()` gate in `preCheckAlloy`; `SetupAlloy` emits phase-level notifications; `SetupAlloyStack` is now a bare container composing the three phases |
| `internal/workflows/steps/step_prometheus_operator_crds.go` | `SetupPrometheusOperatorCRDs` emits phase-level (`PhaseStart`/`PhaseFailure`/`PhaseCompletion`) notifications |
| `cmd/cli/commands/alloy/cluster/cluster.go` | Add `--stop-on-error` / `--rollback-on-error` / `--continue-on-error` as persistent, mutually-exclusive flags |
| `cmd/cli/commands/alloy/cluster/install.go` | Wire `GetExecutionMode` + `WithWorkflowExecutionMode`; drop the stale `var _ = steps.SetupAlloyStack` compile-check and its now-unused import |
| `cmd/cli/commands/alloy/cluster/uninstall.go` | Same execution-mode wiring |
| `docs/quickstart.md` | Document the three flags in the alloy install flag table + notes on mutual exclusion and the cluster gate |

## Review checklist

- [x] Flags are registered on `clusterCmd` via `SetVarP` (PersistentFlags) so **both** install and uninstall inherit them; `MarkFlagsMutuallyExclusive` covers all three.
- [x] `install.go`/`uninstall.go` set `opts.ExecutionMode` from `GetExecutionMode(continue, stop, rollback)` and wrap via `WithWorkflowExecutionMode`.
- [x] The `kube.ClusterExists()` gate runs **before** the `hasRemotes` branch in `preCheckAlloy`, so it fires even with no remotes.
- [x] Both gate failure paths attach `models.ErrPropertyResolution` hints.
- [x] The three phase builders emit `PhaseStart`/`PhaseFailure`/`PhaseCompletion`; their leaf steps still emit `StepStart` (correct phase→step nesting).
- [x] `SetupAlloyStack` no longer has its own `WithPrepare`/`WithOnFailure`/`WithOnCompletion` wrapper.
- [x] `SetupPrometheusOperatorCRDs`/`SetupAlloy` are reached only via the alloy install path (no other workflow regresses to phase-level output).

## Tests run

```bash
task lint                                                               # 0 issues (golangci-lint)
GOOS=linux GOARCH=amd64 go build ./cmd/cli/... ./internal/workflows/... # compiles
GOOS=linux go vet ./cmd/cli/commands/alloy/... ./internal/workflows/steps/...  # clean (also typechecks tests)
```

No new unit tests were added (the change is workflow composition + flag/exec-mode wiring); the existing `parse_remote_test.go` is unaffected. Full unit suite runs in the UTM VM (Linux-only `internal/mount`):

```bash
task vm:test:unit
```

## Manual UAT

Run inside the UTM VM (Ubuntu). Binary built via `task build:cli GOOS=linux GOARCH=amd64` → `./bin/solo-provisioner-linux-amd64` (shown as `$BIN` below).

### UAT-1 — Error-control flags present on both subcommands

```bash
$BIN alloy cluster install --help
$BIN alloy cluster uninstall --help
```

Expected: both list `--stop-on-error`, `--rollback-on-error`, and `--continue-on-error` (inherited from the `cluster` command), alongside the existing alloy flags.

### UAT-2 — Flags are mutually exclusive

```bash
$BIN alloy cluster install --stop-on-error --continue-on-error
```

Expected: exits non-zero with a cobra error, e.g.:

```
Error: if any flags in the group [stop-on-error rollback-on-error continue-on-error] are set none of the others can be; [continue-on-error stop-on-error] were all set
```

### UAT-3 — Fail-fast cluster gate when no cluster is present (the original repro)

On a host with **no** Kubernetes cluster (or an unreachable API server):

```bash
sudo $BIN alloy cluster install
```

Expected: fails in the **Preflight Checks** phase (not the CRD Helm step) with an actionable resolution — instead of the old cryptic `dial localhost:8080` + "contact support":

```
✗ Preflight Checks
✗ Checking Alloy prerequisites
    common.illegal_state: Kubernetes cluster is not reachable

  Resolution:
    1. Install/verify the cluster before installing Alloy:
    2.   solo-provisioner kube cluster install
    3. Confirm the API server is reachable:
    4.   kubectl cluster-info
```

The gate fires even with **no remotes** configured (previously the only cluster contact happened inside the `hasRemotes` branch).

### UAT-4 — Named phase boundaries render (cluster present)

On a host with a healthy cluster and the `grafana-alloy-secrets` secret pre-created (or with no remotes):

```bash
sudo $BIN alloy cluster install --cluster-name=my-cluster
```

Expected: the TUI shows three named phases in order —

```
✓ Preflight Checks
✓ Prometheus Operator CRDs
✓ Alloy Deployment
Successfully installed Alloy observability stack
```

In `--non-interactive` mode the same three phase names appear as phase-start/-completion log lines.

### UAT-5 — `--rollback-on-error` rolls back completed phases (verified in VM)

The failure must land **after** Preflight so there is something to roll back. Note that a missing secret *or* an unreachable remote is caught inside the Preflight phase (`preCheckAlloy` validates cluster reachability → secret presence → remote reachability), so those cannot be used — they fail before any phase completes. Instead, let Preflight pass and inject a fault into the **Alloy Deployment** phase by pre-creating the Alloy config ConfigMap (`grafana-alloy-cm`) as **immutable**, so `deployAlloyConfig`'s apply is rejected:

```bash
# Preflight passes: secret present + a reachable remote (example.com answers HEAD)
kubectl create namespace grafana-alloy 2>/dev/null || true
kubectl -n grafana-alloy create secret generic grafana-alloy-secrets \
  --from-literal=PROMETHEUS_PASSWORD_PRIMARY=dummy
kubectl -n grafana-alloy create configmap grafana-alloy-cm --from-literal=x=y
kubectl -n grafana-alloy patch configmap grafana-alloy-cm --type merge -p '{"immutable":true}'

sudo $BIN alloy cluster install --cluster-name=my-cluster --add-prometheus-remote=name=primary,url=https://example.com/api/v1/write,username=user1 --rollback-on-error
```

Observed: Preflight and Prometheus Operator CRDs succeed, then Alloy Deployment fails at `Deploying Alloy configuration`:

```
✓ Preflight Checks (100ms)
✓ Prometheus Operator CRDs (9.8s)
✗ Alloy Deployment
  ✗ Deploying Alloy configuration
      common.illegal_argument: error during apply configmaps/grafana-alloy-cm, cause: ConfigMap "grafana-alloy-cm" is invalid: data: Forbidden: field is immutable when `immutable` is set
```

Rollback is not rendered in the TUI (there is no rollback notify hook — it is recorded in the report YAML), so confirm via Helm. The releases installed by this run are gone, including the one from the **earlier, already-completed** Prometheus Operator CRDs phase — i.e. rollback cascades across phases:

```bash
helm list -A
# node-exporter and prometheus-operator-crds are absent; only cilium / metallb /
# metrics-server (the base cluster releases) remain.
```

The `grafana-alloy` namespace and the `grafana-alloy-cm` ConfigMap remain (neither `createAlloyNamespace` nor `deployAlloyConfig` removes a pre-existing resource on rollback). Re-running with `--continue-on-error` proceeds past the failing step; with the default (`--stop-on-error`) it stops without rolling back.

> **Rollback logic:** the per-step `WithRollback` handlers (`step_alloy.go` node-exporter/alloy/config/monitoring; `step_prometheus_operator_crds.go` CRDs) do the actual teardown, guarded by `InstalledByThisStep` so pre-existing resources are never touched. `--rollback-on-error` sets `ExecutionMode=RollbackOnError` on the top workflow; automa propagates it to the phase sub-workflows at build time and cascades `Rollback()` through them on failure.

### UAT-6 — Uninstall accepts the flags

```bash
sudo $BIN alloy cluster uninstall --stop-on-error
```

Expected: no `unknown flag` error; teardown proceeds normally.

## Risks

- **New fail-fast behaviour:** installs that previously ran until the Helm step now fail earlier, in Preflight, when the cluster is unreachable. This is the intended fix — it changes the failure point and message, not any success path.
- `SetupPrometheusOperatorCRDs` and `SetupAlloy` now emit phase-level notifications; both are reached only via the alloy install path (verified by grep), so no other workflow's TUI output changes.
- No embedded-template or install-time-config changes; no upgrade/migration path is touched. State management / BLL for alloy is explicitly out of scope per the issue.

### Related Issues

* Closes #445
