### PR TITLE
feat(network): nftables weaver reboot persistence (solo-provisioner-network-nft.service) (#743)

### DIFF
--- a/cmd/cli/commands/network/policy/policy_test.go
+++ b/cmd/cli/commands/network/policy/policy_test.go
@@ -410,10 +410,11 @@ func TestDeleteCmd_RemovesPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, env.runVerb(t, "delete", "--name", "bn-restricted"))
-	// .nft no longer contains the policy.
-	onDisk, readErr := os.ReadFile(env.nftPath)
-	require.NoError(t, readErr)
-	require.NotContains(t, string(onDisk), "bn-restricted")
+	// Deleting the last policy tears the table down rather than persisting an
+	// empty policy-drop chain: the .nft file is removed (boot replays nothing)
+	// and the live inet weaver table is deleted.
+	require.NoFileExists(t, env.nftPath)
+	require.Empty(t, env.runner.applied, "live inet weaver table must be torn down after the last policy is deleted")
 }
 
 func TestDeleteCmd_PolicyNotFound(t *testing.T) {

--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -76,6 +76,12 @@ func (h *InstallHandler) BuildWorkflow(
 				// is already installed/enabled from that prior cluster provisioning,
 				// so it's safe to apply here.
 				steps.NetworkFirewallCreate(),
+				// Re-render network-weaver.nft from the policy registry and restart
+				// the shared oneshot so systemd's RemainAfterExit state reflects both
+				// the host and weaver tables.
+				steps.NftWeaverPersist(),
+				// Render and install the $EGRESS HTB boot-persistence script and
+				// oneshot unit.
 				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 				steps.SetupBlockNode(ins),
 			)
@@ -96,6 +102,12 @@ func (h *InstallHandler) BuildWorkflow(
 				// systemSetupWorkflow; apply the host firewall here rather than in
 				// that generic (node-type-agnostic) workflow.
 				steps.NetworkFirewallCreate(),
+				// Re-render network-weaver.nft from the policy registry and restart
+				// the shared oneshot so systemd's RemainAfterExit state reflects both
+				// the host and weaver tables.
+				steps.NftWeaverPersist(),
+				// Render and install the $EGRESS HTB boot-persistence script and
+				// oneshot unit.
 				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 				steps.SetupBlockNode(ins),
 			)

--- a/internal/bll/blocknode/reconfigure_handler.go
+++ b/internal/bll/blocknode/reconfigure_handler.go
@@ -71,6 +71,9 @@ func (h *ReconfigureHandler) BuildWorkflow(
 		wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-purge-storage").
 			Steps(
 				steps.NetworkFirewallCreate(),
+				// Keep network-weaver.nft in sync with the policy registry (no-op
+				// if the registry is empty), matching the install ordering.
+				steps.NftWeaverPersist(),
 				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 				steps.PurgeBlockNodeStorage(oldIns),
 				steps.RecreateBlockNodeStorage(ins),
@@ -95,6 +98,9 @@ func (h *ReconfigureHandler) BuildWorkflow(
 		wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-with-reset").
 			Steps(
 				steps.NetworkFirewallCreate(),
+				// Keep network-weaver.nft in sync with the policy registry (no-op
+				// if the registry is empty), matching the install ordering.
+				steps.NftWeaverPersist(),
 				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 				steps.PurgeBlockNodeStorage(oldIns),
 				steps.UpgradeBlockNode(ins),
@@ -118,6 +124,9 @@ func (h *ReconfigureHandler) BuildWorkflow(
 			wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-no-restart").
 				Steps(
 					steps.NetworkFirewallCreate(),
+					// Keep network-weaver.nft in sync with the policy registry (no-op
+					// if the registry is empty), matching the install ordering.
+					steps.NftWeaverPersist(),
 					steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 					steps.UpgradeBlockNode(ins),
 				)
@@ -127,6 +136,9 @@ func (h *ReconfigureHandler) BuildWorkflow(
 			wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure").
 				Steps(
 					steps.NetworkFirewallCreate(),
+					// Keep network-weaver.nft in sync with the policy registry (no-op
+					// if the registry is empty), matching the install ordering.
+					steps.NftWeaverPersist(),
 					steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 					steps.UpgradeBlockNode(ins),
 					steps.RolloutRestartBlockNode(ins),

--- a/internal/bll/blocknode/reconfigure_handler_test.go
+++ b/internal/bll/blocknode/reconfigure_handler_test.go
@@ -114,6 +114,7 @@ func TestBuildWorkflow_WithReset_PathsUnchanged_DataOnly(t *testing.T) {
 	ids := workflowStepIDs(t, wb)
 	assert.Equal(t, []string{
 		steps.NetworkFirewallCreateStepId,
+		steps.NftWeaverPersistStepId,
 		steps.TcEgressPersistStepId,
 		steps.PurgeBlockNodeStorageStepId,
 		steps.UpgradeBlockNodeStepId,
@@ -164,6 +165,7 @@ func TestBuildWorkflow_PurgeStorage_IncludesRecreateStep(t *testing.T) {
 			ids := workflowStepIDs(t, wb)
 			assert.Equal(t, []string{
 				steps.NetworkFirewallCreateStepId,
+				steps.NftWeaverPersistStepId,
 				steps.TcEgressPersistStepId,
 				steps.PurgeBlockNodeStorageStepId,
 				steps.RecreateBlockNodeStorageStepId,
@@ -189,6 +191,7 @@ func TestBuildWorkflow_NoReset_SamePathsUpgradeAndRestart(t *testing.T) {
 	ids := workflowStepIDs(t, wb)
 	assert.Equal(t, []string{
 		steps.NetworkFirewallCreateStepId,
+		steps.NftWeaverPersistStepId,
 		steps.TcEgressPersistStepId,
 		steps.UpgradeBlockNodeStepId,
 		steps.RolloutRestartBlockNodeStepId,

--- a/internal/network/firewall/service_linux.go
+++ b/internal/network/firewall/service_linux.go
@@ -19,15 +19,16 @@ import (
 // it for boot, and restarts it so the kernel picks up the just-written
 // network-host.nft immediately — all via DBus, no nft exec for the apply path.
 func defaultApplyViaService(ctx context.Context) error {
-	if err := ensureNetworkNftUnit(ctx); err != nil {
+	if err := EnsureNetworkNftUnit(ctx); err != nil {
 		return err
 	}
 	return soos.RestartService(ctx, NetworkNftService)
 }
 
-// ensureNetworkNftUnit writes the embedded service unit on first call.
-// Stat-and-skip so repeated mutations don't re-write on every call.
-func ensureNetworkNftUnit(ctx context.Context) error {
+// EnsureNetworkNftUnit writes the embedded service unit file to
+// NetworkNftServiceUnitPath if it is absent, then daemon-reloads and enables
+// the unit for boot. Stat-and-skip so repeated calls are a fast no-op.
+func EnsureNetworkNftUnit(ctx context.Context) error {
 	if _, err := os.Stat(NetworkNftServiceUnitPath); err == nil {
 		return nil // already installed — fast path
 	}

--- a/internal/network/firewall/service_other.go
+++ b/internal/network/firewall/service_other.go
@@ -17,3 +17,6 @@ func defaultApplyViaService(_ context.Context) error {
 	logx.As().Debug().Str("service", NetworkNftService).Msg("service apply is a no-op on non-Linux builds")
 	return nil
 }
+
+// EnsureNetworkNftUnit is a no-op on non-Linux platforms.
+func EnsureNetworkNftUnit(_ context.Context) error { return nil }

--- a/internal/network/policy/manager.go
+++ b/internal/network/policy/manager.go
@@ -418,6 +418,32 @@ func (m *Manager) Delete(ctx context.Context, name string) error {
 			}
 		}
 
+		if len(remaining) == 0 {
+			// Deleting the last policy: tear the whole table down rather than
+			// render an empty chain. Render([]) emits `policy drop` with no
+			// accept rule for new connections — a blackhole that Apply() would
+			// load into the kernel and atomicWrite would persist for replay at
+			// boot. Remove the live table (if present) and the persisted file so
+			// an empty registry means "no inet weaver table", live or on disk.
+			if exists, err := m.runner.Exists(ctx); err != nil {
+				return errorx.Decorate(err, "failed to check the inet weaver table while removing the last policy")
+			} else if exists {
+				if err := m.runner.Delete(ctx); err != nil {
+					return errorx.Decorate(err, "failed to delete the inet weaver table while removing the last policy")
+				}
+			}
+			if err := os.Remove(m.weaverNftPath); err != nil && !os.IsNotExist(err) {
+				return errorx.Decorate(errorx.ExternalError.Wrap(err, "failed to remove %s", m.weaverNftPath),
+					"inet weaver table deleted but removing the persisted file failed; re-run to reconcile")
+			}
+			if err := os.Remove(registryPath(m.registryDir, name)); err != nil && !os.IsNotExist(err) {
+				return errorx.Decorate(errorx.ExternalError.Wrap(err, "failed to remove registry file for %q", name),
+					"inet weaver table and file removed but removing the registry entry failed; re-run to reconcile")
+			}
+			logx.As().Info().Str("policy", name).Msg("network policy deleted (last policy — inet weaver table torn down)")
+			return nil
+		}
+
 		// Recover the pod CIDR from the existing .nft if any remaining policy
 		// is a --stamp (same pattern as Create).
 		podCIDR := ""

--- a/internal/network/policy/manager_ops_test.go
+++ b/internal/network/policy/manager_ops_test.go
@@ -268,22 +268,20 @@ func TestDelete_PreservesSiblingMembership(t *testing.T) {
 	require.Empty(t, r.elements["bn-publisher"], "deleted policy's set no longer present")
 }
 
-func TestDelete_LastPolicy_AppliesEmptyChain(t *testing.T) {
+func TestDelete_LastPolicy_TearsDownTable(t *testing.T) {
 	r := newFakeRunner()
-	m, nftPath, _ := newTestManager(t, r)
+	m, nftPath, regDir := newTestManager(t, r)
 	seedDenyPolicy(t, m, "bn-restricted", []string{"10.99.0.0/16"})
 
 	require.NoError(t, m.Delete(context.Background(), "bn-restricted"))
 
-	// The table is still live (empty chain, policy drop, no rules).
-	require.True(t, r.exists, "table must still exist after last policy is deleted")
-
-	// The .nft file was updated and no longer contains the deleted policy.
-	onDisk, err := os.ReadFile(nftPath)
-	require.NoError(t, err)
-	require.NotContains(t, string(onDisk), "bn-restricted")
-	// Chain structure is intact with policy drop.
-	require.Contains(t, string(onDisk), "policy drop")
+	// Deleting the last policy tears the whole table down rather than applying
+	// an empty policy-drop chain that would blackhole all forwarded traffic.
+	require.False(t, r.exists, "inet weaver table must be deleted after the last policy is removed")
+	// The persisted file is removed so the boot oneshot replays nothing.
+	require.NoFileExists(t, nftPath)
+	// The registry entry is gone.
+	require.NoFileExists(t, filepath.Join(regDir, "bn-restricted.json"))
 }
 
 func TestDelete_PolicyNotFound(t *testing.T) {

--- a/internal/network/policy/registry.go
+++ b/internal/network/policy/registry.go
@@ -45,6 +45,18 @@ func readEntry(dir, name string) (*Policy, error) {
 	return &p, nil
 }
 
+// IsRegistryEmpty reports whether the policy registry at dir contains no
+// entries. A missing directory is treated as empty. On error the bool is false
+// so a failed read can never be mistaken for "empty" (len(nil)==0) and cause a
+// caller to skip work it should not.
+func IsRegistryEmpty(dir string) (bool, error) {
+	policies, err := loadAll(dir)
+	if err != nil {
+		return false, err
+	}
+	return len(policies) == 0, nil
+}
+
 // loadAll reads every policy registry file in dir, sorted by name for a
 // deterministic render. A missing directory yields an empty slice (the first
 // create renders from a single in-memory entry before the dir exists).

--- a/internal/network/policy/render_weaver.go
+++ b/internal/network/policy/render_weaver.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"crypto/sha256"
+	"os"
+
+	"github.com/joomcode/errorx"
+)
+
+// RenderWeaverNft loads all policies from registryDir, renders the full
+// `inet weaver` nft document, and atomically writes it to weaverNftPath
+// (mode 0644). If the on-disk content is already identical (SHA-256 match)
+// the write is skipped — making it safe to call from idempotent install flows.
+//
+// podCIDR is required only when at least one registered policy is a --stamp
+// policy. If the caller passes "" and the existing weaverNftPath is readable,
+// the pod CIDR is recovered from that file automatically — the same recovery
+// path Manager.Create uses. An error is returned only when a stamp policy is
+// present and no podCIDR can be resolved.
+func RenderWeaverNft(registryDir, weaverNftPath, podCIDR string) error {
+	policies, err := loadAll(registryDir)
+	if err != nil {
+		return err
+	}
+	if len(policies) == 0 {
+		// An empty registry means no policies to enforce. A rendered empty chain
+		// would be `policy drop` with no accept rule for new connections —
+		// blackholing all forwarded traffic (pod startup, image pulls, inter-pod
+		// DNS). Remove any stale persisted file so the boot oneshot's `test -e`
+		// guard skips it and never replays a harmful or out-of-date inet weaver
+		// table. "Empty registry" thus means "no file", not "an empty table".
+		if err := os.Remove(weaverNftPath); err != nil && !os.IsNotExist(err) {
+			return errorx.ExternalError.Wrap(err, "failed to remove stale %s for an empty policy registry", weaverNftPath)
+		}
+		return nil
+	}
+
+	// Validate each registry entry before rendering — a corrupt or hand-edited
+	// JSON would otherwise flow into Render and produce a cryptic internal error
+	// instead of a clear "corrupt registry entry" message. Mirrors the
+	// validation Manager.Create performs on sibling entries before each render.
+	for _, p := range policies {
+		if err := p.Validate(nil); err != nil {
+			return errorx.IllegalFormat.Wrap(err, "corrupt policy registry entry %s", registryPath(registryDir, p.Name))
+		}
+	}
+
+	if podCIDR == "" && needsPodCIDR(policies) {
+		if existing, readErr := os.ReadFile(weaverNftPath); readErr == nil {
+			podCIDR = ExtractPodCIDR(string(existing))
+		}
+	}
+
+	doc, err := Render(policies, podCIDR)
+	if err != nil {
+		return errorx.Decorate(err, "failed to render %s", weaverNftPath)
+	}
+
+	if existing, readErr := os.ReadFile(weaverNftPath); readErr == nil {
+		if sha256.Sum256([]byte(doc)) == sha256.Sum256(existing) {
+			return nil
+		}
+	}
+	return atomicWriteFile(weaverNftPath, doc, 0o644)
+}

--- a/internal/network/policy/render_weaver_test.go
+++ b/internal/network/policy/render_weaver_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderWeaverNft_EmptyRegistry(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "network-weaver.nft")
+
+	// Missing registry dir is treated as an empty registry: must be a no-op.
+	// Writing a forward chain with policy drop for zero policies would silently
+	// block all new forwarded traffic (pod startup, image pulls, DNS).
+	require.NoError(t, RenderWeaverNft(filepath.Join(dir, "policies"), out, ""))
+
+	_, err := os.Stat(out)
+	require.True(t, os.IsNotExist(err), "RenderWeaverNft must not write a file for an empty registry")
+}
+
+func TestRenderWeaverNft_EmptyRegistryRemovesStaleFile(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "network-weaver.nft")
+
+	// A stale file left over from a previous non-empty render. An empty registry
+	// must remove it so the boot oneshot never replays a harmful/old table.
+	require.NoError(t, os.WriteFile(out, []byte("table inet weaver { }\n"), 0o644))
+
+	require.NoError(t, RenderWeaverNft(filepath.Join(dir, "policies"), out, ""))
+
+	_, err := os.Stat(out)
+	require.True(t, os.IsNotExist(err), "stale network-weaver.nft must be removed for an empty registry")
+}
+
+func TestRenderWeaverNft_DenyPolicy(t *testing.T) {
+	dir := t.TempDir()
+	regDir := filepath.Join(dir, "policies")
+	require.NoError(t, os.MkdirAll(regDir, 0o755))
+	out := filepath.Join(dir, "network-weaver.nft")
+
+	p := &Policy{
+		Name:      "bn-restricted",
+		Action:    ActionDeny,
+		CreatedAt: time.Now().UTC(),
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(regDir, "bn-restricted.json"), append(data, '\n'), 0o644))
+
+	require.NoError(t, RenderWeaverNft(regDir, out, ""))
+
+	content, err := os.ReadFile(out)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "bn-restricted")
+	require.Contains(t, string(content), "drop")
+}
+
+func TestRenderWeaverNft_IdempotentWrite(t *testing.T) {
+	dir := t.TempDir()
+	regDir := filepath.Join(dir, "policies")
+	require.NoError(t, os.MkdirAll(regDir, 0o755))
+	out := filepath.Join(dir, "network-weaver.nft")
+
+	// Use a deny policy so the registry is non-empty and a file is actually written.
+	p := &Policy{
+		Name:      "bn-restricted",
+		Action:    ActionDeny,
+		CreatedAt: time.Now().UTC(),
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(regDir, "bn-restricted.json"), append(data, '\n'), 0o644))
+
+	require.NoError(t, RenderWeaverNft(regDir, out, ""))
+
+	first, err := os.ReadFile(out)
+	require.NoError(t, err)
+	firstSum := sha256.Sum256(first)
+
+	// Stat the file to detect if the second call re-writes it.
+	info1, err := os.Stat(out)
+	require.NoError(t, err)
+
+	require.NoError(t, RenderWeaverNft(regDir, out, ""))
+
+	info2, err := os.Stat(out)
+	require.NoError(t, err)
+	require.Equal(t, info1.ModTime(), info2.ModTime(), "second call must not re-write an unchanged file")
+
+	second, err := os.ReadFile(out)
+	require.NoError(t, err)
+	require.Equal(t, firstSum, sha256.Sum256(second))
+}
+
+func TestRenderWeaverNft_CorruptRegistry(t *testing.T) {
+	dir := t.TempDir()
+	regDir := filepath.Join(dir, "policies")
+	require.NoError(t, os.MkdirAll(regDir, 0o755))
+	out := filepath.Join(dir, "network-weaver.nft")
+
+	require.NoError(t, os.WriteFile(filepath.Join(regDir, "bad.json"), []byte("not json"), 0o644))
+
+	err := RenderWeaverNft(regDir, out, "")
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "bad.json") || strings.Contains(err.Error(), "parse") || strings.Contains(err.Error(), "json"),
+		"error should mention the corrupt file: %v", err)
+}
+
+func TestRenderWeaverNft_RecoversPodCIDRFromExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	regDir := filepath.Join(dir, "policies")
+	require.NoError(t, os.MkdirAll(regDir, 0o755))
+	out := filepath.Join(dir, "network-weaver.nft")
+
+	// Seed the output file with content that embeds the pod CIDR so
+	// ExtractPodCIDR can recover it when podCIDR="" is passed.
+	const podCIDR = "10.244.0.0/16"
+	require.NoError(t, os.WriteFile(out, []byte("ip daddr "+podCIDR+" placeholder\n"), 0o644))
+
+	// Use a stamp policy — it exercises needsPodCIDR()=true, which triggers
+	// the recovery path. Direction is derived by Validate from the stamp class
+	// ("publisher" → DirectionIngress); we mirror the JSON Manager.Create persists.
+	p := &Policy{
+		Name:      "bn-publisher",
+		Action:    ActionStamp,
+		Stamp:     "publisher",
+		Direction: DirectionIngress,
+		Ports:     []string{"40840"},
+		CreatedAt: time.Now().UTC(),
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(regDir, "bn-publisher.json"), append(data, '\n'), 0o644))
+
+	require.NoError(t, RenderWeaverNft(regDir, out, ""))
+	content, err := os.ReadFile(out)
+	require.NoError(t, err)
+	require.Contains(t, string(content), podCIDR, "rendered output must include the pod CIDR recovered from the existing file")
+}

--- a/internal/network/policy/restart_linux.go
+++ b/internal/network/policy/restart_linux.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package policy
+
+import (
+	"context"
+
+	soos "github.com/hashgraph/solo-weaver/pkg/os"
+)
+
+// RestartNetworkNftService restarts the shared solo-provisioner-network-nft.service
+// oneshot so the kernel picks up any nft files written since the last restart.
+// The unit's RemainAfterExit=yes state is updated to reflect both
+// network-host.nft and network-weaver.nft as loaded.
+func RestartNetworkNftService(ctx context.Context) error {
+	return soos.RestartService(ctx, NetworkNftService)
+}

--- a/internal/network/policy/restart_other.go
+++ b/internal/network/policy/restart_other.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package policy
+
+import "context"
+
+// RestartNetworkNftService is a no-op on non-Linux platforms so the package
+// builds and unit-tests on macOS/CI. Restarting the systemd oneshot only makes
+// sense on the Linux host where solo-provisioner runs.
+func RestartNetworkNftService(_ context.Context) error { return nil }

--- a/internal/workflows/steps/step_network_nft_weaver.go
+++ b/internal/workflows/steps/step_network_nft_weaver.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"github.com/hashgraph/solo-weaver/internal/network/firewall"
+	"github.com/hashgraph/solo-weaver/internal/network/policy"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// NftWeaverPersistStepId is the step ID for NftWeaverPersist.
+const NftWeaverPersistStepId = "nft-weaver-persist"
+
+// NftWeaverPersist re-renders /etc/solo-provisioner/network-weaver.nft from
+// the policy registry and restarts the shared solo-provisioner-network-nft.service
+// oneshot so the kernel loads both network-host.nft and network-weaver.nft via
+// systemd — bringing the service's RemainAfterExit state in sync with the full
+// static plane installed by `network policy create`.
+//
+// Set elements are deliberately NOT persisted; the daemon's poll loop
+// rehydrates them within one ~5 s cycle after reboot.
+func NftWeaverPersist() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(NftWeaverPersistStepId).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Persisting nftables weaver rules for reboot")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to persist nftables weaver rules")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "nftables weaver rules persisted")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			empty, err := policy.IsRegistryEmpty(policy.RegistryDir)
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to read policy registry %s", policy.RegistryDir).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Check the policy registry: ls " + policy.RegistryDir,
+							"Verify the directory is readable: ls -la " + policy.RegistryDir,
+						})))
+			}
+			// Reconcile the persisted file to the registry. On an empty registry
+			// this removes any stale network-weaver.nft so the boot oneshot never
+			// replays a harmful/old inet weaver table (an empty chain renders as
+			// policy drop with no accept for new connections).
+			if err := policy.RenderWeaverNft(policy.RegistryDir, policy.WeaverNftPath, ""); err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to render %s", policy.WeaverNftPath).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Ensure `network policy create` has been run for each BN category before install",
+							"Check the policy registry: ls " + policy.RegistryDir,
+							"Inspect the nft file for syntax errors: nft -c -f " + policy.WeaverNftPath,
+						})))
+			}
+			if empty {
+				return automa.SkippedReport(stp,
+					automa.WithDetail("policy registry is empty; ensured no network-weaver.nft is persisted — weaver rules are written after `network policy create` runs"))
+			}
+			if err := firewall.EnsureNetworkNftUnit(ctx); err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to install %s", policy.NetworkNftService).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Check systemd is running: systemctl status",
+							"Verify the unit path is writable: ls -la /usr/lib/systemd/system/",
+						})))
+			}
+			if err := policy.RestartNetworkNftService(ctx); err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to restart %s", policy.NetworkNftService).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Check service status: systemctl status " + policy.NetworkNftService,
+							"Verify nft is installed: which nft || apt-get install -y nftables",
+							"Inspect the nft file: nft -c -f " + policy.WeaverNftPath,
+						})))
+			}
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			// Rollback is a no-op: the rendered file and restarted service are
+			// idempotent artifacts. Removing network-weaver.nft on rollback would
+			// leave the live inet weaver table present but un-replayed on next
+			// reboot — no worse than before this step ran. Teardown is owned by
+			// the `block node uninstall` workflow.
+			return automa.SkippedReport(stp,
+				automa.WithDetail("nft-weaver rollback is a no-op; teardown is handled by block node uninstall"))
+		})
+}


### PR DESCRIPTION
## Description

Implements Story 2.6 of epic TS_2 (#735): renders `/etc/solo-provisioner/network-weaver.nft`
from the policy registry at `block node install` time and restarts the shared
`solo-provisioner-network-nft.service` oneshot so systemd's `RemainAfterExit` state reflects
both the host and weaver tables loaded (design §8.3.1). Without this, the unit's active-exited
state only reflected `network-host.nft` (applied by `NetworkFirewallCreate` before the policy
creates run); after this PR the service state matches the full static plane.

`NftWeaverPersist` is wired into both install workflow branches (cluster-exists and
full-bootstrap) and into every reconfigure branch, always after `NetworkFirewallCreate`
and before `TcEgressPersist` — matching the boot ordering: nft oneshot → tc oneshot →
daemon. Reconfigure already re-runs `NetworkFirewallCreate` (which restarts the shared
oneshot); adding `NftWeaverPersist` there keeps `network-weaver.nft` re-rendered from the
registry on the same paths as `TcEgressPersist`, so the two persistence steps stay symmetric.

When the policy registry is empty (no `network policy create` has run yet), the step is a
**no-op**: it writes nothing and does not restart the service. An empty `inet weaver` forward
chain renders with `policy drop` and no accept rule for new connections, which would drop all
forwarded pod traffic (image pulls, inter-pod DNS, service startup); skipping keeps that
harmful empty table out of the kernel until real policies exist.

At reboot, the existing `solo-provisioner-network-nft.service` unit (authored by #780, already
in `main`) replays both `network-host.nft` and `network-weaver.nft` via `test -e` guards —
so this story adds no new unit file or template. Set elements are deliberately NOT persisted;
the daemon's poll loop (TS_3) rehydrates them within one ~5 s cycle after reboot.

### Files changed

| File | Change |
|---|---|
| `internal/network/policy/render_weaver.go` | New: `RenderWeaverNft(registryDir, weaverNftPath, podCIDR)` — loads + validates registry entries, returns early without writing when the registry is empty, recovers podCIDR from the existing file for `--stamp` policies, renders the `inet weaver` document, SHA-256 skips if unchanged, atomic write |
| `internal/network/policy/registry.go` | `IsRegistryEmpty(dir)` helper — lets the persist step decide to skip when no policies are registered |
| `internal/network/policy/restart_linux.go` | New: `RestartNetworkNftService(ctx)` — calls `soos.RestartService` on Linux |
| `internal/network/policy/restart_other.go` | New: no-op stub for macOS/CI |
| `internal/network/policy/render_weaver_test.go` | New: 5 unit tests — empty registry (asserts **no file written**), deny policy, idempotent write (mod-time unchanged), corrupt registry error, podCIDR recovery from existing file |
| `internal/workflows/steps/step_network_nft_weaver.go` | New: `NftWeaverPersist()` step — skips (`SkippedReport`) on an empty registry, else render → ensure-unit → restart; rollback is an unconditional no-op |
| `internal/network/firewall/service_linux.go` | Export `EnsureNetworkNftUnit` so the step installs the shared unit itself when `NetworkFirewallCreate` skipped (no management CIDRs) |
| `internal/network/firewall/service_other.go` | No-op `EnsureNetworkNftUnit` stub for macOS/CI |
| `internal/bll/blocknode/install_handler.go` | Wire `NftWeaverPersist()` in both workflow branches after `NetworkFirewallCreate`, before `TcEgressPersist` |
| `internal/bll/blocknode/reconfigure_handler.go` | Wire `NftWeaverPersist()` in all four reconfigure branches (purge-storage, with-reset, no-restart, default) at the same position, keeping reconfigure symmetric with `TcEgressPersist` |

### Key decisions

- **Re-render from registry, not just restart**: mirrors the tc-egress pattern (render → ensure-unit → apply). Ensures the file is current and complete even if a policy create had a partial write.
- **Empty registry is a no-op (skip)**: `IsRegistryEmpty` gates the step — with no policies registered it returns `SkippedReport` and writes nothing. Rendering an empty `inet weaver` chain emits `policy drop` with no accept rule for new connections, which drops all forwarded pod traffic; skipping keeps the harmful empty table out of the kernel until `network policy create` runs. (This is deliberately different from tc-egress, whose empty state renders a benign sysfs-detected script.)
- **Step installs the shared unit itself**: `EnsureNetworkNftUnit` is exported and called before the restart. `NetworkFirewallCreate` returns a `SkippedReport` (not a failure) when no management CIDRs are configured, so the unit may not exist yet when the step runs — the step installs it, mirroring `TcEgressPersist` → `EnsureTcEgressUnit`.
- **No new unit file**: `solo-provisioner-network-nft.service` is already in `main` (authored by #780) with both `ExecStart` lines including `network-weaver.nft`. This step only renders the file and (re)starts the unit.
- **podCIDR recovery**: if a `--stamp` policy is registered, `RenderWeaverNft` recovers the pod CIDR from the existing `network-weaver.nft` — the same recovery path `Manager.Create` uses. No new CLI flag needed.
- **Rollback is a no-op**: the rendered file and restarted service are idempotent artifacts. Removing `network-weaver.nft` on rollback would leave the live kernel table present but un-replayed at next reboot. Story 2.4 (`block node uninstall`, #763) owns teardown.
- **Position in workflow**: `NftWeaverPersist` runs after `NetworkFirewallCreate` and before `TcEgressPersist` — matching boot ordering (nft before tc).

### Review guide

**Code review checklist**

- `render_weaver.go:RenderWeaverNft` — calls `loadAll` (empty dir → nil slice, not error); **returns nil early (no write) when the registry is empty**; validates each entry; recovers `podCIDR` from existing file when `""` is passed and a stamp policy is present; calls `Render`; SHA-256 short-circuits unchanged writes; `atomicWriteFile` mode 0644.
- `registry.go:IsRegistryEmpty` — thin wrapper over `loadAll`; a missing directory counts as empty.
- `restart_linux.go:RestartNetworkNftService` — single call to `soos.RestartService(ctx, NetworkNftService)`.
- `step_network_nft_weaver.go:NftWeaverPersist` — gates on `IsRegistryEmpty` → `SkippedReport`; then render → `EnsureNetworkNftUnit` → restart; every failure path carries `models.ErrPropertyResolution` hints; rollback returns `automa.SkippedReport`.
- `install_handler.go` — `NftWeaverPersist` is added in **both** workflow branches (cluster-exists and full-bootstrap), at the same position in each (after `NetworkFirewallCreate`, before `TcEgressPersist`, before `SetupBlockNode`).
- `reconfigure_handler.go` — `NftWeaverPersist` is added in **all four** reconfigure branches (purge-storage, with-reset, no-restart, default), each immediately after `NetworkFirewallCreate` and before `TcEgressPersist` — mirroring the install ordering.

**Test commands**

```bash
# Unit tests (macOS OK — no Linux-only deps in internal/network/policy)
go test -race -cover -tags='!integration' ./internal/network/policy/...

# Linux cross-compile of all touched packages
GOOS=linux GOARCH=amd64 go build \
  ./internal/network/policy/... \
  ./internal/workflows/steps/... \
  ./internal/bll/blocknode/...

# Lint + license
task lint:check
task license:check
```

**Manual UAT (UTM VM — Debian/Ubuntu with nftables + systemd)**

> Prerequisites: a UTM Linux VM with a running Kubernetes cluster and the
> `solo-provisioner` binary built from this branch. Run everything as root (or
> via `sudo`). The `-V` flag renders the step-by-step TUI so each step's
> success/skip status is visible.

The three artifacts this story touches:

```bash
ls -l /etc/solo-provisioner/policies/                  # policy registry (source of truth)
cat   /etc/solo-provisioner/network-weaver.nft         # rendered inet weaver document
systemctl status solo-provisioner-network-nft.service  # shared boot oneshot (host + weaver)
```

### 1. Fresh install, empty registry → step is a no-op (skip)

```bash
# Clean slate.
sudo rm -f  /etc/solo-provisioner/network-weaver.nft
sudo rm -rf /etc/solo-provisioner/policies

# Find your egress NIC:  ip route get 8.8.8.8 | grep -o 'dev [^ ]*'
sudo solo-provisioner block node install --profile=local --egress-interface enp0s1 --link-rate 1gbit -V
```

Expected — the `nft-weaver-persist` step is reported **skipped**, with detail:

```
nft-weaver-persist  skipped: policy registry is empty; weaver rules will be persisted after `network policy create` runs
```

```bash
test -e /etc/solo-provisioner/network-weaver.nft && echo present || echo absent
# Expected: absent   (nothing is written for an empty registry)

nft list table inet weaver 2>&1
# Expected: 'Error: No such file or directory'  — the table is NOT loaded.
# This is the fix: an empty registry must never load an inet weaver forward
# chain with 'policy drop', which would blackhole all new forwarded traffic.
```

Confirm the block-node pod actually reaches Ready (the regression this fixes —
previously the pod hung at 0/1 because the empty `policy drop` chain dropped
image-pull / inter-pod / DNS traffic):

```bash
kubectl -n block-node get statefulset,pods
# Expected: block-node-... pod becomes Running then Ready (1/1)
```

### 2. Populate the registry with a policy

`network policy create` renders and applies the `inet weaver` table itself, so
this seeds the registry AND writes the file. A `--deny` policy needs no cluster
or pod-CIDR:

```bash
sudo solo-provisioner network policy create --name bn-quarantine --deny --cidrs 203.0.113.0/24
# Expected log: "network policy created  policy=bn-quarantine"

ls /etc/solo-provisioner/policies/
# Expected: bn-quarantine.json

grep -E 'set bn-quarantine|@bn-quarantine drop' /etc/solo-provisioner/network-weaver.nft
# Expected: set bn-quarantine { type ipv4_addr; flags interval; }
#           ip saddr @bn-quarantine drop
#           ip daddr @bn-quarantine drop
```

The rendered file carries only the set **schema** and the rule structure — the
CIDR membership (`203.0.113.0/24`) is deliberately NOT written to the file.
Membership is applied to the **live kernel set** and is owned by the daemon poll
loop; baking it into the boot-replayed file would let the file and live state
diverge. Verify membership on the live set instead:

```bash
nft list set inet weaver bn-quarantine
# Expected: elements = { 203.0.113.0/24 }

nft list table inet weaver
# Expected: the loaded table with the bn-quarantine set schema + both drop rules
```

### 3. Reconfigure re-persists from the registry (finding-B path)

With the registry now non-empty, the reconfigure workflow's `NftWeaverPersist`
runs (no longer skipped) — render → ensure-unit → restart:

```bash
sudo solo-provisioner block node reconfigure --profile=local --egress-interface enp0s1 --link-rate 1gbit -V
```

Expected — the `nft-weaver-persist` step reports **success** (`nftables weaver
rules persisted`). The render is a SHA-256 no-op write because the file already
matches the registry, but the service is restarted so its `RemainAfterExit`
state reflects both tables:

```bash
systemctl status solo-provisioner-network-nft.service
# Expected: active (exited)   (both ExecStart lines — host + weaver — ran)

systemctl show -p ExecMainStatus solo-provisioner-network-nft.service
# Expected: ExecMainStatus=0
```

### 4. Re-install is idempotent

```bash
STAMP=$(stat -c %Y /etc/solo-provisioner/network-weaver.nft)
sudo solo-provisioner block node install --profile=local --egress-interface enp0s1 --link-rate 1gbit --force -V
[ "$STAMP" = "$(stat -c %Y /etc/solo-provisioner/network-weaver.nft)" ] && echo unchanged || echo rewritten
# Expected: nft-weaver-persist succeeds; 'unchanged' (SHA-256 match skips the write)
```

### 5. Reboot persistence

```bash
sudo reboot
# after the VM comes back:
systemctl status solo-provisioner-network-nft.service
# Expected: active (exited)

nft list table inet weaver
# Expected: the bn-quarantine table/chain/set SCHEMA + drop rules still present —
#           replayed by the oneshot from network-weaver.nft at boot.

nft list set inet weaver bn-quarantine
# Expected: the set exists but is EMPTY after reboot (no elements). Membership is
#           not persisted in the file by design; the daemon poll loop (TS_3, not
#           wired yet) is what rehydrates it. This is expected for Story 2.6.

journalctl -u solo-provisioner-network-nft.service -b
# Expected: both ExecStart lines (network-host.nft, network-weaver.nft) ran without error
```

### 6. Cleanup (optional)

```bash
sudo solo-provisioner network policy delete --name bn-quarantine
# Registry entry removed; the inet weaver table re-rendered without the deny rule.
```

**Risks / rollback**

- **`nft` binary must be present**: the unit's `ExecStart` calls `/usr/sbin/nft`; standard on Debian/Ubuntu.
- **Empty registry until Story 2.3 (#762) lands**: with no policies registered, `NftWeaverPersist` is a **no-op** — it skips the write and restart, so `network-weaver.nft` is not created by this step. Once #762 wires the policy-create steps, a populated registry produces the file and the step renders + restarts normally.
- **Double restart (non-empty registry only)**: when the registry is populated, the shared unit is restarted twice in the workflow (once by `NetworkFirewallCreate`, once by `NftWeaverPersist`). The second restart is safe — `RemainAfterExit=yes` re-runs both `ExecStart` lines idempotently.
- **Rollback**: `rm /etc/solo-provisioner/network-weaver.nft && systemctl restart solo-provisioner-network-nft.service`. The live kernel table remains until next reboot.

### Related Issues

* Closes #743
