### PR TITLE
fix(tui): react to edited chart version in block node install wizard

### DIFF
--- a/cmd/cli/commands/block/node/init.go
+++ b/cmd/cli/commands/block/node/init.go
@@ -122,9 +122,9 @@ func promptForMissingFlags(cmd *cobra.Command, args []string) error {
 	// Build a single wizard so every prompt page is navigable back and forward
 	// (Shift+Tab / Tab) instead of committing each stage in its own form. Pages are
 	// added in order; each Add* is a no-op when its flag(s) were already supplied on
-	// the command line. Input prompts must be added before the storage and plugin
-	// prompts because they pre-fill flagChartVersion, which the storage and plugin
-	// builders read to filter their options.
+	// the command line. The storage and plugin builders take &flagChartVersion (by
+	// pointer), so their version-dependent pages react to edits made on the earlier
+	// chart-version input page as the operator navigates forward.
 	w := prompt.NewWizard()
 
 	// profileTarget is a local copy the profile prompt writes to; after the wizard
@@ -149,7 +149,7 @@ func promptForMissingFlags(cmd *cobra.Command, args []string) error {
 	// Storage path prompts: mode select → conditional path inputs (single base
 	// path vs individual paths). Applied to all block node commands that configure
 	// storage (install, upgrade, reconfigure).
-	prompt.AddStoragePathPrompts(w, cmd, defaults, flagChartVersion, prompt.StoragePathTargets{
+	prompt.AddStoragePathPrompts(w, cmd, defaults, &flagChartVersion, prompt.StoragePathTargets{
 		BasePath:             &flagBasePath,
 		ArchivePath:          &flagArchivePath,
 		LivePath:             &flagLivePath,
@@ -160,7 +160,7 @@ func promptForMissingFlags(cmd *cobra.Command, args []string) error {
 	}, cv)
 
 	// Plugin preset prompt: preset select → conditional custom multi-select.
-	prompt.AddPluginPresetPrompts(w, cmd, defaults, &flagPluginPreset, &flagPlugins, flagChartVersion, flagValuesFile, cv)
+	prompt.AddPluginPresetPrompts(w, cmd, defaults, &flagPluginPreset, &flagPlugins, &flagChartVersion, flagValuesFile, cv)
 
 	// Run all accumulated pages as a single navigable form.
 	if err := w.Run(); err != nil {

--- a/internal/ui/prompt/blocknode.go
+++ b/internal/ui/prompt/blocknode.go
@@ -317,16 +317,18 @@ func storagePathField(p InputPrompt, active func() bool) huh.Field {
 //   - cv:           chosen-values collector for summary printing
 //
 // The optional-storage prompts (verification, plugins, application-state) are
-// gated on the registry's GetApplicableOptionalStorages(chartVersion) so the
-// operator only sees the storages the target chart actually needs. Because huh
-// cannot add or remove fields from a group mid-run, this applicable set is fixed
-// at construction from the effective chart version; editing the chart-version
-// input later in the same wizard does not re-shape the individual-path fields.
+// gated on the registry's RequiredByVersion for the *live* chart version. Each
+// optional path lives in its own huh group whose WithHideFunc re-reads
+// *chartVersion (huh can hide only whole groups, not individual fields), so
+// editing the chart-version input earlier in the same wizard re-shapes which
+// optional paths are shown — and the individual-paths label — when the operator
+// navigates forward. chartVersion is taken by pointer so huh's dynamic-func
+// bindings observe those later edits.
 func AddStoragePathPrompts(
 	w *Wizard,
 	cmd *cobra.Command,
 	defaults state.PromptDefaults,
-	chartVersion string,
+	chartVersion *string,
 	targets StoragePathTargets,
 	cv *ChosenValues,
 ) {
@@ -341,22 +343,17 @@ func AddStoragePathPrompts(
 	stor := defaults.BlockNode.Storage
 	cfgStor := cfg.BlockNode.Storage
 
-	// Determine which optional storages apply to the target chart version.
-	applicable := blocknode.GetApplicableOptionalStorages(chartVersion)
-	includeVerification := false
-	includePlugins := false
-	includeApplicationState := false
-	optionalLabels := make([]string, 0, len(applicable))
-	for _, optStor := range applicable {
-		switch optStor.Name {
-		case "verification":
-			includeVerification = true
-		case "plugins":
-			includePlugins = true
-		case "application-state":
-			includeApplicationState = true
-		}
-		optionalLabels = append(optionalLabels, optStor.Name)
+	// applicableOptional reports whether the named optional storage is required by
+	// the *current* chart-version value. It re-reads *chartVersion on every call so
+	// the per-optional group hide-funcs and the mode-select OptionsFunc react as the
+	// operator edits the chart-version input earlier in the wizard.
+	optByName := make(map[string]blocknode.OptionalStorage)
+	for _, o := range blocknode.GetOptionalStorages() {
+		optByName[o.Name] = o
+	}
+	applicableOptional := func(name string) bool {
+		o, ok := optByName[name]
+		return ok && o.RequiredByVersion(*chartVersion)
 	}
 
 	// Determine the default mode from persisted state.
@@ -366,25 +363,36 @@ func AddStoragePathPrompts(
 		defaultMode = storagePathModeBasePath
 	}
 
-	// selectedMode is shared by the mode-select field, the two path groups' hide
-	// funcs, and the afterRun callback below.
+	// selectedMode is shared by the mode-select field, the path groups' hide funcs,
+	// and the afterRun callback below.
 	selectedMode := defaultMode
+	inBaseMode := func() bool { return selectedMode == storagePathModeBasePath }
+	inIndividualMode := func() bool { return selectedMode == storagePathModeIndividual }
 
 	// ── Page: mode select ─────────────────────────────────────────────────────
-	individualLabel := "Individual paths  (archive, live, log"
-	for _, n := range optionalLabels {
-		individualLabel += ", " + n
+	// The individual-paths option label lists the optional storages that apply to
+	// the live chart version, so it is rebuilt via OptionsFunc bound to
+	// *chartVersion. The option *values* are stable (only the label changes), so
+	// huh preserves the current selection across rebuilds.
+	modeOptions := func() []huh.Option[string] {
+		var label strings.Builder
+		label.WriteString("Individual paths  (archive, live, log")
+		for _, o := range blocknode.GetApplicableOptionalStorages(*chartVersion) {
+			label.WriteString(", ")
+			label.WriteString(o.Name)
+		}
+		label.WriteString(" must all be provided)")
+		return []huh.Option[string]{
+			huh.NewOption("Single base path  (subdirectories are created automatically)", storagePathModeBasePath),
+			huh.NewOption(label.String(), storagePathModeIndividual),
+		}
 	}
-	individualLabel += " must all be provided)"
 	modeGroup := huh.NewGroup(
 		huh.NewSelect[string]().
 			Key("storage-mode").
 			Title("Storage Path Mode").
 			Description("Choose how to configure storage paths for this block node").
-			Options(
-				huh.NewOption("Single base path  (subdirectories are created automatically)", storagePathModeBasePath),
-				huh.NewOption(individualLabel, storagePathModeIndividual),
-			).
+			OptionsFunc(modeOptions, chartVersion).
 			Value(&selectedMode),
 	)
 
@@ -392,67 +400,90 @@ func AddStoragePathPrompts(
 	baseEff := resolveEffective(stor.BasePath, cfgStor.BasePath, deps.BLOCK_NODE_STORAGE_BASE_PATH)
 	basePrompt := basePathInputPrompt(baseEff, targets.BasePath)
 	*targets.BasePath = baseEff
-	inBaseMode := func() bool { return selectedMode == storagePathModeBasePath }
 	baseGroup := huh.NewGroup(storagePathField(basePrompt, inBaseMode)).
 		WithHideFunc(func() bool { return !inBaseMode() })
 
-	// ── Page: individual path inputs (shown only in individual mode) ──────────
-	// Derive per-path defaults from the effective base path so individual inputs
-	// are pre-filled even when no explicit per-path config exists (fresh install
-	// or switching from base-path mode). Subdirectory names mirror those used by
+	// ── Pages: individual path inputs (shown only in individual mode) ─────────
+	// Core paths (archive, live, log) apply to every chart version and share one
+	// group. Each optional path lives in its own group whose visibility tracks the
+	// live chart version, because huh can hide only whole groups, not fields.
+	// Per-path defaults derive from the effective base path so inputs are pre-filled
+	// even without explicit per-path config; subdirectory names mirror those used by
 	// GetStoragePaths at workflow time.
 	indivDefault := func(subdir string) string { return path.Join(baseEff, subdir) }
-	individualPrompts := []InputPrompt{
-		archivePathInputPrompt(resolveEffective(stor.ArchivePath, cfgStor.ArchivePath, indivDefault("archive")), targets.ArchivePath, true),
-		livePathInputPrompt(resolveEffective(stor.LivePath, cfgStor.LivePath, indivDefault("live")), targets.LivePath, true),
-		logPathInputPrompt(resolveEffective(stor.LogPath, cfgStor.LogPath, indivDefault("logs")), targets.LogPath, true),
+
+	// indivEntry couples an individual-path prompt with the optional-storage name it
+	// represents ("" for a core path that always applies). optName drives both the
+	// per-group hide func and the afterRun applicability filter.
+	type indivEntry struct {
+		prompt  InputPrompt
+		optName string
 	}
-	if includeVerification {
-		individualPrompts = append(individualPrompts,
-			verificationPathInputPrompt(resolveEffective(stor.VerificationPath, cfgStor.VerificationPath, indivDefault("verification")), targets.VerificationPath, true))
-	}
-	if includePlugins {
-		individualPrompts = append(individualPrompts,
-			pluginsPathInputPrompt(resolveEffective(stor.PluginsPath, cfgStor.PluginsPath, indivDefault("plugins")), targets.PluginsPath, true))
-	}
-	if includeApplicationState {
-		individualPrompts = append(individualPrompts,
-			applicationStatePathInputPrompt(resolveEffective(stor.ApplicationStatePath, cfgStor.ApplicationStatePath, indivDefault("application-state")), targets.ApplicationStatePath, true))
+	entries := []indivEntry{
+		{archivePathInputPrompt(resolveEffective(stor.ArchivePath, cfgStor.ArchivePath, indivDefault("archive")), targets.ArchivePath, true), ""},
+		{livePathInputPrompt(resolveEffective(stor.LivePath, cfgStor.LivePath, indivDefault("live")), targets.LivePath, true), ""},
+		{logPathInputPrompt(resolveEffective(stor.LogPath, cfgStor.LogPath, indivDefault("logs")), targets.LogPath, true), ""},
+		{verificationPathInputPrompt(resolveEffective(stor.VerificationPath, cfgStor.VerificationPath, indivDefault("verification")), targets.VerificationPath, true), "verification"},
+		{pluginsPathInputPrompt(resolveEffective(stor.PluginsPath, cfgStor.PluginsPath, indivDefault("plugins")), targets.PluginsPath, true), "plugins"},
+		{applicationStatePathInputPrompt(resolveEffective(stor.ApplicationStatePath, cfgStor.ApplicationStatePath, indivDefault("application-state")), targets.ApplicationStatePath, true), "application-state"},
 	}
 
-	inIndividualMode := func() bool { return selectedMode == storagePathModeIndividual }
-	individualFields := make([]huh.Field, len(individualPrompts))
-	for i := range individualPrompts {
-		p := individualPrompts[i]
-		*p.Target = p.EffectiveValue // pre-fill so the input shows the default
-		individualFields[i] = storagePathField(p, inIndividualMode)
-	}
-	individualGroup := huh.NewGroup(individualFields...).
-		WithHideFunc(func() bool { return !inIndividualMode() })
-
-	// afterRun records the mode, normalises targets so downstream storage-mode
-	// inference is unambiguous (both variants are pre-filled, so the unused one
-	// must be cleared), and records the chosen paths into the summary.
-	after := func() {
-		cv.add("Storage Path Mode", selectedMode)
-		if selectedMode == storagePathModeBasePath {
-			*targets.ArchivePath = ""
-			*targets.LivePath = ""
-			*targets.LogPath = ""
-			*targets.VerificationPath = ""
-			*targets.PluginsPath = ""
-			*targets.ApplicationStatePath = ""
-			cv.add(basePrompt.Title, *targets.BasePath)
-		} else {
-			*targets.BasePath = ""
-			for i := range individualPrompts {
-				p := individualPrompts[i]
-				cv.add(p.Title, *p.Target)
+	// visible reports whether an entry's field should be shown and validated:
+	// always in individual mode for core paths, and additionally gated on the live
+	// chart version for optional paths.
+	visible := func(e indivEntry) func() bool {
+		return func() bool {
+			if !inIndividualMode() {
+				return false
 			}
+			return e.optName == "" || applicableOptional(e.optName)
 		}
 	}
 
-	w.addGroups(after, modeGroup, baseGroup, individualGroup)
+	var coreFields []huh.Field
+	var optGroups []*huh.Group
+	for i := range entries {
+		e := entries[i]
+		*e.prompt.Target = e.prompt.EffectiveValue // pre-fill so the input shows the default
+		active := visible(e)
+		field := storagePathField(e.prompt, active)
+		if e.optName == "" {
+			coreFields = append(coreFields, field)
+			continue
+		}
+		// One group per optional path so its visibility can track the live version.
+		optGroups = append(optGroups, huh.NewGroup(field).WithHideFunc(func() bool { return !active() }))
+	}
+	coreGroup := huh.NewGroup(coreFields...).
+		WithHideFunc(func() bool { return !inIndividualMode() })
+
+	// afterRun records the mode, normalises targets so downstream storage-mode
+	// inference is unambiguous (both variants are pre-filled, so the unused one must
+	// be cleared), and records the chosen paths into the summary. In individual mode
+	// an optional path that does not apply to the *final* chart version is cleared so
+	// a pre-filled but hidden path can never leak into the resolved inputs.
+	after := func() {
+		cv.add("Storage Path Mode", selectedMode)
+		if selectedMode == storagePathModeBasePath {
+			for i := range entries {
+				*entries[i].prompt.Target = ""
+			}
+			cv.add(basePrompt.Title, *targets.BasePath)
+			return
+		}
+		*targets.BasePath = ""
+		for i := range entries {
+			e := entries[i]
+			if e.optName != "" && !applicableOptional(e.optName) {
+				*e.prompt.Target = ""
+				continue
+			}
+			cv.add(e.prompt.Title, *e.prompt.Target)
+		}
+	}
+
+	groups := append([]*huh.Group{modeGroup, baseGroup, coreGroup}, optGroups...)
+	w.addGroups(after, groups...)
 }
 
 // RunStoragePathPrompts presents the storage-path prompts as a standalone wizard.
@@ -468,7 +499,7 @@ func RunStoragePathPrompts(
 	cv *ChosenValues,
 ) error {
 	w := NewWizard()
-	AddStoragePathPrompts(w, cmd, defaults, chartVersion, targets, cv)
+	AddStoragePathPrompts(w, cmd, defaults, &chartVersion, targets, cv)
 	return w.Run()
 }
 
@@ -555,7 +586,7 @@ func BlockNodeReconfigureInputPrompts(
 // "no override" preset (PresetNone) is pre-selected instead so the values file
 // wins unless the operator actively picks a preset.
 //
-// The custom multi-select page lists all known block-node plugins for the given
+// The custom multi-select page lists all known block-node plugins for the live
 // chartVersion; the operator's selection is joined as a comma-separated string
 // and written to *flagPlugins.
 //
@@ -568,21 +599,23 @@ func BlockNodeReconfigureInputPrompts(
 //   - defaults:        prompt defaults read from the on-disk state file
 //   - flagPluginPreset: pointer to the --plugin-preset flag variable
 //   - flagPlugins:     pointer to the --plugins flag variable
-//   - chartVersion:   target chart version (used to filter available plugins)
+//   - chartVersion:   pointer to the target chart version (used to filter available plugins)
 //   - valuesFile:     path to the operator's --values file (empty when not supplied);
 //     used to smart-default the preset to "no override" when it defines plugins.names
 //   - cv:              chosen-values collector for summary printing
 //
-// Note: the custom multi-select's option list is fixed at construction from
-// chartVersion — huh cannot rebuild option lists mid-run, so editing the
-// chart-version input later in the same wizard does not re-shape the plugin list.
+// The custom multi-select's option list and warning are rebuilt via OptionsFunc /
+// DescriptionFunc bound to *chartVersion, so editing the chart-version input earlier
+// in the same wizard re-shapes the available plugins; huh reconciles the current
+// selection against the new option set (dropping plugins that no longer apply).
+// chartVersion is taken by pointer so those bindings observe later edits.
 func AddPluginPresetPrompts(
 	w *Wizard,
 	cmd *cobra.Command,
 	defaults state.PromptDefaults,
 	flagPluginPreset *string,
 	flagPlugins *string,
-	chartVersion string,
+	chartVersion *string,
 	valuesFile string,
 	cv *ChosenValues,
 ) {
@@ -621,42 +654,55 @@ func AddPluginPresetPrompts(
 	)
 
 	// ── Page: custom multi-select (shown only when Custom is selected) ────────
-	// Pre-select the plugins from the last-used custom list (if any), but filter
-	// out any entries that no longer exist in the current available plugin list so
-	// the UI does not silently drop them.
-	versionedPlugins := blocknode.PluginsForVersion(chartVersion)
-	validPlugins := make(map[string]struct{}, len(versionedPlugins))
-	var pluginOptions []huh.Option[string]
-	for _, p := range versionedPlugins {
-		validPlugins[p] = struct{}{}
-		pluginOptions = append(pluginOptions, huh.NewOption(p, p))
-	}
-
-	var preSelected []string
-	var unknownPlugins []string
-	if defaults.BlockNode.PluginList != "" {
-		for _, plugin := range strings.Split(defaults.BlockNode.PluginList, ",") {
-			plugin = strings.TrimSpace(plugin)
-			if plugin == "" {
-				continue
-			}
-			if _, ok := validPlugins[plugin]; ok {
-				preSelected = append(preSelected, plugin)
-				continue
-			}
-			unknownPlugins = append(unknownPlugins, plugin)
+	// The available plugins depend on the live chart version, so validForVersion
+	// re-reads *chartVersion on every call. The last-used custom list (from state)
+	// is pre-selected but filtered to the plugins that still apply.
+	savedPlugins := make([]string, 0)
+	for plugin := range strings.SplitSeq(defaults.BlockNode.PluginList, ",") {
+		if plugin = strings.TrimSpace(plugin); plugin != "" {
+			savedPlugins = append(savedPlugins, plugin)
 		}
 	}
+	validForVersion := func() map[string]struct{} {
+		vp := blocknode.PluginsForVersion(*chartVersion)
+		set := make(map[string]struct{}, len(vp))
+		for _, p := range vp {
+			set[p] = struct{}{}
+		}
+		return set
+	}
+	pluginOptionsFn := func() []huh.Option[string] {
+		var opts []huh.Option[string]
+		for _, p := range blocknode.PluginsForVersion(*chartVersion) {
+			opts = append(opts, huh.NewOption(p, p))
+		}
+		return opts
+	}
+	descriptionFn := func() string {
+		valid := validForVersion()
+		var unknown []string
+		for _, p := range savedPlugins {
+			if _, ok := valid[p]; !ok {
+				unknown = append(unknown, p)
+			}
+		}
+		desc := "Choose the individual plugins to install"
+		if len(unknown) > 0 {
+			desc = fmt.Sprintf(
+				"%s\nWarning: previously saved plugins are not available for chart version %s and were not pre-selected: %s",
+				desc, *chartVersion, strings.Join(unknown, ", "))
+		}
+		return desc
+	}
 
-	selectedPlugins := preSelected
-
-	description := "Choose the individual plugins to install"
-	if len(unknownPlugins) > 0 {
-		description = fmt.Sprintf(
-			"%s\nWarning: previously saved plugins are no longer available and were not pre-selected: %s",
-			description,
-			strings.Join(unknownPlugins, ", "),
-		)
+	// Pre-select the saved plugins that apply to the version at construction time;
+	// huh reconciles this selection against the option set whenever it is rebuilt.
+	initialValid := validForVersion()
+	var selectedPlugins []string
+	for _, p := range savedPlugins {
+		if _, ok := initialValid[p]; ok {
+			selectedPlugins = append(selectedPlugins, p)
+		}
 	}
 
 	isCustom := func() bool { return *flagPluginPreset == blocknode.PresetCustom }
@@ -664,8 +710,8 @@ func AddPluginPresetPrompts(
 		huh.NewMultiSelect[string]().
 			Key("plugins").
 			Title("Select Plugins").
-			Description(description).
-			Options(pluginOptions...).
+			DescriptionFunc(descriptionFn, chartVersion).
+			OptionsFunc(pluginOptionsFn, chartVersion).
 			Value(&selectedPlugins).
 			Validate(func(selected []string) error {
 				// Only enforce a selection while the Custom preset is active; when
@@ -682,14 +728,23 @@ func AddPluginPresetPrompts(
 
 	after := func() {
 		cv.add("Plugin Preset", blocknode.PresetLabel(*flagPluginPreset))
-		if isCustom() {
-			*flagPlugins = strings.Join(selectedPlugins, ",")
-			cv.add("Custom Plugins", *flagPlugins)
-		} else {
+		if !isCustom() {
 			// Ensure a pre-selected-but-hidden multi-select never contaminates a
 			// non-custom preset.
 			*flagPlugins = ""
+			return
 		}
+		// Drop any selection that does not apply to the final chart version, in case
+		// the version changed after the multi-select was last reconciled.
+		valid := validForVersion()
+		var final []string
+		for _, p := range selectedPlugins {
+			if _, ok := valid[p]; ok {
+				final = append(final, p)
+			}
+		}
+		*flagPlugins = strings.Join(final, ",")
+		cv.add("Custom Plugins", *flagPlugins)
 	}
 
 	w.addGroups(after, presetGroup, customGroup)
@@ -710,7 +765,7 @@ func RunPluginPresetPrompts(
 	cv *ChosenValues,
 ) error {
 	w := NewWizard()
-	AddPluginPresetPrompts(w, cmd, defaults, flagPluginPreset, flagPlugins, chartVersion, valuesFile, cv)
+	AddPluginPresetPrompts(w, cmd, defaults, flagPluginPreset, flagPlugins, &chartVersion, valuesFile, cv)
 	return w.Run()
 }
 

--- a/internal/ui/prompt/wizard_test.go
+++ b/internal/ui/prompt/wizard_test.go
@@ -121,13 +121,15 @@ func TestAddStoragePathPrompts_BaseModeNormalisesTargets(t *testing.T) {
 	var defaults state.PromptDefaults
 	defaults.BlockNode.Storage.BasePath = "/data"
 
+	chartVersion := "0.35.1"
 	cv := NewChosenValues()
 	w := NewWizard()
-	AddStoragePathPrompts(w, cmd, defaults, "0.35.1", targets, cv)
+	AddStoragePathPrompts(w, cmd, defaults, &chartVersion, targets, cv)
 
-	// mode group + base-path group + individual-paths group.
-	if len(w.groups) != 3 || len(w.afterRun) != 1 {
-		t.Fatalf("expected 3 groups and 1 afterRun, got %d groups / %d afterRun", len(w.groups), len(w.afterRun))
+	// mode group + base-path group + core-paths group + one group per optional
+	// storage (verification, plugins, application-state).
+	if len(w.groups) != 6 || len(w.afterRun) != 1 {
+		t.Fatalf("expected 6 groups and 1 afterRun, got %d groups / %d afterRun", len(w.groups), len(w.afterRun))
 	}
 
 	// Firing afterRun with the default (base) mode must clear the individual
@@ -158,12 +160,13 @@ func TestAddStoragePathPrompts_IndividualModeClearsBasePath(t *testing.T) {
 	// No persisted base path → individual paths is the default mode.
 	var defaults state.PromptDefaults
 
+	chartVersion := "0.35.1"
 	cv := NewChosenValues()
 	w := NewWizard()
-	AddStoragePathPrompts(w, cmd, defaults, "0.35.1", targets, cv)
+	AddStoragePathPrompts(w, cmd, defaults, &chartVersion, targets, cv)
 
-	if len(w.groups) != 3 || len(w.afterRun) != 1 {
-		t.Fatalf("expected 3 groups and 1 afterRun, got %d groups / %d afterRun", len(w.groups), len(w.afterRun))
+	if len(w.groups) != 6 || len(w.afterRun) != 1 {
+		t.Fatalf("expected 6 groups and 1 afterRun, got %d groups / %d afterRun", len(w.groups), len(w.afterRun))
 	}
 
 	// Individual mode must clear the base path and keep the required per-path
@@ -180,12 +183,61 @@ func TestAddStoragePathPrompts_IndividualModeClearsBasePath(t *testing.T) {
 	}
 }
 
+// TestAddStoragePathPrompts_IndividualModeTracksChartVersionEdit is the #826
+// regression guard: a single wizard built while the chart version is pre-0.37.0
+// must reflect a later edit to a >=0.37.0 version, dropping the retired
+// verification path and keeping application-state — because the builders read the
+// chart-version pointer live rather than snapshotting it at construction.
+func TestAddStoragePathPrompts_IndividualModeTracksChartVersionEdit(t *testing.T) {
+	cmd := &cobra.Command{Use: "install"}
+
+	var basePath, archivePath, livePath, logPath, verificationPath, pluginsPath, applicationStatePath string
+	targets := storageTargets(&basePath, &archivePath, &livePath, &logPath, &verificationPath, &pluginsPath, &applicationStatePath)
+
+	// No persisted base path → individual mode is the default.
+	var defaults state.PromptDefaults
+
+	// Build the wizard on a pre-0.37.0 version, then simulate the operator editing
+	// the chart-version input to a >=0.37.0 version before the wizard completes.
+	chartVersion := "0.35.1"
+	cv := NewChosenValues()
+	w := NewWizard()
+	AddStoragePathPrompts(w, cmd, defaults, &chartVersion, targets, cv)
+
+	chartVersion = "0.37.1"
+	w.afterRun[0]()
+
+	// application-state applies to >=0.37.0 and must be retained; verification is
+	// retired at 0.37.0 and must be cleared; plugins applies across the range.
+	if applicationStatePath == "" {
+		t.Fatalf("expected application-state path retained for chart 0.37.1, got empty")
+	}
+	if verificationPath != "" {
+		t.Fatalf("expected verification path cleared for chart 0.37.1, got %q", verificationPath)
+	}
+	if pluginsPath == "" {
+		t.Fatalf("expected plugins path retained for chart 0.37.1, got empty")
+	}
+
+	recorded := make(map[string]bool)
+	for _, p := range cv.pairs {
+		recorded[p.title] = true
+	}
+	if recorded["Verification Storage Path"] {
+		t.Fatalf("did not expect verification recorded for chart 0.37.1, got %+v", cv.pairs)
+	}
+	if !recorded["Application-State Storage Path"] {
+		t.Fatalf("expected application-state recorded for chart 0.37.1, got %+v", cv.pairs)
+	}
+}
+
 func TestAddPluginPresetPrompts_NonCustomClearsPlugins(t *testing.T) {
 	cmd := &cobra.Command{Use: "install"}
 	var preset, plugins string
 
+	chartVersion := "0.35.1"
 	w := NewWizard()
-	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, "0.35.1", "", NewChosenValues())
+	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, &chartVersion, "", NewChosenValues())
 
 	// preset group + conditional custom group.
 	if len(w.groups) != 2 || len(w.afterRun) != 1 {
@@ -217,9 +269,10 @@ func TestAddPluginPresetPrompts_CustomJoinsSelection(t *testing.T) {
 	defaults.BlockNode.PluginPreset = blocknode.PresetCustom
 	defaults.BlockNode.PluginList = valid[0]
 
+	chartVersion := "0.35.1"
 	cv := NewChosenValues()
 	w := NewWizard()
-	AddPluginPresetPrompts(w, cmd, defaults, &preset, &plugins, "0.35.1", "", cv)
+	AddPluginPresetPrompts(w, cmd, defaults, &preset, &plugins, &chartVersion, "", cv)
 
 	if preset != blocknode.PresetCustom {
 		t.Fatalf("expected Custom preset pre-selected, got %q", preset)
@@ -244,8 +297,9 @@ func TestAddPluginPresetPrompts_SmartDefaultsToNoneWhenValuesFileDefinesPlugins(
 	cmd := &cobra.Command{Use: "install"}
 	var preset, plugins string
 
+	chartVersion := "0.35.1"
 	w := NewWizard()
-	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, "0.35.1", valuesFile, NewChosenValues())
+	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, &chartVersion, valuesFile, NewChosenValues())
 
 	if preset != blocknode.PresetNone {
 		t.Fatalf("expected the values file to smart-default the preset to PresetNone, got %q", preset)
@@ -256,8 +310,9 @@ func TestAddPluginPresetPrompts_DefaultsToTier1LFHWhenNoValuesFile(t *testing.T)
 	cmd := &cobra.Command{Use: "install"}
 	var preset, plugins string
 
+	chartVersion := "0.35.1"
 	w := NewWizard()
-	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, "0.35.1", "", NewChosenValues())
+	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, &chartVersion, "", NewChosenValues())
 
 	if preset != blocknode.PresetTier1LFH {
 		t.Fatalf("expected the default tier1-lfh preset when no --values file is given, got %q", preset)
@@ -271,8 +326,9 @@ func TestAddPluginPresetPrompts_SkipsWhenPresetFlagSet(t *testing.T) {
 	cmd.Flags().StringVar(&plugins, "plugins", "", "")
 	_ = cmd.Flags().Set("plugin-preset", "tier1-lfh")
 
+	chartVersion := "0.35.1"
 	w := NewWizard()
-	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, "0.35.1", "", NewChosenValues())
+	AddPluginPresetPrompts(w, cmd, state.PromptDefaults{}, &preset, &plugins, &chartVersion, "", NewChosenValues())
 
 	if len(w.groups) != 0 {
 		t.Fatalf("expected no groups when --plugin-preset already set, got %d", len(w.groups))

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -11,6 +11,6 @@ const (
 	BLOCK_NODE_NAMESPACE         = "block-node"
 	BLOCK_NODE_RELEASE           = "block-node"
 	BLOCK_NODE_CHART             = "oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server"
-	BLOCK_NODE_VERSION           = "0.35.1"
+	BLOCK_NODE_VERSION           = "0.37.1"
 	BLOCK_NODE_STORAGE_BASE_PATH = "/mnt/fast-storage"
 )


### PR DESCRIPTION
## Description

The interactive `block node install` wizard did not react to a chart-version edit. Its storage-path and plugin pages were built from the *default* chart version (`0.35.1`, `deps.BLOCK_NODE_VERSION`) snapshotted at wizard-construction time. Changing **Chart Version** to a `0.37.x` value in the TUI still prompted for the pre-`0.37.0` optional-storage set — `archive, live, log, verification, plugins` — instead of the correct `0.37.x` set `archive, live, log, plugins, application-state`. Picking individual paths after the edit then prompted for the wrong directories and requested the wrong optional storages.

Root cause: `promptForMissingFlags` passed `flagChartVersion` **by value** to `AddStoragePathPrompts` / `AddPluginPresetPrompts`, which computed their field set and labels once (`GetApplicableOptionalStorages` / `PluginsForVersion`) and baked them into static `huh` groups. This was a regression from #809, which consolidated the previously sequential per-stage `huh` forms into a single up-front wizard — before #809 the chart-version form committed before the storage form was constructed, so the storage page read the final value.

The fix passes `&flagChartVersion` (by pointer) to both builders and drives their version-dependent content from the **live** value, so edits made on the earlier chart-version input page take effect as the operator navigates forward (full Shift+Tab / Tab navigation preserved). `huh` hides only whole groups (not individual fields), so each optional storage path now lives in its own hide-gated group.

This PR also bumps the default block-node chart version `deps.BLOCK_NODE_VERSION` from `0.35.1` to `0.37.1`. As a result, the wizard's default optional-storage set is now the `0.37.x` set (`application-state`, no `verification`); the reactivity fix above is what makes editing the version away from this new default behave correctly.

### Files changed

| File | Change |
|---|---|
| `cmd/cli/commands/block/node/init.go` | Pass `&flagChartVersion` to the storage and plugin builders; update the stale "pre-fill" comment. |
| `internal/ui/prompt/blocknode.go` | Storage page: one hide-gated group per optional storage whose `WithHideFunc` re-reads `*chartVersion`, dynamic mode-select label via `OptionsFunc`, and a version-aware `afterRun` that clears non-applicable optional paths. Plugin page: Custom multi-select options/warning via `OptionsFunc` / `DescriptionFunc` bound to `*chartVersion`, plus an `afterRun` selection filter. Wrappers `RunStoragePathPrompts` / `RunPluginPresetPrompts` adapted. |
| `internal/ui/prompt/wizard_test.go` | Updated call sites (pointer arg) and group count (now 6: mode + base + core + 3 optional groups); added `TestAddStoragePathPrompts_IndividualModeTracksChartVersionEdit` as the regression guard. |
| `pkg/deps/deps.go` | Bump default `BLOCK_NODE_VERSION` `0.35.1` → `0.37.1`. |

### Behavior note

Individual-paths mode now spans multiple pages (core `archive/live/log`, then one page each for the optional storages that apply to the live version) rather than a single page, because `huh` cannot hide individual fields within a group. Full back/forward navigation is retained. Optional-storage applicability is unchanged (`verification` `[0.26.2, 0.37.0)`, `plugins` `[0.28.1, ∞)`, `application-state` `[0.37.0, ∞)`).

### Review guide

**Checklist**
- `blocknode.go` `AddStoragePathPrompts` — `chartVersion *string`; `applicableOptional` re-reads `*chartVersion` per call; each optional path is its own `WithHideFunc` group gated on `!inIndividualMode() || !applicableOptional(name)`; `storagePathField`'s validator is suppressed while the field is not visible; mode-select label rebuilt via `OptionsFunc(modeOptions, chartVersion)` (option *values* stable, so selection is preserved across rebuilds); `afterRun` clears optional targets that do not apply to the final version.
- `blocknode.go` `AddPluginPresetPrompts` — `chartVersion *string`; Custom multi-select uses `OptionsFunc` / `DescriptionFunc` bound to `chartVersion`; `huh` reconciles the bound selection against rebuilt options (drops removed plugins); `afterRun` re-filters the selection against the final version and clears `--plugins` for non-custom presets.
- `init.go` — pointer passed to both builders; profile propagation after `w.Run()` unchanged.
- Pointer binding is required: `huh`'s `Eval` hashes the `bindings` argument, so a pointer is what lets the dynamic funcs observe later edits.

**Tests**
```bash
go test -race -tags='!integration' ./internal/ui/prompt/... ./internal/blocknode/...
GOOS=linux GOARCH=arm64 go build ./cmd/cli/...
task lint
```

**Manual UAT** — `sudo solo-provisioner block node install` on a TTY (no flags):
- On the chart-version page keep the new default (`0.37.1`) → forward → the storage mode page lists `Individual paths (archive, live, log, plugins, application-state must all be provided)`; the individual pages prompt `application-state` and not `verification`.
- Shift+Tab back to chart-version, change it to a `<0.37.0` value (e.g. `0.35.1`), forward again → the label now reads `… archive, live, log, verification, plugins …`; the individual pages prompt `verification` and not `application-state`.
- Change it back to a `0.37.x` value → `application-state` returns and `verification` disappears.
- Regression: `--non-interactive` and fully-flagged runs bypass all prompts; the printed "Selected Inputs" summary matches the final choices.

**Risks / rollback** — The prompt-layer change is pure (no state/schema/workflow/template impact). The `deps.BLOCK_NODE_VERSION` bump changes the chart version used by fresh `block node install` / `upgrade` runs that do not pass `--chart-version` (or set `blocknode.version` in config) from `0.35.1` to `0.37.1`; already-installed clusters are unaffected until an explicit upgrade. The compile-time default is not documented in `docs/quickstart.md`, so no doc change is required. Rollback = revert to the by-value snapshot and the single individual-paths group, and restore `BLOCK_NODE_VERSION`.

### Related Issues

* Closes #826
