### PR TITLE
fix(blocknode): wire application-state path into reality checker and state reader

### DIFF
--- a/internal/reality/blocknode_checker.go
+++ b/internal/reality/blocknode_checker.go
@@ -210,6 +210,9 @@ func (b *blockNodeChecker) populateStorageFromPVs(
 		case strings.Contains(claimName, "plugins"):
 			storage.PluginsPath = hostpath
 			storage.PluginsSize = size
+		case strings.Contains(claimName, "application-state"):
+			storage.ApplicationStatePath = hostpath
+			storage.ApplicationStateSize = size
 		}
 
 	}

--- a/internal/reality/blocknode_checker_test.go
+++ b/internal/reality/blocknode_checker_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package reality
+
+import (
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makePV(claimNamespace, claimName, size, hostPath string) unstructured.Unstructured {
+	return unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"claimRef": map[string]interface{}{
+					"namespace": claimNamespace,
+					"name":      claimName,
+				},
+				"capacity": map[string]interface{}{
+					"storage": size,
+				},
+				"hostPath": map[string]interface{}{
+					"path": hostPath,
+				},
+			},
+		},
+	}
+}
+
+func TestPopulateStorageFromPVs_ApplicationStatePVC(t *testing.T) {
+	pvs := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{
+			makePV("test-ns", "application-state-storage-pvc", "50Gi", "/mnt/fast-storage/block-node/application-state"),
+		},
+	}
+	storage := &models.BlockNodeStorage{}
+	checker := &blockNodeChecker{}
+
+	if err := checker.populateStorageFromPVs(pvs, "test-ns", storage); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if storage.ApplicationStatePath != "/mnt/fast-storage/block-node/application-state" {
+		t.Errorf("expected ApplicationStatePath '/mnt/fast-storage/block-node/application-state', got %q", storage.ApplicationStatePath)
+	}
+	if storage.ApplicationStateSize != "50Gi" {
+		t.Errorf("expected ApplicationStateSize '50Gi', got %q", storage.ApplicationStateSize)
+	}
+}
+
+func TestPopulateStorageFromPVs_AllFields(t *testing.T) {
+	pvs := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{
+			makePV("ns", "live-storage-pvc", "100Gi", "/mnt/live"),
+			makePV("ns", "archive-storage-pvc", "200Gi", "/mnt/archive"),
+			makePV("ns", "log-storage-pvc", "10Gi", "/mnt/log"),
+			makePV("ns", "verification-storage-pvc", "20Gi", "/mnt/verification"),
+			makePV("ns", "plugins-storage-pvc", "5Gi", "/mnt/plugins"),
+			makePV("ns", "application-state-storage-pvc", "50Gi", "/mnt/app-state"),
+		},
+	}
+	storage := &models.BlockNodeStorage{}
+	checker := &blockNodeChecker{}
+
+	if err := checker.populateStorageFromPVs(pvs, "ns", storage); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if storage.LivePath != "/mnt/live" {
+		t.Errorf("LivePath: got %q", storage.LivePath)
+	}
+	if storage.ArchivePath != "/mnt/archive" {
+		t.Errorf("ArchivePath: got %q", storage.ArchivePath)
+	}
+	if storage.LogPath != "/mnt/log" {
+		t.Errorf("LogPath: got %q", storage.LogPath)
+	}
+	if storage.VerificationPath != "/mnt/verification" {
+		t.Errorf("VerificationPath: got %q", storage.VerificationPath)
+	}
+	if storage.PluginsPath != "/mnt/plugins" {
+		t.Errorf("PluginsPath: got %q", storage.PluginsPath)
+	}
+	if storage.ApplicationStatePath != "/mnt/app-state" {
+		t.Errorf("ApplicationStatePath: got %q", storage.ApplicationStatePath)
+	}
+	if storage.ApplicationStateSize != "50Gi" {
+		t.Errorf("ApplicationStateSize: got %q", storage.ApplicationStateSize)
+	}
+}
+
+func TestPopulateStorageFromPVs_SkipsDifferentNamespace(t *testing.T) {
+	pvs := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{
+			makePV("other-ns", "application-state-storage-pvc", "50Gi", "/mnt/app-state"),
+		},
+	}
+	storage := &models.BlockNodeStorage{}
+	checker := &blockNodeChecker{}
+
+	if err := checker.populateStorageFromPVs(pvs, "test-ns", storage); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if storage.ApplicationStatePath != "" {
+		t.Errorf("expected empty ApplicationStatePath for wrong namespace, got %q", storage.ApplicationStatePath)
+	}
+}
+
+func TestPopulateStorageFromPVs_NilInputsNoError(t *testing.T) {
+	checker := &blockNodeChecker{}
+
+	if err := checker.populateStorageFromPVs(nil, "ns", nil); err != nil {
+		t.Fatalf("unexpected error for nil inputs: %v", err)
+	}
+}

--- a/internal/state/state_reader.go
+++ b/internal/state/state_reader.go
@@ -76,12 +76,13 @@ type PromptDefaultsDoc struct {
 			PluginPreset      string `yaml:"pluginPreset"`
 			PluginList        string `yaml:"pluginList"`
 			Storage           struct {
-				BasePath         string `yaml:"basePath"`
-				ArchivePath      string `yaml:"archivePath"`
-				LivePath         string `yaml:"livePath"`
-				LogPath          string `yaml:"logPath"`
-				VerificationPath string `yaml:"verificationPath"`
-				PluginsPath      string `yaml:"pluginsPath"`
+				BasePath             string `yaml:"basePath"`
+				ArchivePath          string `yaml:"archivePath"`
+				LivePath             string `yaml:"livePath"`
+				LogPath              string `yaml:"logPath"`
+				VerificationPath     string `yaml:"verificationPath"`
+				PluginsPath          string `yaml:"pluginsPath"`
+				ApplicationStatePath string `yaml:"applicationStatePath"`
 			} `yaml:"storage"`
 		} `yaml:"blockNodeState"`
 	} `yaml:"state"`
@@ -202,12 +203,13 @@ func ReadPromptDefaultsFromDisk() (PromptDefaults, error) {
 			PluginPreset:      bn.PluginPreset,
 			PluginList:        bn.PluginList,
 			Storage: models.BlockNodeStorage{
-				BasePath:         bn.Storage.BasePath,
-				ArchivePath:      bn.Storage.ArchivePath,
-				LivePath:         bn.Storage.LivePath,
-				LogPath:          bn.Storage.LogPath,
-				VerificationPath: bn.Storage.VerificationPath,
-				PluginsPath:      bn.Storage.PluginsPath,
+				BasePath:             bn.Storage.BasePath,
+				ArchivePath:          bn.Storage.ArchivePath,
+				LivePath:             bn.Storage.LivePath,
+				LogPath:              bn.Storage.LogPath,
+				VerificationPath:     bn.Storage.VerificationPath,
+				PluginsPath:          bn.Storage.PluginsPath,
+				ApplicationStatePath: bn.Storage.ApplicationStatePath,
 			},
 		},
 	}, nil

--- a/internal/state/state_reader_test.go
+++ b/internal/state/state_reader_test.go
@@ -6,6 +6,8 @@ package state
 
 import (
 	"testing"
+
+	"github.com/hashgraph/solo-weaver/pkg/models"
 )
 
 func TestReadProvisionerVersion_ParsesCorrectly(t *testing.T) {
@@ -96,6 +98,7 @@ state:
       logPath: /mnt/log
       verificationPath: /mnt/verification
       pluginsPath: /mnt/plugins
+      applicationStatePath: /mnt/app-state
 `)
 	var doc PromptDefaultsDoc
 	if err := unmarshalStateDoc(data, &doc); err != nil {
@@ -144,6 +147,36 @@ state:
 	}
 	if bn.Storage.PluginsPath != "/mnt/plugins" {
 		t.Errorf("expected Storage.PluginsPath '/mnt/plugins', got %q", bn.Storage.PluginsPath)
+	}
+	if bn.Storage.ApplicationStatePath != "/mnt/app-state" {
+		t.Errorf("expected Storage.ApplicationStatePath '/mnt/app-state', got %q", bn.Storage.ApplicationStatePath)
+	}
+}
+
+func TestReadPromptDefaults_ApplicationStatePathFlowsThroughToModel(t *testing.T) {
+	data := []byte(`
+state:
+  blockNodeState:
+    storage:
+      applicationStatePath: /mnt/app-state
+`)
+	var doc PromptDefaultsDoc
+	if err := unmarshalStateDoc(data, &doc); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	bn := doc.State.BlockNodeState
+	storage := models.BlockNodeStorage{
+		BasePath:             bn.Storage.BasePath,
+		ArchivePath:          bn.Storage.ArchivePath,
+		LivePath:             bn.Storage.LivePath,
+		LogPath:              bn.Storage.LogPath,
+		VerificationPath:     bn.Storage.VerificationPath,
+		PluginsPath:          bn.Storage.PluginsPath,
+		ApplicationStatePath: bn.Storage.ApplicationStatePath,
+	}
+	if storage.ApplicationStatePath != "/mnt/app-state" {
+		t.Errorf("expected ApplicationStatePath '/mnt/app-state' in model, got %q", storage.ApplicationStatePath)
 	}
 }
 


### PR DESCRIPTION
## Description

`block node upgrade --with-reset` silently skipped clearing the `application-state`
directory whenever the command was run with a different (or absent) `--config` than
the one used at install time. Every other storage directory (archive, live, logs,
plugins) was wiped correctly.

Two pieces that enumerate block-node storage paths both missed `application-state`
when that volume was introduced:

1. **Reality checker** (`internal/reality/blocknode_checker.go`) — the `switch` that
   maps PV claim names to `BlockNodeStorage` fields had no case for
   `application-state-storage-pvc`, so `ApplicationStatePath` was always empty after
   a cluster state refresh.
2. **State reader** (`internal/state/state_reader.go`) — the YAML struct for
   `blockNodeState.storage` listed every other path field but not
   `applicationStatePath`, so the value was never round-tripped from disk.

With both sources returning `""`, `ResolveStoragePaths` derived the relative path
`"application-state"`, `DirExists` found nothing, and the wipe was silently skipped.

Both fixes are additive only: the new switch case fires exclusively for
`application-state-storage-pvc`, and adding the field to the state YAML struct is
backward-compatible (existing state files without the key unmarshal to `""`, the
same default as before).

### Related Issues

* Closes #837
