### PR TITLE
feat(network): add `network shape` scope (tc HTB classes + device roots) (#771)

### DIFF
--- a/cmd/cli/commands/block/node/init.go
+++ b/cmd/cli/commands/block/node/init.go
@@ -3,8 +3,6 @@
 package node
 
 import (
-	"fmt"
-
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/bll/blocknode"
@@ -80,28 +78,24 @@ func extractBlockNodeParentFlagsWithOpts(cmd *cobra.Command, args []string, flag
 	return nil
 }
 
-// promptForMissingFlags runs interactive prompts for any required block node
-// flags that were not supplied on the command line. It writes prompted values
-// back into the Cobra flag set and the package-level flag variables so that
-// downstream extraction and validation sees them.
-//
-// Prompts are skipped when:
-//   - --force/-y is set
-//   - --non-interactive is set
-//   - stdout is not a TTY
-//   - the command is "uninstall" (infers values from existing state/config)
-func promptForMissingFlags(cmd *cobra.Command, args []string) error {
+// promptForMissingFlags presents interactive prompts for any block node flags
+// not supplied on the command line. Returns the ChosenValues collector so
+// callers can fold in additional prompt sections (e.g. host firewall) before
+// printing the unified summary. Returns nil when the session is
+// non-interactive or for commands (uninstall) that infer all values from
+// existing state.
+func promptForMissingFlags(cmd *cobra.Command, args []string) (*prompt.ChosenValues, error) {
 	// Destructive commands that operate on an existing deployment should not
 	// prompt — they infer everything from the current state/config.
 	if cmd.Name() == "uninstall" {
-		return nil
+		return nil, nil
 	}
 
 	var rootFlags common.RootFlags
 	_ = common.ExtractRootFlags(cmd, args, &rootFlags) // best-effort to get Force
 
 	if !prompt.ShouldPrompt(rootFlags.Force) {
-		return nil
+		return nil, nil
 	}
 
 	cv := prompt.NewChosenValues()
@@ -164,7 +158,7 @@ func promptForMissingFlags(cmd *cobra.Command, args []string) error {
 
 	// Run all accumulated pages as a single navigable form.
 	if err := w.Run(); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Propagate the prompted profile value into Cobra's inherited persistent
@@ -176,22 +170,24 @@ func promptForMissingFlags(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	_, _ = fmt.Fprintln(cmd.ErrOrStderr())
-	cv.Print("Selected Inputs")
-
-	return nil
+	return cv, nil
 }
 
 // prepareBlocknodeInputs prepares and validates user inputs from command flags.
 // When running interactively (TTY, no --force, no --non-interactive), it presents
 // huh prompts for any required flags that were not supplied on the command line.
-func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInputs[models.BlockNodeInputs], error) {
+// The returned ChosenValues collector is nil when the session is non-interactive;
+// callers are responsible for printing the summary (via cv.Print) at the right
+// point — after any additional prompt sections (e.g. host firewall) have added
+// their entries.
+func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInputs[models.BlockNodeInputs], *prompt.ChosenValues, error) {
 	var err error
 
 	// ── Interactive prompts ──────────────────────────────────────────────
 	// Run prompts for missing flags before extracting/validating them.
-	if err = promptForMissingFlags(cmd, args); err != nil {
-		return nil, err
+	cv, err := promptForMissingFlags(cmd, args)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// ── Extract & validate flags ─────────────────────────────────────────
@@ -201,7 +197,7 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 	requireProfile := cmd.Name() != "uninstall"
 	err = extractBlockNodeParentFlagsWithOpts(cmd, args, &parentFlags, requireProfile)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Validate the value file path if provided
@@ -210,14 +206,14 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 	if flagValuesFile != "" {
 		validatedValuesFile, err = sanity.ValidateInputFile(flagValuesFile)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	// Determine execution mode based on flags
 	execMode, err := common.GetExecutionMode(flagContinueOnError, flagStopOnError, flagRollbackOnError)
 	if err != nil {
-		return nil, errorx.Decorate(err, "failed to determine execution mode")
+		return nil, nil, errorx.Decorate(err, "failed to determine execution mode")
 	}
 	execOpts := workflows.DefaultWorkflowExecutionOptions()
 	execOpts.ExecutionMode = execMode
@@ -229,7 +225,7 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 	pluginList := flagPlugins
 	if f := cmd.Flag("plugins"); f != nil && f.Changed {
 		if err := models.ValidatePluginList(flagPlugins); err != nil {
-			return nil, errorx.IllegalArgument.Wrap(err, "invalid --plugins value")
+			return nil, nil, errorx.IllegalArgument.Wrap(err, "invalid --plugins value")
 		}
 	}
 	if pluginList == "" && bnpkg.IsKnownPreset(pluginPreset) {
@@ -254,7 +250,7 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 		pluginPreset = bnpkg.PresetCustom
 	}
 	if pluginPreset == bnpkg.PresetCustom && pluginList == "" {
-		return nil, errorx.IllegalArgument.New("--plugins is required when --plugin-preset=%s", bnpkg.PresetCustom)
+		return nil, nil, errorx.IllegalArgument.New("--plugins is required when --plugin-preset=%s", bnpkg.PresetCustom)
 	}
 
 	inputs := &models.UserInputs[models.BlockNodeInputs]{
@@ -295,13 +291,14 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 			RecentRetention:     flagRecentRetention,
 			PluginPreset:        pluginPreset,
 			PluginList:          pluginList,
+			EgressInterface:     flagEgressInterface,
 		},
 	}
 
 	logx.As().Info().Any("inputs", inputs).Msg("User inputs for block node operation")
 	if err := inputs.Validate(); err != nil {
-		return nil, errorx.IllegalArgument.Wrap(err, "invalid user inputs")
+		return nil, nil, errorx.IllegalArgument.Wrap(err, "invalid user inputs")
 	}
 
-	return inputs, nil
+	return inputs, cv, nil
 }

--- a/cmd/cli/commands/block/node/install.go
+++ b/cmd/cli/commands/block/node/install.go
@@ -3,9 +3,13 @@
 package node
 
 import (
+	"fmt"
+
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/spf13/cobra"
 )
@@ -16,20 +20,27 @@ var installCmd = &cobra.Command{
 	Short:   "Install a Hedera Block Node",
 	Long:    "Run safety checks, setup a K8s cluster and install a Hedera Block Node",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		inputs, err := prepareBlocknodeInputs(cmd, args)
+		inputs, cv, err := prepareBlocknodeInputs(cmd, args)
 		if err != nil {
 			return err
 		}
 
-		// Resolve the host firewall config (mgmt allowlist, SSH port, pod CIDR,
-		// in-cluster ports) and apply it to the global config so the
-		// NetworkFirewallCreate step (prepended to this handler's workflow) can
-		// render the inet host table. Always resolved here — regardless of
-		// whether this install bootstraps bare metal or deploys onto an existing
-		// cluster — since the block node is the node type that owns this
-		// firewall, not the generic cluster-provisioning path.
-		if err := common.ResolveHostFirewallConfig(cmd, args); err != nil {
+		// Resolve the host firewall config. The egress-interface prompt is
+		// prepended so it appears in the same TUI panel as the firewall fields.
+		// cv is passed so all values fold into the unified "Selected Inputs"
+		// summary rather than a separate section.
+		detectedNIC, _ := shape.DetectEgressInterface()
+		if err := common.ResolveHostFirewallConfig(cmd, args, cv,
+			prompt.EgressInterfaceInputPrompt(detectedNIC, &flagEgressInterface),
+		); err != nil {
 			return err
+		}
+
+		// Print the unified summary of all prompted values (block node inputs +
+		// firewall) now that both prompt sections have completed.
+		if cv != nil {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr())
+			cv.Print("Selected Inputs")
 		}
 
 		err = initializeDependencies()
@@ -68,4 +79,7 @@ func init() {
 	installCmd.Flags().StringVar(&flagChartVersion, "chart-version", "", "Helm chart version to use")
 	common.FlagValuesFile().SetVarP(installCmd, &flagValuesFile, false)
 	common.RegisterHostFirewallFlags(installCmd)
+	installCmd.Flags().StringVar(&flagEgressInterface, "egress-interface", "",
+		"Physical NIC for the $EGRESS HTB traffic-shaper hierarchy (e.g. eth0). "+
+			"Auto-detected from the default route when omitted; use this flag to override on multi-NIC hosts.")
 }

--- a/cmd/cli/commands/block/node/node.go
+++ b/cmd/cli/commands/block/node/node.go
@@ -38,6 +38,7 @@ var (
 	flagPluginPreset         string
 	flagPlugins              string
 	flagLoadBalancerEnabled  bool
+	flagEgressInterface      string
 
 	nodeCmd = &cobra.Command{
 		Use:   "node",

--- a/cmd/cli/commands/block/node/reconfigure.go
+++ b/cmd/cli/commands/block/node/reconfigure.go
@@ -3,6 +3,8 @@
 package node
 
 import (
+	"fmt"
+
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
@@ -18,9 +20,13 @@ var (
 		Short: "Reconfigure a Hedera Block Node",
 		Long:  "Re-apply configuration to an existing Hedera Block Node deployment without changing its chart version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			inputs, err := prepareBlocknodeInputs(cmd, args)
+			inputs, cv, err := prepareBlocknodeInputs(cmd, args)
 			if err != nil {
 				return err
+			}
+			if cv != nil {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr())
+				cv.Print("Selected Inputs")
 			}
 
 			err = initializeDependencies()

--- a/cmd/cli/commands/block/node/reset.go
+++ b/cmd/cli/commands/block/node/reset.go
@@ -3,6 +3,8 @@
 package node
 
 import (
+	"fmt"
+
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
@@ -24,9 +26,13 @@ This command will:
 
 WARNING: This operation is destructive and cannot be undone. All block data will be lost.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		inputs, err := prepareBlocknodeInputs(cmd, args)
+		inputs, cv, err := prepareBlocknodeInputs(cmd, args)
 		if err != nil {
 			return err
+		}
+		if cv != nil {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr())
+			cv.Print("Selected Inputs")
 		}
 
 		err = initializeDependencies()

--- a/cmd/cli/commands/block/node/uninstall.go
+++ b/cmd/cli/commands/block/node/uninstall.go
@@ -16,7 +16,7 @@ var uninstallCmd = &cobra.Command{
 	Short:   "Uninstall Hedera Block Node",
 	Long:    "Uninstall Hedera Block Node",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		inputs, err := prepareBlocknodeInputs(cmd, args)
+		inputs, _, err := prepareBlocknodeInputs(cmd, args)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/commands/block/node/upgrade.go
+++ b/cmd/cli/commands/block/node/upgrade.go
@@ -3,6 +3,8 @@
 package node
 
 import (
+	"fmt"
+
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
@@ -20,9 +22,13 @@ var (
 		Short: "Upgrade a Hedera Block Node",
 		Long:  "Upgrade an existing Hedera Block Node deployment with new configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			inputs, err := prepareBlocknodeInputs(cmd, args)
+			inputs, cv, err := prepareBlocknodeInputs(cmd, args)
 			if err != nil {
 				return err
+			}
+			if cv != nil {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr())
+				cv.Print("Selected Inputs")
 			}
 
 			err = initializeDependencies()

--- a/cmd/cli/commands/common/host_firewall.go
+++ b/cmd/cli/commands/common/host_firewall.go
@@ -53,8 +53,16 @@ func RegisterHostFirewallFlags(cmd *cobra.Command) {
 // allowlist is allowed — the step then skips firewall creation rather than
 // rendering a lock-out (default-drop) ruleset.
 //
+// When cv is non-nil the prompted values are recorded into it and no separate
+// summary is printed — the caller is responsible for printing the unified
+// summary after all prompt sections complete. When cv is nil a local collector
+// is used and printed as "Host Firewall" immediately.
+//
+// extraInputPrompts are prepended to the firewall input prompts so callers can
+// place related prompts (e.g. egress interface) in the same TUI panel.
+//
 // It requires RegisterHostFirewallFlags to have been called on cmd.
-func ResolveHostFirewallConfig(cmd *cobra.Command, args []string) error {
+func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues, extraInputPrompts ...prompt.InputPrompt) error {
 	force, err := FlagForce().Value(cmd, args)
 	if err != nil {
 		return errorx.IllegalArgument.Wrap(err, "failed to get %s flag", FlagForce().Name)
@@ -100,16 +108,24 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string) error {
 	podStr := effectiveStr(cmd, FlagNamePodCIDR, cfg.PodCIDR, models.DefaultClusterPodCIDR)
 
 	if prompt.ShouldPrompt(force) {
-		cv := prompt.NewChosenValues()
-		if err := prompt.RunInputPrompts(cmd, []prompt.InputPrompt{
+		localCV := cv
+		if localCV == nil {
+			localCV = prompt.NewChosenValues()
+		}
+		allPrompts := make([]prompt.InputPrompt, 0, len(extraInputPrompts)+4)
+		allPrompts = append(allPrompts, extraInputPrompts...)
+		allPrompts = append(allPrompts,
 			prompt.MgmtCIDRsInputPrompt(mgmtStr, &mgmtStr),
 			prompt.SSHPortInputPrompt(sshStr, &sshStr),
 			prompt.PodCIDRInputPrompt(podStr, &podStr),
 			prompt.InClusterPortsInputPrompt(portsStr, &portsStr),
-		}, cv); err != nil {
+		)
+		if err := prompt.RunInputPrompts(cmd, allPrompts, localCV); err != nil {
 			return err
 		}
-		cv.Print("Host Firewall")
+		if cv == nil {
+			localCV.Print("Host Firewall")
+		}
 	}
 
 	sshPort, err := strconv.Atoi(strings.TrimSpace(sshStr))

--- a/cmd/cli/commands/network/network.go
+++ b/cmd/cli/commands/network/network.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/network/firewall"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/network/policy"
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/network/shape"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +23,7 @@ var networkCmd = &cobra.Command{
 func init() {
 	networkCmd.AddCommand(firewall.GetCmd())
 	networkCmd.AddCommand(policy.GetCmd())
+	networkCmd.AddCommand(shape.GetCmd())
 }
 
 // GetCmd returns the root of the `network` command group.

--- a/cmd/cli/commands/network/shape/create.go
+++ b/cmd/cli/commands/network/shape/create.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	shp "github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a shape device root or bandwidth class",
+	Long: "Create a tc HTB shape configuration. Exactly one of --device or --class must be supplied:\n\n" +
+		"  --device <dir>  Configure the root qdisc and trunk class for \"ingress\" ($VETH) or\n" +
+		"                  \"egress\" ($NIC). Required: --rate, --default. Must run before any\n" +
+		"                  --class form for the same device (tc parent-before-child requirement).\n\n" +
+		"  --class <name>  Add an HTB leaf class + fq_codel qdisc. The device is implied by the\n" +
+		"                  class direction (§5 map). Required: --rate. Optional: --ceil, --prio.\n\n" +
+		"create-if-missing: an existing entry is left untouched unless --force is passed.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if flagClass != "" && flagDevice != "" {
+			return errorx.IllegalArgument.New("--class and --device are mutually exclusive")
+		}
+		if flagClass == "" && flagDevice == "" {
+			return errorx.IllegalArgument.New("exactly one of --class or --device must be supplied")
+		}
+
+		force, err := common.FlagForce().Value(cmd, args)
+		if err != nil {
+			return err
+		}
+
+		m := newManager()
+
+		if flagDevice != "" {
+			return runCreateDevice(cmd, m, force)
+		}
+		return runCreateClass(cmd, m, force)
+	},
+}
+
+func runCreateDevice(cmd *cobra.Command, m *shp.Manager, force bool) error {
+	if !cmd.Flags().Changed("rate") {
+		return errorx.IllegalArgument.New("--rate is required for --device")
+	}
+	if !cmd.Flags().Changed("default") {
+		return errorx.IllegalArgument.New("--default is required for --device")
+	}
+
+	dev := &shp.DeviceConfig{
+		Dir:          flagDevice,
+		Rate:         flagRate,
+		DefaultClass: flagDefault,
+	}
+	changed, err := m.CreateDevice(cmd.Context(), dev, force)
+	if err != nil {
+		return err
+	}
+	if changed {
+		logx.As().Info().Str("device", dev.Dir).Str("rate", dev.Rate).
+			Str("default", dev.DefaultClass).Msg("network shape device configured")
+	}
+	return nil
+}
+
+func runCreateClass(cmd *cobra.Command, m *shp.Manager, force bool) error {
+	if !cmd.Flags().Changed("rate") {
+		return errorx.IllegalArgument.New("--rate is required for --class")
+	}
+
+	cls := &shp.ClassConfig{
+		Name: flagClass,
+		Rate: flagRate,
+		Prio: flagPrio,
+	}
+	if cmd.Flags().Changed("ceil") {
+		cls.Ceil = flagCeil
+	}
+
+	changed, err := m.CreateClass(cmd.Context(), cls, force)
+	if err != nil {
+		return err
+	}
+	if changed {
+		ceil := cls.Ceil
+		if ceil == "" {
+			ceil = cls.Rate
+		}
+		logx.As().Info().Str("class", cls.Name).Str("rate", cls.Rate).
+			Str("ceil", ceil).Int("prio", cls.Prio).
+			Msg("network shape class configured")
+	}
+	return nil
+}
+
+func init() {
+	createCmd.Flags().StringVar(&flagClass, "class", "", "HTB class name to configure (§5 map: publisher, partner, public, …)")
+	createCmd.Flags().StringVar(&flagDevice, "device", "", "Traffic direction to configure root for: ingress ($VETH) or egress ($NIC)")
+	createCmd.Flags().StringVar(&flagRate, "rate", "", "Bandwidth rate (e.g. 100mbit, 1gbit)")
+	createCmd.Flags().StringVar(&flagCeil, "ceil", "", "Burst ceiling rate (≥ --rate; defaults to --rate if omitted)")
+	createCmd.Flags().IntVar(&flagPrio, "prio", 0, "HTB scheduling priority [0,7] (0 = highest; default 0)")
+	createCmd.Flags().StringVar(&flagDefault, "default", "", "Default class name for unmatched traffic (--device form only)")
+}

--- a/cmd/cli/commands/network/shape/delete.go
+++ b/cmd/cli/commands/network/shape/delete.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a shape device or class configuration",
+	Long: "Delete a shape configuration. Exactly one of --device or --class must be supplied.\n\n" +
+		"  --class <name>  Remove the class configuration. Fails if the class is referenced as\n" +
+		"                  the device default or by any network policy --stamp/--reply-stamp.\n\n" +
+		"  --device <dir>  Remove the device configuration. Fails if any classes are still\n" +
+		"                  configured for this device (delete classes first).\n\n" +
+		"For egress targets, tc-egress.sh is re-rendered and tc-egress.service is restarted.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if flagClass != "" && flagDevice != "" {
+			return errorx.IllegalArgument.New("--class and --device are mutually exclusive")
+		}
+		if flagClass == "" && flagDevice == "" {
+			return errorx.IllegalArgument.New("exactly one of --class or --device must be supplied")
+		}
+
+		m := newManager()
+
+		if flagClass != "" {
+			if err := m.DeleteClass(cmd.Context(), flagClass); err != nil {
+				return err
+			}
+			logx.As().Info().Str("class", flagClass).Msg("network shape class deleted")
+			return nil
+		}
+
+		if err := m.DeleteDevice(cmd.Context(), flagDevice); err != nil {
+			return err
+		}
+		logx.As().Info().Str("device", flagDevice).Msg("network shape device deleted")
+		return nil
+	},
+}
+
+func init() {
+	deleteCmd.Flags().StringVar(&flagClass, "class", "", "Class name to delete")
+	deleteCmd.Flags().StringVar(&flagDevice, "device", "", "Device direction to delete (ingress or egress)")
+}

--- a/cmd/cli/commands/network/shape/set.go
+++ b/cmd/cli/commands/network/shape/set.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var setCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Update bandwidth parameters of an existing class (tc class change, no qdisc churn)",
+	Long: "Atomically update one or more bandwidth parameters of an existing class using " +
+		"`tc class change` on the live kernel (no qdisc teardown). The boot script is " +
+		"re-rendered for reboot persistence. Only the explicitly supplied flags are changed; " +
+		"omitted flags keep their current value. --class is required.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if flagClass == "" {
+			return errorx.IllegalArgument.New("--class is required")
+		}
+		if !cmd.Flags().Changed("rate") && !cmd.Flags().Changed("ceil") && !cmd.Flags().Changed("prio") {
+			return errorx.IllegalArgument.New("at least one of --rate, --ceil, or --prio must be supplied")
+		}
+
+		var rate, ceil *string
+		var prio *int
+		if cmd.Flags().Changed("rate") {
+			v := flagRate
+			rate = &v
+		}
+		if cmd.Flags().Changed("ceil") {
+			v := flagCeil
+			ceil = &v
+		}
+		if cmd.Flags().Changed("prio") {
+			v := flagPrio
+			prio = &v
+		}
+
+		if err := newManager().SetClass(cmd.Context(), flagClass, rate, ceil, prio); err != nil {
+			return err
+		}
+		logx.As().Info().Str("class", flagClass).Msg("network shape class updated")
+		return nil
+	},
+}
+
+func init() {
+	setCmd.Flags().StringVar(&flagClass, "class", "", "Class name to update (required)")
+	setCmd.Flags().StringVar(&flagRate, "rate", "", "New guaranteed bandwidth rate")
+	setCmd.Flags().StringVar(&flagCeil, "ceil", "", "New burst ceiling rate (≥ --rate)")
+	setCmd.Flags().IntVar(&flagPrio, "prio", 0, "New HTB scheduling priority [0,7]")
+}

--- a/cmd/cli/commands/network/shape/shape.go
+++ b/cmd/cli/commands/network/shape/shape.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package shape wires the `solo-provisioner network shape` verbs to the
+// internal/network/shape manager. The shape scope manages the tc HTB bandwidth
+// plane on $EGRESS (physical NIC) and $VETH (pod traffic), maintaining
+// per-class rate/ceil/prio configurations that drive the tc-egress.sh boot
+// script and the daemon pod-lifecycle watcher (TS_3).
+//
+// Two forms of `create` are supported, mutually exclusive via --class/--device:
+//   - create --device <dir> --rate <speed> --default <class>: configure the
+//     root HTB qdisc and trunk class for "ingress" ($VETH) or "egress" ($NIC).
+//   - create --class <name> --rate <speed> [--ceil <speed>] [--prio <n>]:
+//     add an HTB leaf class; device is implied by the class direction (§5).
+package shape
+
+import (
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	shp "github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/spf13/cobra"
+)
+
+// Shared flag binding targets. Only one verb runs per invocation.
+var (
+	flagClass   string
+	flagDevice  string
+	flagRate    string
+	flagCeil    string
+	flagPrio    int
+	flagDefault string
+)
+
+var shapeCmd = &cobra.Command{
+	Use:   "shape",
+	Short: "Manage tc HTB bandwidth classes on $EGRESS and $VETH",
+	Long: "Manage the tc HTB bandwidth plane: configure root qdisc devices and per-class " +
+		"rate/ceil/prio bandwidth parameters. Egress mutations re-render " +
+		"solo-provisioner-tc-egress.sh and restart the boot service. Ingress mutations " +
+		"write config for the daemon's pod-lifecycle watcher (TS_3) to apply to each new veth interface.",
+	RunE: common.DefaultRunE,
+}
+
+func init() {
+	shapeCmd.AddCommand(createCmd)
+	shapeCmd.AddCommand(setCmd)
+	shapeCmd.AddCommand(showCmd)
+	shapeCmd.AddCommand(deleteCmd)
+}
+
+// GetCmd returns the root of the `network shape` command group.
+func GetCmd() *cobra.Command {
+	return shapeCmd
+}
+
+// newManager constructs the production manager. Indirected through a var so
+// command tests can stub it.
+var newManager = func() *shp.Manager { return shp.NewManager() }

--- a/cmd/cli/commands/network/shape/shape_test.go
+++ b/cmd/cli/commands/network/shape/shape_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"testing"
+	"time"
+
+	shp "github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+// resetFlags clears package-level flag vars and cobra's per-flag Changed state.
+// Call via defer at the top of every test that mutates these vars so state
+// does not leak into subsequent tests.
+func resetFlags() {
+	flagClass = ""
+	flagDevice = ""
+	flagRate = ""
+	flagCeil = ""
+	flagPrio = 0
+	flagDefault = ""
+	for _, cmd := range []*cobra.Command{createCmd, setCmd, showCmd, deleteCmd} {
+		cmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+	}
+}
+
+// --- Structure tests ---
+
+func TestShapeCmd_HasExpectedSubcommands(t *testing.T) {
+	subs := map[string]bool{}
+	for _, c := range shapeCmd.Commands() {
+		subs[c.Name()] = true
+	}
+	for _, want := range []string{"create", "set", "show", "delete"} {
+		require.True(t, subs[want], "missing subcommand %q", want)
+	}
+}
+
+func TestGetCmd_ReturnsShapeCmd(t *testing.T) {
+	require.Equal(t, "shape", GetCmd().Name())
+}
+
+func TestCreateCmd_FlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"class", "device", "rate", "ceil", "prio", "default"} {
+		require.NotNil(t, createCmd.Flags().Lookup(flag), "create: missing --%s", flag)
+	}
+}
+
+func TestSetCmd_FlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"class", "rate", "ceil", "prio"} {
+		require.NotNil(t, setCmd.Flags().Lookup(flag), "set: missing --%s", flag)
+	}
+}
+
+func TestShowCmd_FlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"class", "device"} {
+		require.NotNil(t, showCmd.Flags().Lookup(flag), "show: missing --%s", flag)
+	}
+}
+
+func TestDeleteCmd_FlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"class", "device"} {
+		require.NotNil(t, deleteCmd.Flags().Lookup(flag), "delete: missing --%s", flag)
+	}
+}
+
+// --- create: mutual exclusion (validation fires before newManager is called) ---
+
+func TestCreateCmd_BothClassAndDevice_Error(t *testing.T) {
+	defer resetFlags()
+	flagClass = "partner"
+	flagDevice = "egress"
+
+	err := createCmd.RunE(createCmd, nil)
+	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+func TestCreateCmd_NeitherClassNorDevice_Error(t *testing.T) {
+	defer resetFlags()
+
+	err := createCmd.RunE(createCmd, nil)
+	require.ErrorContains(t, err, "exactly one of")
+}
+
+// --- create --class: flag-required validation (fires before manager) ---
+
+func TestRunCreateClass_MissingRate_Error(t *testing.T) {
+	defer resetFlags()
+	// Construct a minimal cmd with only the flags runCreateClass inspects.
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(&flagRate, "rate", "", "")
+	// --rate not Set → Changed returns false → runCreateClass errors.
+	err := runCreateClass(cmd, nil, false)
+	require.ErrorContains(t, err, "--rate is required")
+}
+
+// --- create --device: flag-required validation ---
+
+func TestRunCreateDevice_MissingRate_Error(t *testing.T) {
+	defer resetFlags()
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(&flagRate, "rate", "", "")
+	cmd.Flags().StringVar(&flagDefault, "default", "", "")
+	// --rate not Changed
+	err := runCreateDevice(cmd, nil, false)
+	require.ErrorContains(t, err, "--rate is required")
+}
+
+func TestRunCreateDevice_MissingDefault_Error(t *testing.T) {
+	defer resetFlags()
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(&flagRate, "rate", "", "")
+	cmd.Flags().StringVar(&flagDefault, "default", "", "")
+	require.NoError(t, cmd.Flags().Set("rate", "1gbit"))
+	// --default not Changed
+	err := runCreateDevice(cmd, nil, false)
+	require.ErrorContains(t, err, "--default is required")
+}
+
+// --- set: early validation (fires before newManager is called) ---
+
+func TestSetCmd_NoClass_Error(t *testing.T) {
+	defer resetFlags()
+	// flagClass is "" — RunE should return before calling the manager.
+	// We need a cmd with the same RunE but its own fresh FlagSet so Changed()
+	// works correctly and we do not pollute the shared setCmd FlagSet.
+	cmd := &cobra.Command{
+		RunE: setCmd.RunE,
+	}
+	cmd.Flags().StringVar(&flagClass, "class", "", "")
+	cmd.Flags().StringVar(&flagRate, "rate", "", "")
+	cmd.Flags().StringVar(&flagCeil, "ceil", "", "")
+	cmd.Flags().IntVar(&flagPrio, "prio", 0, "")
+	require.NoError(t, cmd.Flags().Set("rate", "200mbit"))
+
+	err := cmd.RunE(cmd, nil)
+	require.ErrorContains(t, err, "--class is required")
+}
+
+func TestSetCmd_NoChangedBandwidthFlag_Error(t *testing.T) {
+	defer resetFlags()
+	cmd := &cobra.Command{
+		RunE: setCmd.RunE,
+	}
+	cmd.Flags().StringVar(&flagClass, "class", "", "")
+	cmd.Flags().StringVar(&flagRate, "rate", "", "")
+	cmd.Flags().StringVar(&flagCeil, "ceil", "", "")
+	cmd.Flags().IntVar(&flagPrio, "prio", 0, "")
+	// Set --class but do not touch --rate/--ceil/--prio.
+	require.NoError(t, cmd.Flags().Set("class", "partner"))
+
+	err := cmd.RunE(cmd, nil)
+	require.ErrorContains(t, err, "at least one of --rate, --ceil, or --prio")
+}
+
+// --- show: mutual exclusion (fires before newManager) ---
+
+func TestShowCmd_BothClassAndDevice_Error(t *testing.T) {
+	defer resetFlags()
+	flagClass = "partner"
+	flagDevice = "egress"
+
+	err := showCmd.RunE(showCmd, nil)
+	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+// --- delete: mutual exclusion and required-one-of validation ---
+
+func TestDeleteCmd_BothClassAndDevice_Error(t *testing.T) {
+	defer resetFlags()
+	flagClass = "partner"
+	flagDevice = "egress"
+
+	err := deleteCmd.RunE(deleteCmd, nil)
+	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+func TestDeleteCmd_NeitherClassNorDevice_Error(t *testing.T) {
+	defer resetFlags()
+
+	err := deleteCmd.RunE(deleteCmd, nil)
+	require.ErrorContains(t, err, "exactly one of")
+}
+
+// --- model field tests ---
+
+func TestClassConfig_CeilDefaultsToEmpty(t *testing.T) {
+	cls := &shp.ClassConfig{Name: "partner", Rate: "400mbit"}
+	require.Empty(t, cls.Ceil)
+}
+
+func TestDeviceConfig_DirEgressConstant(t *testing.T) {
+	require.Equal(t, "egress", shp.DirEgress)
+	require.Equal(t, "ingress", shp.DirIngress)
+}
+
+func TestDeviceConfig_FieldsRoundtrip(t *testing.T) {
+	dev := &shp.DeviceConfig{
+		Dir:          shp.DirEgress,
+		Rate:         "1gbit",
+		DefaultClass: "reserve-egress",
+		CreatedAt:    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	require.Equal(t, "egress", dev.Dir)
+	require.Equal(t, "1gbit", dev.Rate)
+	require.Equal(t, "reserve-egress", dev.DefaultClass)
+}

--- a/cmd/cli/commands/network/shape/show.go
+++ b/cmd/cli/commands/network/shape/show.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"fmt"
+
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show shape configuration (device or class)",
+	Long: "Show the stored shape configuration. Without flags, shows all configured devices and " +
+		"classes. With --device or --class, shows only the named entry.",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if flagClass != "" && flagDevice != "" {
+			return errorx.IllegalArgument.New("--class and --device are mutually exclusive")
+		}
+
+		m := newManager()
+		var out string
+		var err error
+
+		switch {
+		case flagClass != "":
+			out, err = m.ShowClass(flagClass)
+		case flagDevice != "":
+			out, err = m.ShowDevice(flagDevice)
+		default:
+			out, err = m.ShowAll()
+		}
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(cmd.OutOrStdout(), out)
+		return nil
+	},
+}
+
+func init() {
+	showCmd.Flags().StringVar(&flagClass, "class", "", "Show configuration for the named class")
+	showCmd.Flags().StringVar(&flagDevice, "device", "", "Show configuration for the named device (ingress or egress)")
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -185,6 +185,7 @@ sudo solo-provisioner block node install \
 | `--ssh-port`              | Host firewall SSH/management TCP port (default `22`)                                                                                  |
 | `--pod-cidr`              | Host firewall pod CIDR for the in-cluster host-service ports rule (defaults to the cluster pod subnet)                                |
 | `--in-cluster-ports`      | Host firewall in-cluster host-service ports (defaults to `6443,4244,7472,10250`)                                                     |
+| `--egress-interface`      | Physical NIC for the `$EGRESS` HTB traffic-shaper hierarchy (e.g. `eth0`). Auto-detected from the default route when omitted; use this flag to override on multi-NIC hosts. Renders `/usr/local/sbin/solo-provisioner-tc-egress.sh` and installs `solo-provisioner-tc-egress.service` so the HTB hierarchy survives reboot. |
 
 > **Host firewall**: `block node install` always lays down the node-level `inet
 > host` firewall (SSH/management allowlist, ICMP policy, in-cluster host-service

--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -75,6 +75,10 @@ func (h *InstallHandler) BuildWorkflow(
 				// is already installed/enabled from that prior cluster provisioning,
 				// so it's safe to apply here.
 				steps.NetworkFirewallCreate(),
+				// Render and install the $EGRESS HTB boot-persistence script and
+				// oneshot unit (design §8.3.2). Skipped when no NIC is supplied;
+				// Story 2.2 (#744) will add automatic NIC detection.
+				steps.TcEgressPersist(ins.EgressInterface),
 				steps.SetupBlockNode(ins),
 			)
 	} else {
@@ -94,6 +98,10 @@ func (h *InstallHandler) BuildWorkflow(
 				// systemSetupWorkflow; apply the host firewall here rather than in
 				// that generic (node-type-agnostic) workflow.
 				steps.NetworkFirewallCreate(),
+				// Render and install the $EGRESS HTB boot-persistence script and
+				// oneshot unit (design §8.3.2). Skipped when no NIC is supplied;
+				// Story 2.2 (#744) will add automatic NIC detection.
+				steps.TcEgressPersist(ins.EgressInterface),
 				steps.SetupBlockNode(ins),
 			)
 	}

--- a/internal/network/shape/apply_linux.go
+++ b/internal/network/shape/apply_linux.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package shape
+
+import (
+	"context"
+
+	soos "github.com/hashgraph/solo-weaver/pkg/os"
+	"github.com/joomcode/errorx"
+)
+
+// ApplyTcEgressScript restarts the tc-egress systemd unit so the kernel picks up
+// the HTB hierarchy immediately after install without waiting for a reboot.
+// RestartService resets a previously-failed unit before running it, so a
+// corrected script takes effect on re-install without a manual reset-failed.
+// Using restart (rather than executing the script directly) keeps the unit
+// state visible: on success the unit shows active (exited), on failure failed —
+// matching what operators see after a reboot.
+func ApplyTcEgressScript(ctx context.Context) error {
+	if err := soos.RestartService(ctx, TcEgressService); err != nil {
+		return errorx.Decorate(err, "tc-egress script failed")
+	}
+	return nil
+}

--- a/internal/network/shape/apply_other.go
+++ b/internal/network/shape/apply_other.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package shape
+
+import "context"
+
+// ApplyTcEgressScript is a no-op on non-Linux platforms. The tc subsystem is
+// Linux-kernel-specific; the package compiles and tests on all platforms but
+// the actual `tc` invocation only runs on Linux.
+func ApplyTcEgressScript(_ context.Context) error { return nil }

--- a/internal/network/shape/class.go
+++ b/internal/network/shape/class.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/joomcode/errorx"
+)
+
+// Direction constants for tc device/class mapping (design §5).
+const (
+	DirIngress = "ingress" // $VETH (pod traffic, handled by daemon TS_3)
+	DirEgress  = "egress"  // $EGRESS physical NIC
+)
+
+// classInfo is the static per-class descriptor from the §5 mark map. Minor is
+// the hex tc classid minor (e.g., "40" for partner → classid 1:40 in tc's hex
+// notation where 0x40=64). Handle is the fq_codel qdisc handle string (e.g.,
+// "140" for handle 140: which is 1 concatenated with Minor in hex).
+type classInfo struct {
+	Minor  string
+	Handle string
+	Dir    string
+}
+
+// classInfoMap is the stable §5 name→classid/direction map for the shape
+// package. It is a read-only companion to internal/network/policy.classMap:
+// Minor values are the hex representations of the §5 Mark column, which is
+// what tc uses in "1:40" classid notation (hex minor 0x40 = partner).
+var classInfoMap = map[string]classInfo{
+	"publisher":         {Minor: "10", Handle: "110", Dir: DirIngress},
+	"backfill-response": {Minor: "20", Handle: "120", Dir: DirIngress},
+	"reserve-ingress":   {Minor: "30", Handle: "130", Dir: DirIngress},
+	"partner":           {Minor: "40", Handle: "140", Dir: DirEgress},
+	"public":            {Minor: "50", Handle: "150", Dir: DirEgress},
+	"reserve-egress":    {Minor: "60", Handle: "160", Dir: DirEgress},
+}
+
+// lookupClassInfo resolves a class name to its classid/direction, returning an
+// error naming the known classes when the reference is absent from the §5 map.
+func lookupClassInfo(name string) (classInfo, error) {
+	c, ok := classInfoMap[name]
+	if !ok {
+		return classInfo{}, errorx.IllegalArgument.New(
+			"unknown class %q: must be one of %s", name, strings.Join(knownClassNames(), ", "))
+	}
+	return c, nil
+}
+
+// knownClassNames returns class names sorted for stable error messages.
+func knownClassNames() []string {
+	names := make([]string, 0, len(classInfoMap))
+	for n := range classInfoMap {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// knownClassNamesForDir returns class names for the given direction, sorted.
+func knownClassNamesForDir(dir string) []string {
+	var names []string
+	for n, c := range classInfoMap {
+		if c.Dir == dir {
+			names = append(names, n)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ClassConfig is the persisted bandwidth configuration for one named tc class.
+// One JSON file per class under ClassConfigDir.
+type ClassConfig struct {
+	Name      string    `json:"name"`
+	Rate      string    `json:"rate"`
+	Ceil      string    `json:"ceil,omitempty"` // defaults to Rate when empty
+	Prio      int       `json:"prio"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// effectiveCeil returns Ceil if non-empty, otherwise Rate (ceil defaults to
+// rate per tc HTB semantics: a class can burst up to its rate by default).
+func (c *ClassConfig) effectiveCeil() string {
+	if c.Ceil != "" {
+		return c.Ceil
+	}
+	return c.Rate
+}

--- a/internal/network/shape/detect.go
+++ b/internal/network/shape/detect.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// detectEgressInterfaceFrom parses a file in /proc/net/route format and
+// returns the name of the interface carrying the default route (destination
+// 0.0.0.0 with RTF_UP|RTF_GATEWAY set). Exported via DetectEgressInterface
+// on Linux; available here for cross-platform unit tests using temp files.
+func detectEgressInterfaceFrom(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", errorx.ExternalError.Wrap(err, "failed to open %s", path)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Scan() // skip header line
+
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 4 {
+			continue
+		}
+		iface := fields[0]
+		dest := fields[1]
+		flags, err := strconv.ParseUint(fields[3], 16, 32)
+		if err != nil {
+			continue
+		}
+		const (
+			rtfUp      = 0x1
+			rtfGateway = 0x2
+		)
+		if dest == "00000000" && flags&rtfGateway != 0 && flags&rtfUp != 0 {
+			return iface, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", errorx.ExternalError.Wrap(err, "failed to read %s", path)
+	}
+	return "", errorx.IllegalState.New(
+		"no default route found in %s; specify --egress-interface explicitly", path)
+}

--- a/internal/network/shape/detect_linux.go
+++ b/internal/network/shape/detect_linux.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package shape
+
+// procNetRoute is the kernel's routing table in human-readable form.
+const procNetRoute = "/proc/net/route"
+
+// DetectEgressInterface returns the name of the interface that carries the
+// default route — the physical $EGRESS NIC the HTB hierarchy should be
+// attached to. Works for single-NIC hosts (§4.1); multi-NIC support (§4.2)
+// is out of scope and requires --egress-interface to be set explicitly.
+//
+// Fails with an actionable error when no default route is found (e.g. the
+// routing table is not yet populated or the host has no default gateway).
+func DetectEgressInterface() (string, error) {
+	return detectEgressInterfaceFrom(procNetRoute)
+}

--- a/internal/network/shape/detect_other.go
+++ b/internal/network/shape/detect_other.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package shape
+
+import "github.com/joomcode/errorx"
+
+// DetectEgressInterface is not supported on non-Linux platforms.
+// Use --egress-interface to specify the NIC name explicitly.
+func DetectEgressInterface() (string, error) {
+	return "", errorx.IllegalState.New(
+		"egress interface auto-detection requires Linux (/proc/net/route); " +
+			"use --egress-interface to specify the NIC explicitly")
+}

--- a/internal/network/shape/device.go
+++ b/internal/network/shape/device.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import "time"
+
+// DeviceConfig is the persisted root-level tc configuration for one traffic
+// direction. One JSON file per device under DeviceConfigDir (named by Dir).
+//
+// Dir "egress" targets the $EGRESS physical NIC and drives the re-rendered
+// tc-egress.sh boot script. Dir "ingress" targets $VETH and is consumed by
+// the daemon pod-lifecycle watcher (TS_3); no script is rendered for it.
+type DeviceConfig struct {
+	Dir          string    `json:"dir"`           // "ingress" or "egress"
+	Rate         string    `json:"rate"`          // root HTB trunk class rate
+	DefaultClass string    `json:"default_class"` // class name; unmatched traffic falls here
+	CreatedAt    time.Time `json:"created_at"`
+}

--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -1,0 +1,514 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+)
+
+// Manager implements the `network shape` verb: create, set, show, and delete
+// operations for tc HTB device roots and per-class bandwidth configurations.
+//
+// Egress mutations (Dir "egress") re-render TcEgressScriptPath and restart the
+// tc-egress.service oneshot so the kernel picks up changes immediately. Ingress
+// mutations (Dir "ingress") only write config; the daemon pod-lifecycle watcher
+// (TS_3) reads them and applies them to each new veth interface.
+type Manager struct {
+	scriptPath  string
+	deviceDir   string
+	classDir    string
+	lockPath    string
+	nicDetect   func() (string, error)
+	applyEgress func(ctx context.Context) error
+	tcRunner    TCRunner
+}
+
+// Config customises a Manager. The zero value is not useful; prefer NewManager.
+type Config struct {
+	ScriptPath  string
+	DeviceDir   string
+	ClassDir    string
+	LockPath    string
+	NICDetect   func() (string, error)
+	ApplyEgress func(ctx context.Context) error
+	TCRunner    TCRunner
+}
+
+// NewManager returns a Manager wired to the live kernel and production paths.
+func NewManager() *Manager {
+	return NewManagerWithConfig(Config{})
+}
+
+// NewManagerWithConfig returns a Manager, filling unset Config fields with
+// their production defaults.
+func NewManagerWithConfig(cfg Config) *Manager {
+	m := &Manager{
+		scriptPath:  cfg.ScriptPath,
+		deviceDir:   cfg.DeviceDir,
+		classDir:    cfg.ClassDir,
+		lockPath:    cfg.LockPath,
+		nicDetect:   cfg.NICDetect,
+		applyEgress: cfg.ApplyEgress,
+		tcRunner:    cfg.TCRunner,
+	}
+	if m.scriptPath == "" {
+		m.scriptPath = TcEgressScriptPath
+	}
+	if m.deviceDir == "" {
+		m.deviceDir = DeviceConfigDir
+	}
+	if m.classDir == "" {
+		m.classDir = ClassConfigDir
+	}
+	if m.lockPath == "" {
+		m.lockPath = ShapeLockPath
+	}
+	if m.nicDetect == nil {
+		m.nicDetect = DetectEgressInterface
+	}
+	if m.applyEgress == nil {
+		m.applyEgress = ApplyTcEgressScript
+	}
+	if m.tcRunner == nil {
+		m.tcRunner = newExecTCRunner()
+	}
+	return m
+}
+
+// CreateDevice creates (or replaces with --force) the root device configuration.
+// For "egress": re-renders TcEgressScriptPath and restarts tc-egress.service.
+// For "ingress": writes config only (daemon TS_3 handles VETH apply).
+//
+// Returns true if the config was created or replaced, false if it already
+// existed and force was not set.
+func (m *Manager) CreateDevice(ctx context.Context, dev *DeviceConfig, force bool) (bool, error) {
+	if err := validateDir(dev.Dir); err != nil {
+		return false, err
+	}
+	if err := validateRate(dev.Rate); err != nil {
+		return false, err
+	}
+	if err := validateDefaultClass(dev.DefaultClass, dev.Dir); err != nil {
+		return false, err
+	}
+
+	var changed bool
+	err := m.withLock(func() error {
+		existing, err := readDevice(dev.Dir)
+		if err != nil {
+			return err
+		}
+		if existing != nil && !force {
+			logx.As().Warn().Str("dir", dev.Dir).Msg(
+				"network shape device already configured — flags not applied; pass --force to replace")
+			return nil
+		}
+		if existing != nil {
+			dev.CreatedAt = existing.CreatedAt
+		} else if dev.CreatedAt.IsZero() {
+			dev.CreatedAt = time.Now().UTC()
+		}
+		if err := writeDevice(dev); err != nil {
+			return err
+		}
+		if dev.Dir == DirEgress {
+			if err := m.renderAndApplyEgress(ctx); err != nil {
+				return err
+			}
+		}
+		changed = true
+		return nil
+	})
+	return changed, err
+}
+
+// CreateClass creates (or replaces with --force) a per-class bandwidth configuration.
+// The device for the class direction must exist before adding classes.
+// For egress classes: re-renders TcEgressScriptPath and restarts tc-egress.service.
+// For ingress classes: writes config only (daemon TS_3 handles VETH apply).
+//
+// Returns true if the config was created or replaced, false if it already
+// existed and force was not set.
+func (m *Manager) CreateClass(ctx context.Context, cls *ClassConfig, force bool) (bool, error) {
+	ci, err := lookupClassInfo(cls.Name)
+	if err != nil {
+		return false, err
+	}
+	if err := validateRate(cls.Rate); err != nil {
+		return false, err
+	}
+	if cls.Ceil != "" {
+		if err := validateCeilGeRate(cls.Ceil, cls.Rate); err != nil {
+			return false, err
+		}
+	}
+	if err := validatePrio(cls.Prio); err != nil {
+		return false, err
+	}
+
+	var changed bool
+	err = m.withLock(func() error {
+		dev, err := readDevice(ci.Dir)
+		if err != nil {
+			return err
+		}
+		if dev == nil {
+			return errorx.IllegalState.New(
+				"device %q is not configured; run `network shape create --device %s` first",
+				ci.Dir, ci.Dir)
+		}
+
+		siblings, err := loadClassesForDir(ci.Dir)
+		if err != nil {
+			return err
+		}
+		if err := validateSumRates(siblings, cls, dev.Rate); err != nil {
+			return err
+		}
+
+		existing, err := readClass(cls.Name)
+		if err != nil {
+			return err
+		}
+		if existing != nil && !force {
+			logx.As().Warn().Str("class", cls.Name).Msg(
+				"network shape class already configured — flags not applied; pass --force to replace")
+			return nil
+		}
+		if existing != nil {
+			cls.CreatedAt = existing.CreatedAt
+		} else if cls.CreatedAt.IsZero() {
+			cls.CreatedAt = time.Now().UTC()
+		}
+		if err := writeClass(cls); err != nil {
+			return err
+		}
+		if ci.Dir == DirEgress {
+			if err := m.renderAndApplyEgress(ctx); err != nil {
+				return err
+			}
+		}
+		changed = true
+		return nil
+	})
+	return changed, err
+}
+
+// SetClass atomically updates one or more bandwidth parameters of an existing
+// class. Only non-nil pointer fields are changed; nil means "keep current value".
+// For egress classes: runs `tc class change` on the live kernel and re-renders
+// the boot script for reboot persistence. For ingress classes: updates config only.
+func (m *Manager) SetClass(ctx context.Context, name string, rate, ceil *string, prio *int) error {
+	ci, err := lookupClassInfo(name)
+	if err != nil {
+		return err
+	}
+	return m.withLock(func() error {
+		cls, err := readClass(name)
+		if err != nil {
+			return err
+		}
+		if cls == nil {
+			return errorx.IllegalState.New(
+				"class %q is not configured; run `network shape create --class %s` first", name, name)
+		}
+		if rate != nil {
+			cls.Rate = *rate
+		}
+		if ceil != nil {
+			cls.Ceil = *ceil
+		}
+		if prio != nil {
+			cls.Prio = *prio
+		}
+
+		// Validate the updated state.
+		if err := validateRate(cls.Rate); err != nil {
+			return err
+		}
+		if cls.Ceil != "" {
+			if err := validateCeilGeRate(cls.Ceil, cls.Rate); err != nil {
+				return err
+			}
+		}
+		if err := validatePrio(cls.Prio); err != nil {
+			return err
+		}
+
+		dev, err := readDevice(ci.Dir)
+		if err != nil {
+			return err
+		}
+		if dev != nil {
+			siblings, err := loadClassesForDir(ci.Dir)
+			if err != nil {
+				return err
+			}
+			if err := validateSumRates(siblings, cls, dev.Rate); err != nil {
+				return err
+			}
+		}
+
+		if err := writeClass(cls); err != nil {
+			return err
+		}
+
+		if ci.Dir == DirEgress {
+			nic, err := m.nicDetect()
+			if err != nil {
+				return errorx.Decorate(err, "cannot apply live tc class change: egress NIC detection failed")
+			}
+			if err := m.tcRunner.ClassChange(ctx, nic, ci.Minor, cls.Rate, cls.effectiveCeil(), cls.Prio); err != nil {
+				return errorx.Decorate(err,
+					"class config updated on disk but live tc class change failed; reboot or restart tc-egress.service to sync")
+			}
+			if err := m.renderAndApplyScript(ctx, nic); err != nil {
+				return errorx.Decorate(err,
+					"live tc class change applied but boot script re-render failed; reboot may revert the change")
+			}
+		}
+		return nil
+	})
+}
+
+// ShowClass returns a human-readable summary of the named class config.
+func (m *Manager) ShowClass(name string) (string, error) {
+	cls, err := readClass(name)
+	if err != nil {
+		return "", err
+	}
+	if cls == nil {
+		return "", errorx.IllegalState.New("class %q is not configured", name)
+	}
+	ci, _ := lookupClassInfo(name)
+	var b strings.Builder
+	fmt.Fprintf(&b, "class %s (1:%s, %s device)\n", cls.Name, ci.Minor, ci.Dir)
+	fmt.Fprintf(&b, "  rate:      %s\n", cls.Rate)
+	fmt.Fprintf(&b, "  ceil:      %s\n", cls.effectiveCeil())
+	fmt.Fprintf(&b, "  prio:      %d\n", cls.Prio)
+	fmt.Fprintf(&b, "  created:   %s\n", cls.CreatedAt.Format(time.RFC3339))
+	return b.String(), nil
+}
+
+// ShowDevice returns a human-readable summary of the named device config.
+func (m *Manager) ShowDevice(dir string) (string, error) {
+	if err := validateDir(dir); err != nil {
+		return "", err
+	}
+	dev, err := readDevice(dir)
+	if err != nil {
+		return "", err
+	}
+	if dev == nil {
+		return "", errorx.IllegalState.New("device %q is not configured", dir)
+	}
+	classes, err := loadClassesForDir(dir)
+	if err != nil {
+		return "", err
+	}
+	sort.Slice(classes, func(i, j int) bool {
+		return classes[i].Name < classes[j].Name
+	})
+	var b strings.Builder
+	fmt.Fprintf(&b, "device %s\n", dev.Dir)
+	fmt.Fprintf(&b, "  rate:    %s\n", dev.Rate)
+	fmt.Fprintf(&b, "  default: %s\n", dev.DefaultClass)
+	fmt.Fprintf(&b, "  created: %s\n", dev.CreatedAt.Format(time.RFC3339))
+	if len(classes) > 0 {
+		fmt.Fprintf(&b, "  classes:\n")
+		for _, cls := range classes {
+			ci, _ := lookupClassInfo(cls.Name)
+			fmt.Fprintf(&b, "    %-20s rate=%-10s ceil=%-10s prio=%d (1:%s)\n",
+				cls.Name, cls.Rate, cls.effectiveCeil(), cls.Prio, ci.Minor)
+		}
+	}
+	return b.String(), nil
+}
+
+// ShowAll returns a human-readable summary of all configured devices and classes.
+func (m *Manager) ShowAll() (string, error) {
+	var b strings.Builder
+	for _, dir := range []string{DirEgress, DirIngress} {
+		out, err := m.ShowDevice(dir)
+		if err != nil {
+			continue // not configured: skip
+		}
+		b.WriteString(out)
+		b.WriteString("\n")
+	}
+	if b.Len() == 0 {
+		return "no shape configuration found\n", nil
+	}
+	return b.String(), nil
+}
+
+// DeleteClass removes a class configuration. Fails if the class is referenced
+// as the device's default class or by any policy's --stamp/--reply-stamp.
+// For egress classes: re-renders TcEgressScriptPath and restarts tc-egress.service.
+func (m *Manager) DeleteClass(ctx context.Context, name string) error {
+	ci, err := lookupClassInfo(name)
+	if err != nil {
+		return err
+	}
+	return m.withLock(func() error {
+		cls, err := readClass(name)
+		if err != nil {
+			return err
+		}
+		if cls == nil {
+			return errorx.IllegalState.New("class %q is not configured", name)
+		}
+
+		// Block deletion if this class is the device default.
+		dev, err := readDevice(ci.Dir)
+		if err != nil {
+			return err
+		}
+		if dev != nil && dev.DefaultClass == name {
+			return errorx.IllegalState.New(
+				"class %q is the default class for device %q and cannot be deleted; "+
+					"reconfigure the device with a different --default first", name, ci.Dir)
+		}
+
+		// Block deletion if any policy stamps this class.
+		stamps, err := loadPolicyStamps()
+		if err != nil {
+			return err
+		}
+		if refs := stamps[name]; len(refs) > 0 {
+			return errorx.IllegalState.New(
+				"class %q is referenced by network policy %s and cannot be deleted; "+
+					"delete or update those policies first", name, strings.Join(refs, ", "))
+		}
+
+		if err := removeClass(name); err != nil {
+			return err
+		}
+		if ci.Dir == DirEgress {
+			if err := m.renderAndApplyEgress(ctx); err != nil {
+				return errorx.Decorate(err,
+					"class config deleted but boot script re-render failed; restart tc-egress.service to sync")
+			}
+		}
+		return nil
+	})
+}
+
+// DeleteDevice removes a device configuration. Fails if any classes are still
+// configured for this device (delete classes first).
+func (m *Manager) DeleteDevice(ctx context.Context, dir string) error {
+	if err := validateDir(dir); err != nil {
+		return err
+	}
+	return m.withLock(func() error {
+		dev, err := readDevice(dir)
+		if err != nil {
+			return err
+		}
+		if dev == nil {
+			return errorx.IllegalState.New("device %q is not configured", dir)
+		}
+		classes, err := loadClassesForDir(dir)
+		if err != nil {
+			return err
+		}
+		if len(classes) > 0 {
+			names := make([]string, 0, len(classes))
+			for _, c := range classes {
+				names = append(names, c.Name)
+			}
+			return errorx.IllegalState.New(
+				"device %q still has configured classes (%s); delete them first",
+				dir, strings.Join(names, ", "))
+		}
+		if err := removeDevice(dir); err != nil {
+			return err
+		}
+		if dir == DirEgress {
+			// Re-render with default (empty) egress config.
+			if err := m.renderAndApplyEgress(ctx); err != nil {
+				return errorx.Decorate(err,
+					"device config deleted but boot script re-render failed; restart tc-egress.service to sync")
+			}
+		}
+		return nil
+	})
+}
+
+// renderAndApplyEgress detects the egress NIC, re-renders the boot script from
+// stored config (or the default if no device config exists), and applies via
+// service restart.
+func (m *Manager) renderAndApplyEgress(ctx context.Context) error {
+	nic, err := m.nicDetect()
+	if err != nil {
+		return errorx.Decorate(err, "cannot re-render tc-egress script: egress NIC detection failed")
+	}
+	return m.renderAndApplyScript(ctx, nic)
+}
+
+// renderAndApplyScript renders the tc-egress script with the given NIC name
+// (using stored config if available, else the default) and restarts the service.
+func (m *Manager) renderAndApplyScript(ctx context.Context, nic string) error {
+	dev, err := readDevice(DirEgress)
+	if err != nil {
+		return err
+	}
+	var rendered string
+	if dev != nil {
+		classes, err := loadClassesForDir(DirEgress)
+		if err != nil {
+			return err
+		}
+		rendered, err = renderTcEgressScriptFromConfig(nic, dev, classes)
+		if err != nil {
+			return err
+		}
+	} else {
+		rendered, err = renderTcEgressScript(nic)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Skip the write when on-disk content is already identical.
+	if existing, readErr := os.ReadFile(m.scriptPath); readErr == nil {
+		if sha256.Sum256([]byte(rendered)) == sha256.Sum256(existing) {
+			return m.applyEgress(ctx)
+		}
+	}
+	if err := atomicWriteFile(m.scriptPath, rendered, 0o755); err != nil {
+		return err
+	}
+	return m.applyEgress(ctx)
+}
+
+// withLock serialises a mutation behind a cross-command flock so concurrent
+// operator commands cannot interleave tc transactions.
+func (m *Manager) withLock(fn func() error) error {
+	if err := os.MkdirAll(filepath.Dir(m.lockPath), 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create lock directory %s", filepath.Dir(m.lockPath))
+	}
+	f, err := os.OpenFile(m.lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to open lock file %s", m.lockPath)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to acquire lock %s", m.lockPath)
+	}
+	defer func() { _ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }()
+
+	return fn()
+}

--- a/internal/network/shape/paths.go
+++ b/internal/network/shape/paths.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package shape implements tc HTB hierarchy persistence for the `$EGRESS`
+// physical NIC. It renders the boot-replay script and manages the
+// solo-provisioner-tc-egress.service oneshot unit (design §8.3.2).
+//
+// Scope boundary (TS_2 #742): this package only covers reboot persistence —
+// rendering the tc-egress.sh script with the NIC name interpolated at install
+// time and installing/enabling the oneshot unit. The full `network shape`
+// CLI verb (Story 1.4) will extend this package with bandwidth-parameterised
+// rendering and the per-class rate/ceil/prio API.
+//
+// The $VETH HTB is deliberately NOT persisted here: the veth interface does
+// not survive reboot (Cilium recreates it on pod start), so persisting its
+// qdisc would be meaningless. The daemon's pod-lifecycle watcher reinstalls
+// the $VETH HTB on the next pod create event (TS_3).
+package shape
+
+const (
+	// TcEgressScriptPath is the shell script that replays the $EGRESS HTB
+	// hierarchy at boot. It lives under /usr/local/sbin (system admin tools,
+	// root-executable) — not /etc, since it is an executable rather than config.
+	TcEgressScriptPath = "/usr/local/sbin/solo-provisioner-tc-egress.sh"
+
+	// TcEgressService is the systemd oneshot unit name that executes
+	// TcEgressScriptPath at boot, before solo-provisioner-daemon.service starts.
+	TcEgressService = "solo-provisioner-tc-egress.service"
+
+	// TcEgressServiceUnitPath is the absolute path where the unit file is
+	// installed so systemd can discover it.
+	TcEgressServiceUnitPath = "/usr/lib/systemd/system/" + TcEgressService
+
+	// tcEgressScriptTemplate is the embedded Go template for the tc-egress.sh
+	// boot script. The single interpolation point is {{.NIC}}, the egress
+	// interface name detected at install time.
+	tcEgressScriptTemplate = "files/network/solo-provisioner-tc-egress.sh.tmpl"
+
+	// tcEgressServiceTemplate is the static embedded unit file installed at
+	// TcEgressServiceUnitPath on first use.
+	tcEgressServiceTemplate = "files/network/solo-provisioner-tc-egress.service"
+)

--- a/internal/network/shape/paths.go
+++ b/internal/network/shape/paths.go
@@ -1,29 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
-// Package shape implements tc HTB hierarchy persistence for the `$EGRESS`
-// physical NIC. It renders the boot-replay script and manages the
-// solo-provisioner-tc-egress.service oneshot unit (design §8.3.2).
+// Package shape implements tc HTB hierarchy persistence and the `network shape`
+// CLI verb. It renders the boot-replay script (solo-provisioner-tc-egress.sh)
+// with bandwidth-parameterised class configurations, manages the
+// solo-provisioner-tc-egress.service oneshot unit, and applies live tc class
+// changes to the $EGRESS physical NIC (design §8.3.2, §8.4.3, §5).
 //
-// Scope boundary (TS_2 #742): this package only covers reboot persistence —
-// rendering the tc-egress.sh script with the NIC name interpolated at install
-// time and installing/enabling the oneshot unit. The full `network shape`
-// CLI verb (Story 1.4) will extend this package with bandwidth-parameterised
-// rendering and the per-class rate/ceil/prio API.
-//
-// The $VETH HTB is deliberately NOT persisted here: the veth interface does
-// not survive reboot (Cilium recreates it on pod start), so persisting its
-// qdisc would be meaningless. The daemon's pod-lifecycle watcher reinstalls
-// the $VETH HTB on the next pod create event (TS_3).
+// The $VETH HTB is deliberately NOT persisted here: the veth interface does not
+// survive reboot (Cilium recreates it on pod start), so persisting its qdisc
+// would be meaningless. The daemon's pod-lifecycle watcher (TS_3) reinstalls
+// the $VETH HTB on the next pod create event by reading the class configs stored
+// under ClassConfigDir.
 package shape
 
 const (
 	// TcEgressScriptPath is the shell script that replays the $EGRESS HTB
-	// hierarchy at boot. It lives under /usr/local/sbin (system admin tools,
-	// root-executable) — not /etc, since it is an executable rather than config.
+	// hierarchy at boot. Lives under /usr/local/sbin (root-executable tools).
 	TcEgressScriptPath = "/usr/local/sbin/solo-provisioner-tc-egress.sh"
 
-	// TcEgressService is the systemd oneshot unit name that executes
-	// TcEgressScriptPath at boot, before solo-provisioner-daemon.service starts.
+	// TcEgressService is the systemd oneshot unit that executes TcEgressScriptPath
+	// at boot, before solo-provisioner-daemon.service starts.
 	TcEgressService = "solo-provisioner-tc-egress.service"
 
 	// TcEgressServiceUnitPath is the absolute path where the unit file is
@@ -31,11 +27,34 @@ const (
 	TcEgressServiceUnitPath = "/usr/lib/systemd/system/" + TcEgressService
 
 	// tcEgressScriptTemplate is the embedded Go template for the tc-egress.sh
-	// boot script. The single interpolation point is {{.NIC}}, the egress
-	// interface name detected at install time.
+	// boot script. Interpolation points: {{.NIC}}, {{.Device.*}}, {{range .Classes}}.
 	tcEgressScriptTemplate = "files/network/solo-provisioner-tc-egress.sh.tmpl"
 
-	// tcEgressServiceTemplate is the static embedded unit file installed at
-	// TcEgressServiceUnitPath on first use.
+	// tcEgressServiceTemplate is the static embedded unit file.
 	tcEgressServiceTemplate = "files/network/solo-provisioner-tc-egress.service"
+
+	// ShapeConfigDir is the root of the shape configuration tree persisted by
+	// the `network shape` CLI verb.
+	ShapeConfigDir = "/etc/solo-provisioner/network/shape"
+
+	// DeviceConfigDir holds one JSON file per configured tc device ("ingress"
+	// or "egress"), describing the root qdisc rate and default class.
+	DeviceConfigDir = ShapeConfigDir + "/devices"
+
+	// ClassConfigDir holds one JSON file per configured tc class, describing its
+	// bandwidth parameters (rate, ceil, prio). The daemon watcher (TS_3) reads
+	// this directory to reinstall $VETH classes on each pod create event.
+	ClassConfigDir = ShapeConfigDir + "/classes"
+
+	// ShapeLockDir is the directory containing the tc apply lock (on tmpfs so
+	// it is auto-cleared on reboot).
+	ShapeLockDir = "/run/solo-provisioner/network"
+
+	// ShapeLockPath is the flock acquired (LOCK_EX) for the duration of any
+	// tc mutating verb, preventing concurrent modifications.
+	ShapeLockPath = ShapeLockDir + "/.tc-applying"
+
+	// policyRegistryDir mirrors internal/network/policy.RegistryDir. Duplicated
+	// here to avoid a cross-package import; the values must stay in sync.
+	policyRegistryDir = "/etc/solo-provisioner/policies"
 )

--- a/internal/network/shape/registry.go
+++ b/internal/network/shape/registry.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// devicePath returns the on-disk path of a device's config file.
+func devicePath(dir string) string {
+	return filepath.Join(DeviceConfigDir, dir+".json")
+}
+
+// classPath returns the on-disk path of a class's config file.
+func classPath(name string) string {
+	return filepath.Join(ClassConfigDir, name+".json")
+}
+
+// writeDevice atomically writes the device config JSON.
+func writeDevice(dev *DeviceConfig) error {
+	if err := os.MkdirAll(DeviceConfigDir, 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create device config dir %s", DeviceConfigDir)
+	}
+	data, err := json.MarshalIndent(dev, "", "  ")
+	if err != nil {
+		return errorx.InternalError.Wrap(err, "failed to marshal device config %q", dev.Dir)
+	}
+	return atomicWriteFile(devicePath(dev.Dir), string(data)+"\n", 0o644)
+}
+
+// writeClass atomically writes the class config JSON.
+func writeClass(cls *ClassConfig) error {
+	if err := os.MkdirAll(ClassConfigDir, 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create class config dir %s", ClassConfigDir)
+	}
+	data, err := json.MarshalIndent(cls, "", "  ")
+	if err != nil {
+		return errorx.InternalError.Wrap(err, "failed to marshal class config %q", cls.Name)
+	}
+	return atomicWriteFile(classPath(cls.Name), string(data)+"\n", 0o644)
+}
+
+// readDevice loads a device config by dir, returning nil if not found.
+func readDevice(dir string) (*DeviceConfig, error) {
+	data, err := os.ReadFile(devicePath(dir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read device config %s", devicePath(dir))
+	}
+	var dev DeviceConfig
+	if err := json.Unmarshal(data, &dev); err != nil {
+		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse device config %s", devicePath(dir))
+	}
+	return &dev, nil
+}
+
+// readClass loads a class config by name, returning nil if not found.
+func readClass(name string) (*ClassConfig, error) {
+	data, err := os.ReadFile(classPath(name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read class config %s", classPath(name))
+	}
+	var cls ClassConfig
+	if err := json.Unmarshal(data, &cls); err != nil {
+		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse class config %s", classPath(name))
+	}
+	return &cls, nil
+}
+
+// loadClassesForDir loads all class configs for the given direction, sorted by
+// name. Classes whose name is not in classInfoMap (e.g. hand-edited files) are
+// silently skipped.
+func loadClassesForDir(dir string) ([]*ClassConfig, error) {
+	entries, err := os.ReadDir(ClassConfigDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read class config dir %s", ClassConfigDir)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".json")
+		info, ok := classInfoMap[name]
+		if !ok || info.Dir != dir {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	classes := make([]*ClassConfig, 0, len(names))
+	for _, n := range names {
+		cls, err := readClass(n)
+		if err != nil {
+			return nil, err
+		}
+		if cls != nil {
+			classes = append(classes, cls)
+		}
+	}
+	return classes, nil
+}
+
+// loadAllClasses loads all class configs (any direction), sorted by name.
+func loadAllClasses() ([]*ClassConfig, error) {
+	entries, err := os.ReadDir(ClassConfigDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read class config dir %s", ClassConfigDir)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(e.Name(), ".json"))
+	}
+	sort.Strings(names)
+	classes := make([]*ClassConfig, 0, len(names))
+	for _, n := range names {
+		cls, err := readClass(n)
+		if err != nil {
+			return nil, err
+		}
+		if cls != nil {
+			classes = append(classes, cls)
+		}
+	}
+	return classes, nil
+}
+
+// removeClass deletes a class config file, ignoring not-found.
+func removeClass(name string) error {
+	err := os.Remove(classPath(name))
+	if err != nil && !os.IsNotExist(err) {
+		return errorx.ExternalError.Wrap(err, "failed to remove class config %s", classPath(name))
+	}
+	return nil
+}
+
+// removeDevice deletes a device config file, ignoring not-found.
+func removeDevice(dir string) error {
+	err := os.Remove(devicePath(dir))
+	if err != nil && !os.IsNotExist(err) {
+		return errorx.ExternalError.Wrap(err, "failed to remove device config %s", devicePath(dir))
+	}
+	return nil
+}
+
+// policyStampRef is a minimal representation of a policy registry entry used
+// only to check stamp references when deleting a shape class. Avoids importing
+// internal/network/policy.
+type policyStampRef struct {
+	Stamp      string `json:"stamp"`
+	ReplyStamp string `json:"reply_stamp"`
+}
+
+// loadPolicyStamps reads the stamp and reply_stamp fields from every policy
+// JSON in the policy registry, for cross-package delete validation. Returns a
+// map from class name → slice of policy names that reference it.
+func loadPolicyStamps() (map[string][]string, error) {
+	entries, err := os.ReadDir(policyRegistryDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read policy registry %s", policyRegistryDir)
+	}
+	refs := make(map[string][]string)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		policyName := strings.TrimSuffix(e.Name(), ".json")
+		data, err := os.ReadFile(filepath.Join(policyRegistryDir, e.Name()))
+		if err != nil {
+			continue // best-effort: skip unreadable files
+		}
+		var ref policyStampRef
+		if err := json.Unmarshal(data, &ref); err != nil {
+			continue
+		}
+		if ref.Stamp != "" {
+			refs[ref.Stamp] = append(refs[ref.Stamp], policyName)
+		}
+		if ref.ReplyStamp != "" {
+			refs[ref.ReplyStamp] = append(refs[ref.ReplyStamp], policyName)
+		}
+	}
+	return refs, nil
+}

--- a/internal/network/shape/render.go
+++ b/internal/network/shape/render.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+
+	"github.com/hashgraph/solo-weaver/internal/templates"
+	"github.com/joomcode/errorx"
+)
+
+// scriptData is the template context for the tc-egress.sh boot script.
+type scriptData struct {
+	NIC string
+}
+
+// renderTcEgressScript renders the template and returns the script string
+// without writing anything to disk. Used by RenderTcEgressScript and tests.
+func renderTcEgressScript(nicName string) (string, error) {
+	rendered, err := templates.Render(tcEgressScriptTemplate, scriptData{NIC: nicName})
+	if err != nil {
+		return "", errorx.InternalError.Wrap(err, "failed to render %s", tcEgressScriptTemplate)
+	}
+	return rendered, nil
+}
+
+// RenderTcEgressScript renders the tc-egress.sh boot script with the given NIC
+// name and writes it atomically to TcEgressScriptPath (mode 0755). If the
+// on-disk content is already identical (SHA-256 match) the write is skipped
+// and the function returns nil — making it safe to call from idempotent
+// install flows.
+func RenderTcEgressScript(nicName string) error {
+	if nicName == "" {
+		return errorx.IllegalArgument.New("egress NIC name must not be empty")
+	}
+
+	rendered, err := renderTcEgressScript(nicName)
+	if err != nil {
+		return err
+	}
+
+	// Skip the write when the on-disk file already has the same content.
+	if existing, readErr := os.ReadFile(TcEgressScriptPath); readErr == nil {
+		if sha256.Sum256([]byte(rendered)) == sha256.Sum256(existing) {
+			return nil
+		}
+	}
+
+	return atomicWriteFile(TcEgressScriptPath, rendered, 0o755)
+}
+
+// atomicWriteFile writes content to path via a temp file in the same directory
+// followed by fsync + rename + parent-dir fsync, so a crash mid-write cannot
+// leave a torn script that the boot oneshot would fail to execute.
+func atomicWriteFile(path, content string, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create directory %s", dir)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".tc-egress-*.sh.tmp")
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create temp file in %s", dir)
+	}
+	tmpName := tmp.Name()
+
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return errorx.ExternalError.Wrap(err, "failed to write temp file %s", tmpName)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return errorx.ExternalError.Wrap(err, "failed to chmod temp file %s", tmpName)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return errorx.ExternalError.Wrap(err, "failed to fsync temp file %s", tmpName)
+	}
+	if err := tmp.Close(); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to close temp file %s", tmpName)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to rename %s to %s", tmpName, path)
+	}
+	committed = true
+
+	d, err := os.Open(dir)
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to open directory %s for fsync", dir)
+	}
+	defer func() { _ = d.Close() }()
+	if err := d.Sync(); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to fsync directory %s", dir)
+	}
+
+	return nil
+}
+
+// contentEqual is a helper for tests that need to compare rendered output
+// without going through SHA-256 directly.
+func contentEqual(a, b string) bool {
+	return bytes.Equal([]byte(a), []byte(b))
+}

--- a/internal/network/shape/render.go
+++ b/internal/network/shape/render.go
@@ -14,13 +14,87 @@ import (
 
 // scriptData is the template context for the tc-egress.sh boot script.
 type scriptData struct {
-	NIC string
+	NIC     string
+	Device  deviceRenderData
+	Classes []classRenderData
 }
 
-// renderTcEgressScript renders the template and returns the script string
-// without writing anything to disk. Used by RenderTcEgressScript and tests.
+// deviceRenderData is the device-level template context.
+type deviceRenderData struct {
+	DefaultMinor string // hex tc classid minor for the default class, e.g. "60"
+	Rate         string // root trunk class rate (may be a shell expr for legacy renders)
+}
+
+// classRenderData is the per-class template context.
+type classRenderData struct {
+	Minor  string // hex tc classid minor, e.g. "40"
+	Handle string // fq_codel qdisc handle, e.g. "140"
+	Rate   string // htb rate (may be a shell expr for legacy renders)
+	Ceil   string // htb ceil (may be a shell expr for legacy renders)
+	Prio   int
+}
+
+// renderTcEgressScript renders the tc-egress.sh template with default
+// SPEED-based rate expressions (preserving the pre-shape-config install-time
+// rendering for backward compatibility with `block node install`).
 func renderTcEgressScript(nicName string) (string, error) {
-	rendered, err := templates.Render(tcEgressScriptTemplate, scriptData{NIC: nicName})
+	return renderTcEgressScriptFromData(defaultScriptData(nicName))
+}
+
+// renderTcEgressScriptFromConfig renders the tc-egress.sh template from the
+// provided device and class configurations. Classes are ordered by their Minor
+// (classid) value for a deterministic output.
+func renderTcEgressScriptFromConfig(nicName string, dev *DeviceConfig, classes []*ClassConfig) (string, error) {
+	info, err := lookupClassInfo(dev.DefaultClass)
+	if err != nil {
+		return "", err
+	}
+	crs := make([]classRenderData, 0, len(classes))
+	for _, cls := range classes {
+		ci, err := lookupClassInfo(cls.Name)
+		if err != nil {
+			return "", err
+		}
+		crs = append(crs, classRenderData{
+			Minor:  ci.Minor,
+			Handle: ci.Handle,
+			Rate:   cls.Rate,
+			Ceil:   cls.effectiveCeil(),
+			Prio:   cls.Prio,
+		})
+	}
+	return renderTcEgressScriptFromData(scriptData{
+		NIC: nicName,
+		Device: deviceRenderData{
+			DefaultMinor: info.Minor,
+			Rate:         dev.Rate,
+		},
+		Classes: crs,
+	})
+}
+
+// defaultScriptData returns the legacy SPEED-based scriptData for the egress
+// device: the three default egress classes (partner/public/reserve-egress) with
+// shell arithmetic rate expressions. This matches the pre-shape-config tc-egress.sh
+// template content so install-time rendering is backward-compatible.
+func defaultScriptData(nicName string) scriptData {
+	return scriptData{
+		NIC: nicName,
+		Device: deviceRenderData{
+			DefaultMinor: "60",
+			Rate:         "${SPEED}mbit",
+		},
+		Classes: []classRenderData{
+			{Minor: "40", Handle: "140", Rate: `$(( SPEED * 40 / 100 ))mbit`, Ceil: `$(( SPEED * 70 / 100 ))mbit`, Prio: 0},
+			{Minor: "50", Handle: "150", Rate: `$(( SPEED * 30 / 100 ))mbit`, Ceil: `$(( SPEED * 70 / 100 ))mbit`, Prio: 5},
+			{Minor: "60", Handle: "160", Rate: `$(( SPEED * 30 / 100 ))mbit`, Ceil: `${SPEED}mbit`, Prio: 1},
+		},
+	}
+}
+
+// renderTcEgressScriptFromData renders the template with the given scriptData.
+func renderTcEgressScriptFromData(data scriptData) (string, error) {
+	rendered, err := templates.Render(tcEgressScriptTemplate, data)
 	if err != nil {
 		return "", errorx.InternalError.Wrap(err, "failed to render %s", tcEgressScriptTemplate)
 	}
@@ -30,50 +104,42 @@ func renderTcEgressScript(nicName string) (string, error) {
 // RenderTcEgressScript renders the tc-egress.sh boot script with the given NIC
 // name and writes it atomically to TcEgressScriptPath (mode 0755). If the
 // on-disk content is already identical (SHA-256 match) the write is skipped
-// and the function returns nil — making it safe to call from idempotent
-// install flows.
+// and the function returns nil — making it safe to call from idempotent install flows.
 func RenderTcEgressScript(nicName string) error {
 	if nicName == "" {
 		return errorx.IllegalArgument.New("egress NIC name must not be empty")
 	}
-
 	rendered, err := renderTcEgressScript(nicName)
 	if err != nil {
 		return err
 	}
-
-	// Skip the write when the on-disk file already has the same content.
 	if existing, readErr := os.ReadFile(TcEgressScriptPath); readErr == nil {
 		if sha256.Sum256([]byte(rendered)) == sha256.Sum256(existing) {
 			return nil
 		}
 	}
-
 	return atomicWriteFile(TcEgressScriptPath, rendered, 0o755)
 }
 
 // atomicWriteFile writes content to path via a temp file in the same directory
 // followed by fsync + rename + parent-dir fsync, so a crash mid-write cannot
-// leave a torn script that the boot oneshot would fail to execute.
+// leave a torn file that the boot oneshot would fail to execute.
 func atomicWriteFile(path, content string, perm os.FileMode) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return errorx.ExternalError.Wrap(err, "failed to create directory %s", dir)
 	}
-
-	tmp, err := os.CreateTemp(dir, ".tc-egress-*.sh.tmp")
+	tmp, err := os.CreateTemp(dir, ".shape-*.tmp")
 	if err != nil {
 		return errorx.ExternalError.Wrap(err, "failed to create temp file in %s", dir)
 	}
 	tmpName := tmp.Name()
-
 	committed := false
 	defer func() {
 		if !committed {
 			_ = os.Remove(tmpName)
 		}
 	}()
-
 	if _, err := tmp.WriteString(content); err != nil {
 		_ = tmp.Close()
 		return errorx.ExternalError.Wrap(err, "failed to write temp file %s", tmpName)
@@ -93,7 +159,6 @@ func atomicWriteFile(path, content string, perm os.FileMode) error {
 		return errorx.ExternalError.Wrap(err, "failed to rename %s to %s", tmpName, path)
 	}
 	committed = true
-
 	d, err := os.Open(dir)
 	if err != nil {
 		return errorx.ExternalError.Wrap(err, "failed to open directory %s for fsync", dir)
@@ -102,7 +167,6 @@ func atomicWriteFile(path, content string, perm os.FileMode) error {
 	if err := d.Sync(); err != nil {
 		return errorx.ExternalError.Wrap(err, "failed to fsync directory %s", dir)
 	}
-
 	return nil
 }
 

--- a/internal/network/shape/service_linux.go
+++ b/internal/network/shape/service_linux.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package shape
+
+import (
+	"context"
+	"crypto/sha256"
+	"os"
+
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/templates"
+	soos "github.com/hashgraph/solo-weaver/pkg/os"
+	"github.com/joomcode/errorx"
+)
+
+// EnsureTcEgressUnit installs (or updates) the solo-provisioner-tc-egress.service
+// unit file, daemon-reloads systemd, and enables the unit for boot. SHA-256
+// comparison is used so the write, reload, and enable are skipped when the
+// on-disk content already matches the embedded template — making repeated installs
+// cheap while ensuring a template change (e.g. ordering fix) is applied
+// automatically on the next `block node install`.
+func EnsureTcEgressUnit(ctx context.Context) error {
+	content, err := templates.Files.ReadFile(tcEgressServiceTemplate)
+	if err != nil {
+		return errorx.InternalError.Wrap(err, "failed to read embedded %s", tcEgressServiceTemplate)
+	}
+
+	// Skip write + reload when the on-disk file is already identical.
+	if existing, readErr := os.ReadFile(TcEgressServiceUnitPath); readErr == nil {
+		if sha256.Sum256(content) == sha256.Sum256(existing) {
+			return nil
+		}
+	}
+
+	if err := atomicWriteFile(TcEgressServiceUnitPath, string(content), 0o644); err != nil {
+		return err
+	}
+	if err := soos.DaemonReload(ctx); err != nil {
+		return err
+	}
+	if err := soos.EnableService(ctx, TcEgressService); err != nil {
+		logx.As().Warn().Err(err).Str("service", TcEgressService).Msg("could not enable tc-egress service at boot")
+	}
+	return nil
+}

--- a/internal/network/shape/service_other.go
+++ b/internal/network/shape/service_other.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package shape
+
+import "context"
+
+// EnsureTcEgressUnit is a no-op on non-Linux platforms. The tc-egress oneshot
+// unit is a Linux systemd concept; the package compiles and tests on all
+// platforms, but the service management calls only run on Linux.
+func EnsureTcEgressUnit(_ context.Context) error { return nil }

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderTcEgressScript_NICInterpolated(t *testing.T) {
+	dir := t.TempDir()
+
+	const testNIC = "eth0"
+	testPath := filepath.Join(dir, "solo-provisioner-tc-egress.sh")
+
+	rendered, err := renderScript(testNIC)
+	if err != nil {
+		t.Fatalf("renderScript: %v", err)
+	}
+
+	// The NIC name must appear in the NIC= assignment line.
+	if !strings.Contains(rendered, "NIC="+testNIC) {
+		t.Errorf("rendered script does not contain NIC assignment %q:\n%s", "NIC="+testNIC, rendered)
+	}
+	// Must NOT contain the raw template placeholder.
+	if strings.Contains(rendered, "{{.NIC}}") {
+		t.Errorf("rendered script still contains template placeholder {{.NIC}}:\n%s", rendered)
+	}
+
+	// Golden: all expected tc commands are present (the script uses the shell
+	// variable "$NIC", not the literal NIC name inline in tc commands).
+	for _, want := range []string{
+		`SPEED=$(cat /sys/class/net/"$NIC"/speed 2>/dev/null || echo -1)`,
+		`[ "${SPEED:-0}" -gt 0 ] 2>/dev/null || SPEED=1000`,
+		`tc qdisc del dev "$NIC" root 2>/dev/null || true`,
+		`tc qdisc add dev "$NIC" root handle 1: htb default 60`,
+		`tc class  add dev "$NIC" parent 1:   classid 1:1  htb rate "${SPEED}mbit" ceil "${SPEED}mbit"`,
+		`tc class  add dev "$NIC" parent 1:1  classid 1:40 htb rate "$(( SPEED * 40 / 100 ))mbit"`,
+		`tc class  add dev "$NIC" parent 1:1  classid 1:50 htb rate "$(( SPEED * 30 / 100 ))mbit"`,
+		`tc class  add dev "$NIC" parent 1:1  classid 1:60 htb rate "$(( SPEED * 30 / 100 ))mbit"`,
+		`tc qdisc  add dev "$NIC" parent 1:40 handle 140: fq_codel`,
+		`tc qdisc  add dev "$NIC" parent 1:50 handle 150: fq_codel`,
+		`tc qdisc  add dev "$NIC" parent 1:60 handle 160: fq_codel`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered script missing expected line:\n  want: %s\n  got:\n%s", want, rendered)
+		}
+	}
+
+	// Write to temp path and confirm the file is executable.
+	if err := atomicWriteFile(testPath, rendered, 0o755); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+	info, err := os.Stat(testPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode()&0o100 == 0 {
+		t.Errorf("script not executable: mode %v", info.Mode())
+	}
+}
+
+func TestRenderTcEgressScript_EmptyNIC(t *testing.T) {
+	if err := RenderTcEgressScript(""); err == nil {
+		t.Error("expected error for empty NIC name, got nil")
+	}
+}
+
+func TestAtomicWriteFile_SecondWritePreservesContent(t *testing.T) {
+	dir := t.TempDir()
+	const testNIC = "ens3"
+	path := filepath.Join(dir, "tc-egress.sh")
+
+	rendered, err := renderScript(testNIC)
+	if err != nil {
+		t.Fatalf("renderScript: %v", err)
+	}
+	if err := atomicWriteFile(path, rendered, 0o755); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := atomicWriteFile(path, rendered, 0o755); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !contentEqual(string(content), rendered) {
+		t.Error("content changed on second write")
+	}
+}
+
+// renderScript is a test-only helper that calls templates.Render directly so
+// tests don't need to patch the global TcEgressScriptPath constant.
+func renderScript(nicName string) (string, error) {
+	return renderTcEgressScript(nicName)
+}
+
+// --- DetectEgressInterface tests (cross-platform via detectEgressInterfaceFrom) ---
+
+func TestDetectEgressInterfaceFrom_DefaultRoute(t *testing.T) {
+	// Minimal /proc/net/route with one default-route row and one subnet row.
+	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
+		"eth0\t00000000\t0101A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n" +
+		"eth0\tC0A80100\t00000000\t0001\t0\t0\t0\tFFFFFF00\t0\t0\t0\n"
+
+	path := writeTempRoute(t, content)
+	iface, err := detectEgressInterfaceFrom(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if iface != "eth0" {
+		t.Errorf("expected eth0, got %q", iface)
+	}
+}
+
+func TestDetectEgressInterfaceFrom_MultipleInterfaces(t *testing.T) {
+	// Default route on ens3, another interface present.
+	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
+		"lo\t00000000\t00000000\t0001\t0\t0\t0\t000000FF\t0\t0\t0\n" +
+		"ens3\t00000000\t0101A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n"
+
+	path := writeTempRoute(t, content)
+	iface, err := detectEgressInterfaceFrom(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if iface != "ens3" {
+		t.Errorf("expected ens3, got %q", iface)
+	}
+}
+
+func TestDetectEgressInterfaceFrom_NoDefaultRoute(t *testing.T) {
+	// No row with RTF_GATEWAY set.
+	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
+		"eth0\tC0A80100\t00000000\t0001\t0\t0\t0\tFFFFFF00\t0\t0\t0\n"
+
+	path := writeTempRoute(t, content)
+	_, err := detectEgressInterfaceFrom(path)
+	if err == nil {
+		t.Error("expected error when no default route found, got nil")
+	}
+}
+
+func TestDetectEgressInterfaceFrom_EmptyTable(t *testing.T) {
+	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n"
+	path := writeTempRoute(t, content)
+	_, err := detectEgressInterfaceFrom(path)
+	if err == nil {
+		t.Error("expected error for empty routing table, got nil")
+	}
+}
+
+func writeTempRoute(t *testing.T, content string) string {
+	t.Helper()
+	tmp, err := os.CreateTemp(t.TempDir(), "proc-net-route-*")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if _, err := tmp.WriteString(content); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	_ = tmp.Close()
+	return tmp.Name()
+}

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 )
 
+// --- Existing render tests (default/legacy SPEED-based rendering) ---
+
 func TestRenderTcEgressScript_NICInterpolated(t *testing.T) {
 	dir := t.TempDir()
 
@@ -93,16 +95,90 @@ func TestAtomicWriteFile_SecondWritePreservesContent(t *testing.T) {
 	}
 }
 
-// renderScript is a test-only helper that calls templates.Render directly so
-// tests don't need to patch the global TcEgressScriptPath constant.
+// renderScript is a test-only helper that calls renderTcEgressScript so tests
+// don't need to patch the global TcEgressScriptPath constant.
 func renderScript(nicName string) (string, error) {
 	return renderTcEgressScript(nicName)
+}
+
+// --- New tests: renderTcEgressScriptFromConfig ---
+
+func TestRenderTcEgressScriptFromConfig_ExplicitRates(t *testing.T) {
+	dev := &DeviceConfig{
+		Dir:          DirEgress,
+		Rate:         "1gbit",
+		DefaultClass: "reserve-egress",
+	}
+	classes := []*ClassConfig{
+		{Name: "partner", Rate: "400mbit", Ceil: "700mbit", Prio: 0},
+		{Name: "public", Rate: "300mbit", Ceil: "700mbit", Prio: 5},
+		{Name: "reserve-egress", Rate: "300mbit", Prio: 1},
+	}
+	rendered, err := renderTcEgressScriptFromConfig("ens3", dev, classes)
+	if err != nil {
+		t.Fatalf("renderTcEgressScriptFromConfig: %v", err)
+	}
+
+	if !strings.Contains(rendered, "NIC=ens3") {
+		t.Errorf("expected NIC=ens3:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "htb default 60") {
+		t.Errorf("expected htb default 60 (reserve-egress minor):\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `rate "1gbit" ceil "1gbit"`) {
+		t.Errorf("expected root rate 1gbit:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `classid 1:40 htb rate "400mbit" ceil "700mbit" prio 0`) {
+		t.Errorf("partner class line wrong:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `classid 1:50 htb rate "300mbit" ceil "700mbit" prio 5`) {
+		t.Errorf("public class line wrong:\n%s", rendered)
+	}
+	// reserve-egress: ceil defaults to rate when unset.
+	if !strings.Contains(rendered, `classid 1:60 htb rate "300mbit" ceil "300mbit" prio 1`) {
+		t.Errorf("reserve-egress class line wrong:\n%s", rendered)
+	}
+	for _, want := range []string{
+		`parent 1:40 handle 140: fq_codel`,
+		`parent 1:50 handle 150: fq_codel`,
+		`parent 1:60 handle 160: fq_codel`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("missing fq_codel line %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestRenderTcEgressScriptFromConfig_UnknownClass(t *testing.T) {
+	dev := &DeviceConfig{Dir: DirEgress, Rate: "1gbit", DefaultClass: "reserve-egress"}
+	_, err := renderTcEgressScriptFromConfig("ens3", dev, []*ClassConfig{{Name: "no-such-class", Rate: "100mbit"}})
+	if err == nil {
+		t.Error("expected error for unknown class, got nil")
+	}
+}
+
+func TestRenderTcEgressScriptFromConfig_IngressClasses(t *testing.T) {
+	dev := &DeviceConfig{Dir: DirIngress, Rate: "1gbit", DefaultClass: "reserve-ingress"}
+	classes := []*ClassConfig{
+		{Name: "publisher", Rate: "400mbit", Ceil: "700mbit", Prio: 0},
+		{Name: "reserve-ingress", Rate: "300mbit", Prio: 1},
+	}
+	rendered, err := renderTcEgressScriptFromConfig("veth0", dev, classes)
+	if err != nil {
+		t.Fatalf("renderTcEgressScriptFromConfig: %v", err)
+	}
+	// Default minor for reserve-ingress is "30".
+	if !strings.Contains(rendered, "htb default 30") {
+		t.Errorf("expected htb default 30:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `classid 1:10 htb rate "400mbit"`) {
+		t.Errorf("publisher class (1:10) missing:\n%s", rendered)
+	}
 }
 
 // --- DetectEgressInterface tests (cross-platform via detectEgressInterfaceFrom) ---
 
 func TestDetectEgressInterfaceFrom_DefaultRoute(t *testing.T) {
-	// Minimal /proc/net/route with one default-route row and one subnet row.
 	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
 		"eth0\t00000000\t0101A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n" +
 		"eth0\tC0A80100\t00000000\t0001\t0\t0\t0\tFFFFFF00\t0\t0\t0\n"
@@ -118,7 +194,6 @@ func TestDetectEgressInterfaceFrom_DefaultRoute(t *testing.T) {
 }
 
 func TestDetectEgressInterfaceFrom_MultipleInterfaces(t *testing.T) {
-	// Default route on ens3, another interface present.
 	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
 		"lo\t00000000\t00000000\t0001\t0\t0\t0\t000000FF\t0\t0\t0\n" +
 		"ens3\t00000000\t0101A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n"
@@ -134,7 +209,6 @@ func TestDetectEgressInterfaceFrom_MultipleInterfaces(t *testing.T) {
 }
 
 func TestDetectEgressInterfaceFrom_NoDefaultRoute(t *testing.T) {
-	// No row with RTF_GATEWAY set.
 	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
 		"eth0\tC0A80100\t00000000\t0001\t0\t0\t0\tFFFFFF00\t0\t0\t0\n"
 
@@ -165,4 +239,166 @@ func writeTempRoute(t *testing.T, content string) string {
 	}
 	_ = tmp.Close()
 	return tmp.Name()
+}
+
+// --- Validation tests ---
+
+func TestValidateDir(t *testing.T) {
+	if err := validateDir(DirEgress); err != nil {
+		t.Errorf("validateDir(egress): %v", err)
+	}
+	if err := validateDir(DirIngress); err != nil {
+		t.Errorf("validateDir(ingress): %v", err)
+	}
+	if err := validateDir("sideways"); err == nil {
+		t.Error("expected error for invalid direction, got nil")
+	}
+}
+
+func TestValidatePrio(t *testing.T) {
+	for _, p := range []int{0, 3, 7} {
+		if err := validatePrio(p); err != nil {
+			t.Errorf("validatePrio(%d): %v", p, err)
+		}
+	}
+	for _, p := range []int{-1, 8, 100} {
+		if err := validatePrio(p); err == nil {
+			t.Errorf("expected error for prio %d, got nil", p)
+		}
+	}
+}
+
+func TestParseBandwidthBps(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantBps int64
+	}{
+		{"1gbit", 1_000_000_000},
+		{"100mbit", 100_000_000},
+		{"500kbit", 500_000},
+		{"1000bit", 1_000},
+		{"1GBIT", 1_000_000_000},
+	}
+	for _, c := range cases {
+		got, err := parseBandwidthBps(c.in)
+		if err != nil {
+			t.Errorf("parseBandwidthBps(%q): %v", c.in, err)
+			continue
+		}
+		if got != c.wantBps {
+			t.Errorf("parseBandwidthBps(%q) = %d, want %d", c.in, got, c.wantBps)
+		}
+	}
+	for _, bad := range []string{"", "100", "fast", "$(( SPEED * 40 / 100 ))mbit", "${SPEED}mbit"} {
+		if _, err := parseBandwidthBps(bad); err == nil {
+			t.Errorf("expected error for %q, got nil", bad)
+		}
+	}
+}
+
+func TestValidateSumRates(t *testing.T) {
+	existing := []*ClassConfig{
+		{Name: "partner", Rate: "400mbit"},
+		{Name: "public", Rate: "300mbit"},
+	}
+	// 400+300+300 = 1000mbit = 1gbit: exactly at limit, should pass.
+	cfg := &ClassConfig{Name: "reserve-egress", Rate: "300mbit"}
+	if err := validateSumRates(existing, cfg, "1gbit"); err != nil {
+		t.Errorf("unexpected error at exact limit: %v", err)
+	}
+	// 400+300+400 = 1100mbit > 1gbit: should fail.
+	cfg2 := &ClassConfig{Name: "reserve-egress", Rate: "400mbit"}
+	if err := validateSumRates(existing, cfg2, "1gbit"); err == nil {
+		t.Error("expected sum-rate error, got nil")
+	}
+	// Replacing partner (400→500): 500+300=800mbit ≤ 1gbit: should pass.
+	cfg3 := &ClassConfig{Name: "partner", Rate: "500mbit"}
+	if err := validateSumRates(existing, cfg3, "1gbit"); err != nil {
+		t.Errorf("unexpected error when replacing within limit: %v", err)
+	}
+	// Unparseable device rate: skip validation (legacy).
+	if err := validateSumRates(existing, cfg2, "${SPEED}mbit"); err != nil {
+		t.Errorf("unexpected error for unparseable device rate: %v", err)
+	}
+}
+
+func TestValidateDefaultClass(t *testing.T) {
+	if err := validateDefaultClass("reserve-egress", DirEgress); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := validateDefaultClass("reserve-ingress", DirIngress); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := validateDefaultClass("partner", DirIngress); err == nil {
+		t.Error("expected error: partner is egress, not ingress")
+	}
+	if err := validateDefaultClass("no-such-class", DirEgress); err == nil {
+		t.Error("expected error for unknown class")
+	}
+}
+
+func TestValidateCeilGeRate(t *testing.T) {
+	if err := validateCeilGeRate("700mbit", "400mbit"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := validateCeilGeRate("400mbit", "400mbit"); err != nil {
+		t.Errorf("equal ceil/rate should be valid: %v", err)
+	}
+	if err := validateCeilGeRate("300mbit", "400mbit"); err == nil {
+		t.Error("expected error: ceil < rate")
+	}
+	// Unparseable: skip silently.
+	if err := validateCeilGeRate("${SPEED}mbit", "100mbit"); err != nil {
+		t.Errorf("unexpected error for unparseable ceil: %v", err)
+	}
+}
+
+func TestClassInfoMap_AllClassesPresent(t *testing.T) {
+	expected := []struct {
+		name   string
+		minor  string
+		handle string
+		dir    string
+	}{
+		{"publisher", "10", "110", DirIngress},
+		{"backfill-response", "20", "120", DirIngress},
+		{"reserve-ingress", "30", "130", DirIngress},
+		{"partner", "40", "140", DirEgress},
+		{"public", "50", "150", DirEgress},
+		{"reserve-egress", "60", "160", DirEgress},
+	}
+	for _, e := range expected {
+		ci, err := lookupClassInfo(e.name)
+		if err != nil {
+			t.Errorf("lookupClassInfo(%q): %v", e.name, err)
+			continue
+		}
+		if ci.Minor != e.minor {
+			t.Errorf("%s: Minor=%q, want %q", e.name, ci.Minor, e.minor)
+		}
+		if ci.Handle != e.handle {
+			t.Errorf("%s: Handle=%q, want %q", e.name, ci.Handle, e.handle)
+		}
+		if ci.Dir != e.dir {
+			t.Errorf("%s: Dir=%q, want %q", e.name, ci.Dir, e.dir)
+		}
+	}
+}
+
+func TestLookupClassInfo_UnknownClass(t *testing.T) {
+	_, err := lookupClassInfo("no-such-class")
+	if err == nil {
+		t.Error("expected error for unknown class, got nil")
+	}
+}
+
+func TestEffectiveCeil_DefaultsToRate(t *testing.T) {
+	cls := &ClassConfig{Name: "partner", Rate: "400mbit", Ceil: ""}
+	if cls.effectiveCeil() != "400mbit" {
+		t.Errorf("effectiveCeil() = %q, want %q", cls.effectiveCeil(), "400mbit")
+	}
+	cls.Ceil = "700mbit"
+	if cls.effectiveCeil() != "700mbit" {
+		t.Errorf("effectiveCeil() = %q, want %q", cls.effectiveCeil(), "700mbit")
+	}
 }

--- a/internal/network/shape/tc_linux.go
+++ b/internal/network/shape/tc_linux.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package shape
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// TCRunner abstracts live kernel tc class operations for testability.
+type TCRunner interface {
+	// ClassChange runs `tc class change dev <nic> parent 1:1 classid 1:<minor>
+	// htb rate <rate> ceil <ceil> prio <prio>` on the live kernel.
+	ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error
+}
+
+type execTCRunner struct{}
+
+func (r *execTCRunner) ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error {
+	cmd := exec.CommandContext(ctx, "/sbin/tc",
+		"class", "change",
+		"dev", nic,
+		"parent", "1:1",
+		"classid", "1:"+minor,
+		"htb",
+		"rate", rate,
+		"ceil", ceil,
+		"prio", fmt.Sprintf("%d", prio),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return errorx.ExternalError.Wrap(err,
+			"tc class change dev %s classid 1:%s failed: %s", nic, minor, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// newExecTCRunner returns the production TC runner that shells out to /sbin/tc.
+func newExecTCRunner() TCRunner {
+	return &execTCRunner{}
+}

--- a/internal/network/shape/tc_other.go
+++ b/internal/network/shape/tc_other.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package shape
+
+import (
+	"context"
+
+	"github.com/joomcode/errorx"
+)
+
+// TCRunner abstracts live kernel tc class operations for testability.
+type TCRunner interface {
+	ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error
+}
+
+type noopTCRunner struct{}
+
+func (r *noopTCRunner) ClassChange(_ context.Context, _, _, _, _ string, _ int) error {
+	return errorx.IllegalState.New("tc operations not supported on this platform")
+}
+
+// newExecTCRunner returns a no-op runner on non-Linux platforms.
+func newExecTCRunner() TCRunner {
+	return &noopTCRunner{}
+}

--- a/internal/network/shape/validate.go
+++ b/internal/network/shape/validate.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// validateDir checks that dir is a valid tc device direction.
+func validateDir(dir string) error {
+	if dir != DirIngress && dir != DirEgress {
+		return errorx.IllegalArgument.New("--device must be %q or %q, got %q", DirIngress, DirEgress, dir)
+	}
+	return nil
+}
+
+// validatePrio checks that prio is in the HTB priority range [0, 7].
+func validatePrio(prio int) error {
+	if prio < 0 || prio > 7 {
+		return errorx.IllegalArgument.New("--prio must be in [0,7], got %d", prio)
+	}
+	return nil
+}
+
+// validateDefaultClass checks that className is a valid §5 class for dir.
+func validateDefaultClass(className, dir string) error {
+	info, err := lookupClassInfo(className)
+	if err != nil {
+		return err
+	}
+	if info.Dir != dir {
+		return errorx.IllegalArgument.New(
+			"class %q is a %s class and cannot be the default for the %s device; valid defaults: %s",
+			className, info.Dir, dir, strings.Join(knownClassNamesForDir(dir), ", "))
+	}
+	return nil
+}
+
+// parseBandwidthBps parses a tc-style bandwidth string and returns its value
+// in bits per second. Supports suffixes: bit, kbit, mbit, gbit (case-insensitive).
+// Returns an error for unknown suffixes or non-numeric values. Shell arithmetic
+// expressions (e.g. "$(( SPEED * 40 / 100 ))mbit") are intentionally not
+// supported — they are only used in the legacy default scriptData path.
+func parseBandwidthBps(s string) (int64, error) {
+	low := strings.ToLower(strings.TrimSpace(s))
+	var multiplier int64
+	var numStr string
+	switch {
+	case strings.HasSuffix(low, "gbit"):
+		multiplier = 1_000_000_000
+		numStr = low[:len(low)-4]
+	case strings.HasSuffix(low, "mbit"):
+		multiplier = 1_000_000
+		numStr = low[:len(low)-4]
+	case strings.HasSuffix(low, "kbit"):
+		multiplier = 1_000
+		numStr = low[:len(low)-4]
+	case strings.HasSuffix(low, "bit"):
+		multiplier = 1
+		numStr = low[:len(low)-3]
+	default:
+		return 0, errorx.IllegalArgument.New(
+			"invalid bandwidth %q: expected a number followed by bit/kbit/mbit/gbit (e.g. 100mbit)", s)
+	}
+	n, err := strconv.ParseFloat(numStr, 64)
+	if err != nil || n < 0 {
+		return 0, errorx.IllegalArgument.New("invalid bandwidth %q: numeric part must be a non-negative number", s)
+	}
+	return int64(n * float64(multiplier)), nil
+}
+
+// validateRate checks that rate is a non-empty, parseable tc bandwidth string.
+func validateRate(rate string) error {
+	if strings.TrimSpace(rate) == "" {
+		return errorx.IllegalArgument.New("--rate must not be empty")
+	}
+	_, err := parseBandwidthBps(rate)
+	return err
+}
+
+// validateCeilGeRate checks that ceil >= rate when both are parseable. Silently
+// skips the check when either value cannot be parsed (tc will validate at apply
+// time; legacy shell expressions used in default renders are never user-supplied).
+func validateCeilGeRate(ceil, rate string) error {
+	ceilBps, err1 := parseBandwidthBps(ceil)
+	rateBps, err2 := parseBandwidthBps(rate)
+	if err1 != nil || err2 != nil {
+		return nil
+	}
+	if ceilBps < rateBps {
+		return errorx.IllegalArgument.New("--ceil %s must be >= --rate %s", ceil, rate)
+	}
+	return nil
+}
+
+// validateSumRates checks that the total of all class rates for the same device
+// (including cfg, replacing any existing entry with the same name) does not
+// exceed the device root rate. Skips the check if any value cannot be parsed.
+func validateSumRates(existing []*ClassConfig, cfg *ClassConfig, deviceRate string) error {
+	deviceBps, err := parseBandwidthBps(deviceRate)
+	if err != nil {
+		return nil // device rate unparseable (legacy expression): skip
+	}
+	var sum int64
+	for _, c := range existing {
+		if c.Name == cfg.Name {
+			continue // will be replaced by cfg in the sum
+		}
+		bps, err := parseBandwidthBps(c.Rate)
+		if err != nil {
+			continue // unparseable sibling: skip its contribution
+		}
+		sum += bps
+	}
+	newBps, err := parseBandwidthBps(cfg.Rate)
+	if err != nil {
+		return nil // new rate unparseable: skip
+	}
+	sum += newBps
+	if sum > deviceBps {
+		return errorx.IllegalArgument.New(
+			"total class rates (%d bit) would exceed device root rate %s (%d bit); reduce --rate or raise the device rate",
+			sum, deviceRate, deviceBps)
+	}
+	return nil
+}

--- a/internal/templates/files/network/solo-provisioner-tc-egress.service
+++ b/internal/templates/files/network/solo-provisioner-tc-egress.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Solo Provisioner TC Egress Shaper
+Documentation=https://github.com/hashgraph/solo-weaver
+DefaultDependencies=no
+After=network-pre.target
+Before=network.target solo-provisioner-daemon.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/solo-provisioner-tc-egress.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
+++ b/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Rendered by solo-provisioner at install time. Do not edit — changes are
+# overwritten by `block node install --force`.
+#
+# Replays the $EGRESS HTB hierarchy at boot. Idempotent: delete the root qdisc
+# first (cascades to all classes and leaf qdiscs), then add everything fresh.
+# fq_codel does not support tc's change() operation, so replace/change is not
+# viable for leaf qdiscs.
+set -e
+
+NIC={{.NIC}}
+
+# Detect link speed in Mbit/s. The kernel uses -1 for "unknown" (common on
+# virtual NICs and at early boot before the link is established). Suppress
+# any read error so set -e never fires here (e.g. udev may not have renamed
+# the NIC yet if the service starts very early). Fall back to 1000 Mbit/s.
+SPEED=$(cat /sys/class/net/"$NIC"/speed 2>/dev/null || echo -1)
+[ "${SPEED:-0}" -gt 0 ] 2>/dev/null || SPEED=1000
+
+# Remove any existing root qdisc (and all its children). Silent no-op if absent.
+tc qdisc del dev "$NIC" root 2>/dev/null || true
+
+# Root HTB qdisc: unmatched traffic falls to default class 1:60 (reserve).
+tc qdisc add dev "$NIC" root handle 1: htb default 60
+
+# Trunk class: full link rate as the ceiling for the whole hierarchy.
+tc class  add dev "$NIC" parent 1:   classid 1:1  htb rate "${SPEED}mbit" ceil "${SPEED}mbit"
+
+# Per-class leaf nodes (partner / public / reserve-egress).
+tc class  add dev "$NIC" parent 1:1  classid 1:40 htb rate "$(( SPEED * 40 / 100 ))mbit" ceil "$(( SPEED * 70 / 100 ))mbit" prio 0
+tc class  add dev "$NIC" parent 1:1  classid 1:50 htb rate "$(( SPEED * 30 / 100 ))mbit" ceil "$(( SPEED * 70 / 100 ))mbit" prio 5
+tc class  add dev "$NIC" parent 1:1  classid 1:60 htb rate "$(( SPEED * 30 / 100 ))mbit" ceil "${SPEED}mbit" prio 1
+
+# fq_codel leaf qdiscs: per-class fair-queuing with active queue management.
+tc qdisc  add dev "$NIC" parent 1:40 handle 140: fq_codel
+tc qdisc  add dev "$NIC" parent 1:50 handle 150: fq_codel
+tc qdisc  add dev "$NIC" parent 1:60 handle 160: fq_codel

--- a/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
+++ b/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
@@ -1,6 +1,5 @@
 #!/bin/sh
-# Rendered by solo-provisioner at install time. Do not edit — changes are
-# overwritten by `block node install --force`.
+# Managed by solo-provisioner. Re-rendered by `network shape create`; do not edit.
 #
 # Replays the $EGRESS HTB hierarchy at boot. Idempotent: delete the root qdisc
 # first (cascades to all classes and leaf qdiscs), then add everything fresh.
@@ -20,18 +19,12 @@ SPEED=$(cat /sys/class/net/"$NIC"/speed 2>/dev/null || echo -1)
 # Remove any existing root qdisc (and all its children). Silent no-op if absent.
 tc qdisc del dev "$NIC" root 2>/dev/null || true
 
-# Root HTB qdisc: unmatched traffic falls to default class 1:60 (reserve).
-tc qdisc add dev "$NIC" root handle 1: htb default 60
+# Root HTB qdisc: unmatched traffic falls to default class 1:{{.Device.DefaultMinor}}.
+tc qdisc add dev "$NIC" root handle 1: htb default {{.Device.DefaultMinor}}
 
 # Trunk class: full link rate as the ceiling for the whole hierarchy.
-tc class  add dev "$NIC" parent 1:   classid 1:1  htb rate "${SPEED}mbit" ceil "${SPEED}mbit"
-
-# Per-class leaf nodes (partner / public / reserve-egress).
-tc class  add dev "$NIC" parent 1:1  classid 1:40 htb rate "$(( SPEED * 40 / 100 ))mbit" ceil "$(( SPEED * 70 / 100 ))mbit" prio 0
-tc class  add dev "$NIC" parent 1:1  classid 1:50 htb rate "$(( SPEED * 30 / 100 ))mbit" ceil "$(( SPEED * 70 / 100 ))mbit" prio 5
-tc class  add dev "$NIC" parent 1:1  classid 1:60 htb rate "$(( SPEED * 30 / 100 ))mbit" ceil "${SPEED}mbit" prio 1
-
-# fq_codel leaf qdiscs: per-class fair-queuing with active queue management.
-tc qdisc  add dev "$NIC" parent 1:40 handle 140: fq_codel
-tc qdisc  add dev "$NIC" parent 1:50 handle 150: fq_codel
-tc qdisc  add dev "$NIC" parent 1:60 handle 160: fq_codel
+tc class  add dev "$NIC" parent 1:   classid 1:1  htb rate "{{.Device.Rate}}" ceil "{{.Device.Rate}}"
+{{range .Classes}}
+tc class  add dev "$NIC" parent 1:1  classid 1:{{.Minor}} htb rate "{{.Rate}}" ceil "{{.Ceil}}" prio {{.Prio}}
+tc qdisc  add dev "$NIC" parent 1:{{.Minor}} handle {{.Handle}}: fq_codel
+{{end}}

--- a/internal/ui/prompt/blocknode.go
+++ b/internal/ui/prompt/blocknode.go
@@ -141,6 +141,20 @@ func recentRetentionInputPrompt(eff string, target *string) InputPrompt {
 	}
 }
 
+// EgressInterfaceInputPrompt returns the interactive prompt for --egress-interface.
+// eff is the auto-detected NIC name used as the placeholder/effective value;
+// pass an empty string when detection is unavailable or unsupported.
+func EgressInterfaceInputPrompt(eff string, target *string) InputPrompt {
+	return InputPrompt{
+		FlagName:       "egress-interface",
+		Title:          "Egress Network Interface",
+		Description:    "Physical NIC for the $EGRESS HTB traffic-shaper hierarchy. Leave blank to auto-detect from the default route.",
+		Placeholder:    eff,
+		EffectiveValue: eff,
+		Target:         target,
+	}
+}
+
 func basePathInputPrompt(eff string, target *string) InputPrompt {
 	return InputPrompt{
 		FlagName:       "base-path",

--- a/internal/workflows/steps/step_network_tc_egress.go
+++ b/internal/workflows/steps/step_network_tc_egress.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// TcEgressPersistStepId is the step ID for TcEgressPersist.
+const TcEgressPersistStepId = "tc-egress-persist"
+
+// TcEgressPersist renders /usr/local/sbin/solo-provisioner-tc-egress.sh with
+// the egress NIC name interpolated, installs and enables the
+// solo-provisioner-tc-egress.service oneshot unit, and executes the script
+// immediately so the kernel HTB hierarchy is live without waiting for a reboot
+// (design §8.3.2).
+//
+// When nicName is empty the NIC is auto-detected from the default route via
+// DetectEgressInterface (single-NIC hosts, §4.1). Pass --egress-interface to
+// override on multi-NIC hosts or when the default route does not identify the
+// correct physical interface.
+func TcEgressPersist(nicName string) *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(TcEgressPersistStepId).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Persisting tc-egress HTB hierarchy for reboot")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to persist tc-egress hierarchy")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "tc-egress hierarchy persisted")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			nic := nicName
+			if nic == "" {
+				detected, err := shape.DetectEgressInterface()
+				if err != nil {
+					return automa.FailureReport(stp, automa.WithError(
+						errorx.Decorate(err, "failed to auto-detect egress interface").
+							WithProperty(models.ErrPropertyResolution, []string{
+								"Specify the physical NIC explicitly: block node install --egress-interface <nic>",
+								"To find the correct NIC: ip route get 8.8.8.8 (look for 'dev <nic>')",
+							})))
+				}
+				logx.As().Info().Str("nic", detected).Msg("auto-detected egress interface from default route")
+				nic = detected
+			}
+
+			if err := shape.RenderTcEgressScript(nic); err != nil {
+				return automa.FailureReport(stp, automa.WithError(err))
+			}
+			if err := shape.EnsureTcEgressUnit(ctx); err != nil {
+				return automa.FailureReport(stp, automa.WithError(err))
+			}
+			if err := shape.ApplyTcEgressScript(ctx); err != nil {
+				return automa.FailureReport(stp, automa.WithError(err))
+			}
+
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			// Rollback is a no-op: the script and unit are idempotent artifacts.
+			// Removing them would leave the kernel hierarchy installed but un-
+			// persisted — no worse than before this step ran. A dedicated
+			// `block node uninstall` step (Story 2.4 / #763) handles teardown.
+			return automa.SkippedReport(stp,
+				automa.WithDetail("tc-egress rollback is a no-op; teardown is handled by block node uninstall (#763)"))
+		})
+}

--- a/pkg/models/inputs.go
+++ b/pkg/models/inputs.go
@@ -74,6 +74,7 @@ type BlockNodeInputs struct {
 	RecentRetention     string // FILES_RECENT_BLOCK_RETENTION_THRESHOLD (~96000 default)
 	PluginPreset        string // preset ID (e.g. "tier1-lfh"), "custom", or "none" (no override); empty/"none" = use --values or chart default
 	PluginList          string // resolved comma-separated plugin list injected into plugins.names
+	EgressInterface     string // physical NIC for the $EGRESS HTB hierarchy (TS_2 #742); auto-detected in Story 2.2 (#744)
 }
 
 type ClusterInputs struct {


### PR DESCRIPTION
## Summary

- Implements Story 1.4 (`network shape create/set/show/delete`): CLI verbs to manage tc HTB bandwidth classes and device roots via a JSON registry at `/etc/solo-provisioner/shape/`
- Egress mutations (`--device egress` / egress-direction classes) re-render `solo-provisioner-tc-egress.sh` from stored config and restart the oneshot service — keeping the live kernel and reboot state in sync
- `solo-provisioner-tc-egress.sh.tmpl` is now fully parameterised; `defaultScriptData()` preserves the original SPEED-based shell expressions for installs with no shape config (full backward compatibility)
- `set` uses `tc class change` for a live atomic kernel update with no qdisc teardown; the boot script is re-rendered immediately for reboot persistence
- `delete` is guarded: a class cannot be removed if it is the device's default or referenced by any `network policy --stamp/--reply-stamp`

## Changed Files

| File | Description |
|------|-------------|
| `internal/network/shape/class.go` | §5 class-info map (`classInfoMap`), `ClassConfig` struct, `lookupClassInfo` |
| `internal/network/shape/device.go` | `DeviceConfig` struct |
| `internal/network/shape/validate.go` | dir/rate/ceil/prio/Σ-rate validators |
| `internal/network/shape/registry.go` | JSON read/write for device & class configs; policy stamp cross-ref |
| `internal/network/shape/manager.go` | `Manager` with `CreateDevice`, `CreateClass`, `SetClass`, `ShowClass`, `ShowDevice`, `ShowAll`, `DeleteClass`, `DeleteDevice`; flock-based cross-command locking |
| `internal/network/shape/tc_linux.go` | `TCRunner` interface + `execTCRunner` (`tc class change`) |
| `internal/network/shape/tc_other.go` | `noopTCRunner` stub for non-Linux builds |
| `internal/network/shape/paths.go` | New constants: `ShapeConfigDir`, `DeviceConfigDir`, `ClassConfigDir`, `ShapeLockPath` |
| `internal/network/shape/render.go` | Parameterised template rendering + backward-compat `defaultScriptData()` |
| `internal/network/shape/shape_test.go` | Render-from-config, validation, and class-map unit tests (19 passing) |
| `internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl` | Fully parameterised Go template |
| `cmd/cli/commands/network/shape/shape.go` | `shapeCmd` parent + flag vars |
| `cmd/cli/commands/network/shape/create.go` | `create` verb (`--device` and `--class` forms) |
| `cmd/cli/commands/network/shape/set.go` | `set` verb (live `tc class change` + script re-render) |
| `cmd/cli/commands/network/shape/show.go` | `show` verb |
| `cmd/cli/commands/network/shape/delete.go` | `delete` verb (guarded removal) |
| `cmd/cli/commands/network/shape/shape_test.go` | CLI validation tests (mutual exclusion, missing required flags) |
| `cmd/cli/commands/network/network.go` | Wires `shape.GetCmd()` into the `network` command group |

## Manual UAT

> All steps require the UTM Linux VM with a running Kubernetes cluster.

### 1. Create egress device root

```bash
sudo solo-provisioner network shape create \
  --device egress --rate 1gbit --default reserve-egress
# Expected: "network shape device configured dir=egress rate=1gbit default=reserve-egress" in logs
# Expected: /etc/solo-provisioner/shape/devices/egress.json created
```

### 2. Create egress classes

```bash
sudo solo-provisioner network shape create --class partner      --rate 400mbit --ceil 700mbit  --prio 0
sudo solo-provisioner network shape create --class public       --rate 300mbit --ceil 700mbit  --prio 5
sudo solo-provisioner network shape create --class reserve-egress --rate 300mbit --ceil 1000mbit --prio 1
# Expected: JSON written to /etc/solo-provisioner/shape/classes/<name>.json for each
# Expected: tc-egress.sh re-rendered and tc-egress.service restarted after each create
```

### 3. Verify rendered tc-egress.sh

```bash
cat /usr/local/lib/solo-provisioner/tc-egress.sh
# Expected: NIC=<detected interface>
# Expected: classid 1:40 htb rate "400mbit" ceil "700mbit" prio 0
# Expected: classid 1:50 htb rate "300mbit" ceil "700mbit" prio 5
# Expected: classid 1:60 htb rate "300mbit" ceil "1000mbit" prio 1
```

### 4. Show configuration

```bash
sudo solo-provisioner network shape show
# Expected: device egress listing with rate, default class, and all classes

sudo solo-provisioner network shape show --class partner
# Expected: class partner (1:40, egress device) / rate: 400mbit / ceil: 700mbit / prio: 0
```

### 5. Live update (set — no qdisc teardown)

```bash
sudo solo-provisioner network shape set --class partner --rate 500mbit
# Expected: "network shape class updated class=partner"
sudo tc -s class show dev eth0 classid 1:40
# Expected: rate 500Mbit reflected immediately in kernel
```

### 6. Delete guard — class is device default

```bash
sudo solo-provisioner network shape delete --class reserve-egress
# Expected error: "class \"reserve-egress\" is the default class for device \"egress\"..."

# Reconfigure default, then retry:
sudo solo-provisioner network shape create --device egress --rate 1gbit --default public --force
sudo solo-provisioner network shape delete --class reserve-egress
# Expected: class deleted, tc-egress.sh re-rendered
```

### 7. Reboot persistence

```bash
sudo reboot
# After reboot:
sudo tc -s class show dev eth0
# Expected: HTB classes match the configured rates (partner=500mbit, public=300mbit)
```

### 8. Backward compatibility — no shape config

```bash
# Remove shape config to simulate a fresh-install node:
sudo rm -rf /etc/solo-provisioner/shape/
# Trigger a re-render (e.g. via block node install or direct invocation)
cat /usr/local/lib/solo-provisioner/tc-egress.sh
# Expected: SPEED-based shell arithmetic expressions (original defaults), not hardcoded mbit values
```

## Test Plan

- [x] `go test -tags='!integration' ./internal/network/shape/...` — 19 unit tests pass on macOS
- [x] `GOOS=linux GOARCH=amd64 go build ./cmd/cli/...` — clean
- [x] `task lint` — 0 issues
- [ ] `task vm:test:unit` — run full suite in UTM VM (CLI package tests require Linux)
- [ ] Manual UAT steps 1–8 above on the UTM VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)