### PR TITLE
feat(network): apply membership deltas via non-blocking batched policy set

### DIFF
--- a/internal/network/policy/manager.go
+++ b/internal/network/policy/manager.go
@@ -4,6 +4,7 @@ package policy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -320,18 +321,80 @@ func (m *Manager) Remove(ctx context.Context, name string, cidrs []string) error
 // clears the set. Like Add/Remove, only the live kernel set is changed.
 func (m *Manager) Set(ctx context.Context, name string, cidrs []string) error {
 	return m.withLock(func() error {
-		p, err := m.requirePolicyWithCIDRSet(name)
-		if err != nil {
-			return err
-		}
-		if err := p.validateCIDRs(cidrs); err != nil {
-			return err
-		}
-		if err := m.requireTableExists(ctx, name); err != nil {
-			return err
-		}
-		return m.runner.SetElements(ctx, name, setElements(p, cidrs))
+		return m.applySet(ctx, name, cidrs)
 	})
+}
+
+// applySet replaces the live set for one named policy with cidrs via a single
+// `flush set + add element` transaction (runner.SetElements). It performs NO
+// locking: callers must already hold the shared apply lock (withLock for the
+// CLI `set` verb, withLockNB for the daemon's ApplyMembership batch), so both
+// paths funnel through the identical kernel transaction and can never
+// interleave with a concurrent operator apply.
+func (m *Manager) applySet(ctx context.Context, name string, cidrs []string) error {
+	p, err := m.requirePolicyWithCIDRSet(name)
+	if err != nil {
+		return err
+	}
+	if err := p.validateCIDRs(cidrs); err != nil {
+		return err
+	}
+	if err := m.requireTableExists(ctx, name); err != nil {
+		return err
+	}
+	return m.runner.SetElements(ctx, name, setElements(p, cidrs))
+}
+
+// ApplyMembership pushes desired CIDR membership into one or more policies'
+// live `inet weaver` sets. It is the traffic-shaper daemon's write path, and
+// it reuses the same per-policy transaction as the hand-run `network policy
+// set` CLI (applySet -> runner.SetElements), so both produce identical kernel
+// state for the same input.
+//
+// Each map entry is a full-list replace (like `set`): an empty slice clears
+// that policy's set. Policies are applied in deterministic (sorted) name
+// order, one `nft -f` transaction per policy for atomicity.
+//
+// The whole batch runs under a SINGLE non-blocking acquisition of the shared
+// apply flock. The return value is:
+//   - (false, nil): the lock was already held by a hand-run operator command,
+//     so nothing was written and the caller skips this tick rather than
+//     blocking or interleaving nft transactions;
+//   - (true, nil):  the lock was acquired and every policy applied cleanly;
+//   - (false, err): the lock was acquired but a policy failed mid-batch — the
+//     batch is not considered applied (see the partial-commit note below).
+//
+// ApplyMembership never calls `create`: a name absent from the registry, or
+// one carrying no CIDR set, is an error (the policy structure is fixed by
+// `block node install`). An error mid-batch stops the batch — policies applied
+// before it stay committed and the caller re-drives on the next tick, which is
+// safe because the apply is idempotent.
+//
+// It acquires the lock itself, so it must NOT be called while the caller
+// already holds withLock/withLockNB (doing so would self-deadlock on a second
+// open-file-description of the same lock file).
+func (m *Manager) ApplyMembership(ctx context.Context, desired map[string][]string) (applied bool, err error) {
+	if len(desired) == 0 {
+		return true, nil
+	}
+	names := make([]string, 0, len(desired))
+	for name := range desired {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	acquired, err := m.withLockNB(func() error {
+		for _, name := range names {
+			if err := m.applySet(ctx, name, desired[name]); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return acquired, nil
 }
 
 // Show returns a human-readable summary of a named policy: its registry config
@@ -536,16 +599,28 @@ func (m *Manager) requireTableExists(ctx context.Context, name string) error {
 	return nil
 }
 
-// withLock serialises a mutation behind the shared cross-command flock so a
-// hand-run operator command and the daemon poll loop cannot interleave
-// nft transactions on the shared network tables.
-func (m *Manager) withLock(fn func() error) error {
+// openLockFile creates the lock directory if needed and opens the shared
+// apply-lock file. The caller owns the returned handle and must Close it (which
+// also releases any flock held on it).
+func (m *Manager) openLockFile() (*os.File, error) {
 	if err := os.MkdirAll(filepath.Dir(m.lockPath), 0o755); err != nil {
-		return errorx.ExternalError.Wrap(err, "failed to create lock directory %s", filepath.Dir(m.lockPath))
+		return nil, errorx.ExternalError.Wrap(err, "failed to create lock directory %s", filepath.Dir(m.lockPath))
 	}
 	f, err := os.OpenFile(m.lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
-		return errorx.ExternalError.Wrap(err, "failed to open lock file %s", m.lockPath)
+		return nil, errorx.ExternalError.Wrap(err, "failed to open lock file %s", m.lockPath)
+	}
+	return f, nil
+}
+
+// withLock serialises a mutation behind the shared cross-command flock so a
+// hand-run operator command and the daemon poll loop cannot interleave
+// nft transactions on the shared network tables. It blocks until the lock is
+// available (LOCK_EX).
+func (m *Manager) withLock(fn func() error) error {
+	f, err := m.openLockFile()
+	if err != nil {
+		return err
 	}
 	defer func() { _ = f.Close() }()
 
@@ -555,4 +630,33 @@ func (m *Manager) withLock(fn func() error) error {
 	defer func() { _ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }()
 
 	return fn()
+}
+
+// withLockNB is the non-blocking counterpart to withLock (LOCK_EX|LOCK_NB). It
+// is the daemon poll loop's acquisition mode: when a hand-run operator command
+// is mid-apply and already holds the lock, withLockNB does NOT run fn and
+// returns (false, nil) so the caller skips this tick, rather than blocking and
+// risking interleaved nft transactions. On a clean acquisition it runs fn and
+// returns (true, fn()'s error). Any lock error other than "would block" is
+// returned with acquired=false.
+func (m *Manager) withLockNB(fn func() error) (acquired bool, err error) {
+	f, err := m.openLockFile()
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		// A held lock surfaces as EWOULDBLOCK, which is the same errno value as
+		// EAGAIN on the platforms this runs on (Linux daemon, darwin dev), so
+		// errors.Is here also matches the EAGAIN spelling — the tick is skipped
+		// cleanly rather than being reported as a lock failure.
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return false, nil
+		}
+		return false, errorx.ExternalError.Wrap(err, "failed to acquire lock %s", m.lockPath)
+	}
+	defer func() { _ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }()
+
+	return true, fn()
 }

--- a/internal/network/policy/manager_apply_membership_test.go
+++ b/internal/network/policy/manager_apply_membership_test.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// lockPathFor derives the Manager's shared apply-lock path from the nft path
+// newTestManager returns: both live in the same temp dir, and newTestManager
+// wires LockPath to "<dir>/.applying".
+func lockPathFor(nftPath string) string {
+	return filepath.Join(filepath.Dir(nftPath), ".applying")
+}
+
+func TestApplyMembership_AppliesAllPolicies(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+	seedDenyPolicy(t, m, "bn-restricted", nil)
+
+	applied, err := m.ApplyMembership(context.Background(), map[string][]string{
+		"bn-publisher":  {"10.1.0.1/32", "10.1.0.2/32"},
+		"bn-restricted": {"10.99.0.0/16"},
+	})
+	require.NoError(t, err)
+	require.True(t, applied, "a clean lock acquisition applies the batch")
+	require.Equal(t, []string{"10.1.0.1/32", "10.1.0.2/32"}, r.elements["bn-publisher"])
+	require.Equal(t, []string{"10.99.0.0/16"}, r.elements["bn-restricted"])
+}
+
+func TestApplyMembership_OnePolicyPerTransactionInSortedOrder(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+	seedDenyPolicy(t, m, "bn-restricted", nil)
+	seedDenyPolicy(t, m, "bn-partner", nil)
+
+	applied, err := m.ApplyMembership(context.Background(), map[string][]string{
+		"bn-restricted": {"10.99.0.0/16"},
+		"bn-publisher":  {"10.1.0.1/32"},
+		"bn-partner":    {"10.2.0.0/16"},
+	})
+	require.NoError(t, err)
+	require.True(t, applied)
+	// One SetElements transaction per policy, in deterministic sorted name order.
+	require.Equal(t, []string{"bn-partner", "bn-publisher", "bn-restricted"}, r.setElemOrder)
+}
+
+func TestApplyMembership_FullListReplace(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"},
+		[]string{"10.1.0.1/32", "10.1.0.2/32"}, "10.4.0.0/24")
+
+	applied, err := m.ApplyMembership(context.Background(), map[string][]string{
+		"bn-publisher": {"10.5.0.0/24"},
+	})
+	require.NoError(t, err)
+	require.True(t, applied)
+	require.Equal(t, []string{"10.5.0.0/24"}, r.elements["bn-publisher"],
+		"apply is a full-list replace like `set`, not an append")
+}
+
+func TestApplyMembership_EmptyCIDRsClearsSet(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"},
+		[]string{"10.1.0.1/32"}, "10.4.0.0/24")
+
+	applied, err := m.ApplyMembership(context.Background(), map[string][]string{
+		"bn-publisher": {},
+	})
+	require.NoError(t, err)
+	require.True(t, applied)
+	require.Empty(t, r.elements["bn-publisher"], "an empty desired list clears the policy's set")
+}
+
+func TestApplyMembership_EmptyMapIsNoopAndTakesNoLock(t *testing.T) {
+	r := newFakeRunner()
+	m, nftPath, _ := newTestManager(t, r)
+
+	// Pre-hold the shared flock from the test. If ApplyMembership tried to
+	// acquire it for an empty batch, it would report skipped (false); instead
+	// it must short-circuit to (true, nil) without touching the lock at all.
+	lf, err := os.OpenFile(lockPathFor(nftPath), os.O_CREATE|os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	defer func() { _ = lf.Close() }()
+	require.NoError(t, syscall.Flock(int(lf.Fd()), syscall.LOCK_EX))
+	defer func() { _ = syscall.Flock(int(lf.Fd()), syscall.LOCK_UN) }()
+
+	applied, err := m.ApplyMembership(context.Background(), nil)
+	require.NoError(t, err)
+	require.True(t, applied, "an empty batch is a no-op success, independent of the lock")
+	require.Empty(t, r.setElemOrder, "no policy transactions for an empty batch")
+}
+
+func TestApplyMembership_SkipsWhenLockHeld(t *testing.T) {
+	r := newFakeRunner()
+	m, nftPath, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+
+	// Simulate a hand-run operator apply holding the shared flock (a separate
+	// open-file-description on the same lock path, as a concurrent process
+	// would have). The daemon's non-blocking acquisition must fail cleanly.
+	lf, err := os.OpenFile(lockPathFor(nftPath), os.O_CREATE|os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	defer func() { _ = lf.Close() }()
+	require.NoError(t, syscall.Flock(int(lf.Fd()), syscall.LOCK_EX))
+	defer func() { _ = syscall.Flock(int(lf.Fd()), syscall.LOCK_UN) }()
+
+	applied, err := m.ApplyMembership(context.Background(), map[string][]string{
+		"bn-publisher": {"10.1.0.1/32"},
+	})
+	require.NoError(t, err, "a held lock is not an error — the tick is skipped")
+	require.False(t, applied, "batch is skipped while an operator apply holds the lock")
+	require.Empty(t, r.setElemOrder, "nothing is written when the tick is skipped")
+	require.Empty(t, r.elements["bn-publisher"])
+}
+
+func TestApplyMembership_NeverCreatesMissingPolicy(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	applied, err := m.ApplyMembership(context.Background(), map[string][]string{
+		"bn-nonexistent": {"10.0.0.1/32"},
+	})
+	require.ErrorContains(t, err, "not found")
+	require.False(t, applied)
+	require.Zero(t, r.applyCount, "the apply path must never call create/Apply")
+	require.Empty(t, r.setElemOrder)
+}
+
+func TestApplyMembership_TableMissingReturnsError(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+	require.NoError(t, r.Delete(context.Background()))
+
+	_, err := m.ApplyMembership(context.Background(), map[string][]string{
+		"bn-publisher": {"10.1.0.1/32"},
+	})
+	require.ErrorContains(t, err, "policy table not found")
+}
+
+func TestApplyMembership_PartialBatchCommitsPriorPolicies(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+
+	// "bn-publisher" sorts before "bn-zzz-missing", so it is applied before the
+	// batch hits the missing policy and stops. Prior work stays committed; the
+	// caller re-drives on the next tick (the apply is idempotent).
+	_, err := m.ApplyMembership(context.Background(), map[string][]string{
+		"bn-publisher":   {"10.1.0.1/32"},
+		"bn-zzz-missing": {"10.2.0.2/32"},
+	})
+	require.ErrorContains(t, err, "not found")
+	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"],
+		"policies applied before the failing one remain committed")
+}
+
+func TestApplyMembership_IdenticalKernelStateToLoopedSet(t *testing.T) {
+	desired := map[string][]string{
+		"bn-publisher":  {"10.1.0.1/32", "10.1.0.2/32"},
+		"bn-backfill":   {"10.30.5.7:43473"},
+		"bn-restricted": {"10.99.0.0/16"},
+	}
+
+	seedAll := func(m *Manager) {
+		seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+		seedDenyPolicy(t, m, "bn-restricted", nil)
+		_, err := m.Create(context.Background(),
+			&Policy{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
+			nil, "10.4.0.0/24", false)
+		require.NoError(t, err)
+	}
+
+	// Path A: the daemon's batched ApplyMembership.
+	rBatch := newFakeRunner()
+	mBatch, _, _ := newTestManager(t, rBatch)
+	seedAll(mBatch)
+	applied, err := mBatch.ApplyMembership(context.Background(), desired)
+	require.NoError(t, err)
+	require.True(t, applied)
+
+	// Path B: the hand-run CLI verb, looped over the same input.
+	rLoop := newFakeRunner()
+	mLoop, _, _ := newTestManager(t, rLoop)
+	seedAll(mLoop)
+	for name, cidrs := range desired {
+		require.NoError(t, mLoop.Set(context.Background(), name, cidrs))
+	}
+
+	require.Equal(t, rLoop.elements, rBatch.elements,
+		"monitor and CLI apply paths must produce identical live-set state")
+}

--- a/internal/network/policy/policy_test.go
+++ b/internal/network/policy/policy_test.go
@@ -20,12 +20,13 @@ import (
 // without that, tests wouldn't exercise the membership loss Manager.Create's
 // snapshot/restore is meant to prevent.
 type fakeRunner struct {
-	applied     string
-	applyCount  int
-	elements    map[string][]string
-	exists      bool
-	applyErr    error
-	listElemErr error
+	applied      string
+	applyCount   int
+	elements     map[string][]string
+	exists       bool
+	applyErr     error
+	listElemErr  error
+	setElemOrder []string // set names in the order SetElements was called
 }
 
 func newFakeRunner() *fakeRunner { return &fakeRunner{elements: map[string][]string{}} }
@@ -75,6 +76,7 @@ func (f *fakeRunner) SetElements(_ context.Context, set string, elements []strin
 	if !f.exists {
 		return errors.New("nft flush set " + set + " failed: No such file or directory")
 	}
+	f.setElemOrder = append(f.setElemOrder, set)
 	if len(elements) == 0 {
 		delete(f.elements, set)
 	} else {


### PR DESCRIPTION
## Summary

Adds `Manager.ApplyMembership`, the traffic-shaper daemon's write path for pushing per-policy CIDR membership into the live `inet weaver` nft sets. It shares one apply code path with the hand-run `network policy set` CLI so both produce identical kernel state, and it serializes against operator commands via the shared apply flock — acquired **non-blocking** so the daemon skips a tick rather than blocking when an operator apply is already running.

### What changed

- **`ApplyMembership(ctx, map[policy][]cidr) (applied bool, err error)`** — acquires the shared flock **once, non-blocking** (`LOCK_EX|LOCK_NB`) for the whole batch:
  - lock held by an operator command → `(false, nil)`: nothing written, caller skips the tick;
  - clean acquisition → applies every policy in deterministic sorted order, **one `nft -f` transaction per policy** via the same `runner.SetElements` the CLI uses → `(true, nil)`;
  - mid-batch failure → `(false, err)`; policies applied before it stay committed and the caller re-drives on the next tick (the apply is idempotent).
- **`applySet`** — the per-policy body, extracted lock-free and shared by `Set` and `ApplyMembership` so the CLI and daemon paths can't drift.
- **`openLockFile`** — the lock-file mkdir/open prologue, extracted and shared by the existing blocking `withLock` and the new `withLockNB`.
- The apply path **never calls `create`**: a name absent from the registry, or one with no CIDR set (`--from-entity world`), is a hard error — the policy structure is fixed by `block node install`.

### Scope boundary

This ships the apply primitive and its tests only. The live poll loop (`runStatuszPoll`) is intentionally left a stub — wiring it needs the statusz REST client, the category→policy diff, and bootstrap/outage sequencing, which land in sibling stories of this epic. Shipping the loop now would be dead code ahead of its dependencies.

## Test plan

- [x] Unit: `go test -race -tags='!integration' ./internal/network/policy/...` — 85 pass, incl. 11 new `ApplyMembership` cases:
  - applies all policies; one transaction per policy in sorted order
  - full-list replace (not append); empty list clears a set
  - empty map is a no-op that takes no lock
  - **skips (writes nothing) when the shared flock is already held**
  - never creates a missing policy; errors when the table is absent
  - partial batch commits policies applied before a mid-batch error
  - identical live-set state to the looped CLI `Set` path
- [x] `task lint` — gofmt clean, `lint:errorx` reports 0 issues.

`ApplyMembership` itself has no production caller yet, so end-to-end UAT of the daemon path (statusz → diff → apply → `nft list table inet weaver`) arrives with the loop-wiring sibling story. The manual UAT below is a **refactor-regression** check instead.

## Manual UAT (refactor-regression)

This PR refactors the shared apply path (`Set`→`applySet`, `withLock`→`openLockFile`) that the shipped `network policy` CLI verbs run through, so the useful manual check is confirming those verbs still produce correct kernel state. Run on a Linux VM (`task vm:...`; the `network` CLI is Linux-only):

1. Create a policy with an initial CIDR set:
   ```
   sudo solo-provisioner network policy create --name bn-publisher --stamp publisher --ports 40840 --cidrs 10.1.0.1/32
   ```
2. Replace its membership via the refactored `set` path:
   ```
   sudo solo-provisioner network policy set --name bn-publisher --cidrs 10.5.0.0/24,10.6.0.0/24
   ```
3. Confirm a full-list replace (old CIDR gone, both new present):
   ```
   sudo solo-provisioner network policy show --name bn-publisher
   sudo nft list table inet weaver          # set @bn-publisher: { 10.5.0.0/24, 10.6.0.0/24 }
   ```
4. Clear the set by omitting `--cidrs`, and confirm it empties:
   ```
   sudo solo-provisioner network policy set --name bn-publisher
   sudo solo-provisioner network policy show --name bn-publisher   # live set @bn-publisher: (empty)
   ```

Expected: behavior identical to before this PR — the `applySet`/`openLockFile` extraction is behavior-preserving. (`TestApplyMembership_IdenticalKernelStateToLoopedSet` asserts the same parity at the unit level.)

## Risks

- **Self-deadlock** if a future caller nests `ApplyMembership` inside `withLock`/`Set` — guarded by the method docstring; no such caller exists in this PR.
- **flock portability**: `LOCK_NB`/`EWOULDBLOCK` are available on the same platforms as the pre-existing `withLock`, so no new build-tag surface.
- **Rollback** is trivial — the primitive has no callers in this PR, so reverting removes it without touching daemon runtime behavior.

* Closes #754
