### PR TITLE
feat(network): add `network shape` scope (tc HTB classes + device roots) (#771)

### DIFF
--- a/cmd/cli/commands/common/egress.go
+++ b/cmd/cli/commands/common/egress.go
@@ -3,6 +3,8 @@
 package common
 
 import (
+	"strings"
+
 	"github.com/hashgraph/solo-weaver/internal/network/shape"
 	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
 	"github.com/joomcode/errorx"
@@ -25,8 +27,8 @@ func RegisterEgressFlags(cmd *cobra.Command, egressInterface, linkRate *string) 
 		"Physical NIC for the $EGRESS HTB traffic-shaper hierarchy (e.g. eth0). "+
 			"Auto-detected from the default route when omitted; use this flag to override on multi-NIC hosts.")
 	cmd.Flags().StringVar(linkRate, FlagNameLinkRate, "",
-		"NIC line rate in tc-style format (e.g. 1gbit, 100mbit). "+
-			"Auto-detected from sysfs at boot when omitted; baked into the script when set.")
+		"NIC line rate in tc-style format (e.g. 1gbit, 100mbit), or \"auto\" to detect and store the speed at install time. "+
+			"Auto-detected from sysfs at each boot when omitted; written as explicit proportional class rates when set.")
 }
 
 // ValidateEgressFlags rejects a set --link-rate value that is not a valid
@@ -36,9 +38,12 @@ func RegisterEgressFlags(cmd *cobra.Command, egressInterface, linkRate *string) 
 // It requires RegisterEgressFlags to have been called on cmd.
 func ValidateEgressFlags(cmd *cobra.Command, linkRate string) error {
 	if cmd.Flags().Changed(FlagNameLinkRate) && linkRate != "" {
+		if strings.EqualFold(strings.TrimSpace(linkRate), "auto") {
+			return nil
+		}
 		if _, ok := shape.ParseSpeedMbit(linkRate); !ok {
 			return errorx.IllegalArgument.New(
-				"invalid --%s %q: must be a tc-style rate (e.g. 1gbit, 100mbit)",
+				"invalid --%s %q: must be a tc-style rate (e.g. 1gbit, 100mbit) or \"auto\"",
 				FlagNameLinkRate, linkRate)
 		}
 	}

--- a/cmd/cli/commands/common/egress_test.go
+++ b/cmd/cli/commands/common/egress_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestValidateEgressFlags_LinkRate(t *testing.T) {
+	cases := []struct {
+		val     string
+		wantErr bool
+	}{
+		{"auto", false},
+		{"AUTO", false},
+		{"1gbit", false},
+		{"100mbit", false},
+		{"", false}, // set-but-empty is skipped
+		{"fast", true},
+		{"1gig", true},
+	}
+	for _, c := range cases {
+		var egressIface, linkRate string
+		cmd := &cobra.Command{Use: "x", RunE: func(*cobra.Command, []string) error { return nil }}
+		RegisterEgressFlags(cmd, &egressIface, &linkRate)
+		if err := cmd.Flags().Set(FlagNameLinkRate, c.val); err != nil {
+			t.Fatalf("set %s=%q: %v", FlagNameLinkRate, c.val, err)
+		}
+		err := ValidateEgressFlags(cmd, linkRate)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ValidateEgressFlags(--%s %q) err=%v, wantErr=%v", FlagNameLinkRate, c.val, err, c.wantErr)
+		}
+	}
+}

--- a/cmd/cli/commands/network/network.go
+++ b/cmd/cli/commands/network/network.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/network/firewall"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/network/policy"
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/network/shape"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +23,7 @@ var networkCmd = &cobra.Command{
 func init() {
 	networkCmd.AddCommand(firewall.GetCmd())
 	networkCmd.AddCommand(policy.GetCmd())
+	networkCmd.AddCommand(shape.GetCmd())
 }
 
 // GetCmd returns the root of the `network` command group.

--- a/cmd/cli/commands/network/shape/create.go
+++ b/cmd/cli/commands/network/shape/create.go
@@ -3,6 +3,8 @@
 package shape
 
 import (
+	"strings"
+
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	shp "github.com/hashgraph/solo-weaver/internal/network/shape"
@@ -70,6 +72,9 @@ func runCreateClass(cmd *cobra.Command, m *shp.Manager, force bool) error {
 	if !cmd.Flags().Changed("rate") {
 		return errorx.IllegalArgument.New("--rate is required for --class")
 	}
+	if strings.EqualFold(strings.TrimSpace(flagRate), "auto") {
+		return errorx.IllegalArgument.New("--rate auto is only valid for --device; class rates must be explicit bandwidth values (e.g. 400mbit)")
+	}
 
 	cls := &shp.ClassConfig{
 		Name: flagClass,
@@ -99,7 +104,7 @@ func runCreateClass(cmd *cobra.Command, m *shp.Manager, force bool) error {
 func init() {
 	createCmd.Flags().StringVar(&flagClass, "class", "", "HTB class name to configure (publisher, backfill-response, reserve-ingress, partner, public, reserve-egress)")
 	createCmd.Flags().StringVar(&flagDevice, "device", "", "Traffic direction to configure root for: ingress ($VETH) or egress ($NIC)")
-	createCmd.Flags().StringVar(&flagRate, "rate", "", "Bandwidth rate (e.g. 100mbit, 1gbit)")
+	createCmd.Flags().StringVar(&flagRate, "rate", "", `Bandwidth rate (e.g. 100mbit, 1gbit). For --device only: "auto" detects the link speed from sysfs at create time and stores it as an explicit rate (falls back to 1gbit when unreadable).`)
 	createCmd.Flags().StringVar(&flagCeil, "ceil", "", "Burst ceiling rate (≥ --rate; defaults to --rate if omitted)")
 	createCmd.Flags().IntVar(&flagPrio, "prio", 0, "HTB scheduling priority [0,7] (0 = highest; default 0)")
 	createCmd.Flags().StringVar(&flagDefault, "default", "", "Default class name for unmatched traffic (--device form only)")

--- a/cmd/cli/commands/network/shape/create.go
+++ b/cmd/cli/commands/network/shape/create.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	shp "github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a shape device root or bandwidth class",
+	Long: "Create a tc HTB shape configuration. Exactly one of --device or --class must be supplied:\n\n" +
+		"  --device <dir>  Configure the root qdisc and trunk class for \"ingress\" ($VETH) or\n" +
+		"                  \"egress\" ($NIC). Required: --rate, --default. Must run before any\n" +
+		"                  --class form for the same device (tc parent-before-child requirement).\n\n" +
+		"  --class <name>  Add an HTB leaf class + fq_codel qdisc. The device is implied by the\n" +
+		"                  class name. Required: --rate. Optional: --ceil, --prio.\n\n" +
+		"create-if-missing: an existing entry is left untouched unless --force is passed.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if flagClass != "" && flagDevice != "" {
+			return errorx.IllegalArgument.New("--class and --device are mutually exclusive")
+		}
+		if flagClass == "" && flagDevice == "" {
+			return errorx.IllegalArgument.New("exactly one of --class or --device must be supplied")
+		}
+
+		force, err := common.FlagForce().Value(cmd, args)
+		if err != nil {
+			return err
+		}
+
+		m := newManager()
+
+		if flagDevice != "" {
+			return runCreateDevice(cmd, m, force)
+		}
+		return runCreateClass(cmd, m, force)
+	},
+}
+
+func runCreateDevice(cmd *cobra.Command, m *shp.Manager, force bool) error {
+	if !cmd.Flags().Changed("rate") {
+		return errorx.IllegalArgument.New("--rate is required for --device")
+	}
+	if !cmd.Flags().Changed("default") {
+		return errorx.IllegalArgument.New("--default is required for --device")
+	}
+
+	dev := &shp.DeviceConfig{
+		Dir:          flagDevice,
+		Rate:         flagRate,
+		DefaultClass: flagDefault,
+	}
+	changed, err := m.CreateDevice(cmd.Context(), dev, force)
+	if err != nil {
+		return err
+	}
+	if changed {
+		logx.As().Info().Str("device", dev.Dir).Str("rate", dev.Rate).
+			Str("default", dev.DefaultClass).Msg("network shape device configured")
+	}
+	return nil
+}
+
+func runCreateClass(cmd *cobra.Command, m *shp.Manager, force bool) error {
+	if !cmd.Flags().Changed("rate") {
+		return errorx.IllegalArgument.New("--rate is required for --class")
+	}
+
+	cls := &shp.ClassConfig{
+		Name: flagClass,
+		Rate: flagRate,
+		Prio: flagPrio,
+	}
+	if cmd.Flags().Changed("ceil") {
+		cls.Ceil = flagCeil
+	}
+
+	changed, err := m.CreateClass(cmd.Context(), cls, force)
+	if err != nil {
+		return err
+	}
+	if changed {
+		ceil := cls.Ceil
+		if ceil == "" {
+			ceil = cls.Rate
+		}
+		logx.As().Info().Str("class", cls.Name).Str("rate", cls.Rate).
+			Str("ceil", ceil).Int("prio", cls.Prio).
+			Msg("network shape class configured")
+	}
+	return nil
+}
+
+func init() {
+	createCmd.Flags().StringVar(&flagClass, "class", "", "HTB class name to configure (publisher, backfill-response, reserve-ingress, partner, public, reserve-egress)")
+	createCmd.Flags().StringVar(&flagDevice, "device", "", "Traffic direction to configure root for: ingress ($VETH) or egress ($NIC)")
+	createCmd.Flags().StringVar(&flagRate, "rate", "", "Bandwidth rate (e.g. 100mbit, 1gbit)")
+	createCmd.Flags().StringVar(&flagCeil, "ceil", "", "Burst ceiling rate (≥ --rate; defaults to --rate if omitted)")
+	createCmd.Flags().IntVar(&flagPrio, "prio", 0, "HTB scheduling priority [0,7] (0 = highest; default 0)")
+	createCmd.Flags().StringVar(&flagDefault, "default", "", "Default class name for unmatched traffic (--device form only)")
+}

--- a/cmd/cli/commands/network/shape/delete.go
+++ b/cmd/cli/commands/network/shape/delete.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a shape device or class configuration",
+	Long: "Delete a shape configuration. Exactly one of --device or --class must be supplied.\n\n" +
+		"  --class <name>  Remove the class configuration. Fails if the class is referenced as\n" +
+		"                  the device default or by any network policy --stamp/--reply-stamp.\n\n" +
+		"  --device <dir>  Remove the device configuration. Fails if any classes are still\n" +
+		"                  configured for this device (delete classes first).\n\n" +
+		"For egress targets, tc-egress.sh is re-rendered and tc-egress.service is restarted.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if flagClass != "" && flagDevice != "" {
+			return errorx.IllegalArgument.New("--class and --device are mutually exclusive")
+		}
+		if flagClass == "" && flagDevice == "" {
+			return errorx.IllegalArgument.New("exactly one of --class or --device must be supplied")
+		}
+
+		m := newManager()
+
+		if flagClass != "" {
+			if err := m.DeleteClass(cmd.Context(), flagClass); err != nil {
+				return err
+			}
+			logx.As().Info().Str("class", flagClass).Msg("network shape class deleted")
+			return nil
+		}
+
+		if err := m.DeleteDevice(cmd.Context(), flagDevice); err != nil {
+			return err
+		}
+		logx.As().Info().Str("device", flagDevice).Msg("network shape device deleted")
+		return nil
+	},
+}
+
+func init() {
+	deleteCmd.Flags().StringVar(&flagClass, "class", "", "Class name to delete")
+	deleteCmd.Flags().StringVar(&flagDevice, "device", "", "Device direction to delete (ingress or egress)")
+}

--- a/cmd/cli/commands/network/shape/set.go
+++ b/cmd/cli/commands/network/shape/set.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var setCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Update bandwidth parameters of an existing class (tc class change, no qdisc churn)",
+	Long: "Atomically update one or more bandwidth parameters of an existing class using " +
+		"`tc class change` on the live kernel (no qdisc teardown). The boot script is " +
+		"re-rendered for reboot persistence. Only the explicitly supplied flags are changed; " +
+		"omitted flags keep their current value. --class is required.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if flagClass == "" {
+			return errorx.IllegalArgument.New("--class is required")
+		}
+		if !cmd.Flags().Changed("rate") && !cmd.Flags().Changed("ceil") && !cmd.Flags().Changed("prio") {
+			return errorx.IllegalArgument.New("at least one of --rate, --ceil, or --prio must be supplied")
+		}
+
+		var rate, ceil *string
+		var prio *int
+		if cmd.Flags().Changed("rate") {
+			v := flagRate
+			rate = &v
+		}
+		if cmd.Flags().Changed("ceil") {
+			v := flagCeil
+			ceil = &v
+		}
+		if cmd.Flags().Changed("prio") {
+			v := flagPrio
+			prio = &v
+		}
+
+		if err := newManager().SetClass(cmd.Context(), flagClass, rate, ceil, prio); err != nil {
+			return err
+		}
+		logx.As().Info().Str("class", flagClass).Msg("network shape class updated")
+		return nil
+	},
+}
+
+func init() {
+	setCmd.Flags().StringVar(&flagClass, "class", "", "Class name to update (required)")
+	setCmd.Flags().StringVar(&flagRate, "rate", "", "New guaranteed bandwidth rate")
+	setCmd.Flags().StringVar(&flagCeil, "ceil", "", "New burst ceiling rate (≥ --rate)")
+	setCmd.Flags().IntVar(&flagPrio, "prio", 0, "New HTB scheduling priority [0,7]")
+}

--- a/cmd/cli/commands/network/shape/shape.go
+++ b/cmd/cli/commands/network/shape/shape.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package shape wires the `solo-provisioner network shape` verbs to the
+// internal/network/shape manager. The shape scope manages the tc HTB bandwidth
+// plane on $EGRESS (physical NIC) and $VETH (pod traffic), maintaining
+// per-class rate/ceil/prio configurations that drive the tc-egress.sh boot
+// script and the daemon pod-lifecycle watcher.
+//
+// Two forms of `create` are supported, mutually exclusive via --class/--device:
+//   - create --device <dir> --rate <speed> --default <class>: configure the
+//     root HTB qdisc and trunk class for "ingress" ($VETH) or "egress" ($NIC).
+//   - create --class <name> --rate <speed> [--ceil <speed>] [--prio <n>]:
+//     add an HTB leaf class; device direction is derived from the class name.
+package shape
+
+import (
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	shp "github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/spf13/cobra"
+)
+
+// Shared flag binding targets. Only one verb runs per invocation.
+var (
+	flagClass   string
+	flagDevice  string
+	flagRate    string
+	flagCeil    string
+	flagPrio    int
+	flagDefault string
+)
+
+var shapeCmd = &cobra.Command{
+	Use:   "shape",
+	Short: "Manage tc HTB bandwidth classes on $EGRESS and $VETH",
+	Long: "Manage the tc HTB bandwidth plane: configure root qdisc devices and per-class " +
+		"rate/ceil/prio bandwidth parameters. Egress mutations re-render " +
+		"solo-provisioner-tc-egress.sh and restart the boot service. Ingress mutations " +
+		"write config for the daemon pod-lifecycle watcher to apply to each new veth interface.",
+	RunE: common.DefaultRunE,
+}
+
+func init() {
+	shapeCmd.AddCommand(createCmd)
+	shapeCmd.AddCommand(setCmd)
+	shapeCmd.AddCommand(showCmd)
+	shapeCmd.AddCommand(deleteCmd)
+}
+
+// GetCmd returns the root of the `network shape` command group.
+func GetCmd() *cobra.Command {
+	return shapeCmd
+}
+
+// newManager constructs the production manager. Indirected through a var so
+// command tests can stub it.
+var newManager = func() *shp.Manager { return shp.NewManager() }

--- a/cmd/cli/commands/network/shape/shape_test.go
+++ b/cmd/cli/commands/network/shape/shape_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"testing"
+	"time"
+
+	shp "github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+// resetFlags clears package-level flag vars and cobra's per-flag Changed state.
+// Call via defer at the top of every test that mutates these vars so state
+// does not leak into subsequent tests.
+func resetFlags() {
+	flagClass = ""
+	flagDevice = ""
+	flagRate = ""
+	flagCeil = ""
+	flagPrio = 0
+	flagDefault = ""
+	for _, cmd := range []*cobra.Command{createCmd, setCmd, showCmd, deleteCmd} {
+		cmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
+	}
+}
+
+// --- Structure tests ---
+
+func TestShapeCmd_HasExpectedSubcommands(t *testing.T) {
+	subs := map[string]bool{}
+	for _, c := range shapeCmd.Commands() {
+		subs[c.Name()] = true
+	}
+	for _, want := range []string{"create", "set", "show", "delete"} {
+		require.True(t, subs[want], "missing subcommand %q", want)
+	}
+}
+
+func TestGetCmd_ReturnsShapeCmd(t *testing.T) {
+	require.Equal(t, "shape", GetCmd().Name())
+}
+
+func TestCreateCmd_FlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"class", "device", "rate", "ceil", "prio", "default"} {
+		require.NotNil(t, createCmd.Flags().Lookup(flag), "create: missing --%s", flag)
+	}
+}
+
+func TestSetCmd_FlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"class", "rate", "ceil", "prio"} {
+		require.NotNil(t, setCmd.Flags().Lookup(flag), "set: missing --%s", flag)
+	}
+}
+
+func TestShowCmd_FlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"class", "device"} {
+		require.NotNil(t, showCmd.Flags().Lookup(flag), "show: missing --%s", flag)
+	}
+}
+
+func TestDeleteCmd_FlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"class", "device"} {
+		require.NotNil(t, deleteCmd.Flags().Lookup(flag), "delete: missing --%s", flag)
+	}
+}
+
+// --- create: mutual exclusion (validation fires before newManager is called) ---
+
+func TestCreateCmd_BothClassAndDevice_Error(t *testing.T) {
+	defer resetFlags()
+	flagClass = "partner"
+	flagDevice = "egress"
+
+	err := createCmd.RunE(createCmd, nil)
+	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+func TestCreateCmd_NeitherClassNorDevice_Error(t *testing.T) {
+	defer resetFlags()
+
+	err := createCmd.RunE(createCmd, nil)
+	require.ErrorContains(t, err, "exactly one of")
+}
+
+// --- create --class: flag-required validation (fires before manager) ---
+
+func TestRunCreateClass_MissingRate_Error(t *testing.T) {
+	defer resetFlags()
+	// Construct a minimal cmd with only the flags runCreateClass inspects.
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(&flagRate, "rate", "", "")
+	// --rate not Set → Changed returns false → runCreateClass errors.
+	err := runCreateClass(cmd, nil, false)
+	require.ErrorContains(t, err, "--rate is required")
+}
+
+// --- create --device: flag-required validation ---
+
+func TestRunCreateDevice_MissingRate_Error(t *testing.T) {
+	defer resetFlags()
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(&flagRate, "rate", "", "")
+	cmd.Flags().StringVar(&flagDefault, "default", "", "")
+	// --rate not Changed
+	err := runCreateDevice(cmd, nil, false)
+	require.ErrorContains(t, err, "--rate is required")
+}
+
+func TestRunCreateDevice_MissingDefault_Error(t *testing.T) {
+	defer resetFlags()
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(&flagRate, "rate", "", "")
+	cmd.Flags().StringVar(&flagDefault, "default", "", "")
+	require.NoError(t, cmd.Flags().Set("rate", "1gbit"))
+	// --default not Changed
+	err := runCreateDevice(cmd, nil, false)
+	require.ErrorContains(t, err, "--default is required")
+}
+
+// --- set: early validation (fires before newManager is called) ---
+
+func TestSetCmd_NoClass_Error(t *testing.T) {
+	defer resetFlags()
+	// flagClass is "" — RunE should return before calling the manager.
+	// We need a cmd with the same RunE but its own fresh FlagSet so Changed()
+	// works correctly and we do not pollute the shared setCmd FlagSet.
+	cmd := &cobra.Command{
+		RunE: setCmd.RunE,
+	}
+	cmd.Flags().StringVar(&flagClass, "class", "", "")
+	cmd.Flags().StringVar(&flagRate, "rate", "", "")
+	cmd.Flags().StringVar(&flagCeil, "ceil", "", "")
+	cmd.Flags().IntVar(&flagPrio, "prio", 0, "")
+	require.NoError(t, cmd.Flags().Set("rate", "200mbit"))
+
+	err := cmd.RunE(cmd, nil)
+	require.ErrorContains(t, err, "--class is required")
+}
+
+func TestSetCmd_NoChangedBandwidthFlag_Error(t *testing.T) {
+	defer resetFlags()
+	cmd := &cobra.Command{
+		RunE: setCmd.RunE,
+	}
+	cmd.Flags().StringVar(&flagClass, "class", "", "")
+	cmd.Flags().StringVar(&flagRate, "rate", "", "")
+	cmd.Flags().StringVar(&flagCeil, "ceil", "", "")
+	cmd.Flags().IntVar(&flagPrio, "prio", 0, "")
+	// Set --class but do not touch --rate/--ceil/--prio.
+	require.NoError(t, cmd.Flags().Set("class", "partner"))
+
+	err := cmd.RunE(cmd, nil)
+	require.ErrorContains(t, err, "at least one of --rate, --ceil, or --prio")
+}
+
+// --- show: mutual exclusion (fires before newManager) ---
+
+func TestShowCmd_BothClassAndDevice_Error(t *testing.T) {
+	defer resetFlags()
+	flagClass = "partner"
+	flagDevice = "egress"
+
+	err := showCmd.RunE(showCmd, nil)
+	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+// --- delete: mutual exclusion and required-one-of validation ---
+
+func TestDeleteCmd_BothClassAndDevice_Error(t *testing.T) {
+	defer resetFlags()
+	flagClass = "partner"
+	flagDevice = "egress"
+
+	err := deleteCmd.RunE(deleteCmd, nil)
+	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+func TestDeleteCmd_NeitherClassNorDevice_Error(t *testing.T) {
+	defer resetFlags()
+
+	err := deleteCmd.RunE(deleteCmd, nil)
+	require.ErrorContains(t, err, "exactly one of")
+}
+
+// --- model field tests ---
+
+func TestClassConfig_CeilDefaultsToEmpty(t *testing.T) {
+	cls := &shp.ClassConfig{Name: "partner", Rate: "400mbit"}
+	require.Empty(t, cls.Ceil)
+}
+
+func TestDeviceConfig_DirEgressConstant(t *testing.T) {
+	require.Equal(t, "egress", shp.DirEgress)
+	require.Equal(t, "ingress", shp.DirIngress)
+}
+
+func TestDeviceConfig_FieldsRoundtrip(t *testing.T) {
+	dev := &shp.DeviceConfig{
+		Dir:          shp.DirEgress,
+		Rate:         "1gbit",
+		DefaultClass: "reserve-egress",
+		CreatedAt:    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	require.Equal(t, "egress", dev.Dir)
+	require.Equal(t, "1gbit", dev.Rate)
+	require.Equal(t, "reserve-egress", dev.DefaultClass)
+}

--- a/cmd/cli/commands/network/shape/show.go
+++ b/cmd/cli/commands/network/shape/show.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"fmt"
+
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show shape configuration (device or class)",
+	Long: "Show the stored shape configuration. Without flags, shows all configured devices and " +
+		"classes. With --device or --class, shows only the named entry.",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if flagClass != "" && flagDevice != "" {
+			return errorx.IllegalArgument.New("--class and --device are mutually exclusive")
+		}
+
+		m := newManager()
+		var out string
+		var err error
+
+		switch {
+		case flagClass != "":
+			out, err = m.ShowClass(flagClass)
+		case flagDevice != "":
+			out, err = m.ShowDevice(flagDevice)
+		default:
+			out, err = m.ShowAll()
+		}
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(cmd.OutOrStdout(), out)
+		return nil
+	},
+}
+
+func init() {
+	showCmd.Flags().StringVar(&flagClass, "class", "", "Show configuration for the named class")
+	showCmd.Flags().StringVar(&flagDevice, "device", "", "Show configuration for the named device (ingress or egress)")
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -202,6 +202,7 @@ sudo solo-provisioner block node install \
 | `--pod-cidr`              | Host firewall pod CIDR for the in-cluster host-service ports rule (defaults to the cluster pod subnet)                                |
 | `--in-cluster-ports`      | Host firewall in-cluster host-service ports (defaults to `6443,4244,7472,10250`)                                                     |
 | `--egress-interface`      | Physical NIC for the `$EGRESS` HTB traffic-shaper hierarchy (e.g. `eth0`). Auto-detected from the default route when omitted; use this flag to override on multi-NIC hosts. Renders `/usr/local/sbin/solo-provisioner-tc-egress.sh` and installs `solo-provisioner-tc-egress.service` so the HTB hierarchy survives reboot. |
+| `--link-rate`             | NIC line rate in tc-style format (e.g. `1gbit`, `100mbit`), or `auto` to detect and store the link speed at install time (written as explicit proportional class rates). Auto-detected from sysfs at each boot when omitted. Interactively, the prompt accepts a rate, `auto`, or blank. |
 
 > **Host firewall**: `block node install` always lays down the node-level `inet
 > host` firewall (SSH/management allowlist, ICMP policy, in-cluster host-service
@@ -624,6 +625,78 @@ sudo solo-provisioner network policy delete --name bn-restricted
 | Flag     | Description     | Required |
 |----------|-----------------|----------|
 | `--name` | Policy name     | yes      |
+
+---
+
+#### `network shape` — tc HTB Bandwidth Class Management
+
+Manage the tc HTB shaping hierarchy for the node's egress NIC. Each `create/set/delete` mutation atomically re-renders `/usr/local/sbin/solo-provisioner-tc-egress.sh` and restarts `solo-provisioner-tc-egress.service` so the live kernel and boot script stay in sync.
+
+`block node install` drives the shape registry automatically (from `--link-rate`); `network shape` lets you inspect or adjust individual classes after install.
+
+**Create device root**
+
+```bash
+# Explicit trunk rate: written into the boot script as concrete tc values; no sysfs detection.
+sudo solo-provisioner network shape create \
+  --device egress --rate 1gbit --default reserve-egress
+
+# Auto-detect trunk rate NOW from sysfs (/sys/class/net/<NIC>/speed) and store
+# the resolved value (e.g. 1gbit) as an explicit rate. Unreadable speed → 1gbit.
+sudo solo-provisioner network shape create \
+  --device egress --rate auto --default reserve-egress
+
+# Replace an existing device config.
+sudo solo-provisioner network shape create \
+  --device egress --rate 1gbit --default reserve-egress --force
+```
+
+`--rate auto` reads the detected NIC's link speed from sysfs **at create time** — while the link is up and stable — and stores the resolved value (e.g. `1gbit`) as an ordinary explicit rate. `network shape show` then reports the concrete number and the boot script carries explicit values, with no `SPEED` variable and no sysfs read at boot. If the speed is not readable then (e.g. a virtual NIC reporting `-1`), `auto` falls back to a concrete `1gbit` (1000 Mbit) — still explicit and `SPEED`-free, not a dynamic script. Either way, `--rate auto` always produces a concrete stored rate; the sysfs-at-boot form only appears when no shape device is configured at all (e.g. `block node install` run without `--link-rate` in non-interactive mode).
+
+Until you add the first `--class`, the device root renders a placeholder hierarchy (the three default egress classes at proportional rates: partner 40%/70%, public 30%/70%, reserve-egress 30%/100% of the trunk) at the resolved concrete rate. Adding explicit `--class` configs replaces the placeholder.
+
+**Create / replace HTB leaf classes**
+
+```bash
+sudo solo-provisioner network shape create --class partner        --rate 400mbit --ceil 700mbit  --prio 0
+sudo solo-provisioner network shape create --class public         --rate 300mbit --ceil 700mbit  --prio 5
+sudo solo-provisioner network shape create --class reserve-egress --rate 300mbit --ceil 1000mbit --prio 1
+```
+
+Once all three egress class configs are present, the boot script switches to fully explicit rates (no SPEED variable at all).
+
+**Live update (no qdisc teardown)**
+
+```bash
+sudo solo-provisioner network shape set --class partner --rate 500mbit
+sudo solo-provisioner network shape set --class public  --ceil 600mbit
+```
+
+`set` runs `tc class change` on the live kernel and re-renders the boot script immediately.
+
+**Show**
+
+```bash
+sudo solo-provisioner network shape show              # all devices and classes
+sudo solo-provisioner network shape show --class partner  # single class
+```
+
+**Delete**
+
+```bash
+# Fails if the class is the device default or referenced by a policy --stamp.
+sudo solo-provisioner network shape delete --class reserve-egress
+```
+
+| Flag        | Description                                                                     | Required              |
+|-------------|---------------------------------------------------------------------------------|-----------------------|
+| `--device`  | Traffic direction: `egress` or `ingress`                                        | one of `--device` / `--class` |
+| `--class`   | HTB class name (`partner`, `public`, `reserve-egress`, …)                      | one of `--device` / `--class` |
+| `--rate`    | Bandwidth rate (`100mbit`, `1gbit`) or `"auto"` (sysfs, `--device` form only)  | yes (create/set)      |
+| `--ceil`    | Burst ceiling ≥ `--rate`; defaults to `--rate` when omitted                     | no                    |
+| `--prio`    | HTB scheduling priority `[0,7]`; 0 is highest                                   | no (default 0)        |
+| `--default` | Default class for unmatched traffic (`--device` form only)                      | yes (`--device`)      |
+| `--force`   | Replace an existing device or class config                                       | no                    |
 
 ---
 

--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/hashgraph/solo-weaver/internal/bll"
 	bnpkg "github.com/hashgraph/solo-weaver/internal/blocknode"
-	"github.com/hashgraph/solo-weaver/internal/network/shape"
 	"github.com/hashgraph/solo-weaver/internal/rsl"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/internal/workflows"
@@ -61,7 +60,6 @@ func (h *InstallHandler) BuildWorkflow(
 	}
 
 	ins := inputs.Custom
-	egressSpeedMbit, _ := shape.ParseSpeedMbit(ins.LinkRate)
 
 	var wb *automa.WorkflowBuilder
 	if currentState.ClusterState.Created {
@@ -78,7 +76,7 @@ func (h *InstallHandler) BuildWorkflow(
 				// is already installed/enabled from that prior cluster provisioning,
 				// so it's safe to apply here.
 				steps.NetworkFirewallCreate(),
-				steps.TcEgressPersist(ins.EgressInterface, egressSpeedMbit),
+				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 				steps.SetupBlockNode(ins),
 			)
 	} else {
@@ -98,7 +96,7 @@ func (h *InstallHandler) BuildWorkflow(
 				// systemSetupWorkflow; apply the host firewall here rather than in
 				// that generic (node-type-agnostic) workflow.
 				steps.NetworkFirewallCreate(),
-				steps.TcEgressPersist(ins.EgressInterface, egressSpeedMbit),
+				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 				steps.SetupBlockNode(ins),
 			)
 	}

--- a/internal/bll/blocknode/reconfigure_handler.go
+++ b/internal/bll/blocknode/reconfigure_handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/hashgraph/solo-weaver/internal/bll"
 	bnpkg "github.com/hashgraph/solo-weaver/internal/blocknode"
-	"github.com/hashgraph/solo-weaver/internal/network/shape"
 	"github.com/hashgraph/solo-weaver/internal/rsl"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
@@ -55,7 +54,6 @@ func (h *ReconfigureHandler) BuildWorkflow(
 	}
 
 	ins := inputs.Custom
-	egressSpeedMbit, _ := shape.ParseSpeedMbit(ins.LinkRate)
 
 	var wb *automa.WorkflowBuilder
 	switch {
@@ -73,7 +71,7 @@ func (h *ReconfigureHandler) BuildWorkflow(
 		wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-purge-storage").
 			Steps(
 				steps.NetworkFirewallCreate(),
-				steps.TcEgressPersist(ins.EgressInterface, egressSpeedMbit),
+				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 				steps.PurgeBlockNodeStorage(oldIns),
 				steps.RecreateBlockNodeStorage(ins),
 				steps.UpgradeBlockNode(ins),
@@ -97,7 +95,7 @@ func (h *ReconfigureHandler) BuildWorkflow(
 		wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-with-reset").
 			Steps(
 				steps.NetworkFirewallCreate(),
-				steps.TcEgressPersist(ins.EgressInterface, egressSpeedMbit),
+				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 				steps.PurgeBlockNodeStorage(oldIns),
 				steps.UpgradeBlockNode(ins),
 			)
@@ -120,7 +118,7 @@ func (h *ReconfigureHandler) BuildWorkflow(
 			wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-no-restart").
 				Steps(
 					steps.NetworkFirewallCreate(),
-					steps.TcEgressPersist(ins.EgressInterface, egressSpeedMbit),
+					steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 					steps.UpgradeBlockNode(ins),
 				)
 		} else {
@@ -129,7 +127,7 @@ func (h *ReconfigureHandler) BuildWorkflow(
 			wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure").
 				Steps(
 					steps.NetworkFirewallCreate(),
-					steps.TcEgressPersist(ins.EgressInterface, egressSpeedMbit),
+					steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 					steps.UpgradeBlockNode(ins),
 					steps.RolloutRestartBlockNode(ins),
 				)

--- a/internal/network/shape/apply_linux.go
+++ b/internal/network/shape/apply_linux.go
@@ -11,14 +11,18 @@ import (
 	"github.com/joomcode/errorx"
 )
 
-// ApplyTcEgressScript restarts the tc-egress systemd unit so the kernel picks up
-// the HTB hierarchy immediately after install without waiting for a reboot.
-// RestartService resets a previously-failed unit before running it, so a
-// corrected script takes effect on re-install without a manual reset-failed.
-// Using restart (rather than executing the script directly) keeps the unit
-// state visible: on success the unit shows active (exited), on failure failed —
-// matching what operators see after a reboot.
+// ApplyTcEgressScript ensures the tc-egress systemd unit is installed, then
+// restarts it so the kernel picks up the HTB hierarchy immediately without
+// waiting for a reboot. EnsureTcEgressUnit is idempotent (SHA-256 gated) so
+// repeated calls are cheap. RestartService resets a previously-failed unit
+// before running it, so a corrected script takes effect without a manual
+// reset-failed. Using restart (rather than executing the script directly) keeps
+// unit state visible: on success the unit shows active (exited), on failure
+// failed — matching what operators see after a reboot.
 func ApplyTcEgressScript(ctx context.Context) error {
+	if err := EnsureTcEgressUnit(ctx); err != nil {
+		return errorx.Decorate(err, "failed to install tc-egress service unit")
+	}
 	if err := soos.RestartService(ctx, TcEgressService); err != nil {
 		return errorx.Decorate(err, "tc-egress script failed")
 	}

--- a/internal/network/shape/class.go
+++ b/internal/network/shape/class.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/joomcode/errorx"
+)
+
+// Direction constants for tc device/class mapping.
+const (
+	DirIngress = "ingress" // $VETH (pod traffic, applied by the daemon pod-lifecycle watcher)
+	DirEgress  = "egress"  // $EGRESS physical NIC
+)
+
+// classInfo is the static per-class descriptor. Minor is the hex tc classid
+// minor (e.g., "40" for partner → classid 1:40 in tc's hex notation where
+// 0x40=64). Handle is the fq_codel qdisc handle string (e.g., "140" for
+// handle 140: which is 1 concatenated with Minor in hex).
+type classInfo struct {
+	Minor  string
+	Handle string
+	Dir    string
+}
+
+// classInfoMap is the static name→classid/direction map for the shape package.
+// It is a read-only companion to the policy classMap: Minor values are hex
+// tc classid minors (e.g. 0x40=64 → "40" → classid 1:40 for partner).
+var classInfoMap = map[string]classInfo{
+	"publisher":         {Minor: "10", Handle: "110", Dir: DirIngress},
+	"backfill-response": {Minor: "20", Handle: "120", Dir: DirIngress},
+	"reserve-ingress":   {Minor: "30", Handle: "130", Dir: DirIngress},
+	"partner":           {Minor: "40", Handle: "140", Dir: DirEgress},
+	"public":            {Minor: "50", Handle: "150", Dir: DirEgress},
+	"reserve-egress":    {Minor: "60", Handle: "160", Dir: DirEgress},
+}
+
+// lookupClassInfo resolves a class name to its classid/direction, returning an
+// error naming the known classes when the name is not recognised.
+func lookupClassInfo(name string) (classInfo, error) {
+	c, ok := classInfoMap[name]
+	if !ok {
+		return classInfo{}, errorx.IllegalArgument.New(
+			"unknown class %q: must be one of %s", name, strings.Join(knownClassNames(), ", "))
+	}
+	return c, nil
+}
+
+// knownClassNames returns class names sorted for stable error messages.
+func knownClassNames() []string {
+	names := make([]string, 0, len(classInfoMap))
+	for n := range classInfoMap {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// knownClassNamesForDir returns class names for the given direction, sorted.
+func knownClassNamesForDir(dir string) []string {
+	var names []string
+	for n, c := range classInfoMap {
+		if c.Dir == dir {
+			names = append(names, n)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ClassConfig is the persisted bandwidth configuration for one named tc class.
+// One JSON file per class under ClassConfigDir.
+type ClassConfig struct {
+	Name      string    `json:"name"`
+	Rate      string    `json:"rate"`
+	Ceil      string    `json:"ceil,omitempty"` // defaults to Rate when empty
+	Prio      int       `json:"prio"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// effectiveCeil returns Ceil if non-empty, otherwise Rate (ceil defaults to
+// rate per tc HTB semantics: a class can burst up to its rate by default).
+func (c *ClassConfig) effectiveCeil() string {
+	if c.Ceil != "" {
+		return c.Ceil
+	}
+	return c.Rate
+}

--- a/internal/network/shape/detect_linux.go
+++ b/internal/network/shape/detect_linux.go
@@ -9,8 +9,8 @@ const procNetRoute = "/proc/net/route"
 
 // DetectEgressInterface returns the name of the interface that carries the
 // default route — the physical $EGRESS NIC the HTB hierarchy should be
-// attached to. Works for single-NIC hosts (§4.1); multi-NIC support (§4.2)
-// is out of scope and requires --egress-interface to be set explicitly.
+// attached to. On multi-NIC hosts the desired interface must be specified
+// explicitly via --egress-interface.
 //
 // Fails with an actionable error when no default route is found (e.g. the
 // routing table is not yet populated or the host has no default gateway).

--- a/internal/network/shape/device.go
+++ b/internal/network/shape/device.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import "time"
+
+// DeviceConfig is the persisted root-level tc configuration for one traffic
+// direction. One JSON file per device under DeviceConfigDir (named by Dir).
+//
+// Dir "egress" targets the $EGRESS physical NIC and drives the re-rendered
+// tc-egress.sh boot script. Dir "ingress" targets $VETH and is consumed by
+// the daemon pod-lifecycle watcher; no script is rendered for it.
+type DeviceConfig struct {
+	Dir          string    `json:"dir"`           // "ingress" or "egress"
+	Rate         string    `json:"rate"`          // root HTB trunk class rate
+	DefaultClass string    `json:"default_class"` // class name; unmatched traffic falls here
+	CreatedAt    time.Time `json:"created_at"`
+}

--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -23,11 +23,12 @@ import (
 // Egress mutations (Dir "egress") re-render TcEgressScriptPath and restart the
 // tc-egress.service oneshot so the kernel picks up changes immediately. Ingress
 // mutations (Dir "ingress") only write config; the daemon pod-lifecycle watcher
-// The daemon pod-lifecycle watcher reads them and applies them to each new veth interface.
+// reads them and applies them to each new veth interface.
 type Manager struct {
 	scriptPath  string
 	lockPath    string
 	nicDetect   func() (string, error)
+	speedDetect func(nic string) (int, bool)
 	applyEgress func(ctx context.Context) error
 	tcRunner    TCRunner
 }
@@ -37,6 +38,7 @@ type Config struct {
 	ScriptPath  string
 	LockPath    string
 	NICDetect   func() (string, error)
+	SpeedDetect func(nic string) (int, bool)
 	ApplyEgress func(ctx context.Context) error
 	TCRunner    TCRunner
 }
@@ -53,6 +55,7 @@ func NewManagerWithConfig(cfg Config) *Manager {
 		scriptPath:  cfg.ScriptPath,
 		lockPath:    cfg.LockPath,
 		nicDetect:   cfg.NICDetect,
+		speedDetect: cfg.SpeedDetect,
 		applyEgress: cfg.ApplyEgress,
 		tcRunner:    cfg.TCRunner,
 	}
@@ -64,6 +67,9 @@ func NewManagerWithConfig(cfg Config) *Manager {
 	}
 	if m.nicDetect == nil {
 		m.nicDetect = DetectEgressInterface
+	}
+	if m.speedDetect == nil {
+		m.speedDetect = ReadLinkSpeedMbit
 	}
 	if m.applyEgress == nil {
 		m.applyEgress = ApplyTcEgressScript
@@ -84,8 +90,12 @@ func (m *Manager) CreateDevice(ctx context.Context, dev *DeviceConfig, force boo
 	if err := validateDir(dev.Dir); err != nil {
 		return false, err
 	}
-	if err := validateRate(dev.Rate); err != nil {
-		return false, err
+	// "auto" is a valid device rate meaning "detect link speed from sysfs at
+	// boot". All other non-empty values must be parseable bandwidth strings.
+	if strings.ToLower(strings.TrimSpace(dev.Rate)) != "auto" {
+		if err := validateRate(dev.Rate); err != nil {
+			return false, err
+		}
 	}
 	if err := validateDefaultClass(dev.DefaultClass, dev.Dir); err != nil {
 		return false, err
@@ -107,6 +117,7 @@ func (m *Manager) CreateDevice(ctx context.Context, dev *DeviceConfig, force boo
 		} else if dev.CreatedAt.IsZero() {
 			dev.CreatedAt = time.Now().UTC()
 		}
+		m.resolveAutoRate(dev)
 		if err := writeDevice(dev); err != nil {
 			return err
 		}
@@ -261,7 +272,10 @@ func (m *Manager) SetClass(ctx context.Context, name string, rate, ceil *string,
 				return errorx.Decorate(err,
 					"class config updated on disk but live tc class change failed; reboot or restart tc-egress.service to sync")
 			}
-			if err := m.renderAndApplyScript(ctx, nic); err != nil {
+			// Persist the boot script for reboot without restarting the service:
+			// the live tc class change above already updated the kernel, and a
+			// restart would tear down and rebuild the root qdisc.
+			if err := m.persistEgressScript(nic); err != nil {
 				return errorx.Decorate(err,
 					"live tc class change applied but boot script re-render failed; reboot may revert the change")
 			}
@@ -441,6 +455,48 @@ func (m *Manager) DeleteDevice(ctx context.Context, dir string) error {
 	})
 }
 
+// isAutoRate reports whether rate is the literal "auto" (case-insensitive),
+// the operator-facing request to detect the egress link speed at create time.
+func isAutoRate(rate string) bool {
+	return strings.EqualFold(strings.TrimSpace(rate), "auto")
+}
+
+// resolveAutoRateString resolves a rate of "auto" to a concrete tc bandwidth at
+// create time — the NIC's currently detected link speed when readable, else
+// DefaultLinkSpeedMbit (the same value the boot script's sysfs fallback would
+// use). This keeps the value explicit in the registry and the rendered script
+// (visible via `network shape show`, no SPEED variable, no sysfs read at boot),
+// even on a virtual NIC reporting -1. Non-"auto" rates are returned unchanged.
+// Shared by the `network shape` create path and `block node install`'s
+// ProvisionDefaultEgress so the two cannot drift.
+func (m *Manager) resolveAutoRateString(rate string) string {
+	if !isAutoRate(rate) {
+		return rate
+	}
+	if nic, err := m.nicDetect(); err == nil {
+		if mbit, ok := m.speedDetect(nic); ok {
+			resolved := FormatSpeedHint(mbit)
+			logx.As().Info().Str("nic", nic).Str("rate", resolved).Msg(
+				"resolved auto rate to detected link speed")
+			return resolved
+		}
+	}
+	resolved := FormatSpeedHint(DefaultLinkSpeedMbit)
+	logx.As().Warn().Str("rate", resolved).Msg(
+		"auto rate: link speed not detectable at create time; using default fallback rate")
+	return resolved
+}
+
+// resolveAutoRate replaces an egress device rate of "auto" with a concrete
+// bandwidth (see resolveAutoRateString). Only egress is resolved (ingress
+// shaping is per-veth, applied by the daemon on each pod create).
+func (m *Manager) resolveAutoRate(dev *DeviceConfig) {
+	if dev.Dir != DirEgress {
+		return
+	}
+	dev.Rate = m.resolveAutoRateString(dev.Rate)
+}
+
 // renderAndApplyEgress detects the egress NIC, re-renders the boot script from
 // stored config (or the default if no device config exists), and applies via
 // service restart.
@@ -452,46 +508,72 @@ func (m *Manager) renderAndApplyEgress(ctx context.Context) error {
 	return m.renderAndApplyScript(ctx, nic)
 }
 
-// renderAndApplyScript renders the tc-egress script with the given NIC name
-// (using stored config if available, else the default) and restarts the service.
-func (m *Manager) renderAndApplyScript(ctx context.Context, nic string) error {
+// renderEgressScript renders the tc-egress boot script for nic from the current
+// registry (stored device + classes), or the sysfs-detect default when no
+// device config exists.
+func (m *Manager) renderEgressScript(nic string) (string, error) {
 	dev, err := readDevice(DirEgress)
+	if err != nil {
+		return "", err
+	}
+	if dev == nil {
+		return renderTcEgressScript(nic)
+	}
+	classes, err := loadClassesForDir(DirEgress)
+	if err != nil {
+		return "", err
+	}
+	if len(classes) == 0 {
+		// Device configured but no class configs yet. When the device rate is
+		// an explicit bandwidth, render the three default egress classes at
+		// proportional explicit rates so the boot script carries the operator's
+		// rate without a SPEED variable. "auto" (and any unparseable rate) makes
+		// defaultEgressConfig fail, falling back to sysfs detection at boot.
+		if _, defClasses, derr := defaultEgressConfig(dev.Rate); derr == nil {
+			return renderTcEgressScriptFromConfig(nic, dev, defClasses)
+		}
+		return renderTcEgressScript(nic)
+	}
+	return renderTcEgressScriptFromConfig(nic, dev, classes)
+}
+
+// writeEgressScript writes rendered to the script path, skipping the write when
+// the on-disk content is already identical.
+func (m *Manager) writeEgressScript(rendered string) error {
+	if existing, readErr := os.ReadFile(m.scriptPath); readErr == nil {
+		if sha256.Sum256([]byte(rendered)) == sha256.Sum256(existing) {
+			return nil
+		}
+	}
+	return atomicWriteFile(m.scriptPath, rendered, 0o755)
+}
+
+// renderAndApplyScript renders the boot script, persists it, and restarts the
+// tc-egress oneshot so the kernel replays the full hierarchy. Used by mutations
+// that change the qdisc structure (create/delete of a device or class), where a
+// full re-apply is the correct way to reach the new state.
+func (m *Manager) renderAndApplyScript(ctx context.Context, nic string) error {
+	rendered, err := m.renderEgressScript(nic)
 	if err != nil {
 		return err
 	}
-	var rendered string
-	if dev != nil {
-		classes, err := loadClassesForDir(DirEgress)
-		if err != nil {
-			return err
-		}
-		if len(classes) == 0 {
-			// Device configured but no classes yet: render the default SPEED-based
-			// script so the boot oneshot always runs a self-consistent hierarchy.
-			rendered, err = renderTcEgressScript(nic)
-		} else {
-			rendered, err = renderTcEgressScriptFromConfig(nic, dev, classes)
-		}
-		if err != nil {
-			return err
-		}
-	} else {
-		rendered, err = renderTcEgressScript(nic)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Skip the write when on-disk content is already identical.
-	if existing, readErr := os.ReadFile(m.scriptPath); readErr == nil {
-		if sha256.Sum256([]byte(rendered)) == sha256.Sum256(existing) {
-			return m.applyEgress(ctx)
-		}
-	}
-	if err := atomicWriteFile(m.scriptPath, rendered, 0o755); err != nil {
+	if err := m.writeEgressScript(rendered); err != nil {
 		return err
 	}
 	return m.applyEgress(ctx)
+}
+
+// persistEgressScript renders and writes the boot script for reboot persistence
+// WITHOUT restarting the service. Used by `set`, whose live `tc class change`
+// has already updated the running kernel: restarting the oneshot would run the
+// boot script, which deletes and re-adds the root qdisc — reintroducing exactly
+// the qdisc teardown a live update is meant to avoid.
+func (m *Manager) persistEgressScript(nic string) error {
+	rendered, err := m.renderEgressScript(nic)
+	if err != nil {
+		return err
+	}
+	return m.writeEgressScript(rendered)
 }
 
 // defaultEgressConfig returns the device root and three default egress classes
@@ -522,9 +604,12 @@ func defaultEgressConfig(trunkRate string) (*DeviceConfig, []*ClassConfig, error
 // ProvisionDefaultEgress configures the egress device root and three default
 // HTB classes at proportions derived from trunkRate (partner 40%/70%, public
 // 30%/70%, reserve-egress 30%/100%), then renders and applies the boot script.
-// Existing configs are always replaced. Called by block node install so the
-// shape registry is the single source of truth from first install.
+// trunkRate may be "auto", which is resolved to the detected link speed at
+// create time (see resolveAutoRateString). Existing configs are always
+// replaced. Called by block node install so the shape registry is the single
+// source of truth from first install.
 func (m *Manager) ProvisionDefaultEgress(ctx context.Context, nicName, trunkRate string) error {
+	trunkRate = m.resolveAutoRateString(trunkRate)
 	dev, classes, err := defaultEgressConfig(trunkRate)
 	if err != nil {
 		return err

--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -1,0 +1,515 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+)
+
+// Manager implements the `network shape` verb: create, set, show, and delete
+// operations for tc HTB device roots and per-class bandwidth configurations.
+//
+// Egress mutations (Dir "egress") re-render TcEgressScriptPath and restart the
+// tc-egress.service oneshot so the kernel picks up changes immediately. Ingress
+// mutations (Dir "ingress") only write config; the daemon pod-lifecycle watcher
+// The daemon pod-lifecycle watcher reads them and applies them to each new veth interface.
+type Manager struct {
+	scriptPath  string
+	lockPath    string
+	nicDetect   func() (string, error)
+	applyEgress func(ctx context.Context) error
+	tcRunner    TCRunner
+}
+
+// Config customises a Manager. The zero value is not useful; prefer NewManager.
+type Config struct {
+	ScriptPath  string
+	LockPath    string
+	NICDetect   func() (string, error)
+	ApplyEgress func(ctx context.Context) error
+	TCRunner    TCRunner
+}
+
+// NewManager returns a Manager wired to the live kernel and production paths.
+func NewManager() *Manager {
+	return NewManagerWithConfig(Config{})
+}
+
+// NewManagerWithConfig returns a Manager, filling unset Config fields with
+// their production defaults.
+func NewManagerWithConfig(cfg Config) *Manager {
+	m := &Manager{
+		scriptPath:  cfg.ScriptPath,
+		lockPath:    cfg.LockPath,
+		nicDetect:   cfg.NICDetect,
+		applyEgress: cfg.ApplyEgress,
+		tcRunner:    cfg.TCRunner,
+	}
+	if m.scriptPath == "" {
+		m.scriptPath = TcEgressScriptPath
+	}
+	if m.lockPath == "" {
+		m.lockPath = ShapeLockPath
+	}
+	if m.nicDetect == nil {
+		m.nicDetect = DetectEgressInterface
+	}
+	if m.applyEgress == nil {
+		m.applyEgress = ApplyTcEgressScript
+	}
+	if m.tcRunner == nil {
+		m.tcRunner = newExecTCRunner()
+	}
+	return m
+}
+
+// CreateDevice creates (or replaces with --force) the root device configuration.
+// For "egress": re-renders TcEgressScriptPath and restarts tc-egress.service.
+// For "ingress": writes config only (daemon pod-lifecycle watcher handles VETH apply).
+//
+// Returns true if the config was created or replaced, false if it already
+// existed and force was not set.
+func (m *Manager) CreateDevice(ctx context.Context, dev *DeviceConfig, force bool) (bool, error) {
+	if err := validateDir(dev.Dir); err != nil {
+		return false, err
+	}
+	if err := validateRate(dev.Rate); err != nil {
+		return false, err
+	}
+	if err := validateDefaultClass(dev.DefaultClass, dev.Dir); err != nil {
+		return false, err
+	}
+
+	var changed bool
+	err := m.withLock(func() error {
+		existing, err := readDevice(dev.Dir)
+		if err != nil {
+			return err
+		}
+		if existing != nil && !force {
+			logx.As().Warn().Str("dir", dev.Dir).Msg(
+				"network shape device already configured — flags not applied; pass --force to replace")
+			return nil
+		}
+		if existing != nil {
+			dev.CreatedAt = existing.CreatedAt
+		} else if dev.CreatedAt.IsZero() {
+			dev.CreatedAt = time.Now().UTC()
+		}
+		if err := writeDevice(dev); err != nil {
+			return err
+		}
+		if dev.Dir == DirEgress {
+			if err := m.renderAndApplyEgress(ctx); err != nil {
+				return err
+			}
+		}
+		changed = true
+		return nil
+	})
+	return changed, err
+}
+
+// CreateClass creates (or replaces with --force) a per-class bandwidth configuration.
+// The device for the class direction must exist before adding classes.
+// For egress classes: re-renders TcEgressScriptPath and restarts tc-egress.service.
+// For ingress classes: writes config only (daemon pod-lifecycle watcher handles VETH apply).
+//
+// Returns true if the config was created or replaced, false if it already
+// existed and force was not set.
+func (m *Manager) CreateClass(ctx context.Context, cls *ClassConfig, force bool) (bool, error) {
+	ci, err := lookupClassInfo(cls.Name)
+	if err != nil {
+		return false, err
+	}
+	if err := validateRate(cls.Rate); err != nil {
+		return false, err
+	}
+	if cls.Ceil != "" {
+		if err := validateCeilGeRate(cls.Ceil, cls.Rate); err != nil {
+			return false, err
+		}
+	}
+	if err := validatePrio(cls.Prio); err != nil {
+		return false, err
+	}
+
+	var changed bool
+	err = m.withLock(func() error {
+		dev, err := readDevice(ci.Dir)
+		if err != nil {
+			return err
+		}
+		if dev == nil {
+			return errorx.IllegalState.New(
+				"device %q is not configured; run `network shape create --device %s` first",
+				ci.Dir, ci.Dir)
+		}
+
+		siblings, err := loadClassesForDir(ci.Dir)
+		if err != nil {
+			return err
+		}
+		if err := validateSumRates(siblings, cls, dev.Rate); err != nil {
+			return err
+		}
+
+		existing, err := readClass(cls.Name)
+		if err != nil {
+			return err
+		}
+		if existing != nil && !force {
+			logx.As().Warn().Str("class", cls.Name).Msg(
+				"network shape class already configured — flags not applied; pass --force to replace")
+			return nil
+		}
+		if existing != nil {
+			cls.CreatedAt = existing.CreatedAt
+		} else if cls.CreatedAt.IsZero() {
+			cls.CreatedAt = time.Now().UTC()
+		}
+		if err := writeClass(cls); err != nil {
+			return err
+		}
+		if ci.Dir == DirEgress {
+			if err := m.renderAndApplyEgress(ctx); err != nil {
+				return err
+			}
+		}
+		changed = true
+		return nil
+	})
+	return changed, err
+}
+
+// SetClass atomically updates one or more bandwidth parameters of an existing
+// class. Only non-nil pointer fields are changed; nil means "keep current value".
+// For egress classes: runs `tc class change` on the live kernel and re-renders
+// the boot script for reboot persistence. For ingress classes: updates config only.
+func (m *Manager) SetClass(ctx context.Context, name string, rate, ceil *string, prio *int) error {
+	ci, err := lookupClassInfo(name)
+	if err != nil {
+		return err
+	}
+	return m.withLock(func() error {
+		cls, err := readClass(name)
+		if err != nil {
+			return err
+		}
+		if cls == nil {
+			return errorx.IllegalState.New(
+				"class %q is not configured; run `network shape create --class %s` first", name, name)
+		}
+		if rate != nil {
+			cls.Rate = *rate
+		}
+		if ceil != nil {
+			cls.Ceil = *ceil
+		}
+		if prio != nil {
+			cls.Prio = *prio
+		}
+
+		// Validate the updated state.
+		if err := validateRate(cls.Rate); err != nil {
+			return err
+		}
+		if cls.Ceil != "" {
+			if err := validateCeilGeRate(cls.Ceil, cls.Rate); err != nil {
+				return err
+			}
+		}
+		if err := validatePrio(cls.Prio); err != nil {
+			return err
+		}
+
+		dev, err := readDevice(ci.Dir)
+		if err != nil {
+			return err
+		}
+		if dev != nil {
+			siblings, err := loadClassesForDir(ci.Dir)
+			if err != nil {
+				return err
+			}
+			if err := validateSumRates(siblings, cls, dev.Rate); err != nil {
+				return err
+			}
+		}
+
+		if err := writeClass(cls); err != nil {
+			return err
+		}
+
+		if ci.Dir == DirEgress {
+			nic, err := m.nicDetect()
+			if err != nil {
+				return errorx.Decorate(err, "cannot apply live tc class change: egress NIC detection failed")
+			}
+			if err := m.tcRunner.ClassChange(ctx, nic, ci.Minor, cls.Rate, cls.effectiveCeil(), cls.Prio); err != nil {
+				return errorx.Decorate(err,
+					"class config updated on disk but live tc class change failed; reboot or restart tc-egress.service to sync")
+			}
+			if err := m.renderAndApplyScript(ctx, nic); err != nil {
+				return errorx.Decorate(err,
+					"live tc class change applied but boot script re-render failed; reboot may revert the change")
+			}
+		}
+		return nil
+	})
+}
+
+// ShowClass returns a human-readable summary of the named class config.
+func (m *Manager) ShowClass(name string) (string, error) {
+	cls, err := readClass(name)
+	if err != nil {
+		return "", err
+	}
+	if cls == nil {
+		return "", errorx.IllegalState.New("class %q is not configured", name)
+	}
+	ci, _ := lookupClassInfo(name)
+	var b strings.Builder
+	fmt.Fprintf(&b, "class %s (1:%s, %s device)\n", cls.Name, ci.Minor, ci.Dir)
+	fmt.Fprintf(&b, "  rate:      %s\n", cls.Rate)
+	fmt.Fprintf(&b, "  ceil:      %s\n", cls.effectiveCeil())
+	fmt.Fprintf(&b, "  prio:      %d\n", cls.Prio)
+	fmt.Fprintf(&b, "  created:   %s\n", cls.CreatedAt.Format(time.RFC3339))
+	return b.String(), nil
+}
+
+// ShowDevice returns a human-readable summary of the named device config.
+func (m *Manager) ShowDevice(dir string) (string, error) {
+	if err := validateDir(dir); err != nil {
+		return "", err
+	}
+	dev, err := readDevice(dir)
+	if err != nil {
+		return "", err
+	}
+	if dev == nil {
+		return "", errorx.IllegalState.New("device %q is not configured", dir)
+	}
+	classes, err := loadClassesForDir(dir)
+	if err != nil {
+		return "", err
+	}
+	sort.Slice(classes, func(i, j int) bool {
+		return classes[i].Name < classes[j].Name
+	})
+	var b strings.Builder
+	fmt.Fprintf(&b, "device %s\n", dev.Dir)
+	fmt.Fprintf(&b, "  rate:    %s\n", dev.Rate)
+	fmt.Fprintf(&b, "  default: %s\n", dev.DefaultClass)
+	fmt.Fprintf(&b, "  created: %s\n", dev.CreatedAt.Format(time.RFC3339))
+	if len(classes) > 0 {
+		fmt.Fprintf(&b, "  classes:\n")
+		for _, cls := range classes {
+			ci, _ := lookupClassInfo(cls.Name)
+			fmt.Fprintf(&b, "    %-20s rate=%-10s ceil=%-10s prio=%d (1:%s)\n",
+				cls.Name, cls.Rate, cls.effectiveCeil(), cls.Prio, ci.Minor)
+		}
+	}
+	return b.String(), nil
+}
+
+// ShowAll returns a human-readable summary of all configured devices and classes.
+func (m *Manager) ShowAll() (string, error) {
+	var b strings.Builder
+	for _, dir := range []string{DirEgress, DirIngress} {
+		dev, err := readDevice(dir)
+		if err != nil {
+			return "", err
+		}
+		if dev == nil {
+			continue // not configured
+		}
+		out, err := m.ShowDevice(dir)
+		if err != nil {
+			return "", err
+		}
+		b.WriteString(out)
+		b.WriteString("\n")
+	}
+	if b.Len() == 0 {
+		return "no shape configuration found\n", nil
+	}
+	return b.String(), nil
+}
+
+// DeleteClass removes a class configuration. Fails if the class is referenced
+// as the device's default class or by any policy's --stamp/--reply-stamp.
+// For egress classes: re-renders TcEgressScriptPath and restarts tc-egress.service.
+func (m *Manager) DeleteClass(ctx context.Context, name string) error {
+	ci, err := lookupClassInfo(name)
+	if err != nil {
+		return err
+	}
+	return m.withLock(func() error {
+		cls, err := readClass(name)
+		if err != nil {
+			return err
+		}
+		if cls == nil {
+			return errorx.IllegalState.New("class %q is not configured", name)
+		}
+
+		// Block deletion if this class is the device default.
+		dev, err := readDevice(ci.Dir)
+		if err != nil {
+			return err
+		}
+		if dev != nil && dev.DefaultClass == name {
+			return errorx.IllegalState.New(
+				"class %q is the default class for device %q and cannot be deleted; "+
+					"reconfigure the device with a different --default first", name, ci.Dir)
+		}
+
+		// Block deletion if any policy stamps this class.
+		stamps, err := loadPolicyStamps()
+		if err != nil {
+			return err
+		}
+		if refs := stamps[name]; len(refs) > 0 {
+			return errorx.IllegalState.New(
+				"class %q is referenced by network policy %s and cannot be deleted; "+
+					"delete or update those policies first", name, strings.Join(refs, ", "))
+		}
+
+		if err := removeClass(name); err != nil {
+			return err
+		}
+		if ci.Dir == DirEgress {
+			if err := m.renderAndApplyEgress(ctx); err != nil {
+				return errorx.Decorate(err,
+					"class config deleted but boot script re-render failed; restart tc-egress.service to sync")
+			}
+		}
+		return nil
+	})
+}
+
+// DeleteDevice removes a device configuration. Fails if any classes are still
+// configured for this device (delete classes first).
+func (m *Manager) DeleteDevice(ctx context.Context, dir string) error {
+	if err := validateDir(dir); err != nil {
+		return err
+	}
+	return m.withLock(func() error {
+		dev, err := readDevice(dir)
+		if err != nil {
+			return err
+		}
+		if dev == nil {
+			return errorx.IllegalState.New("device %q is not configured", dir)
+		}
+		classes, err := loadClassesForDir(dir)
+		if err != nil {
+			return err
+		}
+		if len(classes) > 0 {
+			names := make([]string, 0, len(classes))
+			for _, c := range classes {
+				names = append(names, c.Name)
+			}
+			return errorx.IllegalState.New(
+				"device %q still has configured classes (%s); delete them first",
+				dir, strings.Join(names, ", "))
+		}
+		if err := removeDevice(dir); err != nil {
+			return err
+		}
+		if dir == DirEgress {
+			// Re-render with default (empty) egress config.
+			if err := m.renderAndApplyEgress(ctx); err != nil {
+				return errorx.Decorate(err,
+					"device config deleted but boot script re-render failed; restart tc-egress.service to sync")
+			}
+		}
+		return nil
+	})
+}
+
+// renderAndApplyEgress detects the egress NIC, re-renders the boot script from
+// stored config (or the default if no device config exists), and applies via
+// service restart.
+func (m *Manager) renderAndApplyEgress(ctx context.Context) error {
+	nic, err := m.nicDetect()
+	if err != nil {
+		return errorx.Decorate(err, "cannot re-render tc-egress script: egress NIC detection failed")
+	}
+	return m.renderAndApplyScript(ctx, nic)
+}
+
+// renderAndApplyScript renders the tc-egress script with the given NIC name
+// (using stored config if available, else the default) and restarts the service.
+func (m *Manager) renderAndApplyScript(ctx context.Context, nic string) error {
+	dev, err := readDevice(DirEgress)
+	if err != nil {
+		return err
+	}
+	var rendered string
+	if dev != nil {
+		classes, err := loadClassesForDir(DirEgress)
+		if err != nil {
+			return err
+		}
+		if len(classes) == 0 {
+			// Device configured but no classes yet: render the default SPEED-based
+			// script so the boot oneshot always runs a self-consistent hierarchy.
+			rendered, err = renderTcEgressScript(nic, 0)
+		} else {
+			rendered, err = renderTcEgressScriptFromConfig(nic, dev, classes)
+		}
+		if err != nil {
+			return err
+		}
+	} else {
+		rendered, err = renderTcEgressScript(nic, 0)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Skip the write when on-disk content is already identical.
+	if existing, readErr := os.ReadFile(m.scriptPath); readErr == nil {
+		if sha256.Sum256([]byte(rendered)) == sha256.Sum256(existing) {
+			return m.applyEgress(ctx)
+		}
+	}
+	if err := atomicWriteFile(m.scriptPath, rendered, 0o755); err != nil {
+		return err
+	}
+	return m.applyEgress(ctx)
+}
+
+// withLock serialises a mutation behind a cross-command flock so concurrent
+// operator commands cannot interleave tc transactions.
+func (m *Manager) withLock(fn func() error) error {
+	if err := os.MkdirAll(filepath.Dir(m.lockPath), 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create lock directory %s", filepath.Dir(m.lockPath))
+	}
+	f, err := os.OpenFile(m.lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to open lock file %s", m.lockPath)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to acquire lock %s", m.lockPath)
+	}
+	defer func() { _ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }()
+
+	return fn()
+}

--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -468,7 +468,7 @@ func (m *Manager) renderAndApplyScript(ctx context.Context, nic string) error {
 		if len(classes) == 0 {
 			// Device configured but no classes yet: render the default SPEED-based
 			// script so the boot oneshot always runs a self-consistent hierarchy.
-			rendered, err = renderTcEgressScript(nic, 0)
+			rendered, err = renderTcEgressScript(nic)
 		} else {
 			rendered, err = renderTcEgressScriptFromConfig(nic, dev, classes)
 		}
@@ -476,7 +476,7 @@ func (m *Manager) renderAndApplyScript(ctx context.Context, nic string) error {
 			return err
 		}
 	} else {
-		rendered, err = renderTcEgressScript(nic, 0)
+		rendered, err = renderTcEgressScript(nic)
 		if err != nil {
 			return err
 		}
@@ -492,6 +492,76 @@ func (m *Manager) renderAndApplyScript(ctx context.Context, nic string) error {
 		return err
 	}
 	return m.applyEgress(ctx)
+}
+
+// defaultEgressConfig returns the device root and three default egress classes
+// at proportions derived from trunkRate (partner 40%/70%, public 30%/70%,
+// reserve-egress 30%/100%). Exposed as a package-internal helper so tests can
+// verify the computation without disk I/O.
+func defaultEgressConfig(trunkRate string) (*DeviceConfig, []*ClassConfig, error) {
+	bps, err := parseBandwidthBps(trunkRate)
+	if err != nil {
+		return nil, nil, errorx.IllegalArgument.Wrap(err, "invalid trunk rate %q", trunkRate)
+	}
+	mbps := bps / 1_000_000
+	now := time.Now().UTC()
+	dev := &DeviceConfig{
+		Dir:          DirEgress,
+		Rate:         trunkRate,
+		DefaultClass: "reserve-egress",
+		CreatedAt:    now,
+	}
+	classes := []*ClassConfig{
+		{Name: "partner", Rate: fmt.Sprintf("%dmbit", mbps*40/100), Ceil: fmt.Sprintf("%dmbit", mbps*70/100), Prio: 0, CreatedAt: now},
+		{Name: "public", Rate: fmt.Sprintf("%dmbit", mbps*30/100), Ceil: fmt.Sprintf("%dmbit", mbps*70/100), Prio: 5, CreatedAt: now},
+		{Name: "reserve-egress", Rate: fmt.Sprintf("%dmbit", mbps*30/100), Ceil: trunkRate, Prio: 1, CreatedAt: now},
+	}
+	return dev, classes, nil
+}
+
+// ProvisionDefaultEgress configures the egress device root and three default
+// HTB classes at proportions derived from trunkRate (partner 40%/70%, public
+// 30%/70%, reserve-egress 30%/100%), then renders and applies the boot script.
+// Existing configs are always replaced. Called by block node install so the
+// shape registry is the single source of truth from first install.
+func (m *Manager) ProvisionDefaultEgress(ctx context.Context, nicName, trunkRate string) error {
+	dev, classes, err := defaultEgressConfig(trunkRate)
+	if err != nil {
+		return err
+	}
+	return m.withLock(func() error {
+		if err := writeDevice(dev); err != nil {
+			return err
+		}
+		for _, cls := range classes {
+			if err := writeClass(cls); err != nil {
+				return err
+			}
+		}
+		return m.renderAndApplyScript(ctx, nicName)
+	})
+}
+
+// RenderAndApplyEgress renders the tc-egress boot script for nic from stored
+// shape config (if available) or the sysfs auto-detect default, then installs
+// and restarts tc-egress.service. Idempotent.
+func (m *Manager) RenderAndApplyEgress(ctx context.Context, nic string) error {
+	return m.renderAndApplyScript(ctx, nic)
+}
+
+// ProvisionDefaultEgressShape configures the egress shape registry with the
+// three default HTB classes at proportions derived from trunkRate, then renders
+// and applies the boot script. Convenience wrapper over NewManager().ProvisionDefaultEgress.
+func ProvisionDefaultEgressShape(ctx context.Context, nicName, trunkRate string) error {
+	return NewManager().ProvisionDefaultEgress(ctx, nicName, trunkRate)
+}
+
+// RenderAndApplyDefaultEgress renders the tc-egress script for nic from the
+// shape registry (or sysfs fallback when no config exists) and applies it.
+// Used when no trunk rate is supplied (e.g. block node reconfigure without
+// --link-rate).
+func RenderAndApplyDefaultEgress(ctx context.Context, nic string) error {
+	return NewManager().RenderAndApplyEgress(ctx, nic)
 }
 
 // withLock serialises a mutation behind a cross-command flock so concurrent

--- a/internal/network/shape/paths.go
+++ b/internal/network/shape/paths.go
@@ -1,29 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
-// Package shape implements tc HTB hierarchy persistence for the `$EGRESS`
-// physical NIC. It renders the boot-replay script and manages the
-// solo-provisioner-tc-egress.service oneshot unit (design §8.3.2).
+// Package shape implements tc HTB hierarchy persistence and the `network shape`
+// CLI verb. It renders the boot-replay script (solo-provisioner-tc-egress.sh)
+// with bandwidth-parameterised class configurations, manages the
+// solo-provisioner-tc-egress.service oneshot unit, and applies live tc class
+// changes to the $EGRESS physical NIC.
 //
-// Scope boundary (TS_2 #742): this package only covers reboot persistence —
-// rendering the tc-egress.sh script with the NIC name interpolated at install
-// time and installing/enabling the oneshot unit. The full `network shape`
-// CLI verb (Story 1.4) will extend this package with bandwidth-parameterised
-// rendering and the per-class rate/ceil/prio API.
-//
-// The $VETH HTB is deliberately NOT persisted here: the veth interface does
-// not survive reboot (Cilium recreates it on pod start), so persisting its
-// qdisc would be meaningless. The daemon's pod-lifecycle watcher reinstalls
-// the $VETH HTB on the next pod create event (TS_3).
+// The $VETH HTB is deliberately NOT persisted here: the veth interface does not
+// survive reboot (Cilium recreates it on pod start), so persisting its qdisc
+// would be meaningless. The daemon pod-lifecycle watcher reinstalls the $VETH
+// HTB on the next pod create event by reading the class configs stored under
+// ClassConfigDir.
 package shape
 
 const (
 	// TcEgressScriptPath is the shell script that replays the $EGRESS HTB
-	// hierarchy at boot. It lives under /usr/local/sbin (system admin tools,
-	// root-executable) — not /etc, since it is an executable rather than config.
+	// hierarchy at boot. Lives under /usr/local/sbin (root-executable tools).
 	TcEgressScriptPath = "/usr/local/sbin/solo-provisioner-tc-egress.sh"
 
-	// TcEgressService is the systemd oneshot unit name that executes
-	// TcEgressScriptPath at boot, before solo-provisioner-daemon.service starts.
+	// TcEgressService is the systemd oneshot unit that executes TcEgressScriptPath
+	// at boot, before solo-provisioner-daemon.service starts.
 	TcEgressService = "solo-provisioner-tc-egress.service"
 
 	// TcEgressServiceUnitPath is the absolute path where the unit file is
@@ -31,11 +27,34 @@ const (
 	TcEgressServiceUnitPath = "/usr/lib/systemd/system/" + TcEgressService
 
 	// tcEgressScriptTemplate is the embedded Go template for the tc-egress.sh
-	// boot script. The single interpolation point is {{.NIC}}, the egress
-	// interface name detected at install time.
+	// boot script. Interpolation points: {{.NIC}}, {{.Device.*}}, {{range .Classes}}.
 	tcEgressScriptTemplate = "files/network/solo-provisioner-tc-egress.sh.tmpl"
 
-	// tcEgressServiceTemplate is the static embedded unit file installed at
-	// TcEgressServiceUnitPath on first use.
+	// tcEgressServiceTemplate is the static embedded unit file.
 	tcEgressServiceTemplate = "files/network/solo-provisioner-tc-egress.service"
+
+	// ShapeConfigDir is the root of the shape configuration tree persisted by
+	// the `network shape` CLI verb.
+	ShapeConfigDir = "/etc/solo-provisioner/network/shape"
+
+	// DeviceConfigDir holds one JSON file per configured tc device ("ingress"
+	// or "egress"), describing the root qdisc rate and default class.
+	DeviceConfigDir = ShapeConfigDir + "/devices"
+
+	// ClassConfigDir holds one JSON file per configured tc class, describing its
+	// bandwidth parameters (rate, ceil, prio). The daemon pod-lifecycle watcher
+	// reads this directory to reinstall $VETH classes on each pod create event.
+	ClassConfigDir = ShapeConfigDir + "/classes"
+
+	// ShapeLockDir is the directory containing the tc apply lock (on tmpfs so
+	// it is auto-cleared on reboot).
+	ShapeLockDir = "/run/solo-provisioner/network"
+
+	// ShapeLockPath is the flock acquired (LOCK_EX) for the duration of any
+	// tc mutating verb, preventing concurrent modifications.
+	ShapeLockPath = ShapeLockDir + "/.tc-applying"
+
+	// policyRegistryDir mirrors internal/network/policy.RegistryDir. Duplicated
+	// here to avoid a cross-package import; the values must stay in sync.
+	policyRegistryDir = "/etc/solo-provisioner/policies"
 )

--- a/internal/network/shape/registry.go
+++ b/internal/network/shape/registry.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// devicePath returns the on-disk path of a device's config file.
+func devicePath(dir string) string {
+	return filepath.Join(DeviceConfigDir, dir+".json")
+}
+
+// classPath returns the on-disk path of a class's config file.
+func classPath(name string) string {
+	return filepath.Join(ClassConfigDir, name+".json")
+}
+
+// writeDevice atomically writes the device config JSON.
+func writeDevice(dev *DeviceConfig) error {
+	if err := os.MkdirAll(DeviceConfigDir, 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create device config dir %s", DeviceConfigDir)
+	}
+	data, err := json.MarshalIndent(dev, "", "  ")
+	if err != nil {
+		return errorx.InternalError.Wrap(err, "failed to marshal device config %q", dev.Dir)
+	}
+	return atomicWriteFile(devicePath(dev.Dir), string(data)+"\n", 0o644)
+}
+
+// writeClass atomically writes the class config JSON.
+func writeClass(cls *ClassConfig) error {
+	if err := os.MkdirAll(ClassConfigDir, 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create class config dir %s", ClassConfigDir)
+	}
+	data, err := json.MarshalIndent(cls, "", "  ")
+	if err != nil {
+		return errorx.InternalError.Wrap(err, "failed to marshal class config %q", cls.Name)
+	}
+	return atomicWriteFile(classPath(cls.Name), string(data)+"\n", 0o644)
+}
+
+// readDevice loads a device config by dir, returning nil if not found.
+func readDevice(dir string) (*DeviceConfig, error) {
+	data, err := os.ReadFile(devicePath(dir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read device config %s", devicePath(dir))
+	}
+	var dev DeviceConfig
+	if err := json.Unmarshal(data, &dev); err != nil {
+		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse device config %s", devicePath(dir))
+	}
+	return &dev, nil
+}
+
+// readClass loads a class config by name, returning nil if not found.
+func readClass(name string) (*ClassConfig, error) {
+	data, err := os.ReadFile(classPath(name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read class config %s", classPath(name))
+	}
+	var cls ClassConfig
+	if err := json.Unmarshal(data, &cls); err != nil {
+		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse class config %s", classPath(name))
+	}
+	return &cls, nil
+}
+
+// loadClassesForDir loads all class configs for the given direction, sorted by
+// name. Classes whose name is not in classInfoMap (e.g. hand-edited files) are
+// silently skipped.
+func loadClassesForDir(dir string) ([]*ClassConfig, error) {
+	entries, err := os.ReadDir(ClassConfigDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read class config dir %s", ClassConfigDir)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".json")
+		info, ok := classInfoMap[name]
+		if !ok || info.Dir != dir {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	classes := make([]*ClassConfig, 0, len(names))
+	for _, n := range names {
+		cls, err := readClass(n)
+		if err != nil {
+			return nil, err
+		}
+		if cls != nil {
+			classes = append(classes, cls)
+		}
+	}
+	return classes, nil
+}
+
+// loadAllClasses loads all class configs (any direction), sorted by name.
+func loadAllClasses() ([]*ClassConfig, error) {
+	entries, err := os.ReadDir(ClassConfigDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read class config dir %s", ClassConfigDir)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(e.Name(), ".json"))
+	}
+	sort.Strings(names)
+	classes := make([]*ClassConfig, 0, len(names))
+	for _, n := range names {
+		cls, err := readClass(n)
+		if err != nil {
+			return nil, err
+		}
+		if cls != nil {
+			classes = append(classes, cls)
+		}
+	}
+	return classes, nil
+}
+
+// removeClass deletes a class config file, ignoring not-found.
+func removeClass(name string) error {
+	err := os.Remove(classPath(name))
+	if err != nil && !os.IsNotExist(err) {
+		return errorx.ExternalError.Wrap(err, "failed to remove class config %s", classPath(name))
+	}
+	return nil
+}
+
+// removeDevice deletes a device config file, ignoring not-found.
+func removeDevice(dir string) error {
+	err := os.Remove(devicePath(dir))
+	if err != nil && !os.IsNotExist(err) {
+		return errorx.ExternalError.Wrap(err, "failed to remove device config %s", devicePath(dir))
+	}
+	return nil
+}
+
+// policyStampRef is a minimal representation of a policy registry entry used
+// only to check stamp references when deleting a shape class. Avoids importing
+// internal/network/policy.
+type policyStampRef struct {
+	Stamp      string `json:"stamp"`
+	ReplyStamp string `json:"reply_stamp"`
+}
+
+// loadPolicyStamps reads the stamp and reply_stamp fields from every policy
+// JSON in the policy registry, for cross-package delete validation. Returns a
+// map from class name → slice of policy names that reference it.
+func loadPolicyStamps() (map[string][]string, error) {
+	entries, err := os.ReadDir(policyRegistryDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errorx.ExternalError.Wrap(err, "failed to read policy registry %s", policyRegistryDir)
+	}
+	refs := make(map[string][]string)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		policyName := strings.TrimSuffix(e.Name(), ".json")
+		data, err := os.ReadFile(filepath.Join(policyRegistryDir, e.Name()))
+		if err != nil {
+			return nil, errorx.ExternalError.Wrap(err, "failed to read policy file %s", e.Name())
+		}
+		var ref policyStampRef
+		if err := json.Unmarshal(data, &ref); err != nil {
+			return nil, errorx.IllegalFormat.Wrap(err, "failed to parse policy file %s", e.Name())
+		}
+		if ref.Stamp != "" {
+			refs[ref.Stamp] = append(refs[ref.Stamp], policyName)
+		}
+		if ref.ReplyStamp != "" {
+			refs[ref.ReplyStamp] = append(refs[ref.ReplyStamp], policyName)
+		}
+	}
+	return refs, nil
+}

--- a/internal/network/shape/registry.go
+++ b/internal/network/shape/registry.go
@@ -115,36 +115,6 @@ func loadClassesForDir(dir string) ([]*ClassConfig, error) {
 	return classes, nil
 }
 
-// loadAllClasses loads all class configs (any direction), sorted by name.
-func loadAllClasses() ([]*ClassConfig, error) {
-	entries, err := os.ReadDir(ClassConfigDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, errorx.ExternalError.Wrap(err, "failed to read class config dir %s", ClassConfigDir)
-	}
-	var names []string
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
-			continue
-		}
-		names = append(names, strings.TrimSuffix(e.Name(), ".json"))
-	}
-	sort.Strings(names)
-	classes := make([]*ClassConfig, 0, len(names))
-	for _, n := range names {
-		cls, err := readClass(n)
-		if err != nil {
-			return nil, err
-		}
-		if cls != nil {
-			classes = append(classes, cls)
-		}
-	}
-	return classes, nil
-}
-
 // removeClass deletes a class config file, ignoring not-found.
 func removeClass(name string) error {
 	err := os.Remove(classPath(name))

--- a/internal/network/shape/render.go
+++ b/internal/network/shape/render.go
@@ -41,14 +41,10 @@ type classRenderData struct {
 }
 
 // renderTcEgressScript renders the tc-egress.sh template with default
-// SPEED-based rate expressions (preserving the pre-shape-config install-time
-// rendering for backward compatibility with `block node install`).
-// speedMbit > 0 bakes the link rate into the script, bypassing sysfs detection
-// at boot; pass 0 to keep the auto-detect behaviour.
-func renderTcEgressScript(nicName string, speedMbit int) (string, error) {
-	data := defaultScriptData(nicName)
-	data.SpeedMbit = speedMbit
-	return renderTcEgressScriptFromData(data)
+// SPEED-based rate expressions, preserving backward compatibility when no
+// shape config exists. SpeedMbit is left at 0 (sysfs auto-detect at boot).
+func renderTcEgressScript(nicName string) (string, error) {
+	return renderTcEgressScriptFromData(defaultScriptData(nicName))
 }
 
 // renderTcEgressScriptFromConfig renders the tc-egress.sh template from the
@@ -113,18 +109,15 @@ func renderTcEgressScriptFromData(data scriptData) (string, error) {
 }
 
 // RenderTcEgressScript renders the tc-egress.sh boot script with the given NIC
-// name and writes it atomically to TcEgressScriptPath (mode 0755). If the
-// on-disk content is already identical (SHA-256 match) the write is skipped
-// and the function returns nil — making it safe to call from idempotent install flows.
-//
-// speedMbit sets the link rate in Mbit/s directly in the rendered script,
-// bypassing the runtime sysfs detection. Pass 0 to keep the auto-detect
-// behaviour (reads /sys/class/net/<nic>/speed at boot, falls back to 1000).
-func RenderTcEgressScript(nicName string, speedMbit int) error {
+// name using sysfs speed auto-detect and writes it atomically to
+// TcEgressScriptPath (mode 0755). If the on-disk content is already identical
+// (SHA-256 match) the write is skipped — making it safe to call from idempotent
+// install flows. Use Manager.ProvisionDefaultEgress when a trunk rate is known.
+func RenderTcEgressScript(nicName string) error {
 	if !nicNameRe.MatchString(nicName) {
 		return errorx.IllegalArgument.New("egress NIC name %q is invalid: must match %s", nicName, nicNameRe.String())
 	}
-	rendered, err := renderTcEgressScript(nicName, speedMbit)
+	rendered, err := renderTcEgressScript(nicName)
 	if err != nil {
 		return err
 	}

--- a/internal/network/shape/render.go
+++ b/internal/network/shape/render.go
@@ -7,21 +7,104 @@ import (
 	"crypto/sha256"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/hashgraph/solo-weaver/internal/templates"
 	"github.com/joomcode/errorx"
 )
 
+// nicNameRe matches valid Linux network interface names: letters, digits,
+// hyphens, underscores, and periods; 1–15 characters (kernel IFNAMSIZ limit).
+var nicNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,15}$`)
+
 // scriptData is the template context for the tc-egress.sh boot script.
 type scriptData struct {
 	NIC       string
 	SpeedMbit int // 0 means auto-detect from sysfs at boot
+	Device    deviceRenderData
+	Classes   []classRenderData
 }
 
-// renderTcEgressScript renders the template and returns the script string
-// without writing anything to disk. Used by RenderTcEgressScript and tests.
+// deviceRenderData is the device-level template context.
+type deviceRenderData struct {
+	DefaultMinor string // hex tc classid minor for the default class, e.g. "60"
+	Rate         string // root trunk class rate (may be a shell expr for legacy renders)
+}
+
+// classRenderData is the per-class template context.
+type classRenderData struct {
+	Minor  string // hex tc classid minor, e.g. "40"
+	Handle string // fq_codel qdisc handle, e.g. "140"
+	Rate   string // htb rate (may be a shell expr for legacy renders)
+	Ceil   string // htb ceil (may be a shell expr for legacy renders)
+	Prio   int
+}
+
+// renderTcEgressScript renders the tc-egress.sh template with default
+// SPEED-based rate expressions (preserving the pre-shape-config install-time
+// rendering for backward compatibility with `block node install`).
+// speedMbit > 0 bakes the link rate into the script, bypassing sysfs detection
+// at boot; pass 0 to keep the auto-detect behaviour.
 func renderTcEgressScript(nicName string, speedMbit int) (string, error) {
-	rendered, err := templates.Render(tcEgressScriptTemplate, scriptData{NIC: nicName, SpeedMbit: speedMbit})
+	data := defaultScriptData(nicName)
+	data.SpeedMbit = speedMbit
+	return renderTcEgressScriptFromData(data)
+}
+
+// renderTcEgressScriptFromConfig renders the tc-egress.sh template from the
+// provided device and class configurations. Classes are rendered in the order
+// supplied by the caller; loadClassesForDir returns them sorted by name.
+func renderTcEgressScriptFromConfig(nicName string, dev *DeviceConfig, classes []*ClassConfig) (string, error) {
+	info, err := lookupClassInfo(dev.DefaultClass)
+	if err != nil {
+		return "", err
+	}
+	crs := make([]classRenderData, 0, len(classes))
+	for _, cls := range classes {
+		ci, err := lookupClassInfo(cls.Name)
+		if err != nil {
+			return "", err
+		}
+		crs = append(crs, classRenderData{
+			Minor:  ci.Minor,
+			Handle: ci.Handle,
+			Rate:   cls.Rate,
+			Ceil:   cls.effectiveCeil(),
+			Prio:   cls.Prio,
+		})
+	}
+	return renderTcEgressScriptFromData(scriptData{
+		NIC: nicName,
+		Device: deviceRenderData{
+			DefaultMinor: info.Minor,
+			Rate:         dev.Rate,
+		},
+		Classes: crs,
+	})
+}
+
+// defaultScriptData returns the legacy SPEED-based scriptData for the egress
+// device: the three default egress classes (partner/public/reserve-egress) with
+// shell arithmetic rate expressions. This matches the pre-shape-config tc-egress.sh
+// template content so install-time rendering is backward-compatible.
+func defaultScriptData(nicName string) scriptData {
+	return scriptData{
+		NIC: nicName,
+		Device: deviceRenderData{
+			DefaultMinor: "60",
+			Rate:         "${SPEED}mbit",
+		},
+		Classes: []classRenderData{
+			{Minor: "40", Handle: "140", Rate: `$(( SPEED * 40 / 100 ))mbit`, Ceil: `$(( SPEED * 70 / 100 ))mbit`, Prio: 0},
+			{Minor: "50", Handle: "150", Rate: `$(( SPEED * 30 / 100 ))mbit`, Ceil: `$(( SPEED * 70 / 100 ))mbit`, Prio: 5},
+			{Minor: "60", Handle: "160", Rate: `$(( SPEED * 30 / 100 ))mbit`, Ceil: `${SPEED}mbit`, Prio: 1},
+		},
+	}
+}
+
+// renderTcEgressScriptFromData renders the template with the given scriptData.
+func renderTcEgressScriptFromData(data scriptData) (string, error) {
+	rendered, err := templates.Render(tcEgressScriptTemplate, data)
 	if err != nil {
 		return "", errorx.InternalError.Wrap(err, "failed to render %s", tcEgressScriptTemplate)
 	}
@@ -31,54 +114,46 @@ func renderTcEgressScript(nicName string, speedMbit int) (string, error) {
 // RenderTcEgressScript renders the tc-egress.sh boot script with the given NIC
 // name and writes it atomically to TcEgressScriptPath (mode 0755). If the
 // on-disk content is already identical (SHA-256 match) the write is skipped
-// and the function returns nil — making it safe to call from idempotent
-// install flows.
+// and the function returns nil — making it safe to call from idempotent install flows.
 //
 // speedMbit sets the link rate in Mbit/s directly in the rendered script,
 // bypassing the runtime sysfs detection. Pass 0 to keep the auto-detect
 // behaviour (reads /sys/class/net/<nic>/speed at boot, falls back to 1000).
 func RenderTcEgressScript(nicName string, speedMbit int) error {
-	if nicName == "" {
-		return errorx.IllegalArgument.New("egress NIC name must not be empty")
+	if !nicNameRe.MatchString(nicName) {
+		return errorx.IllegalArgument.New("egress NIC name %q is invalid: must match %s", nicName, nicNameRe.String())
 	}
-
 	rendered, err := renderTcEgressScript(nicName, speedMbit)
 	if err != nil {
 		return err
 	}
-
-	// Skip the write when the on-disk file already has the same content.
 	if existing, readErr := os.ReadFile(TcEgressScriptPath); readErr == nil {
 		if sha256.Sum256([]byte(rendered)) == sha256.Sum256(existing) {
 			return nil
 		}
 	}
-
 	return atomicWriteFile(TcEgressScriptPath, rendered, 0o755)
 }
 
 // atomicWriteFile writes content to path via a temp file in the same directory
 // followed by fsync + rename + parent-dir fsync, so a crash mid-write cannot
-// leave a torn script that the boot oneshot would fail to execute.
+// leave a torn file that the boot oneshot would fail to execute.
 func atomicWriteFile(path, content string, perm os.FileMode) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return errorx.ExternalError.Wrap(err, "failed to create directory %s", dir)
 	}
-
-	tmp, err := os.CreateTemp(dir, ".tc-egress-*.sh.tmp")
+	tmp, err := os.CreateTemp(dir, ".shape-*.tmp")
 	if err != nil {
 		return errorx.ExternalError.Wrap(err, "failed to create temp file in %s", dir)
 	}
 	tmpName := tmp.Name()
-
 	committed := false
 	defer func() {
 		if !committed {
 			_ = os.Remove(tmpName)
 		}
 	}()
-
 	if _, err := tmp.WriteString(content); err != nil {
 		_ = tmp.Close()
 		return errorx.ExternalError.Wrap(err, "failed to write temp file %s", tmpName)
@@ -98,7 +173,6 @@ func atomicWriteFile(path, content string, perm os.FileMode) error {
 		return errorx.ExternalError.Wrap(err, "failed to rename %s to %s", tmpName, path)
 	}
 	committed = true
-
 	d, err := os.Open(dir)
 	if err != nil {
 		return errorx.ExternalError.Wrap(err, "failed to open directory %s for fsync", dir)
@@ -107,7 +181,6 @@ func atomicWriteFile(path, content string, perm os.FileMode) error {
 	if err := d.Sync(); err != nil {
 		return errorx.ExternalError.Wrap(err, "failed to fsync directory %s", dir)
 	}
-
 	return nil
 }
 

--- a/internal/network/shape/render.go
+++ b/internal/network/shape/render.go
@@ -20,7 +20,7 @@ var nicNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,15}$`)
 // scriptData is the template context for the tc-egress.sh boot script.
 type scriptData struct {
 	NIC       string
-	SpeedMbit int // 0 means auto-detect from sysfs at boot
+	SpeedMbit int // >0 bakes SPEED=N; 0 sysfs auto-detect; <0 skip SPEED block (explicit per-class rates)
 	Device    deviceRenderData
 	Classes   []classRenderData
 }
@@ -74,7 +74,8 @@ func renderTcEgressScriptFromConfig(nicName string, dev *DeviceConfig, classes [
 		})
 	}
 	return renderTcEgressScriptFromData(scriptData{
-		NIC: nicName,
+		NIC:       nicName,
+		SpeedMbit: -1, // all rates are explicit; SPEED variable not needed
 		Device: deviceRenderData{
 			DefaultMinor: info.Minor,
 			Rate:         dev.Rate,

--- a/internal/network/shape/render.go
+++ b/internal/network/shape/render.go
@@ -3,8 +3,6 @@
 package shape
 
 import (
-	"bytes"
-	"crypto/sha256"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -20,7 +18,7 @@ var nicNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,15}$`)
 // scriptData is the template context for the tc-egress.sh boot script.
 type scriptData struct {
 	NIC       string
-	SpeedMbit int // >0 bakes SPEED=N; 0 sysfs auto-detect; <0 skip SPEED block (explicit per-class rates)
+	SpeedMbit int // <0 omits the SPEED block (explicit per-class rates); >=0 emits sysfs auto-detect
 	Device    deviceRenderData
 	Classes   []classRenderData
 }
@@ -99,34 +97,20 @@ func defaultScriptData(nicName string) scriptData {
 	}
 }
 
-// renderTcEgressScriptFromData renders the template with the given scriptData.
+// renderTcEgressScriptFromData validates the NIC name and renders the template
+// with the given scriptData. NIC validation lives here — the single funnel every
+// render passes through — so operator-supplied names (e.g. block node install
+// --egress-interface) cannot inject into the root-executed boot script.
 func renderTcEgressScriptFromData(data scriptData) (string, error) {
+	if !nicNameRe.MatchString(data.NIC) {
+		return "", errorx.IllegalArgument.New(
+			"egress NIC name %q is invalid: must match %s", data.NIC, nicNameRe.String())
+	}
 	rendered, err := templates.Render(tcEgressScriptTemplate, data)
 	if err != nil {
 		return "", errorx.InternalError.Wrap(err, "failed to render %s", tcEgressScriptTemplate)
 	}
 	return rendered, nil
-}
-
-// RenderTcEgressScript renders the tc-egress.sh boot script with the given NIC
-// name using sysfs speed auto-detect and writes it atomically to
-// TcEgressScriptPath (mode 0755). If the on-disk content is already identical
-// (SHA-256 match) the write is skipped — making it safe to call from idempotent
-// install flows. Use Manager.ProvisionDefaultEgress when a trunk rate is known.
-func RenderTcEgressScript(nicName string) error {
-	if !nicNameRe.MatchString(nicName) {
-		return errorx.IllegalArgument.New("egress NIC name %q is invalid: must match %s", nicName, nicNameRe.String())
-	}
-	rendered, err := renderTcEgressScript(nicName)
-	if err != nil {
-		return err
-	}
-	if existing, readErr := os.ReadFile(TcEgressScriptPath); readErr == nil {
-		if sha256.Sum256([]byte(rendered)) == sha256.Sum256(existing) {
-			return nil
-		}
-	}
-	return atomicWriteFile(TcEgressScriptPath, rendered, 0o755)
 }
 
 // atomicWriteFile writes content to path via a temp file in the same directory
@@ -176,10 +160,4 @@ func atomicWriteFile(path, content string, perm os.FileMode) error {
 		return errorx.ExternalError.Wrap(err, "failed to fsync directory %s", dir)
 	}
 	return nil
-}
-
-// contentEqual is a helper for tests that need to compare rendered output
-// without going through SHA-256 directly.
-func contentEqual(a, b string) bool {
-	return bytes.Equal([]byte(a), []byte(b))
 }

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -3,6 +3,7 @@
 package shape
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,8 +66,13 @@ func TestRenderTcEgressScript_NICInterpolated(t *testing.T) {
 }
 
 func TestRenderTcEgressScript_EmptyNIC(t *testing.T) {
-	if err := RenderTcEgressScript(""); err == nil {
+	// The NIC-name check lives in the render funnel, so an empty (or invalid)
+	// NIC is rejected on the live path, not just in a dedicated wrapper.
+	if _, err := renderTcEgressScript(""); err == nil {
 		t.Error("expected error for empty NIC name, got nil")
+	}
+	if _, err := renderTcEgressScript(`eth0";reboot;#`); err == nil {
+		t.Error("expected error for injection-style NIC name, got nil")
 	}
 }
 
@@ -90,7 +96,7 @@ func TestAtomicWriteFile_SecondWritePreservesContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
-	if !contentEqual(string(content), rendered) {
+	if string(content) != rendered {
 		t.Error("content changed on second write")
 	}
 }
@@ -591,5 +597,174 @@ func TestEffectiveCeil_DefaultsToRate(t *testing.T) {
 	cls.Ceil = "700mbit"
 	if cls.effectiveCeil() != "700mbit" {
 		t.Errorf("effectiveCeil() = %q, want %q", cls.effectiveCeil(), "700mbit")
+	}
+}
+
+// --- Device-only rendering tests ---
+//
+// When a device root is configured but no class configs exist yet,
+// renderAndApplyScript branches on defaultEgressConfig(dev.Rate): an explicit
+// rate yields the three default egress classes at proportional explicit rates
+// (no SPEED variable); "auto" or any unparseable rate makes defaultEgressConfig
+// fail and the render falls back to sysfs auto-detect. These tests pin that
+// branch condition and the two rendered outcomes.
+
+func TestDefaultEgressConfig_AutoRateFallsBack(t *testing.T) {
+	// "auto" is not a parseable bandwidth, so defaultEgressConfig returns an
+	// error — the signal renderAndApplyScript uses to fall back to sysfs detect.
+	if _, _, err := defaultEgressConfig("auto"); err == nil {
+		t.Error("expected defaultEgressConfig(\"auto\") to error, got nil")
+	}
+	// An explicit rate must succeed (→ explicit device-only render path).
+	if _, _, err := defaultEgressConfig("500mbit"); err != nil {
+		t.Errorf("defaultEgressConfig(\"500mbit\"): unexpected error: %v", err)
+	}
+}
+
+func TestDeviceOnly_ExplicitRate_NoSpeed(t *testing.T) {
+	// Device-only explicit render reuses the same path as renderAndApplyScript:
+	// defaultEgressConfig(rate) → renderTcEgressScriptFromConfig(dev, classes).
+	dev := &DeviceConfig{Dir: DirEgress, Rate: "500mbit", DefaultClass: "reserve-egress"}
+	_, classes, err := defaultEgressConfig(dev.Rate)
+	if err != nil {
+		t.Fatalf("defaultEgressConfig: %v", err)
+	}
+	rendered, err := renderTcEgressScriptFromConfig("enp0s1", dev, classes)
+	if err != nil {
+		t.Fatalf("renderTcEgressScriptFromConfig: %v", err)
+	}
+	// No SPEED variable and no sysfs detection when the rate is explicit.
+	if strings.Contains(rendered, "SPEED") {
+		t.Errorf("device-only explicit render must not contain SPEED:\n%s", rendered)
+	}
+	// 500mbit → partner 200mbit/350mbit, public 150mbit/350mbit, reserve 150mbit/500mbit.
+	if !strings.Contains(rendered, `htb rate "500mbit" ceil "500mbit"`) {
+		t.Errorf("trunk 500mbit missing:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `rate "200mbit" ceil "350mbit"`) {
+		t.Errorf("partner 200mbit/350mbit missing:\n%s", rendered)
+	}
+}
+
+// --- resolveAutoRate tests ---
+
+func newTestManager(nic string, mbit int, speedOK bool) *Manager {
+	return NewManagerWithConfig(Config{
+		NICDetect:   func() (string, error) { return nic, nil },
+		SpeedDetect: func(string) (int, bool) { return mbit, speedOK },
+	})
+}
+
+func TestResolveAutoRate_ResolvesToDetectedSpeed(t *testing.T) {
+	m := newTestManager("eth0", 1000, true)
+	dev := &DeviceConfig{Dir: DirEgress, Rate: "auto", DefaultClass: "reserve-egress"}
+	m.resolveAutoRate(dev)
+	if dev.Rate != "1gbit" {
+		t.Errorf("expected auto resolved to 1gbit, got %q", dev.Rate)
+	}
+}
+
+func TestResolveAutoRate_FallbackToDefaultWhenUnreadable(t *testing.T) {
+	m := newTestManager("eth0", 0, false)
+	dev := &DeviceConfig{Dir: DirEgress, Rate: "auto", DefaultClass: "reserve-egress"}
+	m.resolveAutoRate(dev)
+	want := FormatSpeedHint(DefaultLinkSpeedMbit)
+	if dev.Rate != want {
+		t.Errorf("expected unreadable sysfs to bake default %q, got %q", want, dev.Rate)
+	}
+	// Must not stay dynamic — the whole point is an explicit, SPEED-free rate.
+	if dev.Rate == "auto" {
+		t.Error("rate must not remain \"auto\" when sysfs is unreadable")
+	}
+}
+
+func TestResolveAutoRate_IngressUntouched(t *testing.T) {
+	m := newTestManager("eth0", 1000, true)
+	dev := &DeviceConfig{Dir: DirIngress, Rate: "auto", DefaultClass: "reserve-ingress"}
+	m.resolveAutoRate(dev)
+	if dev.Rate != "auto" {
+		t.Errorf("ingress \"auto\" must not be sysfs-resolved (per-veth), got %q", dev.Rate)
+	}
+}
+
+func TestResolveAutoRate_ExplicitRateUntouched(t *testing.T) {
+	m := newTestManager("eth0", 1000, true)
+	dev := &DeviceConfig{Dir: DirEgress, Rate: "500mbit", DefaultClass: "reserve-egress"}
+	m.resolveAutoRate(dev)
+	if dev.Rate != "500mbit" {
+		t.Errorf("explicit rate must be left unchanged, got %q", dev.Rate)
+	}
+}
+
+func TestPersistEgressScript_NoServiceRestart(t *testing.T) {
+	// `set` persists the boot script for reboot but must NOT restart the service:
+	// its live `tc class change` already updated the kernel, and a restart would
+	// tear down and rebuild the root qdisc. persistEgressScript writes; only
+	// renderAndApplyScript restarts.
+	scriptPath := filepath.Join(t.TempDir(), "tc-egress.sh")
+	applied := false
+	m := NewManagerWithConfig(Config{
+		ScriptPath:  scriptPath,
+		NICDetect:   func() (string, error) { return "eth0", nil },
+		ApplyEgress: func(context.Context) error { applied = true; return nil },
+	})
+
+	if err := m.persistEgressScript("eth0"); err != nil {
+		t.Fatalf("persistEgressScript: %v", err)
+	}
+	if applied {
+		t.Error("persistEgressScript must not restart the service (no qdisc churn)")
+	}
+	if _, err := os.Stat(scriptPath); err != nil {
+		t.Errorf("expected boot script persisted to disk: %v", err)
+	}
+
+	// Contrast: renderAndApplyScript does restart the service.
+	applied = false
+	if err := m.renderAndApplyScript(context.Background(), "eth0"); err != nil {
+		t.Fatalf("renderAndApplyScript: %v", err)
+	}
+	if !applied {
+		t.Error("renderAndApplyScript must restart the service")
+	}
+}
+
+func TestParseBandwidthBps_RejectsZeroAndFractional(t *testing.T) {
+	for _, bad := range []string{"0mbit", "0gbit", "1.5gbit", "0.5mbit", "1e3mbit", "-5mbit"} {
+		if _, err := parseBandwidthBps(bad); err == nil {
+			t.Errorf("parseBandwidthBps(%q): expected error, got nil", bad)
+		}
+	}
+	// Positive integers still parse.
+	if bps, err := parseBandwidthBps("1gbit"); err != nil || bps != 1_000_000_000 {
+		t.Errorf("parseBandwidthBps(1gbit) = (%d, %v), want (1000000000, nil)", bps, err)
+	}
+}
+
+func TestResolveAutoRateString(t *testing.T) {
+	// "auto" with a readable speed resolves to the detected rate.
+	if got := newTestManager("eth0", 1000, true).resolveAutoRateString("auto"); got != "1gbit" {
+		t.Errorf("resolveAutoRateString(auto, readable) = %q, want 1gbit", got)
+	}
+	// case-insensitive.
+	if got := newTestManager("eth0", 100, true).resolveAutoRateString("AUTO"); got != "100mbit" {
+		t.Errorf("resolveAutoRateString(AUTO) = %q, want 100mbit", got)
+	}
+	// unreadable → default fallback.
+	want := FormatSpeedHint(DefaultLinkSpeedMbit)
+	if got := newTestManager("eth0", 0, false).resolveAutoRateString("auto"); got != want {
+		t.Errorf("resolveAutoRateString(auto, unreadable) = %q, want %q", got, want)
+	}
+	// non-"auto" values pass through unchanged.
+	if got := newTestManager("eth0", 1000, true).resolveAutoRateString("400mbit"); got != "400mbit" {
+		t.Errorf("resolveAutoRateString(400mbit) = %q, want 400mbit (unchanged)", got)
+	}
+}
+
+func TestValidateSumRates_AutoDeviceRate(t *testing.T) {
+	// "auto" is not a parseable bandwidth; validateSumRates must skip the check.
+	cfg := &ClassConfig{Name: "partner", Rate: "400mbit"}
+	if err := validateSumRates(nil, cfg, "auto"); err != nil {
+		t.Errorf("validateSumRates with device rate \"auto\" must skip: %v", err)
 	}
 }

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -147,6 +147,10 @@ func TestRenderTcEgressScriptFromConfig_ExplicitRates(t *testing.T) {
 			t.Errorf("missing fq_codel line %q:\n%s", want, rendered)
 		}
 	}
+	// SPEED variable must not appear: all rates are explicit, sysfs detection is dead code.
+	if strings.Contains(rendered, "SPEED") {
+		t.Errorf("rendered script must not contain SPEED when rates are explicit:\n%s", rendered)
+	}
 }
 
 func TestRenderTcEgressScriptFromConfig_UnknownClass(t *testing.T) {

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -65,7 +65,7 @@ func TestRenderTcEgressScript_NICInterpolated(t *testing.T) {
 }
 
 func TestRenderTcEgressScript_EmptyNIC(t *testing.T) {
-	if err := RenderTcEgressScript("", 0); err == nil {
+	if err := RenderTcEgressScript(""); err == nil {
 		t.Error("expected error for empty NIC name, got nil")
 	}
 }
@@ -98,7 +98,7 @@ func TestAtomicWriteFile_SecondWritePreservesContent(t *testing.T) {
 // renderScript is a test-only helper that calls renderTcEgressScript so tests
 // don't need to patch the global TcEgressScriptPath constant.
 func renderScript(nicName string) (string, error) {
-	return renderTcEgressScript(nicName, 0)
+	return renderTcEgressScript(nicName)
 }
 
 // --- New tests: renderTcEgressScriptFromConfig ---
@@ -362,26 +362,69 @@ func TestParseSpeedMbit(t *testing.T) {
 	}
 }
 
-func TestRenderTcEgressScript_BakedSpeed(t *testing.T) {
-	rendered, err := renderTcEgressScript("eth0", 1000)
-	if err != nil {
-		t.Fatalf("renderTcEgressScript: %v", err)
-	}
-	if !strings.Contains(rendered, "SPEED=1000") {
-		t.Errorf("rendered script missing baked SPEED=1000:\n%s", rendered)
-	}
-	if strings.Contains(rendered, `cat /sys/class/net`) {
-		t.Errorf("rendered script should not contain sysfs detection when speed is baked in:\n%s", rendered)
-	}
-}
-
 func TestRenderTcEgressScript_AutoDetectSpeed(t *testing.T) {
-	rendered, err := renderTcEgressScript("eth0", 0)
+	rendered, err := renderTcEgressScript("eth0")
 	if err != nil {
 		t.Fatalf("renderTcEgressScript: %v", err)
 	}
 	if !strings.Contains(rendered, `cat /sys/class/net/"$NIC"/speed`) {
-		t.Errorf("rendered script missing sysfs detection when speedMbit=0:\n%s", rendered)
+		t.Errorf("rendered script missing sysfs detection:\n%s", rendered)
+	}
+}
+
+func renderDefaultEgressScript(t *testing.T, trunkRate string) string {
+	t.Helper()
+	dev, classes, err := defaultEgressConfig(trunkRate)
+	if err != nil {
+		t.Fatalf("defaultEgressConfig(%q): %v", trunkRate, err)
+	}
+	rendered, err := renderTcEgressScriptFromConfig("eth0", dev, classes)
+	if err != nil {
+		t.Fatalf("renderTcEgressScriptFromConfig: %v", err)
+	}
+	return rendered
+}
+
+func TestDefaultEgressConfig_1gbit_ProportionalRates(t *testing.T) {
+	rendered := renderDefaultEgressScript(t, "1gbit")
+
+	// Explicit rates: SPEED variable must be absent.
+	if strings.Contains(rendered, "SPEED") {
+		t.Errorf("rendered script must not contain SPEED when rates are explicit:\n%s", rendered)
+	}
+	// Trunk at 1gbit.
+	if !strings.Contains(rendered, `htb rate "1gbit" ceil "1gbit"`) {
+		t.Errorf("trunk class missing 1gbit rate:\n%s", rendered)
+	}
+	// partner: 40%/70% of 1gbit = 400mbit/700mbit
+	if !strings.Contains(rendered, `rate "400mbit" ceil "700mbit"`) {
+		t.Errorf("partner class missing 400mbit/700mbit:\n%s", rendered)
+	}
+	// public: 30%/70% of 1gbit = 300mbit/700mbit
+	if !strings.Contains(rendered, `rate "300mbit" ceil "700mbit"`) {
+		t.Errorf("public class missing 300mbit/700mbit:\n%s", rendered)
+	}
+	// reserve-egress: 30%/100% = 300mbit / trunk (1gbit)
+	if !strings.Contains(rendered, `rate "300mbit" ceil "1gbit"`) {
+		t.Errorf("reserve-egress class missing 300mbit/1gbit:\n%s", rendered)
+	}
+}
+
+func TestDefaultEgressConfig_100mbit_ProportionalRates(t *testing.T) {
+	rendered := renderDefaultEgressScript(t, "100mbit")
+
+	if strings.Contains(rendered, "SPEED") {
+		t.Errorf("rendered script must not contain SPEED:\n%s", rendered)
+	}
+	// partner: 40mbit/70mbit; public: 30mbit/70mbit; reserve-egress: 30mbit/100mbit trunk
+	if !strings.Contains(rendered, `rate "40mbit" ceil "70mbit"`) {
+		t.Errorf("partner class missing 40mbit/70mbit:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `rate "30mbit" ceil "70mbit"`) {
+		t.Errorf("public class missing 30mbit/70mbit:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `rate "30mbit" ceil "100mbit"`) {
+		t.Errorf("reserve-egress class missing 30mbit/100mbit:\n%s", rendered)
 	}
 }
 

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 )
 
+// --- Existing render tests (default/legacy SPEED-based rendering) ---
+
 func TestRenderTcEgressScript_NICInterpolated(t *testing.T) {
 	dir := t.TempDir()
 
@@ -20,9 +22,9 @@ func TestRenderTcEgressScript_NICInterpolated(t *testing.T) {
 		t.Fatalf("renderScript: %v", err)
 	}
 
-	// The NIC name must appear in the NIC= assignment line.
-	if !strings.Contains(rendered, "NIC="+testNIC) {
-		t.Errorf("rendered script does not contain NIC assignment %q:\n%s", "NIC="+testNIC, rendered)
+	// The NIC name must appear in the quoted NIC= assignment line.
+	if !strings.Contains(rendered, `NIC="`+testNIC+`"`) {
+		t.Errorf("rendered script does not contain NIC assignment %q:\n%s", `NIC="`+testNIC+`"`, rendered)
 	}
 	// Must NOT contain the raw template placeholder.
 	if strings.Contains(rendered, "{{.NIC}}") {
@@ -93,16 +95,90 @@ func TestAtomicWriteFile_SecondWritePreservesContent(t *testing.T) {
 	}
 }
 
-// renderScript is a test-only helper that calls templates.Render directly so
-// tests don't need to patch the global TcEgressScriptPath constant.
+// renderScript is a test-only helper that calls renderTcEgressScript so tests
+// don't need to patch the global TcEgressScriptPath constant.
 func renderScript(nicName string) (string, error) {
 	return renderTcEgressScript(nicName, 0)
+}
+
+// --- New tests: renderTcEgressScriptFromConfig ---
+
+func TestRenderTcEgressScriptFromConfig_ExplicitRates(t *testing.T) {
+	dev := &DeviceConfig{
+		Dir:          DirEgress,
+		Rate:         "1gbit",
+		DefaultClass: "reserve-egress",
+	}
+	classes := []*ClassConfig{
+		{Name: "partner", Rate: "400mbit", Ceil: "700mbit", Prio: 0},
+		{Name: "public", Rate: "300mbit", Ceil: "700mbit", Prio: 5},
+		{Name: "reserve-egress", Rate: "300mbit", Prio: 1},
+	}
+	rendered, err := renderTcEgressScriptFromConfig("ens3", dev, classes)
+	if err != nil {
+		t.Fatalf("renderTcEgressScriptFromConfig: %v", err)
+	}
+
+	if !strings.Contains(rendered, `NIC="ens3"`) {
+		t.Errorf("expected NIC=\"ens3\":\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "htb default 60") {
+		t.Errorf("expected htb default 60 (reserve-egress minor):\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `rate "1gbit" ceil "1gbit"`) {
+		t.Errorf("expected root rate 1gbit:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `classid 1:40 htb rate "400mbit" ceil "700mbit" prio 0`) {
+		t.Errorf("partner class line wrong:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `classid 1:50 htb rate "300mbit" ceil "700mbit" prio 5`) {
+		t.Errorf("public class line wrong:\n%s", rendered)
+	}
+	// reserve-egress: ceil defaults to rate when unset.
+	if !strings.Contains(rendered, `classid 1:60 htb rate "300mbit" ceil "300mbit" prio 1`) {
+		t.Errorf("reserve-egress class line wrong:\n%s", rendered)
+	}
+	for _, want := range []string{
+		`parent 1:40 handle 140: fq_codel`,
+		`parent 1:50 handle 150: fq_codel`,
+		`parent 1:60 handle 160: fq_codel`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("missing fq_codel line %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestRenderTcEgressScriptFromConfig_UnknownClass(t *testing.T) {
+	dev := &DeviceConfig{Dir: DirEgress, Rate: "1gbit", DefaultClass: "reserve-egress"}
+	_, err := renderTcEgressScriptFromConfig("ens3", dev, []*ClassConfig{{Name: "no-such-class", Rate: "100mbit"}})
+	if err == nil {
+		t.Error("expected error for unknown class, got nil")
+	}
+}
+
+func TestRenderTcEgressScriptFromConfig_IngressClasses(t *testing.T) {
+	dev := &DeviceConfig{Dir: DirIngress, Rate: "1gbit", DefaultClass: "reserve-ingress"}
+	classes := []*ClassConfig{
+		{Name: "publisher", Rate: "400mbit", Ceil: "700mbit", Prio: 0},
+		{Name: "reserve-ingress", Rate: "300mbit", Prio: 1},
+	}
+	rendered, err := renderTcEgressScriptFromConfig("veth0", dev, classes)
+	if err != nil {
+		t.Fatalf("renderTcEgressScriptFromConfig: %v", err)
+	}
+	// Default minor for reserve-ingress is "30".
+	if !strings.Contains(rendered, "htb default 30") {
+		t.Errorf("expected htb default 30:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `classid 1:10 htb rate "400mbit"`) {
+		t.Errorf("publisher class (1:10) missing:\n%s", rendered)
+	}
 }
 
 // --- DetectEgressInterface tests (cross-platform via detectEgressInterfaceFrom) ---
 
 func TestDetectEgressInterfaceFrom_DefaultRoute(t *testing.T) {
-	// Minimal /proc/net/route with one default-route row and one subnet row.
 	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
 		"eth0\t00000000\t0101A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n" +
 		"eth0\tC0A80100\t00000000\t0001\t0\t0\t0\tFFFFFF00\t0\t0\t0\n"
@@ -118,7 +194,6 @@ func TestDetectEgressInterfaceFrom_DefaultRoute(t *testing.T) {
 }
 
 func TestDetectEgressInterfaceFrom_MultipleInterfaces(t *testing.T) {
-	// Default route on ens3, another interface present.
 	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
 		"lo\t00000000\t00000000\t0001\t0\t0\t0\t000000FF\t0\t0\t0\n" +
 		"ens3\t00000000\t0101A8C0\t0003\t0\t0\t100\t00000000\t0\t0\t0\n"
@@ -134,7 +209,6 @@ func TestDetectEgressInterfaceFrom_MultipleInterfaces(t *testing.T) {
 }
 
 func TestDetectEgressInterfaceFrom_NoDefaultRoute(t *testing.T) {
-	// No row with RTF_GATEWAY set.
 	content := "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n" +
 		"eth0\tC0A80100\t00000000\t0001\t0\t0\t0\tFFFFFF00\t0\t0\t0\n"
 
@@ -304,5 +378,171 @@ func TestRenderTcEgressScript_AutoDetectSpeed(t *testing.T) {
 	}
 	if !strings.Contains(rendered, `cat /sys/class/net/"$NIC"/speed`) {
 		t.Errorf("rendered script missing sysfs detection when speedMbit=0:\n%s", rendered)
+	}
+}
+
+// --- Validation tests ---
+
+func TestValidateDir(t *testing.T) {
+	if err := validateDir(DirEgress); err != nil {
+		t.Errorf("validateDir(egress): %v", err)
+	}
+	if err := validateDir(DirIngress); err != nil {
+		t.Errorf("validateDir(ingress): %v", err)
+	}
+	if err := validateDir("sideways"); err == nil {
+		t.Error("expected error for invalid direction, got nil")
+	}
+}
+
+func TestValidatePrio(t *testing.T) {
+	for _, p := range []int{0, 3, 7} {
+		if err := validatePrio(p); err != nil {
+			t.Errorf("validatePrio(%d): %v", p, err)
+		}
+	}
+	for _, p := range []int{-1, 8, 100} {
+		if err := validatePrio(p); err == nil {
+			t.Errorf("expected error for prio %d, got nil", p)
+		}
+	}
+}
+
+func TestParseBandwidthBps(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantBps int64
+	}{
+		{"1gbit", 1_000_000_000},
+		{"100mbit", 100_000_000},
+		{"500kbit", 500_000},
+		{"1000bit", 1_000},
+		{"1GBIT", 1_000_000_000},
+	}
+	for _, c := range cases {
+		got, err := parseBandwidthBps(c.in)
+		if err != nil {
+			t.Errorf("parseBandwidthBps(%q): %v", c.in, err)
+			continue
+		}
+		if got != c.wantBps {
+			t.Errorf("parseBandwidthBps(%q) = %d, want %d", c.in, got, c.wantBps)
+		}
+	}
+	for _, bad := range []string{"", "100", "fast", "$(( SPEED * 40 / 100 ))mbit", "${SPEED}mbit"} {
+		if _, err := parseBandwidthBps(bad); err == nil {
+			t.Errorf("expected error for %q, got nil", bad)
+		}
+	}
+}
+
+func TestValidateSumRates(t *testing.T) {
+	existing := []*ClassConfig{
+		{Name: "partner", Rate: "400mbit"},
+		{Name: "public", Rate: "300mbit"},
+	}
+	// 400+300+300 = 1000mbit = 1gbit: exactly at limit, should pass.
+	cfg := &ClassConfig{Name: "reserve-egress", Rate: "300mbit"}
+	if err := validateSumRates(existing, cfg, "1gbit"); err != nil {
+		t.Errorf("unexpected error at exact limit: %v", err)
+	}
+	// 400+300+400 = 1100mbit > 1gbit: should fail.
+	cfg2 := &ClassConfig{Name: "reserve-egress", Rate: "400mbit"}
+	if err := validateSumRates(existing, cfg2, "1gbit"); err == nil {
+		t.Error("expected sum-rate error, got nil")
+	}
+	// Replacing partner (400→500): 500+300=800mbit ≤ 1gbit: should pass.
+	cfg3 := &ClassConfig{Name: "partner", Rate: "500mbit"}
+	if err := validateSumRates(existing, cfg3, "1gbit"); err != nil {
+		t.Errorf("unexpected error when replacing within limit: %v", err)
+	}
+	// Unparseable device rate: skip validation (legacy).
+	if err := validateSumRates(existing, cfg2, "${SPEED}mbit"); err != nil {
+		t.Errorf("unexpected error for unparseable device rate: %v", err)
+	}
+}
+
+func TestValidateDefaultClass(t *testing.T) {
+	if err := validateDefaultClass("reserve-egress", DirEgress); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := validateDefaultClass("reserve-ingress", DirIngress); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := validateDefaultClass("partner", DirIngress); err == nil {
+		t.Error("expected error: partner is egress, not ingress")
+	}
+	if err := validateDefaultClass("no-such-class", DirEgress); err == nil {
+		t.Error("expected error for unknown class")
+	}
+}
+
+func TestValidateCeilGeRate(t *testing.T) {
+	if err := validateCeilGeRate("700mbit", "400mbit"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := validateCeilGeRate("400mbit", "400mbit"); err != nil {
+		t.Errorf("equal ceil/rate should be valid: %v", err)
+	}
+	if err := validateCeilGeRate("300mbit", "400mbit"); err == nil {
+		t.Error("expected error: ceil < rate")
+	}
+	// Unparseable ceil is an error (user-supplied; shell expressions are not accepted).
+	if err := validateCeilGeRate("${SPEED}mbit", "100mbit"); err == nil {
+		t.Error("expected error for unparseable ceil")
+	}
+	// Unparseable rate (legacy shell expression in defaultScriptData): skip the comparison.
+	if err := validateCeilGeRate("100mbit", "$(( SPEED * 40 / 100 ))mbit"); err != nil {
+		t.Errorf("unexpected error when rate is a legacy shell expression: %v", err)
+	}
+}
+
+func TestClassInfoMap_AllClassesPresent(t *testing.T) {
+	expected := []struct {
+		name   string
+		minor  string
+		handle string
+		dir    string
+	}{
+		{"publisher", "10", "110", DirIngress},
+		{"backfill-response", "20", "120", DirIngress},
+		{"reserve-ingress", "30", "130", DirIngress},
+		{"partner", "40", "140", DirEgress},
+		{"public", "50", "150", DirEgress},
+		{"reserve-egress", "60", "160", DirEgress},
+	}
+	for _, e := range expected {
+		ci, err := lookupClassInfo(e.name)
+		if err != nil {
+			t.Errorf("lookupClassInfo(%q): %v", e.name, err)
+			continue
+		}
+		if ci.Minor != e.minor {
+			t.Errorf("%s: Minor=%q, want %q", e.name, ci.Minor, e.minor)
+		}
+		if ci.Handle != e.handle {
+			t.Errorf("%s: Handle=%q, want %q", e.name, ci.Handle, e.handle)
+		}
+		if ci.Dir != e.dir {
+			t.Errorf("%s: Dir=%q, want %q", e.name, ci.Dir, e.dir)
+		}
+	}
+}
+
+func TestLookupClassInfo_UnknownClass(t *testing.T) {
+	_, err := lookupClassInfo("no-such-class")
+	if err == nil {
+		t.Error("expected error for unknown class, got nil")
+	}
+}
+
+func TestEffectiveCeil_DefaultsToRate(t *testing.T) {
+	cls := &ClassConfig{Name: "partner", Rate: "400mbit", Ceil: ""}
+	if cls.effectiveCeil() != "400mbit" {
+		t.Errorf("effectiveCeil() = %q, want %q", cls.effectiveCeil(), "400mbit")
+	}
+	cls.Ceil = "700mbit"
+	if cls.effectiveCeil() != "700mbit" {
+		t.Errorf("effectiveCeil() = %q, want %q", cls.effectiveCeil(), "700mbit")
 	}
 }

--- a/internal/network/shape/speed.go
+++ b/internal/network/shape/speed.go
@@ -24,6 +24,12 @@ func readLinkSpeedMbitFrom(path string) (int, bool) {
 	return n, true
 }
 
+// DefaultLinkSpeedMbit is the link speed assumed when sysfs cannot report one
+// (common on virtual NICs and at early boot, where /sys/class/net/<nic>/speed
+// reads -1). It mirrors the fallback baked into the tc-egress boot script's
+// sysfs-detection block; keep the two in sync.
+const DefaultLinkSpeedMbit = 1000
+
 // FormatSpeedHint converts a Mbit/s value into a tc-style bandwidth string
 // suitable for operator-facing prompts (e.g. 1000 → "1gbit", 10000 → "10gbit",
 // 100 → "100mbit").

--- a/internal/network/shape/tc_linux.go
+++ b/internal/network/shape/tc_linux.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package shape
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// TCRunner abstracts live kernel tc class operations for testability.
+type TCRunner interface {
+	// ClassChange runs `tc class change dev <nic> parent 1:1 classid 1:<minor>
+	// htb rate <rate> ceil <ceil> prio <prio>` on the live kernel.
+	ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error
+}
+
+type execTCRunner struct{}
+
+func (r *execTCRunner) ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error {
+	cmd := exec.CommandContext(ctx, "/sbin/tc",
+		"class", "change",
+		"dev", nic,
+		"parent", "1:1",
+		"classid", "1:"+minor,
+		"htb",
+		"rate", rate,
+		"ceil", ceil,
+		"prio", fmt.Sprintf("%d", prio),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return errorx.ExternalError.Wrap(err,
+			"tc class change dev %s classid 1:%s failed: %s", nic, minor, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// newExecTCRunner returns the production TC runner that shells out to /sbin/tc.
+func newExecTCRunner() TCRunner {
+	return &execTCRunner{}
+}

--- a/internal/network/shape/tc_other.go
+++ b/internal/network/shape/tc_other.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package shape
+
+import (
+	"context"
+
+	"github.com/joomcode/errorx"
+)
+
+// TCRunner abstracts live kernel tc class operations for testability.
+type TCRunner interface {
+	ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error
+}
+
+type noopTCRunner struct{}
+
+func (r *noopTCRunner) ClassChange(_ context.Context, _, _, _, _ string, _ int) error {
+	return errorx.IllegalState.New("tc operations not supported on this platform")
+}
+
+// newExecTCRunner returns a no-op runner on non-Linux platforms.
+func newExecTCRunner() TCRunner {
+	return &noopTCRunner{}
+}

--- a/internal/network/shape/validate.go
+++ b/internal/network/shape/validate.go
@@ -41,9 +41,11 @@ func validateDefaultClass(className, dir string) error {
 
 // parseBandwidthBps parses a tc-style bandwidth string and returns its value
 // in bits per second. Supports suffixes: bit, kbit, mbit, gbit (case-insensitive).
-// Returns an error for unknown suffixes or non-numeric values. Shell arithmetic
-// expressions (e.g. "$(( SPEED * 40 / 100 ))mbit") are intentionally not
-// supported — they are only used in the legacy default scriptData path.
+// The numeric part must be a positive integer — zero, fractional, and scientific
+// forms are rejected, matching what tc actually accepts. Returns an error for
+// unknown suffixes too. Shell arithmetic expressions (e.g.
+// "$(( SPEED * 40 / 100 ))mbit") are intentionally not supported — they are only
+// used in the legacy default scriptData path.
 func parseBandwidthBps(s string) (int64, error) {
 	low := strings.ToLower(strings.TrimSpace(s))
 	var multiplier int64
@@ -65,11 +67,11 @@ func parseBandwidthBps(s string) (int64, error) {
 		return 0, errorx.IllegalArgument.New(
 			"invalid bandwidth %q: expected a number followed by bit/kbit/mbit/gbit (e.g. 100mbit)", s)
 	}
-	n, err := strconv.ParseFloat(numStr, 64)
-	if err != nil || n < 0 {
-		return 0, errorx.IllegalArgument.New("invalid bandwidth %q: numeric part must be a non-negative number", s)
+	n, err := strconv.ParseInt(numStr, 10, 64)
+	if err != nil || n <= 0 {
+		return 0, errorx.IllegalArgument.New("invalid bandwidth %q: numeric part must be a positive integer", s)
 	}
-	return int64(n * float64(multiplier)), nil
+	return n * multiplier, nil
 }
 
 // validateRate checks that rate is a non-empty, parseable tc bandwidth string.

--- a/internal/network/shape/validate.go
+++ b/internal/network/shape/validate.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/joomcode/errorx"
+)
+
+// validateDir checks that dir is a valid tc device direction.
+func validateDir(dir string) error {
+	if dir != DirIngress && dir != DirEgress {
+		return errorx.IllegalArgument.New("--device must be %q or %q, got %q", DirIngress, DirEgress, dir)
+	}
+	return nil
+}
+
+// validatePrio checks that prio is in the HTB priority range [0, 7].
+func validatePrio(prio int) error {
+	if prio < 0 || prio > 7 {
+		return errorx.IllegalArgument.New("--prio must be in [0,7], got %d", prio)
+	}
+	return nil
+}
+
+// validateDefaultClass checks that className is a known class for the given direction.
+func validateDefaultClass(className, dir string) error {
+	info, err := lookupClassInfo(className)
+	if err != nil {
+		return err
+	}
+	if info.Dir != dir {
+		return errorx.IllegalArgument.New(
+			"class %q is a %s class and cannot be the default for the %s device; valid defaults: %s",
+			className, info.Dir, dir, strings.Join(knownClassNamesForDir(dir), ", "))
+	}
+	return nil
+}
+
+// parseBandwidthBps parses a tc-style bandwidth string and returns its value
+// in bits per second. Supports suffixes: bit, kbit, mbit, gbit (case-insensitive).
+// Returns an error for unknown suffixes or non-numeric values. Shell arithmetic
+// expressions (e.g. "$(( SPEED * 40 / 100 ))mbit") are intentionally not
+// supported — they are only used in the legacy default scriptData path.
+func parseBandwidthBps(s string) (int64, error) {
+	low := strings.ToLower(strings.TrimSpace(s))
+	var multiplier int64
+	var numStr string
+	switch {
+	case strings.HasSuffix(low, "gbit"):
+		multiplier = 1_000_000_000
+		numStr = low[:len(low)-4]
+	case strings.HasSuffix(low, "mbit"):
+		multiplier = 1_000_000
+		numStr = low[:len(low)-4]
+	case strings.HasSuffix(low, "kbit"):
+		multiplier = 1_000
+		numStr = low[:len(low)-4]
+	case strings.HasSuffix(low, "bit"):
+		multiplier = 1
+		numStr = low[:len(low)-3]
+	default:
+		return 0, errorx.IllegalArgument.New(
+			"invalid bandwidth %q: expected a number followed by bit/kbit/mbit/gbit (e.g. 100mbit)", s)
+	}
+	n, err := strconv.ParseFloat(numStr, 64)
+	if err != nil || n < 0 {
+		return 0, errorx.IllegalArgument.New("invalid bandwidth %q: numeric part must be a non-negative number", s)
+	}
+	return int64(n * float64(multiplier)), nil
+}
+
+// validateRate checks that rate is a non-empty, parseable tc bandwidth string.
+func validateRate(rate string) error {
+	if strings.TrimSpace(rate) == "" {
+		return errorx.IllegalArgument.New("--rate must not be empty")
+	}
+	_, err := parseBandwidthBps(rate)
+	return err
+}
+
+// validateCeilGeRate checks that ceil >= rate. Returns an error if ceil is not
+// a valid bandwidth string. Skips the >= comparison only when rate cannot be
+// parsed (indicating a legacy shell expression that is never user-supplied).
+func validateCeilGeRate(ceil, rate string) error {
+	ceilBps, err := parseBandwidthBps(ceil)
+	if err != nil {
+		return err
+	}
+	rateBps, err := parseBandwidthBps(rate)
+	if err != nil {
+		return nil // rate is a legacy shell expression; skip the >= comparison
+	}
+	if ceilBps < rateBps {
+		return errorx.IllegalArgument.New("--ceil %s must be >= --rate %s", ceil, rate)
+	}
+	return nil
+}
+
+// validateSumRates checks that the total of all class rates for the same device
+// (including cfg, replacing any existing entry with the same name) does not
+// exceed the device root rate. Skips the check if any value cannot be parsed.
+func validateSumRates(existing []*ClassConfig, cfg *ClassConfig, deviceRate string) error {
+	deviceBps, err := parseBandwidthBps(deviceRate)
+	if err != nil {
+		return nil // device rate unparseable (legacy expression): skip
+	}
+	var sum int64
+	for _, c := range existing {
+		if c.Name == cfg.Name {
+			continue // will be replaced by cfg in the sum
+		}
+		bps, err := parseBandwidthBps(c.Rate)
+		if err != nil {
+			continue // unparseable sibling: skip its contribution
+		}
+		sum += bps
+	}
+	newBps, err := parseBandwidthBps(cfg.Rate)
+	if err != nil {
+		return nil // new rate unparseable: skip
+	}
+	sum += newBps
+	if sum > deviceBps {
+		return errorx.IllegalArgument.New(
+			"total class rates (%d bit) would exceed device root rate %s (%d bit); reduce --rate or raise the device rate",
+			sum, deviceRate, deviceBps)
+	}
+	return nil
+}

--- a/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
+++ b/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
@@ -12,6 +12,8 @@ NIC="{{.NIC}}"
 {{- if gt .SpeedMbit 0}}
 # Link speed set by operator at install time; sysfs detection is skipped.
 SPEED={{.SpeedMbit}}
+{{- else if lt .SpeedMbit 0}}
+{{- /* All tc rates are explicit strings; SPEED variable is not used. */}}
 {{- else}}
 # Detect link speed in Mbit/s. The kernel uses -1 for "unknown" (common on
 # virtual NICs and at early boot before the link is established). Suppress

--- a/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
+++ b/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
@@ -9,10 +9,7 @@ set -e
 
 NIC="{{.NIC}}"
 
-{{- if gt .SpeedMbit 0}}
-# Link speed set by operator at install time; sysfs detection is skipped.
-SPEED={{.SpeedMbit}}
-{{- else if lt .SpeedMbit 0}}
+{{- if lt .SpeedMbit 0}}
 {{- /* All tc rates are explicit strings; SPEED variable is not used. */}}
 {{- else}}
 # Detect link speed in Mbit/s. The kernel uses -1 for "unknown" (common on

--- a/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
+++ b/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
@@ -1,6 +1,5 @@
 #!/bin/sh
-# Rendered by solo-provisioner at install time. Do not edit — changes are
-# overwritten by `block node install --force`.
+# Managed by solo-provisioner. Re-rendered by `network shape create/set/delete` and `block node install`; do not edit.
 #
 # Replays the $EGRESS HTB hierarchy at boot. Idempotent: delete the root qdisc
 # first (cascades to all classes and leaf qdiscs), then add everything fresh.
@@ -8,7 +7,7 @@
 # viable for leaf qdiscs.
 set -e
 
-NIC={{.NIC}}
+NIC="{{.NIC}}"
 
 {{- if gt .SpeedMbit 0}}
 # Link speed set by operator at install time; sysfs detection is skipped.
@@ -25,18 +24,12 @@ SPEED=$(cat /sys/class/net/"$NIC"/speed 2>/dev/null || echo -1)
 # Remove any existing root qdisc (and all its children). Silent no-op if absent.
 tc qdisc del dev "$NIC" root 2>/dev/null || true
 
-# Root HTB qdisc: unmatched traffic falls to default class 1:60 (reserve).
-tc qdisc add dev "$NIC" root handle 1: htb default 60
+# Root HTB qdisc: unmatched traffic falls to default class 1:{{.Device.DefaultMinor}}.
+tc qdisc add dev "$NIC" root handle 1: htb default {{.Device.DefaultMinor}}
 
 # Trunk class: full link rate as the ceiling for the whole hierarchy.
-tc class  add dev "$NIC" parent 1:   classid 1:1  htb rate "${SPEED}mbit" ceil "${SPEED}mbit"
-
-# Per-class leaf nodes (partner / public / reserve-egress).
-tc class  add dev "$NIC" parent 1:1  classid 1:40 htb rate "$(( SPEED * 40 / 100 ))mbit" ceil "$(( SPEED * 70 / 100 ))mbit" prio 0
-tc class  add dev "$NIC" parent 1:1  classid 1:50 htb rate "$(( SPEED * 30 / 100 ))mbit" ceil "$(( SPEED * 70 / 100 ))mbit" prio 5
-tc class  add dev "$NIC" parent 1:1  classid 1:60 htb rate "$(( SPEED * 30 / 100 ))mbit" ceil "${SPEED}mbit" prio 1
-
-# fq_codel leaf qdiscs: per-class fair-queuing with active queue management.
-tc qdisc  add dev "$NIC" parent 1:40 handle 140: fq_codel
-tc qdisc  add dev "$NIC" parent 1:50 handle 150: fq_codel
-tc qdisc  add dev "$NIC" parent 1:60 handle 160: fq_codel
+tc class  add dev "$NIC" parent 1:   classid 1:1  htb rate "{{.Device.Rate}}" ceil "{{.Device.Rate}}"
+{{range .Classes}}
+tc class  add dev "$NIC" parent 1:1  classid 1:{{.Minor}} htb rate "{{.Rate}}" ceil "{{.Ceil}}" prio {{.Prio}}
+tc qdisc  add dev "$NIC" parent 1:{{.Minor}} handle {{.Handle}}: fq_codel
+{{end}}

--- a/internal/ui/prompt/blocknode.go
+++ b/internal/ui/prompt/blocknode.go
@@ -167,7 +167,8 @@ func EgressInterfaceInputPrompt(eff, speedHint string, target *string) InputProm
 // leave the field blank to keep runtime auto-detection from sysfs.
 func LinkRateInputPrompt(speedHint string, target *string) InputPrompt {
 	desc := "NIC line rate in tc-style format (e.g. 1gbit, 100mbit). " +
-		"Leave blank to auto-detect at boot from /sys/class/net/<nic>/speed (falls back to 1000mbit on virtual NICs)."
+		"Enter \"auto\" to detect the link speed now and store it as an explicit rate; " +
+		"leave blank to auto-detect at each boot from /sys/class/net/<nic>/speed (falls back to 1000mbit on virtual NICs)."
 	return InputPrompt{
 		FlagName:       "link-rate",
 		Title:          "NIC Link Rate",
@@ -176,11 +177,11 @@ func LinkRateInputPrompt(speedHint string, target *string) InputPrompt {
 		EffectiveValue: speedHint,
 		Target:         target,
 		Validate: func(s string) error {
-			if s == "" {
+			if s == "" || strings.EqualFold(strings.TrimSpace(s), "auto") {
 				return nil
 			}
 			if _, ok := shape.ParseSpeedMbit(s); !ok {
-				return errorx.IllegalArgument.New("must be a tc-style rate with a positive integer prefix (e.g. 1gbit, 100mbit)")
+				return errorx.IllegalArgument.New("must be a tc-style rate with a positive integer prefix (e.g. 1gbit, 100mbit) or \"auto\"")
 			}
 			return nil
 		},

--- a/internal/ui/prompt/prompt_test.go
+++ b/internal/ui/prompt/prompt_test.go
@@ -423,6 +423,23 @@ func TestValidateRequiredPath(t *testing.T) {
 	}
 }
 
+func TestLinkRateInputPrompt_Validate(t *testing.T) {
+	var target string
+	p := LinkRateInputPrompt("1gbit", &target)
+	// Accepted: blank (detect at boot), "auto" (detect at create, any case), tc rates.
+	for _, ok := range []string{"", "auto", "AUTO", " auto ", "1gbit", "100mbit"} {
+		if err := p.Validate(ok); err != nil {
+			t.Errorf("Validate(%q): unexpected error: %v", ok, err)
+		}
+	}
+	// Rejected: non-rate garbage.
+	for _, bad := range []string{"fast", "1gig", "abc", "0mbit"} {
+		if err := p.Validate(bad); err == nil {
+			t.Errorf("Validate(%q): expected error, got nil", bad)
+		}
+	}
+}
+
 func TestArchivePathInputPrompt_RequiredValidation(t *testing.T) {
 	var target string
 	// required=true: empty value must be rejected.

--- a/internal/workflows/steps/step_network_tc_egress.go
+++ b/internal/workflows/steps/step_network_tc_egress.go
@@ -55,9 +55,18 @@ func TcEgressPersist(nicName string, trunkRate string) *automa.StepBuilder {
 				nic = detected
 			}
 
+			tcEgressResolution := []string{
+				"Check the tc-egress service journal for the actual tc error: journalctl -u solo-provisioner-tc-egress.service -n 20",
+				"Verify the NIC name exists on this host: ip link show",
+				"If the NIC is wrong, specify the correct one: block node install --egress-interface <nic>",
+				"Find the NIC used by the default route: ip route get 8.8.8.8 | grep dev",
+			}
+
 			if trunkRate != "" {
 				if err := shape.ProvisionDefaultEgressShape(ctx, nic, trunkRate); err != nil {
-					return automa.FailureReport(stp, automa.WithError(err))
+					return automa.FailureReport(stp, automa.WithError(
+						errorx.Decorate(err, "failed to provision default egress shape").
+							WithProperty(models.ErrPropertyResolution, tcEgressResolution)))
 				}
 				return automa.SuccessReport(stp)
 			}
@@ -65,7 +74,9 @@ func TcEgressPersist(nicName string, trunkRate string) *automa.StepBuilder {
 			// No trunk rate supplied: re-render from existing shape registry (if
 			// populated) or sysfs auto-detect, then apply.
 			if err := shape.RenderAndApplyDefaultEgress(ctx, nic); err != nil {
-				return automa.FailureReport(stp, automa.WithError(err))
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to apply tc-egress script").
+						WithProperty(models.ErrPropertyResolution, tcEgressResolution)))
 			}
 			return automa.SuccessReport(stp)
 		}).

--- a/internal/workflows/steps/step_network_tc_egress.go
+++ b/internal/workflows/steps/step_network_tc_egress.go
@@ -16,21 +16,18 @@ import (
 // TcEgressPersistStepId is the step ID for TcEgressPersist.
 const TcEgressPersistStepId = "tc-egress-persist"
 
-// TcEgressPersist renders /usr/local/sbin/solo-provisioner-tc-egress.sh with
-// the egress NIC name and optional link speed interpolated, installs and
-// enables the solo-provisioner-tc-egress.service oneshot unit, and executes
-// the script immediately so the kernel HTB hierarchy is live without waiting
-// for a reboot.
+// TcEgressPersist provisions the egress tc HTB hierarchy for reboot persistence.
+// When trunkRate is non-empty it writes the egress device root and three default
+// classes (partner/public/reserve-egress) at proportional rates into the shape
+// registry and renders the boot script from those explicit values. When
+// trunkRate is empty it re-renders the script from whatever shape config
+// already exists, falling back to sysfs auto-detect.
 //
 // When nicName is empty the NIC is auto-detected from the default route via
 // DetectEgressInterface. Pass --egress-interface to override on multi-NIC
 // hosts or when the default route does not identify the correct physical
 // interface.
-//
-// speedMbit sets the link rate in Mbit/s directly in the rendered script.
-// Pass 0 to keep the auto-detect behaviour (reads /sys/class/net/<nic>/speed
-// at boot, falls back to 1000 Mbit/s).
-func TcEgressPersist(nicName string, speedMbit int) *automa.StepBuilder {
+func TcEgressPersist(nicName string, trunkRate string) *automa.StepBuilder {
 	return automa.NewStepBuilder().WithId(TcEgressPersistStepId).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
 			notify.As().StepStart(ctx, stp, "Persisting tc-egress HTB hierarchy for reboot")
@@ -58,24 +55,26 @@ func TcEgressPersist(nicName string, speedMbit int) *automa.StepBuilder {
 				nic = detected
 			}
 
-			if err := shape.RenderTcEgressScript(nic, speedMbit); err != nil {
-				return automa.FailureReport(stp, automa.WithError(err))
-			}
-			if err := shape.EnsureTcEgressUnit(ctx); err != nil {
-				return automa.FailureReport(stp, automa.WithError(err))
-			}
-			if err := shape.ApplyTcEgressScript(ctx); err != nil {
-				return automa.FailureReport(stp, automa.WithError(err))
+			if trunkRate != "" {
+				if err := shape.ProvisionDefaultEgressShape(ctx, nic, trunkRate); err != nil {
+					return automa.FailureReport(stp, automa.WithError(err))
+				}
+				return automa.SuccessReport(stp)
 			}
 
+			// No trunk rate supplied: re-render from existing shape registry (if
+			// populated) or sysfs auto-detect, then apply.
+			if err := shape.RenderAndApplyDefaultEgress(ctx, nic); err != nil {
+				return automa.FailureReport(stp, automa.WithError(err))
+			}
 			return automa.SuccessReport(stp)
 		}).
 		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
 			// Rollback is a no-op: the script and unit are idempotent artifacts.
 			// Removing them would leave the kernel hierarchy installed but un-
-			// persisted — no worse than before this step ran. A dedicated
-			// `block node uninstall` step (Story 2.4 / #763) handles teardown.
+			// persisted — no worse than before this step ran. Teardown is handled
+			// by block node uninstall.
 			return automa.SkippedReport(stp,
-				automa.WithDetail("tc-egress rollback is a no-op; teardown is handled by block node uninstall (#763)"))
+				automa.WithDetail("tc-egress rollback is a no-op; teardown is handled by block node uninstall"))
 		})
 }


### PR DESCRIPTION
## Summary

- Implements `network shape create/set/show/delete`: CLI verbs to manage tc HTB bandwidth classes and device roots via a JSON registry at `/etc/solo-provisioner/network/shape/`
- Egress mutations re-render `/usr/local/sbin/solo-provisioner-tc-egress.sh` from stored config and restart `solo-provisioner-tc-egress.service` — keeping the live kernel and reboot state in sync
- **`block node install` now drives the shape registry**: the egress device root and three default HTB classes (partner 40%/70%, public 30%/70%, reserve-egress 30%/100% of trunk) are written at install time from `--link-rate`; the boot script is rendered from those explicit rates — the SPEED variable never appears
- The SPEED-baking path (`SPEED=N` baked from `--link-rate`) is **eliminated entirely** from the template, render functions, and workflow step; the template is now two-way: explicit rates (from shape config) vs sysfs auto-detect (legacy fallback when no shape config exists)
- `ApplyTcEgressScript` calls `EnsureTcEgressUnit` first (SHA-256 gated) so `network shape` commands are self-contained — the unit installs automatically without a prior `block node install`
- `renderTcEgressScriptFromConfig` passes `SpeedMbit=-1` so the SPEED detection block is omitted when all rates are explicit strings
- `network shape create --device egress --rate <bw>` accepts an explicit bandwidth **or** `--rate auto`. `--rate auto` reads the NIC's link speed from sysfs **at create time** and stores the resolved value (e.g. `1gbit`) as an explicit rate — so `network shape show` reports a concrete number, the boot script carries explicit values, and there is no `SPEED` variable or sysfs read at boot. This also avoids the flaky early-boot sysfs read that would otherwise silently throttle to 1000mbit. If the speed is unreadable at create time (virtual NIC → −1), `auto` falls back to a concrete `1gbit` (still explicit, never dynamic). `--rate auto` is rejected on the `--class` form (class rates must be explicit). `block node install` accepts `auto` too — at the NIC Link Rate prompt or via `--link-rate auto` — resolved through the same shared path, so install and `network shape` behave identically (blank at the prompt keeps the detect-at-each-boot behavior)
- Device-only intermediate state (device configured, no class configs yet): renders the three default egress classes at proportional **explicit** rates from the (always concrete) device rate. Previously an explicit device `--rate` was silently ignored here and always fell back to sysfs
- `set` uses `tc class change` for a live atomic kernel update with no qdisc teardown; the boot script is re-rendered and **persisted without restarting the service**, so reboot persistence does not reintroduce qdisc churn
- `delete` is guarded: a class cannot be removed if it is the device's default or referenced by any `network policy --stamp/--reply-stamp`
- Dead-code cleanup + hardening: removed the unused exported `RenderTcEgressScript` wrapper, the test-only `contentEqual`, and the never-called `loadAllClasses`. The NIC-name validation that lived only in the dead wrapper is relocated into `renderTcEgressScriptFromData` (the single render funnel), so an operator-supplied `--egress-interface` can no longer inject into the root-executed boot script

## Changed Files

| File | Description |
|------|-------------|
| `internal/network/shape/class.go` | Class-info map (`classInfoMap`), `ClassConfig` struct, `lookupClassInfo` |
| `internal/network/shape/device.go` | `DeviceConfig` struct |
| `internal/network/shape/validate.go` | dir/rate/ceil/prio/Σ-rate validators |
| `internal/network/shape/registry.go` | JSON read/write for device & class configs; policy stamp cross-ref; removed unused `loadAllClasses` |
| `internal/network/shape/manager.go` | `Manager` with full CRUD; `defaultEgressConfig` computes proportional rates; `ProvisionDefaultEgress` writes registry + renders (resolves `auto` first); `RenderAndApplyEgress` re-renders from existing config or sysfs fallback; device-only render emits explicit proportional rates; shared `resolveAutoRateString` resolves `auto` at create time (detected speed, or `DefaultLinkSpeedMbit` when unreadable — always concrete) for both `CreateDevice` and install; injectable `SpeedDetect`/`NICDetect` for tests |
| `internal/network/shape/speed.go` | `DefaultLinkSpeedMbit` (1000) — the fallback link speed when sysfs is unreadable, mirroring the boot-script fallback |
| `internal/network/shape/apply_linux.go` | `ApplyTcEgressScript` self-installs the unit via `EnsureTcEgressUnit` before restarting |
| `internal/network/shape/render.go` | `renderTcEgressScriptFromConfig` passes `SpeedMbit=-1` to omit SPEED block; sysfs auto-detect is the only fallback; removed dead `RenderTcEgressScript` and test-only `contentEqual`; NIC-name validation moved into the `renderTcEgressScriptFromData` funnel so operator-supplied `--egress-interface` names are validated on the live path |
| `internal/network/shape/tc_linux.go` | `TCRunner` interface + `execTCRunner` (`tc class change`) |
| `internal/network/shape/tc_other.go` | `noopTCRunner` stub for non-Linux builds |
| `internal/network/shape/paths.go` | New constants: `ShapeConfigDir`, `DeviceConfigDir`, `ClassConfigDir`, `ShapeLockPath` |
| `internal/network/shape/shape_test.go` | All shape unit tests; proportion-correctness tests for `defaultEgressConfig`; asserts SPEED absent when rates are explicit; device-only tests; `resolveAutoRate` tests; NIC-validation test now exercises the live render funnel (empty + injection-style names rejected) |
| `internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl` | Two-way `SpeedMbit` branch: `<0` explicit rates (omit SPEED), else sysfs auto-detect |
| `internal/workflows/steps/step_network_tc_egress.go` | `TcEgressPersist(nicName, trunkRate string)`: non-empty rate provisions the registry; empty re-renders from existing config or sysfs fallback |
| `cmd/cli/commands/common/egress.go` | `--link-rate` accepts `auto` (detect + store at install time) in addition to rates/blank; `ValidateEgressFlags` and the flag description updated |
| `cmd/cli/commands/common/egress_test.go` | `ValidateEgressFlags` accepts `auto`/rates/blank, rejects garbage |
| `internal/ui/prompt/blocknode.go` | NIC Link Rate prompt accepts `auto` (case-insensitive) alongside a rate or blank; help text documents all three |
| `internal/ui/prompt/prompt_test.go` | `LinkRateInputPrompt` validator test (accepts blank/`auto`/rates, rejects garbage) |
| `internal/bll/blocknode/install_handler.go` | Pass `ins.LinkRate` directly to `TcEgressPersist`; remove `ParseSpeedMbit` conversion |
| `internal/bll/blocknode/reconfigure_handler.go` | Same |
| `cmd/cli/commands/network/shape/shape.go` | `shapeCmd` parent + flag vars |
| `cmd/cli/commands/network/shape/create.go` | `create` verb; `--rate auto` accepted for `--device`, rejected for `--class`; flag description updated |
| `cmd/cli/commands/network/shape/set.go` | `set` verb (live `tc class change` + script re-render) |
| `cmd/cli/commands/network/shape/show.go` | `show` verb |
| `cmd/cli/commands/network/shape/delete.go` | `delete` verb (guarded removal) |
| `cmd/cli/commands/network/shape/shape_test.go` | CLI validation tests |
| `cmd/cli/commands/network/network.go` | Wires `shape.GetCmd()` into the `network` command group |

## Manual UAT

> All steps require the UTM Linux VM with a running Kubernetes cluster.

### 1. Block node install — shape registry populated from --link-rate

```bash
# Find your NIC first: ip link show  OR  ip route get 8.8.8.8 | grep dev
sudo solo-provisioner block node install --egress-interface enp0s1
# At the NIC Link Rate prompt, enter or confirm a value (e.g. "1gbit")

# Verify the script has explicit rates — no SPEED variable:
cat /usr/local/sbin/solo-provisioner-tc-egress.sh
# Expected: NO line containing "SPEED"
# Expected: htb rate "1gbit" ceil "1gbit"   ← trunk
# Expected: htb rate "400mbit" ceil "700mbit" prio 0   ← partner (40%/70%)
# Expected: htb rate "300mbit" ceil "700mbit" prio 5   ← public (30%/70%)
# Expected: htb rate "300mbit" ceil "1gbit"  prio 1   ← reserve-egress (30%/100%)

# Verify the shape registry was written:
cat /etc/solo-provisioner/network/shape/devices/egress.json
# Expected: {"dir":"egress","rate":"1gbit","default_class":"reserve-egress",...}

sudo solo-provisioner network shape show
# Expected: device egress rate=1gbit default=reserve-egress; three classes listed
```

### 2. Create egress device root standalone (self-install check)

```bash
# Start from a clean slate so class configs from prior runs don't interfere:
sudo rm -rf /etc/solo-provisioner/network/shape/

# 2a. Explicit rate — explicit proportional placeholder classes, no SPEED.
sudo solo-provisioner network shape create \
  --device egress --rate 1gbit --default reserve-egress
# Expected: "network shape device configured dir=egress rate=1gbit default=reserve-egress"

systemctl status solo-provisioner-tc-egress.service
# Expected: active (exited)

grep -c 'SPEED' /usr/local/sbin/solo-provisioner-tc-egress.sh
# Expected: 0  (explicit rate → no SPEED even before classes are added)
grep 'classid 1:40' /usr/local/sbin/solo-provisioner-tc-egress.sh
# Expected: htb rate "400mbit" ceil "700mbit"  (partner placeholder, 40%/70% of 1gbit)

# 2b. --rate auto — resolves to a concrete rate at create time (always).
sudo solo-provisioner network shape create \
  --device egress --rate auto --default reserve-egress --force

sudo solo-provisioner network shape show --device egress
# Readable link speed: rate=<detected> (e.g. 1gbit).
# Virtual NIC (sysfs -1, e.g. UTM VM): rate=1gbit (default fallback).
# Either way it is concrete, NOT "auto".
grep -c 'SPEED' /usr/local/sbin/solo-provisioner-tc-egress.sh
# Expected: 0  (explicit rates; no SPEED, no sysfs read at boot)
```

### 3. Create egress classes — explicit rates, SPEED gone

> Prerequisite: step 2 ran first (clean device, no class configs yet).

```bash
sudo solo-provisioner network shape create --class partner        --rate 400mbit --ceil 700mbit  --prio 0
sudo solo-provisioner network shape create --class public         --rate 300mbit --ceil 700mbit  --prio 5
sudo solo-provisioner network shape create --class reserve-egress --rate 300mbit --ceil 1000mbit --prio 1

systemctl status solo-provisioner-tc-egress.service
# Expected: active (exited)

grep -c 'SPEED' /usr/local/sbin/solo-provisioner-tc-egress.sh
# Expected: 0  (SPEED block absent when all rates are explicit)

grep 'classid 1:40' /usr/local/sbin/solo-provisioner-tc-egress.sh
# Expected: ... htb rate "400mbit" ceil "700mbit" prio 0
```

### 4. Show configuration

```bash
sudo solo-provisioner network shape show
sudo solo-provisioner network shape show --class partner
# Expected: class partner (1:40, egress device) / rate: 400mbit / ceil: 700mbit / prio: 0
```

### 5. Live update (set — no qdisc teardown)

```bash
sudo solo-provisioner network shape set --class partner --rate 500mbit
sudo tc -s class show dev enp0s1 classid 1:40
# Expected: rate 500Mbit reflected immediately in kernel
```

### 6. Delete guard — class is device default

```bash
sudo solo-provisioner network shape delete --class reserve-egress
# Expected error: "class \"reserve-egress\" is the default class for device \"egress\"..."

sudo solo-provisioner network shape create --device egress --rate 1gbit --default public --force
sudo solo-provisioner network shape delete --class reserve-egress
# Expected: class deleted, script re-rendered, service restarted
```

### 7. Reboot persistence

```bash
sudo reboot
systemctl status solo-provisioner-tc-egress.service
# Expected: active (exited)

journalctl -u solo-provisioner-tc-egress.service -n 50
# Expected: tc commands executed without error

sudo tc -s class show dev enp0s1
# Expected: HTB classes match configured rates
```

### 8. Backward compatibility — no shape config

```bash
sudo rm -rf /etc/solo-provisioner/network/shape/
# Trigger a re-render (e.g. re-run block node install or create --device)
cat /usr/local/sbin/solo-provisioner-tc-egress.sh
# Expected: SPEED=$(cat /sys/class/net/"$NIC"/speed ...)  ← sysfs detection present
# Expected: ${SPEED}mbit and $(( SPEED * N / 100 ))mbit  ← SPEED-proportional
# Expected: NO explicit mbit values like "400mbit"
```

### 9. Validation — invalid flags

```bash
sudo solo-provisioner network shape create --class partner --rate 400mbit --ceil fast
# Expected error: invalid bandwidth "fast"

sudo solo-provisioner network shape create --class partner --rate 400mbit --ceil 300mbit
# Expected error: --ceil 300mbit must be >= --rate 400mbit
```

## Test Plan

- [x] `go test -tags='!integration' ./internal/network/shape/...` — all unit tests pass on macOS
- [x] `GOOS=linux GOARCH=amd64 go build ./cmd/cli/...` — clean
- [x] `task lint` — 0 issues
- [ ] `task vm:test:unit` — run full suite in UTM VM (CLI package tests require Linux)
- [ ] Manual UAT steps 1–9 above on the UTM VM

- Closes #771 
