### PR TITLE
feat(blocknode): add roster-bootstrap plugins to LFH/RFH presets for BN 0.37.1

### DIFF
--- a/internal/blocknode/blocknode_plugins.go
+++ b/internal/blocknode/blocknode_plugins.go
@@ -101,6 +101,34 @@ var blockNodePluginHistory = []blockNodePluginConfig{
 			"cloud-storage-expanded",
 		},
 	},
+	{
+		// BN 0.37.1: roster-bootstrap-rsa + roster-bootstrap-tss added to both presets.
+		// The RFH preset was also trimmed upstream: block-access-service, stream-publisher,
+		// stream-subscriber, and blocks-file-recent were dropped (recent blocks now flow to
+		// cloud storage rather than the local live volume). Strings copied verbatim from the
+		// chart's values-overrides/plugin-profile-{lfh,rfh,all}.yaml at tag v0.37.1.
+		MinVersion: "0.37.1",
+		Presets: map[string]string{
+			PresetTier1LFH: "backfill,block-access-service,blocks-file-historic,blocks-file-recent,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status,stream-publisher,stream-subscriber,verification",
+			PresetTier1RFH: "backfill,cloud-storage-archive,cloud-storage-expanded,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status,verification",
+		},
+		AllPlugins: []string{
+			"backfill",
+			"block-access-service",
+			"blocks-file-historic",
+			"blocks-file-recent",
+			"cloud-storage-archive",
+			"cloud-storage-expanded",
+			"facility-messaging",
+			"health",
+			"roster-bootstrap-rsa",
+			"roster-bootstrap-tss",
+			"server-status",
+			"stream-publisher",
+			"stream-subscriber",
+			"verification",
+		},
+	},
 }
 
 // AllBlockNodePlugins is the ordered list of available plugins for the current

--- a/internal/blocknode/blocknode_plugins_test.go
+++ b/internal/blocknode/blocknode_plugins_test.go
@@ -203,7 +203,7 @@ func TestPluginListForPreset_UpgradeScenario(t *testing.T) {
 			wantAbsent:      []string{"s3-archive", "block-access-service", "stream-publisher", "stream-subscriber", "blocks-file-recent"},
 		},
 		{
-			name:            "RFH upgrade 0.37.0 to 0.37.1 crosses the roster-bootstrap boundary",
+			name:            "RFH target 0.37.0 stays pre-0.37.1 (no roster-bootstrap)",
 			installedPreset: PresetTier1RFH,
 			targetVersion:   "0.37.0",
 			wantContains:    []string{"cloud-storage-archive", "cloud-storage-expanded", "blocks-file-recent", "block-access-service"},

--- a/internal/blocknode/blocknode_plugins_test.go
+++ b/internal/blocknode/blocknode_plugins_test.go
@@ -116,6 +116,51 @@ func TestPluginListForPreset_Tier1RFH_LegacyBN(t *testing.T) {
 	}
 }
 
+// ── BN 0.37.1 roster-bootstrap boundary ──────────────────────────────────────
+
+// TestPluginListForPreset_BN0371_ExactLists pins the 0.37.1 preset strings to the
+// verbatim upstream values-overrides/plugin-profile-{lfh,rfh}.yaml so the injected
+// plugins.names is byte-identical to the chart default. "" resolves to the latest
+// (0.37.1) entry.
+func TestPluginListForPreset_BN0371_ExactLists(t *testing.T) {
+	const wantLFH = "backfill,block-access-service,blocks-file-historic,blocks-file-recent,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status,stream-publisher,stream-subscriber,verification"
+	const wantRFH = "backfill,cloud-storage-archive,cloud-storage-expanded,facility-messaging,health,roster-bootstrap-rsa,roster-bootstrap-tss,server-status,verification"
+	for _, ver := range []string{"", "0.37.1", "0.38.0", "1.0.0"} {
+		assert.Equal(t, wantLFH, PluginListForPreset(PresetTier1LFH, ver), "LFH version=%q", ver)
+		assert.Equal(t, wantRFH, PluginListForPreset(PresetTier1RFH, ver), "RFH version=%q", ver)
+	}
+}
+
+// TestPluginListForPreset_Pre0371_NoRosterBootstrap verifies that chart versions
+// below 0.37.1 keep resolving to the 0.35.0 bracket: no roster-bootstrap plugins,
+// and the RFH preset still carries the plugins that 0.37.1 trims.
+func TestPluginListForPreset_Pre0371_NoRosterBootstrap(t *testing.T) {
+	for _, ver := range []string{"0.35.0", "0.36.0", "0.37.0"} {
+		lfh := PluginListForPreset(PresetTier1LFH, ver)
+		rfh := PluginListForPreset(PresetTier1RFH, ver)
+		assert.NotContains(t, lfh, "roster-bootstrap", "LFH version=%q", ver)
+		assert.NotContains(t, rfh, "roster-bootstrap", "RFH version=%q", ver)
+		for _, kept := range []string{"block-access-service", "stream-publisher", "stream-subscriber", "blocks-file-recent"} {
+			assert.Contains(t, rfh, kept, "RFH version=%q must still carry %q below 0.37.1", ver, kept)
+		}
+	}
+}
+
+// TestPluginsForVersion_BN0371Boundary verifies the TUI custom multi-select menu
+// gains roster-bootstrap only at 0.37.1+.
+func TestPluginsForVersion_BN0371Boundary(t *testing.T) {
+	for _, ver := range []string{"", "0.37.1", "0.38.0"} {
+		plugins := PluginsForVersion(ver)
+		assert.Contains(t, plugins, "roster-bootstrap-rsa", "version=%q", ver)
+		assert.Contains(t, plugins, "roster-bootstrap-tss", "version=%q", ver)
+	}
+	for _, ver := range []string{"0.35.0", "0.37.0"} {
+		plugins := PluginsForVersion(ver)
+		assert.NotContains(t, plugins, "roster-bootstrap-rsa", "version=%q", ver)
+		assert.NotContains(t, plugins, "roster-bootstrap-tss", "version=%q", ver)
+	}
+}
+
 // TestPluginListForPreset_UpgradeScenario documents the expected behaviour when an
 // operator upgrades from a pre-0.35 chart to 0.35+. solo-weaver reads the stored
 // PluginPreset ("tier1-rfh") and calls PluginListForPreset with the new target
@@ -148,6 +193,27 @@ func TestPluginListForPreset_UpgradeScenario(t *testing.T) {
 			installedPreset: PresetTier1LFH,
 			targetVersion:   "0.35.0",
 			wantContains:    []string{"blocks-file-historic", "blocks-file-recent"},
+			wantAbsent:      []string{"s3-archive", "cloud-storage-archive", "cloud-storage-expanded"},
+		},
+		{
+			name:            "RFH upgrade to 0.37.1 adds roster-bootstrap and drops trimmed plugins",
+			installedPreset: PresetTier1RFH,
+			targetVersion:   "0.37.1",
+			wantContains:    []string{"roster-bootstrap-rsa", "roster-bootstrap-tss", "cloud-storage-archive", "cloud-storage-expanded"},
+			wantAbsent:      []string{"s3-archive", "block-access-service", "stream-publisher", "stream-subscriber", "blocks-file-recent"},
+		},
+		{
+			name:            "RFH upgrade 0.37.0 to 0.37.1 crosses the roster-bootstrap boundary",
+			installedPreset: PresetTier1RFH,
+			targetVersion:   "0.37.0",
+			wantContains:    []string{"cloud-storage-archive", "cloud-storage-expanded", "blocks-file-recent", "block-access-service"},
+			wantAbsent:      []string{"roster-bootstrap-rsa", "roster-bootstrap-tss"},
+		},
+		{
+			name:            "LFH upgrade to 0.37.1 adds roster-bootstrap and keeps file plugins",
+			installedPreset: PresetTier1LFH,
+			targetVersion:   "0.37.1",
+			wantContains:    []string{"roster-bootstrap-rsa", "roster-bootstrap-tss", "blocks-file-historic", "blocks-file-recent"},
 			wantAbsent:      []string{"s3-archive", "cloud-storage-archive", "cloud-storage-expanded"},
 		},
 	}

--- a/internal/ui/prompt/blocknode.go
+++ b/internal/ui/prompt/blocknode.go
@@ -27,6 +27,18 @@ const (
 	storagePathModeIndividual = "Individual paths"
 )
 
+// Custom plugin multi-select sizing. huh sets the option viewport to
+// (fieldHeight − title − description), so the field height is sized to the option
+// count plus chrome for the title and (up to three-line) description, letting the
+// whole menu render without paging. It is capped so an unexpectedly large menu — or a
+// mis-sized terminal — can't produce an unwieldy field; huh scrolls past the cap and
+// the field stays filterable ("/") by huh's default. Without an explicit height,
+// huh's OptionsFunc path forces a default of 10 (only ~8 plugins visible).
+const (
+	pluginMultiSelectMaxHeight = 50
+	pluginMultiSelectChrome    = 4
+)
+
 // validateRetentionThreshold validates that a retention threshold is a non-negative integer.
 func validateRetentionThreshold(s string) error {
 	if s == "" {
@@ -425,29 +437,34 @@ func AddStoragePathPrompts(
 	inIndividualMode := func() bool { return selectedMode == storagePathModeIndividual }
 
 	// ── Page: mode select ─────────────────────────────────────────────────────
-	// The individual-paths option label lists the optional storages that apply to
-	// the live chart version, so it is rebuilt via OptionsFunc bound to
-	// *chartVersion. The option *values* are stable (only the label changes), so
-	// huh preserves the current selection across rebuilds.
-	modeOptions := func() []huh.Option[string] {
-		var label strings.Builder
-		label.WriteString("Individual paths  (archive, live, log")
+	// Options are STATIC (two fixed modes). The per-version detail — which optional
+	// storages must be supplied in individual mode — lives in the field description
+	// via DescriptionFunc, not in the option labels. This is deliberate: using
+	// OptionsFunc would force huh's field height to its default and route through the
+	// viewport's `YOffset = selected` path, which scrolls the non-selected option out
+	// of view (with the default being Individual, "Single base path" was hidden until
+	// the user arrowed up). Static Options leave the height at 0, so huh sizes the
+	// viewport to the option count and shows both modes.
+	modeDescription := func() string {
+		var b strings.Builder
+		b.WriteString("Choose how to configure storage paths for this block node.\n")
+		b.WriteString("Individual paths mode requires archive, live, log")
 		for _, o := range blocknode.GetApplicableOptionalStorages(*chartVersion) {
-			label.WriteString(", ")
-			label.WriteString(o.Name)
+			b.WriteString(", ")
+			b.WriteString(o.Name)
 		}
-		label.WriteString(" must all be provided)")
-		return []huh.Option[string]{
-			huh.NewOption("Single base path  (subdirectories are created automatically)", storagePathModeBasePath),
-			huh.NewOption(label.String(), storagePathModeIndividual),
-		}
+		b.WriteString(" to all be provided.")
+		return b.String()
 	}
 	modeGroup := huh.NewGroup(
 		huh.NewSelect[string]().
 			Key("storage-mode").
 			Title("Storage Path Mode").
-			Description("Choose how to configure storage paths for this block node").
-			OptionsFunc(modeOptions, chartVersion).
+			DescriptionFunc(modeDescription, chartVersion).
+			Options(
+				huh.NewOption("Single base path  (subdirectories created automatically)", storagePathModeBasePath),
+				huh.NewOption("Individual paths  (set each path separately)", storagePathModeIndividual),
+			).
 			Value(&selectedMode),
 	)
 
@@ -781,6 +798,12 @@ func AddPluginPresetPrompts(
 	}
 
 	isCustom := func() bool { return *flagPluginPreset == blocknode.PresetCustom }
+	// Size the field to the current plugin count (plus chrome) so every option shows
+	// without paging, capped at pluginMultiSelectMaxHeight. Computed from the chart
+	// version at construction; huh keeps this height across OptionsFunc rebuilds, so a
+	// mid-wizard version change to a larger menu falls back to scrolling — acceptable
+	// since real menus are far below the cap.
+	pluginFieldHeight := min(len(blocknode.PluginsForVersion(*chartVersion))+pluginMultiSelectChrome, pluginMultiSelectMaxHeight)
 	customGroup := huh.NewGroup(
 		huh.NewMultiSelect[string]().
 			Key("plugins").
@@ -788,6 +811,12 @@ func AddPluginPresetPrompts(
 			DescriptionFunc(descriptionFn, chartVersion).
 			OptionsFunc(pluginOptionsFn, chartVersion).
 			Value(&selectedPlugins).
+			// Show the whole plugin menu at once instead of huh's OptionsFunc-forced
+			// default of ~8 visible rows. Type-to-filter ("/") is already available
+			// via huh's default Filterable state; do NOT call Filtering(true) — that
+			// boots the field into active filter-input mode, which hijacks space
+			// (typed into the filter, clearing the list) and shift+tab.
+			Height(pluginFieldHeight).
 			Validate(func(selected []string) error {
 				// Only enforce a selection while the Custom preset is active; when
 				// the group is hidden this validator must not block submission.


### PR DESCRIPTION
## Description

The block-node chart's LFH and RFH plugin profiles gained `roster-bootstrap-rsa` and
`roster-bootstrap-tss` at chart `v0.37.1`. solo-weaver's plugin-preset registry stopped at a
`0.35.0` bracket, and since that entry is open-ended it also answered for 0.36/0.37/0.37.1 — so a
default install (default chart version is already `0.37.1`) was resolving to a **stale** plugin
list: missing roster-bootstrap and still carrying plugins that upstream has since removed from RFH.

This PR adds a version-gated registry entry at `MinVersion: "0.37.1"` so 0.37.1+ installs resolve
to the correct profiles, while 0.35.0–0.37.0 installs keep resolving to the existing bracket
unchanged.

* Add `roster-bootstrap-rsa` / `roster-bootstrap-tss` to the **tier1-lfh** and **tier1-rfh** presets for BN 0.37.1+.
* Match the RFH preset to upstream `v0.37.1` exactly — this also **drops** `block-access-service`, `stream-publisher`, `stream-subscriber`, and `blocks-file-recent` from RFH (see Risks).
* Fix stale resolution for the default chart version (`0.37.1`), which previously fell back to the `0.35.0` bracket.
* No caller changes and no migration — the resolver/TUI already thread `chartVersion`, and `plugins.names` is a plain Helm value (not a PVC), so no state or storage migration is involved.

### Approach — why a static registry entry (not dynamic fetch)

The plugin-to-version mapping stays compiled into the binary (the version-aware registry from #656),
so resolution is deterministic and works offline/air-gapped for **any** BN version — including
installing an older release, which is just a local table lookup. The alternative (reading the
chart's plugin profiles dynamically at runtime) would require a network fetch of each target
version's chart and couple us to the upstream `values-overrides/` file layout. The tradeoff we
accept is manual upkeep: a new registry entry per upstream profile change (this PR is one such
update).

### Where the plugin lists live

- **In this repo (source of truth for what solo-weaver injects):** `internal/blocknode/blocknode_plugins.go` — the `blockNodePluginHistory` registry. Each entry is a `blockNodePluginConfig` with a `MinVersion`, a `Presets` map (`tier1-lfh` / `tier1-rfh`), and `AllPlugins` (the TUI custom multi-select menu).
- **Upstream source of truth (what the registry strings are copied from):** `charts/block-node-server/values-overrides/plugin-profile-lfh.yaml`, `plugin-profile-rfh.yaml`, and `plugin-profile-all.yaml` in `hiero-ledger/hiero-block-node`, at tag **`v0.37.1`**.
- **At runtime after install:** `helm get values block-node -n block-node` → the `plugins.names` key.

### Review guide

**Code-review checklist**
- [ ] New `blockNodePluginHistory` entry is in ascending `MinVersion` order (`internal/blocknode/blocknode_plugins.go`), after the `0.35.0` entry — enforced by `TestPluginHistory_AscendingVersionOrder`.
- [ ] Both `tier1-lfh` and `tier1-rfh` are present in the new entry's `Presets` map — enforced by `TestPluginHistory_AllKnownPresetsInEveryEntry`.
- [ ] Preset strings and `AllPlugins` match the upstream `v0.37.1` `plugin-profile-{lfh,rfh,all}.yaml` **verbatim** (order included), so injected `plugins.names` is byte-identical to the chart default — locked by `TestPluginListForPreset_BN0371_ExactLists`.
- [ ] Versions below `0.37.1` still resolve to the `0.35.0` bracket (no roster-bootstrap; RFH keeps the four plugins) — `TestPluginListForPreset_Pre0371_NoRosterBootstrap`.

**Test commands**
```bash
# Unit (VM recommended; blocknode pkg has Linux-tagged files, but the plugin tests build on macOS too)
task vm:test:unit
go test -race -tags='!integration' ./internal/blocknode/... -run Plugin
```

**Manual UAT** (UTM VM: `task vm:start`)

1. Fresh install at the default chart version, both presets — verify `plugins.names`:
   ```bash
   solo-provisioner block node install --plugin-preset=tier1-lfh --non-interactive --profile=local
   helm get values block-node -n block-node
   # LFH expected names:
   #   backfill,block-access-service,blocks-file-historic,blocks-file-recent,facility-messaging,health,
   #   roster-bootstrap-rsa,roster-bootstrap-tss,server-status,stream-publisher,stream-subscriber,verification

   solo-provisioner block node install --plugin-preset=tier1-rfh --non-interactive --profile=local
   helm get values block-node -n block-node
   # RFH expected names:
   #   backfill,cloud-storage-archive,cloud-storage-expanded,facility-messaging,health,
   #   roster-bootstrap-rsa,roster-bootstrap-tss,server-status,verification
   # (block-access-service, stream-publisher, stream-subscriber, blocks-file-recent must be ABSENT)
   ```

2. Legacy version still correct (boundary proof) — roster-bootstrap must NOT appear:
   ```bash
   solo-provisioner block node install --chart-version=0.37.0 --plugin-preset=tier1-rfh --non-interactive --profile=local
   helm get values block-node -n block-node   # 0.35-bracket list; no roster-bootstrap-*
   ```

3. Non-interactive upgrade auto-resolves across the boundary:
   ```bash
   solo-provisioner block node install --chart-version=0.37.0 --plugin-preset=tier1-rfh --non-interactive --profile=local
   solo-provisioner block node upgrade --chart-version=0.37.1 --non-interactive --profile=local
   helm get values block-node -n block-node
   # plugins.names now carries roster-bootstrap-rsa/tss; the four RFH plugins are dropped.
   # Confirm NO StorageMigration runs for the 0.37.0 -> 0.37.1 span (app-state boundary already crossed at 0.37.0).
   ```

4. TUI custom multi-select at 0.37.1 (interactive, no preset flag): the picker lists `roster-bootstrap-rsa` and `roster-bootstrap-tss`.

### Risks

- **RFH silently drops four plugins on unattended upgrade.** Matching upstream `v0.37.1` means a non-interactive `block node upgrade` on an existing `tier1-rfh` install (from 0.35–0.37.0) disables `block-access-service`, `stream-publisher`, `stream-subscriber`, and — notably — `blocks-file-recent` (recent blocks no longer written to the local `live` volume; RFH relies on cloud storage). This is a runtime-behavior / data-continuity change the operator did not explicitly request. Same class of risk as the `s3-archive → cloud-storage-*` rename in #656 — **BN-team sign-off requested** before rolling to live RFH nodes. Interactive upgrades surface the preset prompt; the drop only auto-applies to known-preset, non-interactive upgrades (`custom` / `PresetNone` / values-file-managed installs are unaffected).
- **Rollback:** revert the single registry entry; resolution returns to the `0.35.0` bracket for all versions. No state or cluster cleanup needed.

### TUI rendering fixes (separate from the plugin-preset change)

Two prompt-rendering bugs found during manual `block node install` testing, both rooted in the same huh v1.0.0 behavior: `OptionsFunc` forces a field's height to the default (10), so the visible-option count is `height - title - description`, and for a `Select` the viewport also pins `YOffset = selected`. Committed separately (`ccf17ec`) in `internal/ui/prompt/blocknode.go`; no logic change to prompts, mode inference, or path handling.

- **Storage Path Mode page:** with "Individual paths" as the default (option index 1), "Single base path" was scrolled out of view until the user arrowed up. Fixed by switching the select from `OptionsFunc` to static `Options` and moving the version-dependent detail to `DescriptionFunc`, so the field height stays auto-sized and both modes always render.
- **Plugin Preset -> Custom multi-select:** only ~8 of 14 plugins were visible; the rest required scrolling (worsened by this PR adding roster-bootstrap). Fixed by sizing the field height dynamically to the plugin count (plus title/description headroom, capped at 50). Type-to-filter ("/") remains available via huh's default Filterable state.

> Note: the Storage Path Mode page originated in #834; this fix is unrelated to the plugin-preset change and is bundled here only for efficiency.

### Related Issues

* Closes #829

