### PR TITLE
feat(blocknode): add statusz REST client for BN traffic-shaper monitor

### DIFF
--- a/internal/daemon/blocknode/statusz_client.go
+++ b/internal/daemon/blocknode/statusz_client.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package blocknode
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/joomcode/errorx"
+)
+
+// statuszClientTimeout bounds a single statusz request. It is deliberately
+// shorter than the poll loop's 5 s steady-state cadence so a hung BN response
+// fails fast and surfaces to the outage policy rather than stacking requests.
+const statuszClientTimeout = 4 * time.Second
+
+// statusz endpoint paths, relative to the client's base URL. The transport is
+// REST/JSON: network-data.proto defines only the payload shape, not a gRPC
+// service.
+const (
+	inboundClientsPath  = "statusz/inbound-clients"
+	outboundClientsPath = "statusz/outbound-clients"
+)
+
+// The types below mirror the JSON encoding of
+// block-node/api/network-data.proto. They are the decode boundary: the poll
+// loop consumes these types via the client, never raw JSON, so coupling to the
+// (provisional) BN schema stays in this one file. json.Decode drops the proto
+// fields the traffic-shaper doesn't consume (scheme, protocol, certificate), so
+// they are simply absent here rather than modelled and thrown away.
+
+// Endpoint is one side (local or remote) of a NetworkConnection. Port is a
+// string because the BN reports "*" (any port) alongside numeric ports, and
+// Address may be a single IP or a CIDR (e.g. "10.10.1.0/24").
+type Endpoint struct {
+	Address string `json:"address"`
+	Port    string `json:"port"`
+}
+
+// NetworkConnection is one active endpoint reported by a statusz endpoint.
+// Category is left as the raw BN string here — mapping categories to policy
+// names and nft sets is a separate concern from reading the endpoint.
+type NetworkConnection struct {
+	Local       Endpoint `json:"local"`
+	Remote      Endpoint `json:"remote"`
+	Category    string   `json:"category"`
+	TLSRequired bool     `json:"tls_required"`
+}
+
+// NetworkData is the decoded payload of a statusz endpoint: the set of active
+// endpoints the BN currently reports.
+type NetworkData struct {
+	ActiveEndpoints []NetworkConnection `json:"active_endpoints"`
+}
+
+// StatuszClient reads a Block Node's statusz REST/JSON endpoints.
+type StatuszClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewStatuszClient returns a StatuszClient that reads statusz endpoints under
+// baseURL (e.g. "http://10.0.0.5:8080"), using an HTTP client with a bounded
+// per-request timeout.
+func NewStatuszClient(baseURL string) *StatuszClient {
+	return &StatuszClient{
+		baseURL:    baseURL,
+		httpClient: &http.Client{Timeout: statuszClientTimeout},
+	}
+}
+
+// InboundClients fetches GET {base}/statusz/inbound-clients and decodes the
+// NetworkData payload.
+func (c *StatuszClient) InboundClients(ctx context.Context) (NetworkData, error) {
+	return c.fetch(ctx, inboundClientsPath)
+}
+
+// OutboundClients fetches GET {base}/statusz/outbound-clients and decodes the
+// NetworkData payload.
+func (c *StatuszClient) OutboundClients(ctx context.Context) (NetworkData, error) {
+	return c.fetch(ctx, outboundClientsPath)
+}
+
+// fetch performs the GET, checks the status, and decodes the body. Every
+// failure mode returns a wrapped error (never a panic) so the poll loop can hand
+// the fault to the outage policy: a bad base URL is IllegalArgument and an
+// unbuildable request is InternalError (both configuration faults), a transport
+// failure or non-200 response is ExternalError, and a malformed body is
+// IllegalFormat.
+func (c *StatuszClient) fetch(ctx context.Context, path string) (NetworkData, error) {
+	endpoint, err := url.JoinPath(c.baseURL, path)
+	if err != nil {
+		return NetworkData{}, errorx.IllegalArgument.Wrap(err, "build statusz URL from base %q", c.baseURL)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return NetworkData{}, errorx.InternalError.Wrap(err, "build statusz request for %s", path)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return NetworkData{}, errorx.ExternalError.Wrap(err, "fetch statusz %s", path)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return NetworkData{}, errorx.ExternalError.New("statusz %s returned status %d", path, resp.StatusCode)
+	}
+
+	var data NetworkData
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return NetworkData{}, errorx.IllegalFormat.Wrap(err, "decode statusz %s response", path)
+	}
+	return data, nil
+}

--- a/internal/daemon/blocknode/statusz_client_test.go
+++ b/internal/daemon/blocknode/statusz_client_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package blocknode
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/require"
+)
+
+// Sample statusz payloads taken verbatim from the traffic-shaper design doc's
+// worked example (network-data.proto JSON encoding). Address may be a CIDR and
+// port may be "*" — both are exercised here so the decode boundary is pinned to
+// the real BN schema rather than a simplified stand-in.
+const sampleInboundClientsJSON = `{
+  "active_endpoints": [
+    { "local": {"address": "0.0.0.0", "port": "40840"}, "remote": {"address": "10.10.1.0/24", "port": "*"}, "category": "publisher", "tls_required": true },
+    { "local": {"address": "0.0.0.0", "port": "40980"}, "remote": {"address": "10.20.1.0/24", "port": "*"}, "category": "partner",   "tls_required": true },
+    { "local": {"address": "0.0.0.0", "port": "40980"}, "remote": {"address": "0.0.0.0/0",    "port": "*"}, "category": "public",    "tls_required": false }
+  ]
+}`
+
+const sampleOutboundClientsJSON = `{
+  "active_endpoints": [
+    { "local": {"address": "0.0.0.0", "port": "*"}, "remote": {"address": "10.30.5.7", "port": "43473"}, "category": "peer_bn", "tls_required": true }
+  ]
+}`
+
+// newMockStatuszServer starts an httptest server that serves the given handlers
+// for the two statusz endpoints. A nil handler leaves that route unregistered.
+func newMockStatuszServer(t *testing.T, inbound, outbound http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	if inbound != nil {
+		mux.HandleFunc("/statusz/inbound-clients", inbound)
+	}
+	if outbound != nil {
+		mux.HandleFunc("/statusz/outbound-clients", outbound)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// jsonResponder replies 200 with the given JSON body.
+func jsonResponder(body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}
+}
+
+func TestStatuszClient_InboundClients_DecodesSample(t *testing.T) {
+	srv := newMockStatuszServer(t, jsonResponder(sampleInboundClientsJSON), nil)
+	c := NewStatuszClient(srv.URL)
+
+	data, err := c.InboundClients(context.Background())
+	require.NoError(t, err)
+	require.Len(t, data.ActiveEndpoints, 3)
+
+	pub := data.ActiveEndpoints[0]
+	require.Equal(t, "publisher", pub.Category)
+	require.Equal(t, "10.10.1.0/24", pub.Remote.Address)
+	require.Equal(t, "*", pub.Remote.Port)
+	require.True(t, pub.TLSRequired)
+	// local is decoded too — #755's install path reads local.port.
+	require.Equal(t, "0.0.0.0", pub.Local.Address)
+	require.Equal(t, "40840", pub.Local.Port)
+
+	require.Equal(t, "partner", data.ActiveEndpoints[1].Category)
+
+	pubClear := data.ActiveEndpoints[2]
+	require.Equal(t, "public", pubClear.Category)
+	require.False(t, pubClear.TLSRequired)
+}
+
+func TestStatuszClient_OutboundClients_DecodesSample(t *testing.T) {
+	srv := newMockStatuszServer(t, nil, jsonResponder(sampleOutboundClientsJSON))
+	c := NewStatuszClient(srv.URL)
+
+	data, err := c.OutboundClients(context.Background())
+	require.NoError(t, err)
+	require.Len(t, data.ActiveEndpoints, 1)
+
+	peer := data.ActiveEndpoints[0]
+	require.Equal(t, "peer_bn", peer.Category)
+	require.Equal(t, "10.30.5.7", peer.Remote.Address)
+	require.Equal(t, "43473", peer.Remote.Port)
+	require.True(t, peer.TLSRequired)
+}
+
+func TestStatuszClient_EmptyEndpoints_DecodesToEmptySlice(t *testing.T) {
+	srv := newMockStatuszServer(t, jsonResponder(`{"active_endpoints": []}`), nil)
+	c := NewStatuszClient(srv.URL)
+
+	data, err := c.InboundClients(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, data.ActiveEndpoints)
+}
+
+func TestStatuszClient_NonOKStatus_ReturnsExternalError(t *testing.T) {
+	srv := newMockStatuszServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}, nil)
+	c := NewStatuszClient(srv.URL)
+
+	_, err := c.InboundClients(context.Background())
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, errorx.ExternalError))
+	require.ErrorContains(t, err, "503")
+}
+
+func TestStatuszClient_MalformedBody_ReturnsIllegalFormat(t *testing.T) {
+	srv := newMockStatuszServer(t, jsonResponder(`this is not json`), nil)
+	c := NewStatuszClient(srv.URL)
+
+	_, err := c.InboundClients(context.Background())
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, errorx.IllegalFormat))
+}
+
+func TestStatuszClient_TransportFailure_ReturnsExternalError(t *testing.T) {
+	// Start then immediately stop a server so the URL is well-formed but the
+	// connection is refused — a transport-level failure, not a status code.
+	srv := httptest.NewServer(http.NewServeMux())
+	baseURL := srv.URL
+	srv.Close()
+	c := NewStatuszClient(baseURL)
+
+	_, err := c.InboundClients(context.Background())
+	require.Error(t, err)
+	require.True(t, errorx.IsOfType(err, errorx.ExternalError))
+}
+
+func TestStatuszClient_CancelledContext_ReturnsErrorWithoutPanic(t *testing.T) {
+	srv := newMockStatuszServer(t, jsonResponder(sampleInboundClientsJSON), nil)
+	c := NewStatuszClient(srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.InboundClients(ctx)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Description

Implements the REST client the traffic-shaper monitor's poll loop uses to read the Block Node's statusz endpoints and decode the `network-data` payload. Before this, `runStatuszPoll` was a stub and there was no Go representation of the statusz schema; this lands the read+decode half of the poll loop as a standalone, unit-tested unit.

The transport is deliberately plain **REST/JSON over `net/http`, not gRPC** — `network-data.proto` defines only the payload *shape*. Decode is confined to the client's `fetch` boundary and a single set of tagged types, so the still-provisional BN schema can evolve in one place without churning the poll loop or its downstream consumers. Every failure mode returns a wrapped `errorx` error and never panics, so the poll loop can hand faults to the outage policy rather than crashing the monitor.

This PR does **not** wire the client into `runStatuszPoll` (the stub stays), and does not implement category→policy mapping, membership apply, or the 5 s poll cadence / outage-policy behaviour — those are sibling stories in the epic.

### API changes

New in `internal/daemon/blocknode`:

```go
type StatuszClient struct { /* ... */ }
func NewStatuszClient(baseURL string) *StatuszClient
func (c *StatuszClient) InboundClients(ctx context.Context) (NetworkData, error)
func (c *StatuszClient) OutboundClients(ctx context.Context) (NetworkData, error)

type NetworkData struct { ActiveEndpoints []NetworkConnection }
type NetworkConnection struct { Local, Remote Endpoint; Category string; TLSRequired bool }
type Endpoint struct { Address, Port string }
```

`Endpoint.Port` is a string because the BN reports `"*"` (any port) alongside numeric ports, and `Address` may be a CIDR (e.g. `10.10.1.0/24`).

### Review guide

**Schema provenance / provisional contract.** The tagged types mirror the `network-data.proto` message and JSON samples in the traffic-shaper v4 design doc (§7.1, §7.2). The contract is still provisional — the BN team should confirm the live statusz payload matches before this client is considered locked. The tagged types + `fetch` decode in `statusz_client.go` are the single place a schema revision needs to touch; `json.Decode` already ignores the proto fields the traffic-shaper doesn't consume (`scheme`, `protocol`, `certificate`).

**Checklist:**
- `internal/daemon/blocknode/statusz_client.go` — error namespaces: transport/non-200 → `ExternalError`, malformed body → `IllegalFormat`, URL build → `IllegalArgument`. Confirm no path can panic.
- Per-request timeout (`statuszClientTimeout = 4s`) is intentionally below the 5 s poll cadence so a hung response fails fast.
- Category is kept as the raw BN string here — mapping to policy names / nft sets is a separate story.

**Test commands:**

```
go test ./internal/daemon/blocknode/...
task lint
```

`statusz_client_test.go` runs against an `httptest` mock statusz server and covers: inbound/outbound decode against the design doc's verbatim sample payloads, empty endpoints, non-200 → `ExternalError`, malformed JSON → `IllegalFormat`, transport failure, and cancelled context (no panic).

**Risks / rollback:** the client is unreferenced by production paths (not wired into the poll loop), so reverting is a clean file removal with no behavioural impact.

### Related Issues

* Closes #751
