### PR TITLE
feat(network): hint NIC link speed in block node install egress prompt (#744)

### DIFF
--- a/cmd/cli/commands/block/node/init.go
+++ b/cmd/cli/commands/block/node/init.go
@@ -292,6 +292,7 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 			PluginPreset:        pluginPreset,
 			PluginList:          pluginList,
 			EgressInterface:     flagEgressInterface,
+			LinkRate:            flagLinkRate,
 		},
 	}
 

--- a/cmd/cli/commands/block/node/init.go
+++ b/cmd/cli/commands/block/node/init.go
@@ -173,6 +173,24 @@ func promptForMissingFlags(cmd *cobra.Command, args []string) (*prompt.ChosenVal
 	return cv, nil
 }
 
+// validateBlockNodeFlags validates format-sensitive flags that would otherwise
+// only produce an error after the interactive wizard has already run. Call this
+// at the top of RunE, before prepareBlocknodeInputs, so operators get immediate
+// feedback for invalid CLI inputs rather than sitting through all the prompts.
+func validateBlockNodeFlags(cmd *cobra.Command) error {
+	if flagValuesFile != "" {
+		if _, err := sanity.ValidateInputFile(flagValuesFile); err != nil {
+			return err
+		}
+	}
+	if f := cmd.Flag("plugins"); f != nil && f.Changed && flagPlugins != "" {
+		if err := models.ValidatePluginList(flagPlugins); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --plugins value")
+		}
+	}
+	return nil
+}
+
 // prepareBlocknodeInputs prepares and validates user inputs from command flags.
 // When running interactively (TTY, no --force, no --non-interactive), it presents
 // huh prompts for any required flags that were not supplied on the command line.

--- a/cmd/cli/commands/block/node/install.go
+++ b/cmd/cli/commands/block/node/install.go
@@ -18,7 +18,13 @@ var installCmd = &cobra.Command{
 	Short:   "Install a Hedera Block Node",
 	Long:    "Run safety checks, setup a K8s cluster and install a Hedera Block Node",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateBlockNodeFlags(cmd); err != nil {
+			return err
+		}
 		if err := common.ValidateEgressFlags(cmd, flagLinkRate); err != nil {
+			return err
+		}
+		if err := common.ValidateHostFirewallFlags(cmd); err != nil {
 			return err
 		}
 

--- a/cmd/cli/commands/block/node/install.go
+++ b/cmd/cli/commands/block/node/install.go
@@ -8,8 +8,6 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
-	"github.com/hashgraph/solo-weaver/internal/network/shape"
-	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/spf13/cobra"
 )
@@ -20,19 +18,26 @@ var installCmd = &cobra.Command{
 	Short:   "Install a Hedera Block Node",
 	Long:    "Run safety checks, setup a K8s cluster and install a Hedera Block Node",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := common.ValidateEgressFlags(cmd, flagLinkRate); err != nil {
+			return err
+		}
+
 		inputs, cv, err := prepareBlocknodeInputs(cmd, args)
 		if err != nil {
 			return err
 		}
 
-		// Resolve the host firewall config. The egress-interface prompt is
-		// prepended so it appears in the same TUI panel as the firewall fields.
-		// cv is passed so all values fold into the unified "Selected Inputs"
-		// summary rather than a separate section.
-		detectedNIC, _ := shape.DetectEgressInterface()
-		if err := common.ResolveHostFirewallConfig(cmd, args, cv,
-			prompt.EgressInterfaceInputPrompt(detectedNIC, &flagEgressInterface),
-		); err != nil {
+		// Prompt for egress NIC and bandwidth independently of the host firewall —
+		// tc-egress traffic shaping applies regardless of whether the host
+		// firewall is enabled.
+		if err := common.ResolveEgressConfig(cmd, args, cv, &flagEgressInterface, &flagLinkRate); err != nil {
+			return err
+		}
+		// prepareBlocknodeInputs ran before the prompts; patch in the final values.
+		inputs.Custom.EgressInterface = flagEgressInterface
+		inputs.Custom.LinkRate = flagLinkRate
+
+		if err := common.ResolveHostFirewallConfig(cmd, args, cv); err != nil {
 			return err
 		}
 
@@ -79,7 +84,5 @@ func init() {
 	installCmd.Flags().StringVar(&flagChartVersion, "chart-version", "", "Helm chart version to use")
 	common.FlagValuesFile().SetVarP(installCmd, &flagValuesFile, false)
 	common.RegisterHostFirewallFlags(installCmd)
-	installCmd.Flags().StringVar(&flagEgressInterface, "egress-interface", "",
-		"Physical NIC for the $EGRESS HTB traffic-shaper hierarchy (e.g. eth0). "+
-			"Auto-detected from the default route when omitted; use this flag to override on multi-NIC hosts.")
+	common.RegisterEgressFlags(installCmd, &flagEgressInterface, &flagLinkRate)
 }

--- a/cmd/cli/commands/block/node/node.go
+++ b/cmd/cli/commands/block/node/node.go
@@ -39,6 +39,7 @@ var (
 	flagPlugins              string
 	flagLoadBalancerEnabled  bool
 	flagEgressInterface      string
+	flagLinkRate             string
 
 	nodeCmd = &cobra.Command{
 		Use:   "node",

--- a/cmd/cli/commands/block/node/reconfigure.go
+++ b/cmd/cli/commands/block/node/reconfigure.go
@@ -20,7 +20,13 @@ var (
 		Short: "Reconfigure a Hedera Block Node",
 		Long:  "Re-apply configuration to an existing Hedera Block Node deployment without changing its chart version",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateBlockNodeFlags(cmd); err != nil {
+				return err
+			}
 			if err := common.ValidateEgressFlags(cmd, flagLinkRate); err != nil {
+				return err
+			}
+			if err := common.ValidateHostFirewallFlags(cmd); err != nil {
 				return err
 			}
 

--- a/cmd/cli/commands/block/node/reconfigure.go
+++ b/cmd/cli/commands/block/node/reconfigure.go
@@ -20,10 +20,26 @@ var (
 		Short: "Reconfigure a Hedera Block Node",
 		Long:  "Re-apply configuration to an existing Hedera Block Node deployment without changing its chart version",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := common.ValidateEgressFlags(cmd, flagLinkRate); err != nil {
+				return err
+			}
+
 			inputs, cv, err := prepareBlocknodeInputs(cmd, args)
 			if err != nil {
 				return err
 			}
+
+			if err := common.ResolveEgressConfig(cmd, args, cv, &flagEgressInterface, &flagLinkRate); err != nil {
+				return err
+			}
+			// prepareBlocknodeInputs ran before the prompts; patch in the final values.
+			inputs.Custom.EgressInterface = flagEgressInterface
+			inputs.Custom.LinkRate = flagLinkRate
+
+			if err := common.ResolveHostFirewallConfig(cmd, args, cv); err != nil {
+				return err
+			}
+
 			if cv != nil {
 				_, _ = fmt.Fprintln(cmd.ErrOrStderr())
 				cv.Print("Selected Inputs")
@@ -67,4 +83,6 @@ func init() {
 	common.FlagValuesFile().SetVarP(reconfigureCmd, &flagValuesFile, false)
 	common.FlagNoReuseValues().SetVarP(reconfigureCmd, &flagNoReuseValues, false)
 	common.FlagNoRestart().SetVar(reconfigureCmd, &flagNoRestart, false)
+	common.RegisterHostFirewallFlags(reconfigureCmd)
+	common.RegisterEgressFlags(reconfigureCmd, &flagEgressInterface, &flagLinkRate)
 }

--- a/cmd/cli/commands/block/node/upgrade.go
+++ b/cmd/cli/commands/block/node/upgrade.go
@@ -22,6 +22,10 @@ var (
 		Short: "Upgrade a Hedera Block Node",
 		Long:  "Upgrade an existing Hedera Block Node deployment with new configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateBlockNodeFlags(cmd); err != nil {
+				return err
+			}
+
 			inputs, cv, err := prepareBlocknodeInputs(cmd, args)
 			if err != nil {
 				return err

--- a/cmd/cli/commands/common/egress.go
+++ b/cmd/cli/commands/common/egress.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+// FlagNameEgressInterface and FlagNameLinkRate are the CLI flag names for
+// the tc-egress NIC and link-rate settings, shared by every block-node command
+// that renders the tc-egress script (install, reconfigure).
+const (
+	FlagNameEgressInterface = "egress-interface"
+	FlagNameLinkRate        = "link-rate"
+)
+
+// RegisterEgressFlags registers the egress-interface and link-rate flags on
+// cmd, binding them to the caller-supplied variables. The values are read back
+// by ResolveEgressConfig.
+func RegisterEgressFlags(cmd *cobra.Command, egressInterface, linkRate *string) {
+	cmd.Flags().StringVar(egressInterface, FlagNameEgressInterface, "",
+		"Physical NIC for the $EGRESS HTB traffic-shaper hierarchy (e.g. eth0). "+
+			"Auto-detected from the default route when omitted; use this flag to override on multi-NIC hosts.")
+	cmd.Flags().StringVar(linkRate, FlagNameLinkRate, "",
+		"NIC line rate in tc-style format (e.g. 1gbit, 100mbit). "+
+			"Auto-detected from sysfs at boot when omitted; baked into the script when set.")
+}
+
+// ValidateEgressFlags rejects a set --link-rate value that is not a valid
+// tc-style rate. Call this before any interactive prompts so the operator gets
+// an immediate error rather than sitting through the whole wizard first.
+//
+// It requires RegisterEgressFlags to have been called on cmd.
+func ValidateEgressFlags(cmd *cobra.Command, linkRate string) error {
+	if cmd.Flags().Changed(FlagNameLinkRate) && linkRate != "" {
+		if _, ok := shape.ParseSpeedMbit(linkRate); !ok {
+			return errorx.IllegalArgument.New(
+				"invalid --%s %q: must be a tc-style rate (e.g. 1gbit, 100mbit)",
+				FlagNameLinkRate, linkRate)
+		}
+	}
+	return nil
+}
+
+// ResolveEgressConfig detects the egress NIC from the default route and the
+// link speed from sysfs, then prompts for both values when the session is
+// interactive and the flags were not supplied on the CLI. egressInterface and
+// linkRate are updated in-place by the prompts.
+//
+// When cv is non-nil the prompted values are recorded into it and no separate
+// summary is printed — the caller is responsible for printing the unified
+// summary after all prompt sections complete. When cv is nil a local collector
+// is used and printed as "Egress" immediately.
+//
+// It requires RegisterEgressFlags to have been called on cmd.
+func ResolveEgressConfig(
+	cmd *cobra.Command,
+	args []string,
+	cv *prompt.ChosenValues,
+	egressInterface, linkRate *string,
+) error {
+	force, err := FlagForce().Value(cmd, args)
+	if err != nil {
+		return errorx.IllegalArgument.Wrap(err, "failed to get %s flag", FlagForce().Name)
+	}
+
+	if !prompt.ShouldPrompt(force) {
+		return nil
+	}
+
+	// Detect the egress NIC to use as the prompt default.
+	detectedNIC, _ := shape.DetectEgressInterface()
+
+	// Speed hint from sysfs: prefer the already-set flag value over the
+	// auto-detected one so the hint reflects the NIC the operator chose.
+	effectiveNIC := detectedNIC
+	if cmd.Flags().Changed(FlagNameEgressInterface) {
+		effectiveNIC = *egressInterface
+	}
+	var speedHint string
+	if effectiveNIC != "" {
+		if mbit, ok := shape.ReadLinkSpeedMbit(effectiveNIC); ok {
+			speedHint = shape.FormatSpeedHint(mbit)
+		}
+	}
+
+	localCV := cv
+	if localCV == nil {
+		localCV = prompt.NewChosenValues()
+	}
+	if err := prompt.RunInputPrompts(cmd, []prompt.InputPrompt{
+		prompt.EgressInterfaceInputPrompt(detectedNIC, speedHint, egressInterface),
+		prompt.LinkRateInputPrompt(speedHint, linkRate),
+	}, localCV); err != nil {
+		return err
+	}
+	if cv == nil {
+		localCV.Print("Egress")
+	}
+	return nil
+}

--- a/cmd/cli/commands/common/host_firewall.go
+++ b/cmd/cli/commands/common/host_firewall.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
 	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
 	"github.com/joomcode/errorx"
 	"github.com/spf13/cobra"
 )
@@ -24,6 +25,46 @@ const (
 	FlagNamePodCIDR         = "pod-cidr"
 	FlagNameInClusterPorts  = "in-cluster-ports"
 )
+
+// ValidateHostFirewallFlags validates format-sensitive host-firewall flags that
+// are only caught in ResolveHostFirewallConfig — which runs after the interactive
+// wizard. Call this at the top of RunE, before prepareBlocknodeInputs, so
+// operators get immediate feedback for invalid CLI inputs.
+//
+// Only flags explicitly Changed on the CLI are checked; un-set flags fall back
+// to config / built-in defaults and are validated later inside
+// ResolveHostFirewallConfig as always.
+func ValidateHostFirewallFlags(cmd *cobra.Command) error {
+	if cmd.Flags().Changed(FlagNameSSHPort) {
+		port, _ := cmd.Flags().GetInt(FlagNameSSHPort)
+		if err := sanity.ValidatePort(strconv.Itoa(port)); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --%s %d", FlagNameSSHPort, port)
+		}
+	}
+	if cmd.Flags().Changed(FlagNameInClusterPorts) {
+		ports, _ := cmd.Flags().GetIntSlice(FlagNameInClusterPorts)
+		for _, p := range ports {
+			if err := sanity.ValidatePort(strconv.Itoa(p)); err != nil {
+				return errorx.IllegalArgument.Wrap(err, "invalid --%s %d", FlagNameInClusterPorts, p)
+			}
+		}
+	}
+	if cmd.Flags().Changed(FlagNameMgmtCIDRs) {
+		cidrs, _ := cmd.Flags().GetStringSlice(FlagNameMgmtCIDRs)
+		for _, cidr := range normalizeCIDRs(cidrs) {
+			if err := sanity.ValidateIPv4CIDR(cidr); err != nil {
+				return errorx.IllegalArgument.Wrap(err, "invalid --%s %q", FlagNameMgmtCIDRs, cidr)
+			}
+		}
+	}
+	if cmd.Flags().Changed(FlagNamePodCIDR) {
+		podCIDR, _ := cmd.Flags().GetString(FlagNamePodCIDR)
+		if err := sanity.ValidateIPv4CIDR(strings.TrimSpace(podCIDR)); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --%s %q", FlagNamePodCIDR, podCIDR)
+		}
+	}
+	return nil
+}
 
 // RegisterHostFirewallFlags registers the node-level host firewall flags on cmd.
 // The values are read back by name in ResolveHostFirewallConfig (no bound vars),

--- a/cmd/cli/commands/common/host_firewall.go
+++ b/cmd/cli/commands/common/host_firewall.go
@@ -58,11 +58,8 @@ func RegisterHostFirewallFlags(cmd *cobra.Command) {
 // summary after all prompt sections complete. When cv is nil a local collector
 // is used and printed as "Host Firewall" immediately.
 //
-// extraInputPrompts are prepended to the firewall input prompts so callers can
-// place related prompts (e.g. egress interface) in the same TUI panel.
-//
 // It requires RegisterHostFirewallFlags to have been called on cmd.
-func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues, extraInputPrompts ...prompt.InputPrompt) error {
+func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues) error {
 	force, err := FlagForce().Value(cmd, args)
 	if err != nil {
 		return errorx.IllegalArgument.Wrap(err, "failed to get %s flag", FlagForce().Name)
@@ -112,15 +109,12 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.Cho
 		if localCV == nil {
 			localCV = prompt.NewChosenValues()
 		}
-		allPrompts := make([]prompt.InputPrompt, 0, len(extraInputPrompts)+4)
-		allPrompts = append(allPrompts, extraInputPrompts...)
-		allPrompts = append(allPrompts,
+		if err := prompt.RunInputPrompts(cmd, []prompt.InputPrompt{
 			prompt.MgmtCIDRsInputPrompt(mgmtStr, &mgmtStr),
 			prompt.SSHPortInputPrompt(sshStr, &sshStr),
 			prompt.PodCIDRInputPrompt(podStr, &podStr),
 			prompt.InClusterPortsInputPrompt(portsStr, &portsStr),
-		)
-		if err := prompt.RunInputPrompts(cmd, allPrompts, localCV); err != nil {
+		}, localCV); err != nil {
 			return err
 		}
 		if cv == nil {

--- a/internal/bll/blocknode/helpers.go
+++ b/internal/bll/blocknode/helpers.go
@@ -149,6 +149,8 @@ func resolveBlocknodeEffectiveInputs(
 			LoadBalancerEnabled: inputs.Custom.LoadBalancerEnabled,
 			PluginPreset:        inputs.Custom.PluginPreset,
 			PluginList:          inputs.Custom.PluginList,
+			EgressInterface:     inputs.Custom.EgressInterface,
+			LinkRate:            inputs.Custom.LinkRate,
 		},
 	}
 

--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/hashgraph/solo-weaver/internal/bll"
 	bnpkg "github.com/hashgraph/solo-weaver/internal/blocknode"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
 	"github.com/hashgraph/solo-weaver/internal/rsl"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/internal/workflows"
@@ -60,6 +61,8 @@ func (h *InstallHandler) BuildWorkflow(
 	}
 
 	ins := inputs.Custom
+	egressSpeedMbit, _ := shape.ParseSpeedMbit(ins.LinkRate)
+
 	var wb *automa.WorkflowBuilder
 	if currentState.ClusterState.Created {
 		wb = automa.NewWorkflowBuilder().WithId("block-node-install").
@@ -75,10 +78,7 @@ func (h *InstallHandler) BuildWorkflow(
 				// is already installed/enabled from that prior cluster provisioning,
 				// so it's safe to apply here.
 				steps.NetworkFirewallCreate(),
-				// Render and install the $EGRESS HTB boot-persistence script and
-				// oneshot unit (design §8.3.2). Skipped when no NIC is supplied;
-				// Story 2.2 (#744) will add automatic NIC detection.
-				steps.TcEgressPersist(ins.EgressInterface),
+				steps.TcEgressPersist(ins.EgressInterface, egressSpeedMbit),
 				steps.SetupBlockNode(ins),
 			)
 	} else {
@@ -98,10 +98,7 @@ func (h *InstallHandler) BuildWorkflow(
 				// systemSetupWorkflow; apply the host firewall here rather than in
 				// that generic (node-type-agnostic) workflow.
 				steps.NetworkFirewallCreate(),
-				// Render and install the $EGRESS HTB boot-persistence script and
-				// oneshot unit (design §8.3.2). Skipped when no NIC is supplied;
-				// Story 2.2 (#744) will add automatic NIC detection.
-				steps.TcEgressPersist(ins.EgressInterface),
+				steps.TcEgressPersist(ins.EgressInterface, egressSpeedMbit),
 				steps.SetupBlockNode(ins),
 			)
 	}

--- a/internal/bll/blocknode/reconfigure_handler.go
+++ b/internal/bll/blocknode/reconfigure_handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/hashgraph/solo-weaver/internal/bll"
 	bnpkg "github.com/hashgraph/solo-weaver/internal/blocknode"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
 	"github.com/hashgraph/solo-weaver/internal/rsl"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
@@ -54,6 +55,8 @@ func (h *ReconfigureHandler) BuildWorkflow(
 	}
 
 	ins := inputs.Custom
+	egressSpeedMbit, _ := shape.ParseSpeedMbit(ins.LinkRate)
+
 	var wb *automa.WorkflowBuilder
 	switch {
 	case ins.PurgeStorage:
@@ -68,7 +71,13 @@ func (h *ReconfigureHandler) BuildWorkflow(
 		// After purging old dirs, recreate PVs/PVCs and create new directories at
 		// the new paths, then upgrade the chart.
 		wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-purge-storage").
-			Steps(steps.PurgeBlockNodeStorage(oldIns), steps.RecreateBlockNodeStorage(ins), steps.UpgradeBlockNode(ins))
+			Steps(
+				steps.NetworkFirewallCreate(),
+				steps.TcEgressPersist(ins.EgressInterface, egressSpeedMbit),
+				steps.PurgeBlockNodeStorage(oldIns),
+				steps.RecreateBlockNodeStorage(ins),
+				steps.UpgradeBlockNode(ins),
+			)
 	case ins.ResetStorage:
 		// --with-reset wipes data only; PVs/PVCs are preserved. Storage paths must
 		// not have changed because local-PV hostPath is immutable.
@@ -86,7 +95,12 @@ func (h *ReconfigureHandler) BuildWorkflow(
 		oldIns := ins
 		oldIns.Storage = currentState.BlockNodeState.Storage
 		wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-with-reset").
-			Steps(steps.PurgeBlockNodeStorage(oldIns), steps.UpgradeBlockNode(ins))
+			Steps(
+				steps.NetworkFirewallCreate(),
+				steps.TcEgressPersist(ins.EgressInterface, egressSpeedMbit),
+				steps.PurgeBlockNodeStorage(oldIns),
+				steps.UpgradeBlockNode(ins),
+			)
 	default:
 		// For non-reset reconfigures, storage path changes require --purge-storage because
 		// existing PVs/PVCs cannot be mutated in-place; block with a clear error.
@@ -104,12 +118,21 @@ func (h *ReconfigureHandler) BuildWorkflow(
 		if ins.NoRestart {
 			// Opt-out: apply new values via helm but skip the rollout-restart.
 			wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-no-restart").
-				Steps(steps.UpgradeBlockNode(ins))
+				Steps(
+					steps.NetworkFirewallCreate(),
+					steps.TcEgressPersist(ins.EgressInterface, egressSpeedMbit),
+					steps.UpgradeBlockNode(ins),
+				)
 		} else {
 			// Default: apply new values then trigger a rolling restart so ConfigMap-only
 			// changes are picked up by the running pod.
 			wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure").
-				Steps(steps.UpgradeBlockNode(ins), steps.RolloutRestartBlockNode(ins))
+				Steps(
+					steps.NetworkFirewallCreate(),
+					steps.TcEgressPersist(ins.EgressInterface, egressSpeedMbit),
+					steps.UpgradeBlockNode(ins),
+					steps.RolloutRestartBlockNode(ins),
+				)
 		}
 	}
 	return wb, nil

--- a/internal/bll/blocknode/reconfigure_handler_test.go
+++ b/internal/bll/blocknode/reconfigure_handler_test.go
@@ -113,6 +113,8 @@ func TestBuildWorkflow_WithReset_PathsUnchanged_DataOnly(t *testing.T) {
 
 	ids := workflowStepIDs(t, wb)
 	assert.Equal(t, []string{
+		steps.NetworkFirewallCreateStepId,
+		steps.TcEgressPersistStepId,
 		steps.PurgeBlockNodeStorageStepId,
 		steps.UpgradeBlockNodeStepId,
 	}, ids)
@@ -161,6 +163,8 @@ func TestBuildWorkflow_PurgeStorage_IncludesRecreateStep(t *testing.T) {
 
 			ids := workflowStepIDs(t, wb)
 			assert.Equal(t, []string{
+				steps.NetworkFirewallCreateStepId,
+				steps.TcEgressPersistStepId,
 				steps.PurgeBlockNodeStorageStepId,
 				steps.RecreateBlockNodeStorageStepId,
 				steps.UpgradeBlockNodeStepId,
@@ -184,6 +188,8 @@ func TestBuildWorkflow_NoReset_SamePathsUpgradeAndRestart(t *testing.T) {
 
 	ids := workflowStepIDs(t, wb)
 	assert.Equal(t, []string{
+		steps.NetworkFirewallCreateStepId,
+		steps.TcEgressPersistStepId,
 		steps.UpgradeBlockNodeStepId,
 		steps.RolloutRestartBlockNodeStepId,
 	}, ids)

--- a/internal/network/shape/render.go
+++ b/internal/network/shape/render.go
@@ -14,13 +14,14 @@ import (
 
 // scriptData is the template context for the tc-egress.sh boot script.
 type scriptData struct {
-	NIC string
+	NIC       string
+	SpeedMbit int // 0 means auto-detect from sysfs at boot
 }
 
 // renderTcEgressScript renders the template and returns the script string
 // without writing anything to disk. Used by RenderTcEgressScript and tests.
-func renderTcEgressScript(nicName string) (string, error) {
-	rendered, err := templates.Render(tcEgressScriptTemplate, scriptData{NIC: nicName})
+func renderTcEgressScript(nicName string, speedMbit int) (string, error) {
+	rendered, err := templates.Render(tcEgressScriptTemplate, scriptData{NIC: nicName, SpeedMbit: speedMbit})
 	if err != nil {
 		return "", errorx.InternalError.Wrap(err, "failed to render %s", tcEgressScriptTemplate)
 	}
@@ -32,12 +33,16 @@ func renderTcEgressScript(nicName string) (string, error) {
 // on-disk content is already identical (SHA-256 match) the write is skipped
 // and the function returns nil — making it safe to call from idempotent
 // install flows.
-func RenderTcEgressScript(nicName string) error {
+//
+// speedMbit sets the link rate in Mbit/s directly in the rendered script,
+// bypassing the runtime sysfs detection. Pass 0 to keep the auto-detect
+// behaviour (reads /sys/class/net/<nic>/speed at boot, falls back to 1000).
+func RenderTcEgressScript(nicName string, speedMbit int) error {
 	if nicName == "" {
 		return errorx.IllegalArgument.New("egress NIC name must not be empty")
 	}
 
-	rendered, err := renderTcEgressScript(nicName)
+	rendered, err := renderTcEgressScript(nicName, speedMbit)
 	if err != nil {
 		return err
 	}

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -63,7 +63,7 @@ func TestRenderTcEgressScript_NICInterpolated(t *testing.T) {
 }
 
 func TestRenderTcEgressScript_EmptyNIC(t *testing.T) {
-	if err := RenderTcEgressScript(""); err == nil {
+	if err := RenderTcEgressScript("", 0); err == nil {
 		t.Error("expected error for empty NIC name, got nil")
 	}
 }
@@ -96,7 +96,7 @@ func TestAtomicWriteFile_SecondWritePreservesContent(t *testing.T) {
 // renderScript is a test-only helper that calls templates.Render directly so
 // tests don't need to patch the global TcEgressScriptPath constant.
 func renderScript(nicName string) (string, error) {
-	return renderTcEgressScript(nicName)
+	return renderTcEgressScript(nicName, 0)
 }
 
 // --- DetectEgressInterface tests (cross-platform via detectEgressInterfaceFrom) ---
@@ -165,4 +165,144 @@ func writeTempRoute(t *testing.T, content string) string {
 	}
 	_ = tmp.Close()
 	return tmp.Name()
+}
+
+// --- Speed hint tests (cross-platform via readLinkSpeedMbitFrom) ---
+
+func TestReadLinkSpeedMbitFrom_ValidSpeed(t *testing.T) {
+	for _, tc := range []struct {
+		content string
+		want    int
+	}{
+		{"1000\n", 1000},
+		{"10000\n", 10000},
+		{"100\n", 100},
+		{"1000", 1000}, // no trailing newline
+	} {
+		path := writeTempSpeed(t, tc.content)
+		got, ok := readLinkSpeedMbitFrom(path)
+		if !ok || got != tc.want {
+			t.Errorf("readLinkSpeedMbitFrom(%q) = (%d, %v), want (%d, true)", tc.content, got, ok, tc.want)
+		}
+	}
+}
+
+func TestReadLinkSpeedMbitFrom_NegativeValue(t *testing.T) {
+	path := writeTempSpeed(t, "-1\n")
+	_, ok := readLinkSpeedMbitFrom(path)
+	if ok {
+		t.Error("expected (0, false) for -1, got ok=true")
+	}
+}
+
+func TestReadLinkSpeedMbitFrom_ZeroValue(t *testing.T) {
+	path := writeTempSpeed(t, "0\n")
+	_, ok := readLinkSpeedMbitFrom(path)
+	if ok {
+		t.Error("expected (0, false) for 0, got ok=true")
+	}
+}
+
+func TestReadLinkSpeedMbitFrom_NonNumeric(t *testing.T) {
+	path := writeTempSpeed(t, "unknown\n")
+	_, ok := readLinkSpeedMbitFrom(path)
+	if ok {
+		t.Error("expected (0, false) for non-numeric content, got ok=true")
+	}
+}
+
+func TestReadLinkSpeedMbitFrom_MissingFile(t *testing.T) {
+	_, ok := readLinkSpeedMbitFrom("/nonexistent/path/speed")
+	if ok {
+		t.Error("expected (0, false) for missing file, got ok=true")
+	}
+}
+
+func TestReadLinkSpeedMbit_PathTraversal(t *testing.T) {
+	_, ok := ReadLinkSpeedMbit("../../../etc/passwd")
+	if ok {
+		t.Error("expected (0, false) for NIC name containing path separator, got ok=true")
+	}
+}
+
+func writeTempSpeed(t *testing.T, content string) string {
+	t.Helper()
+	tmp, err := os.CreateTemp(t.TempDir(), "sysfs-speed-*")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if _, err := tmp.WriteString(content); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	_ = tmp.Close()
+	return tmp.Name()
+}
+
+// --- FormatSpeedHint tests ---
+
+func TestFormatSpeedHint(t *testing.T) {
+	cases := []struct {
+		mbit int
+		want string
+	}{
+		{1000, "1gbit"},
+		{10000, "10gbit"},
+		{100, "100mbit"},
+		{500, "500mbit"},
+		{2000, "2gbit"},
+		{1500, "1500mbit"},
+	}
+	for _, c := range cases {
+		got := FormatSpeedHint(c.mbit)
+		if got != c.want {
+			t.Errorf("FormatSpeedHint(%d) = %q, want %q", c.mbit, got, c.want)
+		}
+	}
+}
+
+func TestParseSpeedMbit(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  int
+		ok    bool
+	}{
+		{"1gbit", 1000, true},
+		{"10gbit", 10000, true},
+		{"100mbit", 100, true},
+		{"500mbit", 500, true},
+		{"1GBIT", 1000, true}, // case-insensitive
+		{"", 0, false},
+		{"auto", 0, false},
+		{"0gbit", 0, false},
+		{"0mbit", 0, false},
+		{"-1mbit", 0, false},
+	} {
+		got, ok := ParseSpeedMbit(tc.input)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("ParseSpeedMbit(%q) = (%d, %v), want (%d, %v)", tc.input, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+func TestRenderTcEgressScript_BakedSpeed(t *testing.T) {
+	rendered, err := renderTcEgressScript("eth0", 1000)
+	if err != nil {
+		t.Fatalf("renderTcEgressScript: %v", err)
+	}
+	if !strings.Contains(rendered, "SPEED=1000") {
+		t.Errorf("rendered script missing baked SPEED=1000:\n%s", rendered)
+	}
+	if strings.Contains(rendered, `cat /sys/class/net`) {
+		t.Errorf("rendered script should not contain sysfs detection when speed is baked in:\n%s", rendered)
+	}
+}
+
+func TestRenderTcEgressScript_AutoDetectSpeed(t *testing.T) {
+	rendered, err := renderTcEgressScript("eth0", 0)
+	if err != nil {
+		t.Fatalf("renderTcEgressScript: %v", err)
+	}
+	if !strings.Contains(rendered, `cat /sys/class/net/"$NIC"/speed`) {
+		t.Errorf("rendered script missing sysfs detection when speedMbit=0:\n%s", rendered)
+	}
 }

--- a/internal/network/shape/speed.go
+++ b/internal/network/shape/speed.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// readLinkSpeedMbitFrom reads a /sys/class/net/<nic>/speed-style file and
+// returns its Mbit/s value. Exported via ReadLinkSpeedMbit on Linux; available
+// here for cross-platform unit tests using temp files.
+func readLinkSpeedMbitFrom(path string) (int, bool) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// FormatSpeedHint converts a Mbit/s value into a tc-style bandwidth string
+// suitable for operator-facing prompts (e.g. 1000 → "1gbit", 10000 → "10gbit",
+// 100 → "100mbit").
+func FormatSpeedHint(mbit int) string {
+	if mbit >= 1000 && mbit%1000 == 0 {
+		return fmt.Sprintf("%dgbit", mbit/1000)
+	}
+	return fmt.Sprintf("%dmbit", mbit)
+}
+
+// ParseSpeedMbit parses a tc-style bandwidth string (e.g. "1gbit", "100mbit")
+// into Mbit/s. Returns (0, false) for empty input or unrecognised formats.
+func ParseSpeedMbit(s string) (int, bool) {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return 0, false
+	}
+	if strings.HasSuffix(s, "gbit") {
+		n, err := strconv.Atoi(strings.TrimSuffix(s, "gbit"))
+		if err != nil || n <= 0 {
+			return 0, false
+		}
+		return n * 1000, true
+	}
+	if strings.HasSuffix(s, "mbit") {
+		n, err := strconv.Atoi(strings.TrimSuffix(s, "mbit"))
+		if err != nil || n <= 0 {
+			return 0, false
+		}
+		return n, true
+	}
+	return 0, false
+}

--- a/internal/network/shape/speed_linux.go
+++ b/internal/network/shape/speed_linux.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package shape
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ReadLinkSpeedMbit reads the link speed of nic from the kernel sysfs entry
+// /sys/class/net/<nic>/speed and returns it in Mbit/s.
+//
+// Returns (0, false) when the speed is unavailable: the file is missing (virtual
+// NIC, tunnel), the value is non-positive (kernel reports -1 for unknown/down
+// links), or the content is non-numeric.  Callers treat false as "no hint
+// available" and must never block an install on this.
+func ReadLinkSpeedMbit(nic string) (int, bool) {
+	if strings.ContainsRune(nic, '/') {
+		return 0, false
+	}
+	return readLinkSpeedMbitFrom(fmt.Sprintf("/sys/class/net/%s/speed", nic))
+}

--- a/internal/network/shape/speed_other.go
+++ b/internal/network/shape/speed_other.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package shape
+
+// ReadLinkSpeedMbit is not supported on non-Linux platforms.
+func ReadLinkSpeedMbit(_ string) (int, bool) { return 0, false }

--- a/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
+++ b/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
@@ -10,12 +10,17 @@ set -e
 
 NIC={{.NIC}}
 
+{{- if gt .SpeedMbit 0}}
+# Link speed set by operator at install time; sysfs detection is skipped.
+SPEED={{.SpeedMbit}}
+{{- else}}
 # Detect link speed in Mbit/s. The kernel uses -1 for "unknown" (common on
 # virtual NICs and at early boot before the link is established). Suppress
 # any read error so set -e never fires here (e.g. udev may not have renamed
 # the NIC yet if the service starts very early). Fall back to 1000 Mbit/s.
 SPEED=$(cat /sys/class/net/"$NIC"/speed 2>/dev/null || echo -1)
 [ "${SPEED:-0}" -gt 0 ] 2>/dev/null || SPEED=1000
+{{- end}}
 
 # Remove any existing root qdisc (and all its children). Silent no-op if absent.
 tc qdisc del dev "$NIC" root 2>/dev/null || true

--- a/internal/ui/prompt/blocknode.go
+++ b/internal/ui/prompt/blocknode.go
@@ -143,15 +143,47 @@ func recentRetentionInputPrompt(eff string, target *string) InputPrompt {
 
 // EgressInterfaceInputPrompt returns the interactive prompt for --egress-interface.
 // eff is the auto-detected NIC name used as the placeholder/effective value;
-// pass an empty string when detection is unavailable or unsupported.
-func EgressInterfaceInputPrompt(eff string, target *string) InputPrompt {
+// speedHint is a tc-style bandwidth string (e.g. "1gbit") derived from the
+// detected NIC's link speed — pass an empty string when the speed is unavailable.
+func EgressInterfaceInputPrompt(eff, speedHint string, target *string) InputPrompt {
+	desc := "Physical NIC for the $EGRESS HTB traffic-shaper hierarchy. Leave blank to auto-detect from the default route."
+	if speedHint != "" {
+		desc += " Detected link speed: " + speedHint + "."
+	}
 	return InputPrompt{
 		FlagName:       "egress-interface",
 		Title:          "Egress Network Interface",
-		Description:    "Physical NIC for the $EGRESS HTB traffic-shaper hierarchy. Leave blank to auto-detect from the default route.",
+		Description:    desc,
 		Placeholder:    eff,
 		EffectiveValue: eff,
 		Target:         target,
+	}
+}
+
+// LinkRateInputPrompt returns the interactive prompt for --link-rate.
+// speedHint is the auto-detected link speed (e.g. "1gbit") used as the pre-filled
+// default; pass an empty string when detection was unavailable. The operator may
+// leave the field blank to keep runtime auto-detection from sysfs.
+func LinkRateInputPrompt(speedHint string, target *string) InputPrompt {
+	desc := "NIC line rate in tc-style format (e.g. 1gbit, 100mbit). " +
+		"Leave blank to auto-detect at boot from /sys/class/net/<nic>/speed (falls back to 1000mbit on virtual NICs)."
+	return InputPrompt{
+		FlagName:       "link-rate",
+		Title:          "NIC Link Rate",
+		Description:    desc,
+		Placeholder:    speedHint,
+		EffectiveValue: speedHint,
+		Target:         target,
+		Validate: func(s string) error {
+			if s == "" {
+				return nil
+			}
+			sl := strings.ToLower(strings.TrimSpace(s))
+			if !strings.HasSuffix(sl, "gbit") && !strings.HasSuffix(sl, "mbit") {
+				return errorx.IllegalArgument.New("must be a tc-style rate (e.g. 1gbit, 100mbit)")
+			}
+			return nil
+		},
 	}
 }
 

--- a/internal/ui/prompt/blocknode.go
+++ b/internal/ui/prompt/blocknode.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/hashgraph/solo-weaver/internal/blocknode"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/deps"
@@ -178,9 +179,8 @@ func LinkRateInputPrompt(speedHint string, target *string) InputPrompt {
 			if s == "" {
 				return nil
 			}
-			sl := strings.ToLower(strings.TrimSpace(s))
-			if !strings.HasSuffix(sl, "gbit") && !strings.HasSuffix(sl, "mbit") {
-				return errorx.IllegalArgument.New("must be a tc-style rate (e.g. 1gbit, 100mbit)")
+			if _, ok := shape.ParseSpeedMbit(s); !ok {
+				return errorx.IllegalArgument.New("must be a tc-style rate with a positive integer prefix (e.g. 1gbit, 100mbit)")
 			}
 			return nil
 		},

--- a/internal/workflows/steps/step_network_tc_egress.go
+++ b/internal/workflows/steps/step_network_tc_egress.go
@@ -17,16 +17,20 @@ import (
 const TcEgressPersistStepId = "tc-egress-persist"
 
 // TcEgressPersist renders /usr/local/sbin/solo-provisioner-tc-egress.sh with
-// the egress NIC name interpolated, installs and enables the
-// solo-provisioner-tc-egress.service oneshot unit, and executes the script
-// immediately so the kernel HTB hierarchy is live without waiting for a reboot
-// (design §8.3.2).
+// the egress NIC name and optional link speed interpolated, installs and
+// enables the solo-provisioner-tc-egress.service oneshot unit, and executes
+// the script immediately so the kernel HTB hierarchy is live without waiting
+// for a reboot.
 //
 // When nicName is empty the NIC is auto-detected from the default route via
-// DetectEgressInterface (single-NIC hosts, §4.1). Pass --egress-interface to
-// override on multi-NIC hosts or when the default route does not identify the
-// correct physical interface.
-func TcEgressPersist(nicName string) *automa.StepBuilder {
+// DetectEgressInterface. Pass --egress-interface to override on multi-NIC
+// hosts or when the default route does not identify the correct physical
+// interface.
+//
+// speedMbit sets the link rate in Mbit/s directly in the rendered script.
+// Pass 0 to keep the auto-detect behaviour (reads /sys/class/net/<nic>/speed
+// at boot, falls back to 1000 Mbit/s).
+func TcEgressPersist(nicName string, speedMbit int) *automa.StepBuilder {
 	return automa.NewStepBuilder().WithId(TcEgressPersistStepId).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
 			notify.As().StepStart(ctx, stp, "Persisting tc-egress HTB hierarchy for reboot")
@@ -47,14 +51,14 @@ func TcEgressPersist(nicName string) *automa.StepBuilder {
 						errorx.Decorate(err, "failed to auto-detect egress interface").
 							WithProperty(models.ErrPropertyResolution, []string{
 								"Specify the physical NIC explicitly: block node install --egress-interface <nic>",
-								"To find the correct NIC: ip route get 8.8.8.8 (look for 'dev <nic>')",
+								"To find the correct NIC: ip route get 8.8.8.8 | grep dev",
 							})))
 				}
 				logx.As().Info().Str("nic", detected).Msg("auto-detected egress interface from default route")
 				nic = detected
 			}
 
-			if err := shape.RenderTcEgressScript(nic); err != nil {
+			if err := shape.RenderTcEgressScript(nic, speedMbit); err != nil {
 				return automa.FailureReport(stp, automa.WithError(err))
 			}
 			if err := shape.EnsureTcEgressUnit(ctx); err != nil {

--- a/pkg/models/inputs.go
+++ b/pkg/models/inputs.go
@@ -74,7 +74,8 @@ type BlockNodeInputs struct {
 	RecentRetention     string // FILES_RECENT_BLOCK_RETENTION_THRESHOLD (~96000 default)
 	PluginPreset        string // preset ID (e.g. "tier1-lfh"), "custom", or "none" (no override); empty/"none" = use --values or chart default
 	PluginList          string // resolved comma-separated plugin list injected into plugins.names
-	EgressInterface     string // physical NIC for the $EGRESS HTB hierarchy (TS_2 #742); auto-detected in Story 2.2 (#744)
+	EgressInterface     string // physical NIC for the $EGRESS HTB hierarchy; auto-detected from the default route when empty
+	LinkRate            string // tc-style NIC line rate override (e.g. "1gbit"); empty = auto-detect from sysfs at boot
 }
 
 type ClusterInputs struct {


### PR DESCRIPTION
## Description

After `block node install` detects the egress NIC from the default route, it now reads the link speed from `/sys/class/net/<nic>/speed` (pure Go, no `ethtool` binary) and surfaces it in the prompt description. On a bare-metal node with a 1 GbE card the operator sees "Detected link speed: 1gbit." The hint is silently omitted when the speed is unavailable (virtual NIC, link down, or non-Linux host) — the install never blocks on it.

A new `--link-rate` flag and interactive prompt let operators bake the NIC line rate directly into the rendered `solo-provisioner-tc-egress.sh` script. When set, the script contains a hard-coded `SPEED=<mbit>` line and skips the runtime sysfs detection; when left blank, the existing auto-detect behaviour (read sysfs, fall back to 1000 Mbit/s) is preserved. The prompt is pre-filled with the detected speed so operators on bare-metal can confirm with Enter. The flag is named `--link-rate` rather than `--egress-bandwidth` because it describes the physical NIC line rate — a property shared by both ingress and egress shaping — rather than a directionally-scoped limit.

The egress-interface and link-rate prompts are now decoupled from the host-firewall resolver so they appear regardless of whether the operator enables the node-level firewall — tc-egress traffic shaping is independent of the inet-host firewall.

`block node reconfigure` gains the same `--egress-interface`, `--link-rate`, and host-firewall flags. The reconfigure workflow now re-renders both the tc-egress script and the nftables host firewall on every run, so operators can change their egress NIC, bake in a new link rate, or update management CIDRs without a full reinstall.

The prompt and flag registration logic is extracted into `common.RegisterEgressFlags` / `common.ResolveEgressConfig`, mirroring the existing `RegisterHostFirewallFlags` / `ResolveHostFirewallConfig` pattern, so there is no duplication between install and reconfigure.

All format-sensitive flags (`--link-rate`, `--values-file`, `--plugins`, `--ssh-port`, `--in-cluster-ports`, `--mgmt-cidrs`, `--pod-cidr`) are now validated at the very start of `RunE` — before the interactive wizard runs — so operators get an immediate error for an invalid CLI flag rather than sitting through all the prompts first.

> **Note:** `--link-rate` is not persisted to solo-weaver state — it is baked into the rendered script at install/reconfigure time. A subsequent `block node install --force` without the flag re-renders the script with sysfs auto-detect, silently reverting a previously baked value. Tracked in #871.

### Files changed

| File | Change |
|---|---|
| `internal/network/shape/speed.go` | `readLinkSpeedMbitFrom` (test-injectable), `FormatSpeedHint`, `ParseSpeedMbit` |
| `internal/network/shape/speed_linux.go` | `ReadLinkSpeedMbit` — reads `/sys/class/net/<nic>/speed`; guards against `/` in NIC name |
| `internal/network/shape/speed_other.go` | Non-Linux stub returning `(0, false)` |
| `internal/network/shape/render.go` | `scriptData.SpeedMbit` field; `renderTcEgressScript` and `RenderTcEgressScript` gain `speedMbit int` param |
| `internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl` | Conditional: bake `SPEED=<mbit>` when `SpeedMbit > 0`, else keep sysfs auto-detect |
| `internal/workflows/steps/step_network_tc_egress.go` | `TcEgressPersist` gains `speedMbit int` param, threads it to `RenderTcEgressScript` |
| `internal/bll/blocknode/install_handler.go` | Parses `ins.LinkRate` via `ParseSpeedMbit`, passes result to `TcEgressPersist` |
| `internal/bll/blocknode/reconfigure_handler.go` | Adds `NetworkFirewallCreate` + `TcEgressPersist` to all workflow branches |
| `internal/bll/blocknode/helpers.go` | Passes `EgressInterface` and `LinkRate` through `resolveBlocknodeEffectiveInputs` |
| `internal/network/shape/shape_test.go` | `ParseSpeedMbit` tests, baked-speed and auto-detect render tests |
| `internal/ui/prompt/blocknode.go` | `EgressInterfaceInputPrompt` gains `speedHint` param; adds `LinkRateInputPrompt` |
| `cmd/cli/commands/common/egress.go` | New: `RegisterEgressFlags` + `ValidateEgressFlags` + `ResolveEgressConfig` (shared by install and reconfigure) |
| `cmd/cli/commands/common/host_firewall.go` | New: `ValidateHostFirewallFlags` — validates `--ssh-port`, `--in-cluster-ports`, `--mgmt-cidrs`, `--pod-cidr` eagerly |
| `cmd/cli/commands/block/node/init.go` | New: `validateBlockNodeFlags` — validates `--values-file` and `--plugins` eagerly |
| `cmd/cli/commands/block/node/install.go` | Uses `common.ResolveEgressConfig`; drops inline detection block; calls three validators at top of RunE |
| `cmd/cli/commands/block/node/reconfigure.go` | Adds egress + firewall prompts; registers both flag sets in `init()`; calls three validators at top of RunE |
| `cmd/cli/commands/block/node/upgrade.go` | Calls `validateBlockNodeFlags` at top of RunE |
| `cmd/cli/commands/block/node/node.go` | `flagLinkRate` var |
| `pkg/models/inputs.go` | `BlockNodeInputs.LinkRate string` |

### Review guide

**Code review checklist**
- [ ] `ReadLinkSpeedMbit` (`speed_linux.go`) rejects NIC names containing `/` before building the sysfs path
- [ ] `readLinkSpeedMbitFrom` treats non-positive values (kernel `-1`) and non-numeric content as `(0, false)` — never errors
- [ ] `ParseSpeedMbit` handles `gbit`/`mbit` suffixes case-insensitively; rejects zero/negative numerals
- [ ] Template conditional (`solo-provisioner-tc-egress.sh.tmpl`) only bakes speed when `SpeedMbit > 0`; else the full sysfs block is preserved verbatim
- [ ] `LinkRateInputPrompt` validator allows empty (opt-out to sysfs auto-detect)
- [ ] `ValidateEgressFlags` is called before `prepareBlocknodeInputs` in both install and reconfigure
- [ ] `ValidateHostFirewallFlags` only checks flags that are `Changed` on the CLI; un-set flags fall through to `ResolveHostFirewallConfig` as before
- [ ] `validateBlockNodeFlags` only validates `--values-file` when non-empty (guards the sanity check) and `--plugins` when the flag is `Changed`
- [ ] `ResolveEgressConfig` guards the prompt section with `ShouldPrompt` — non-interactive runs skip prompts cleanly
- [ ] `resolveBlocknodeEffectiveInputs` in `helpers.go` passes `EgressInterface` and `LinkRate` through to the effective inputs
- [ ] `reconfigure_handler.go` calls `NetworkFirewallCreate` and `TcEgressPersist` in all four workflow branches (default, no-restart, reset, purge)

**Test commands**
```bash
# Unit tests (macOS OK)
go test -tags='!integration' ./internal/network/shape/...

# Linux build check
task build:cli GOOS=linux GOARCH=amd64
```

**Manual UAT (UTM VM)**

*Egress / link-rate flags*
1. Run `sudo solo-provisioner block node install` interactively. A standalone **Egress Network Interface** prompt appears (before the firewall question), followed by **NIC Link Rate** pre-filled with the detected speed (blank on virtual NICs).
2. Leave link rate blank → after install, `cat /usr/local/sbin/solo-provisioner-tc-egress.sh` should show the sysfs detection block (`cat /sys/class/net/"$NIC"/speed`).
3. Re-run with `--link-rate 500mbit` → the script should contain `SPEED=500` with no sysfs block.
4. Run with `--firewall-enabled=false` → the egress prompts should **still** appear (previously they were silently skipped when the firewall was disabled).
5. Run `sudo solo-provisioner block node install --link-rate 2gb` → should be rejected **immediately** (before any prompts appear) with a validation error.
6. Run `sudo solo-provisioner block node reconfigure` interactively → same **Egress Network Interface** and **NIC Link Rate** prompts appear, followed by the **Host Firewall** section. After confirm, `cat /usr/local/sbin/solo-provisioner-tc-egress.sh` should reflect the chosen link rate.
7. Run `sudo solo-provisioner block node reconfigure --link-rate 100mbit --firewall-enabled=false` non-interactively → script should contain `SPEED=100` and no prompts should appear.
8. Run `sudo solo-provisioner block node reconfigure --link-rate 2gb` → should be rejected **immediately** with a validation error.

*Values-file and plugins flags*
9. Run `sudo solo-provisioner block node install --values-file /nonexistent/path.yaml` → should be rejected **immediately** with a "file not found" error (before any prompts appear).
10. Run `sudo solo-provisioner block node install --plugins "bad plugin!name"` → should be rejected **immediately** with an invalid plugin list error.
11. Run `sudo solo-provisioner block node upgrade --values-file /nonexistent/path.yaml` → same immediate rejection.

*Firewall flags*
12. Run `sudo solo-provisioner block node install --ssh-port 99999` → should be rejected **immediately** with an invalid port error.
13. Run `sudo solo-provisioner block node install --mgmt-cidrs 999.0.0.0/24` → should be rejected **immediately** with an invalid CIDR error.
14. Run `sudo solo-provisioner block node install --in-cluster-ports 0` → should be rejected **immediately** with an invalid port error.
15. Run `sudo solo-provisioner block node reconfigure --pod-cidr not-a-cidr` → should be rejected **immediately** with an invalid CIDR error.

**Risks / rollback**
- Speed read and link rate override are best-effort — no install regression risk if sysfs is unavailable.
- `RenderTcEgressScript` signature changed (added `speedMbit int`); only called from `TcEgressPersist` which is only called from `install_handler.go` and `reconfigure_handler.go` — no other call sites.
- A `block node install --force` without `--link-rate` silently reverts a previously baked value to sysfs auto-detect (see note above).
- `reconfigure` previously ran no host-level steps. Adding `NetworkFirewallCreate` and `TcEgressPersist` means reconfigure now writes to `/usr/local/sbin/solo-provisioner-tc-egress.sh` and re-applies nftables rules. Both steps are idempotent; a reconfigure without the flags re-renders with auto-detect / current config values.
- Early flag validation is an additive change — it only turns a late error into an immediate one; it cannot cause a previously-valid invocation to fail.

### Related Issues

* Closes #744
