### PR TITLE
feat(traffic-shaper): map statusz categories to policies and diff vs live nft sets

### DIFF
--- a/internal/daemon/blocknode/statusz_policy.go
+++ b/internal/daemon/blocknode/statusz_policy.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package blocknode
+
+import (
+	"context"
+	"sort"
+
+	"github.com/hashgraph/solo-weaver/internal/network/policy"
+	"github.com/joomcode/errorx"
+)
+
+// Category is a statusz traffic category as reported by the block node's statusz
+// endpoints (inbound-clients / outbound-clients). The vocabulary is fixed by the
+// BN's contract, not operator-configurable.
+type Category string
+
+const (
+	// CategoryPublisher is the inbound publisher category.
+	CategoryPublisher Category = "publisher"
+	// CategoryPartner is the inbound partner category.
+	CategoryPartner Category = "partner"
+	// CategoryRestricted is the inbound restricted category.
+	CategoryRestricted Category = "restricted"
+	// CategoryPeerBN is the outbound peer-block-node category. Its endpoints are
+	// compound ip:port pairs — the backfill set is keyed on destination address
+	// AND port.
+	CategoryPeerBN Category = "peer_bn"
+)
+
+// categoryBinding is the fixed mapping from a statusz category to the nft policy
+// set it drives and how that set is keyed.
+type categoryBinding struct {
+	// policyName is the nft set (network policy) the category's endpoints
+	// populate.
+	policyName string
+	// compound is true when the set is a compound `ipv4_addr . inet_service`
+	// key set fed ip:port endpoints (bn-backfill); false for plain ipv4_addr
+	// sets fed host/CIDR endpoints.
+	compound bool
+}
+
+// categoryBindings is the internal, non-configurable statusz-category → policy
+// mapping. Both the BN's category vocabulary and the provisioner's policy names
+// are fixed in code, so this is a static table rather than config. Categories
+// not listed here — including the operator-curated mgmt sets — are never touched
+// by the monitor.
+var categoryBindings = map[Category]categoryBinding{
+	CategoryPublisher:  {policyName: "bn-publisher"},
+	CategoryPartner:    {policyName: "bn-partner"},
+	CategoryRestricted: {policyName: "bn-restricted"},
+	CategoryPeerBN:     {policyName: "bn-backfill", compound: true},
+}
+
+// CategoryEndpoints is one poll's desired membership view, keyed by statusz
+// category. For each category PRESENT in the map, the slice is its active
+// endpoints: plain IPv4 hosts/CIDRs for inbound categories, "ip:port" pairs for
+// the outbound peer_bn category. The present-vs-absent distinction is load
+// bearing and preserved end to end:
+//
+//   - a category present with an empty (or nil) slice clears that policy's set;
+//   - a category absent from the map leaves that policy's set untouched.
+//
+// This is the minimal shape the diff needs; the statusz client (#751) decodes the
+// wire NetworkData response into it, and the apply path (#754) consumes the
+// resulting deltas.
+type CategoryEndpoints map[Category][]string
+
+// PolicyDelta is the computed membership change for one policy set: the policy
+// (nft set) name and the canonicalized add/delete lists.
+type PolicyDelta struct {
+	Policy string
+	policy.SetDelta
+}
+
+// elementLister reads one nft set's live membership. Satisfied by policy.Runner
+// (via ListElements) and by test fakes; kept deliberately narrow so the diff can
+// never mutate sets — applying deltas is #754's responsibility, not this stage's.
+type elementLister interface {
+	ListElements(ctx context.Context, set string) ([]string, error)
+}
+
+// computePolicyDeltas maps each category present in ce to its policy, builds the
+// desired membership, reads the policy's live nft set membership back from the
+// kernel, and diffs the two. Categories absent from ce produce no delta (the set
+// is left untouched); a present-but-empty category produces a delta that clears
+// the set. Unmapped categories are ignored. No-op deltas are omitted and the
+// result is ordered by policy name for deterministic output.
+func computePolicyDeltas(ctx context.Context, lister elementLister, ce CategoryEndpoints) ([]PolicyDelta, error) {
+	cats := make([]Category, 0, len(ce))
+	for c := range ce {
+		cats = append(cats, c)
+	}
+	sort.Slice(cats, func(i, j int) bool { return cats[i] < cats[j] })
+
+	var deltas []PolicyDelta
+	for _, c := range cats {
+		b, ok := categoryBindings[c]
+		if !ok {
+			// Unmapped category (e.g. an mgmt set, or one the BN adds later):
+			// not monitor-owned, so leave it untouched.
+			continue
+		}
+		desired, err := desiredElements(b, ce[c])
+		if err != nil {
+			return nil, err
+		}
+		live, err := lister.ListElements(ctx, b.policyName)
+		if err != nil {
+			return nil, errorx.Decorate(err, "read live membership for policy %s", b.policyName)
+		}
+		delta := policy.DiffElements(desired, live)
+		if delta.Empty() {
+			continue
+		}
+		deltas = append(deltas, PolicyDelta{Policy: b.policyName, SetDelta: delta})
+	}
+	sort.Slice(deltas, func(i, j int) bool { return deltas[i].Policy < deltas[j].Policy })
+	return deltas, nil
+}
+
+// desiredElements converts a category's raw statusz endpoints into nft set
+// element tokens for its policy: compound "<ip> . <port>" keys for the peer_bn
+// category, plain elements otherwise. Canonicalization (ordering, /32 collapse)
+// happens later in policy.DiffElements, so this only handles the compound-key
+// conversion.
+func desiredElements(b categoryBinding, endpoints []string) ([]string, error) {
+	if !b.compound {
+		return endpoints, nil
+	}
+	out := make([]string, 0, len(endpoints))
+	for _, e := range endpoints {
+		tok, err := policy.CompoundElement(e)
+		if err != nil {
+			return nil, errorx.Decorate(err, "policy %s endpoint", b.policyName)
+		}
+		out = append(out, tok)
+	}
+	return out, nil
+}

--- a/internal/daemon/blocknode/statusz_policy_test.go
+++ b/internal/daemon/blocknode/statusz_policy_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package blocknode
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/internal/network/policy"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeLister is a hand-written elementLister that returns seeded live membership
+// per set and records which sets were read. A set with a configured err returns
+// it instead of membership.
+type fakeLister struct {
+	elements map[string][]string
+	err      map[string]error
+	reads    []string
+}
+
+func newFakeLister() *fakeLister {
+	return &fakeLister{elements: map[string][]string{}, err: map[string]error{}}
+}
+
+func (f *fakeLister) ListElements(_ context.Context, set string) ([]string, error) {
+	f.reads = append(f.reads, set)
+	if e, ok := f.err[set]; ok {
+		return nil, e
+	}
+	return f.elements[set], nil
+}
+
+func TestComputePolicyDeltas_MapsCategoriesToPolicies(t *testing.T) {
+	l := newFakeLister()
+	l.elements["bn-publisher"] = []string{"10.1.0.1/32"}
+
+	ce := CategoryEndpoints{
+		CategoryPublisher:  {"10.1.0.1/32", "10.1.0.2/32"}, // one add
+		CategoryPartner:    {"10.2.0.1/32"},                // all add (empty live)
+		CategoryRestricted: {"10.3.0.0/24"},                // all add
+		CategoryPeerBN:     {"10.30.5.7:43473"},            // compound add
+	}
+
+	deltas, err := computePolicyDeltas(context.Background(), l, ce)
+	require.NoError(t, err)
+
+	// Ordered by policy name; no-op deltas omitted (all four have changes here).
+	require.Equal(t, []PolicyDelta{
+		{Policy: "bn-backfill", SetDelta: setDelta([]string{"10.30.5.7 . 43473"}, nil)},
+		{Policy: "bn-partner", SetDelta: setDelta([]string{"10.2.0.1"}, nil)},
+		{Policy: "bn-publisher", SetDelta: setDelta([]string{"10.1.0.2"}, nil)},
+		{Policy: "bn-restricted", SetDelta: setDelta([]string{"10.3.0.0/24"}, nil)},
+	}, deltas)
+}
+
+func TestComputePolicyDeltas_EmptyCategoryClearsSet(t *testing.T) {
+	l := newFakeLister()
+	l.elements["bn-publisher"] = []string{"10.1.0.1/32", "10.1.0.2/32"}
+
+	// Present with an empty slice → clear the whole set.
+	deltas, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{CategoryPublisher: {}})
+	require.NoError(t, err)
+	require.Equal(t, []PolicyDelta{
+		{Policy: "bn-publisher", SetDelta: setDelta(nil, []string{"10.1.0.1", "10.1.0.2"})},
+	}, deltas)
+}
+
+func TestComputePolicyDeltas_AbsentCategoryLeavesSetUntouched(t *testing.T) {
+	l := newFakeLister()
+	l.elements["bn-publisher"] = []string{"10.1.0.1/32"}
+
+	// bn-publisher's category is absent entirely → no delta, and its live set is
+	// never even read.
+	deltas, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{CategoryPartner: {"10.2.0.1/32"}})
+	require.NoError(t, err)
+	require.Equal(t, []PolicyDelta{
+		{Policy: "bn-partner", SetDelta: setDelta([]string{"10.2.0.1"}, nil)},
+	}, deltas)
+	require.NotContains(t, l.reads, "bn-publisher", "absent category's set must not be read")
+}
+
+func TestComputePolicyDeltas_NoOpDeltaOmitted(t *testing.T) {
+	l := newFakeLister()
+	// Live already matches desired (modulo spelling) → no delta.
+	l.elements["bn-publisher"] = []string{"10.1.0.1", "10.1.0.2"}
+
+	deltas, err := computePolicyDeltas(context.Background(), l,
+		CategoryEndpoints{CategoryPublisher: {"10.1.0.2/32", "10.1.0.1/32"}})
+	require.NoError(t, err)
+	require.Empty(t, deltas)
+}
+
+func TestComputePolicyDeltas_UnmappedCategoryIgnored(t *testing.T) {
+	l := newFakeLister()
+	deltas, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{Category("mgmt"): {"10.9.0.1/32"}})
+	require.NoError(t, err)
+	require.Empty(t, deltas)
+	require.Empty(t, l.reads, "unmapped category must not trigger any live-set read")
+}
+
+func TestComputePolicyDeltas_CompoundEndpointConversion(t *testing.T) {
+	l := newFakeLister()
+	l.elements["bn-backfill"] = []string{"10.30.5.7 . 43473"}
+
+	deltas, err := computePolicyDeltas(context.Background(), l,
+		CategoryEndpoints{CategoryPeerBN: {"10.30.5.8:43473"}})
+	require.NoError(t, err)
+	require.Equal(t, []PolicyDelta{
+		{Policy: "bn-backfill", SetDelta: setDelta([]string{"10.30.5.8 . 43473"}, []string{"10.30.5.7 . 43473"})},
+	}, deltas)
+}
+
+func TestComputePolicyDeltas_MalformedCompoundEndpointErrors(t *testing.T) {
+	for _, bad := range []string{
+		"10.30.5.8",       // missing port
+		"10.30.5.8:-1",    // negative port
+		"10.30.5.8:99999", // out-of-range port
+		"::1:80",          // IPv6 host
+	} {
+		l := newFakeLister()
+		_, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{CategoryPeerBN: {bad}})
+		require.Error(t, err, "expected %q to be rejected", bad)
+		require.ErrorContains(t, err, "bn-backfill")
+	}
+}
+
+func TestComputePolicyDeltas_LiveReadErrorPropagates(t *testing.T) {
+	l := newFakeLister()
+	l.err["bn-publisher"] = errors.New("nft boom")
+	_, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{CategoryPublisher: {"10.1.0.1/32"}})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "bn-publisher")
+}
+
+func TestReconcilePolicies_NilListerErrors(t *testing.T) {
+	m := &TrafficShaperMonitor{} // no lister injected
+	_, err := m.reconcilePolicies(context.Background(), CategoryEndpoints{CategoryPublisher: {"10.1.0.1/32"}})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "live-set reader")
+}
+
+func TestReconcilePolicies_ComputesDeltas(t *testing.T) {
+	l := newFakeLister()
+	m := &TrafficShaperMonitor{lister: l}
+	deltas, err := m.reconcilePolicies(context.Background(), CategoryEndpoints{CategoryPublisher: {"10.1.0.1/32"}})
+	require.NoError(t, err)
+	require.Equal(t, []PolicyDelta{
+		{Policy: "bn-publisher", SetDelta: setDelta([]string{"10.1.0.1"}, nil)},
+	}, deltas)
+}
+
+// setDelta builds a policy.SetDelta so tests express expectations as an
+// (adds, deletes) pair.
+func setDelta(adds, deletes []string) policy.SetDelta {
+	return policy.SetDelta{Adds: adds, Deletes: deletes}
+}

--- a/internal/daemon/blocknode/traffic_shaper_monitor.go
+++ b/internal/daemon/blocknode/traffic_shaper_monitor.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/network/policy"
+	"github.com/joomcode/errorx"
 )
 
 // Per-responsibility back-off bounds. A fault in one subsystem (pod watcher or
@@ -41,13 +43,22 @@ type TrafficShaperMonitor struct {
 	// resolver resolves the host-side veth name for a BN pod (story #747).
 	// Used by runPodWatcher once the real watch loop lands in #748.
 	resolver *VethResolver
+	// lister reads live nft set membership so the poll loop can diff desired
+	// statusz-derived membership against the kernel. Satisfied by the network
+	// policy Runner; a fake is injected in tests.
+	lister elementLister
 }
 
 // NewTrafficShaperMonitor constructs a TrafficShaperMonitor with the given
 // VethResolver. The resolver is wired into runPodWatcher by #748; it is held
-// here so #748 can use it without further constructor changes.
+// here so #748 can use it without further constructor changes. The live-set
+// reader defaults to the network policy exec Runner, which reads the `inet
+// weaver` sets via `nft list set`.
 func NewTrafficShaperMonitor(resolver *VethResolver) *TrafficShaperMonitor {
-	return &TrafficShaperMonitor{resolver: resolver}
+	return &TrafficShaperMonitor{
+		resolver: resolver,
+		lister:   policy.NewExecRunner(),
+	}
 }
 
 // Name implements daemonkit.MonitorRunner.
@@ -128,16 +139,35 @@ func (m *TrafficShaperMonitor) runPodWatcher(ctx context.Context) error {
 	return nil
 }
 
-// runStatuszPoll is the statusz poll-loop responsibility. Stub for #746; the
-// real implementation lands in #751 (statusz client), #752 (category→policy
-// diff), #754 (membership apply) and #755 (bootstrap/outage policy).
+// runStatuszPoll is the statusz poll-loop responsibility. The category→policy
+// diff engine is in place; the surrounding loop is not yet wired — statusz fetch
+// lands in #751, delta apply in #754, and bootstrap/outage policy in #755. It
+// exercises the diff seam once with an empty desired view so the plumbing (the
+// live-set reader and reconcilePolicies) is ready for #754 to drive from real
+// statusz data. An empty view maps to zero deltas and touches no set.
 func (m *TrafficShaperMonitor) runStatuszPoll(ctx context.Context) error {
+	deltas, err := m.reconcilePolicies(ctx, nil)
+	if err != nil {
+		return err
+	}
 	logx.As().Info().
 		Str("reason", "TrafficShaperStatuszPollStub").
 		Str("monitor", m.Name()).
-		Msg("statusz poll loop not yet implemented — stub running")
+		Int("policy_deltas", len(deltas)).
+		Msg("statusz poll loop not yet wired — diff engine ready, awaiting statusz client")
 	<-ctx.Done()
 	return nil
+}
+
+// reconcilePolicies computes the per-policy membership deltas between the desired
+// category endpoints and the live nft sets. It does NOT apply them — applying is
+// #754's responsibility. It is the seam the poll loop drives once the statusz
+// client (#751) supplies real endpoints.
+func (m *TrafficShaperMonitor) reconcilePolicies(ctx context.Context, ce CategoryEndpoints) ([]PolicyDelta, error) {
+	if m.lister == nil {
+		return nil, errorx.IllegalState.New("traffic-shaper monitor has no live-set reader")
+	}
+	return computePolicyDeltas(ctx, m.lister, ce)
 }
 
 // minDuration returns the smaller of a and b.

--- a/internal/network/policy/diff.go
+++ b/internal/network/policy/diff.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"net"
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
+	"github.com/joomcode/errorx"
+)
+
+// compoundSep is the separator nft prints between the two halves of a compound
+// `ipv4_addr . inet_service` set element. `network policy set` renders it and
+// `nft list set` prints it back, so both the desired and live element forms use
+// this exact spelling.
+const compoundSep = " . "
+
+// maxPort is the highest valid inet_service port; ports outside [1, maxPort] are
+// not valid set-element keys.
+const maxPort = 65535
+
+// CompoundElement converts an "ip:port" pair into the nft compound set element
+// token "<ip> . <port>" used by --reply-stamp policies' sets (e.g. bn-backfill).
+// It is the single conversion the apply path (`network policy set`) and the
+// daemon poll loop's diff both call, so desired membership is built byte for
+// byte identical to what gets written to the kernel. The set is
+// `ipv4_addr . inet_service`, so the host must be IPv4 and the port in range;
+// the returned token is canonical (host normalized, port stripped of any leading
+// zeros) and a malformed pair is rejected here rather than poisoning a later
+// batch apply.
+func CompoundElement(ipPort string) (string, error) {
+	host, port, err := net.SplitHostPort(ipPort)
+	if err != nil {
+		return "", errorx.IllegalArgument.Wrap(err, "invalid ip:port %q: compound-set entries require an ip:port pair", ipPort)
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil || !addr.Is4() {
+		return "", errorx.IllegalArgument.New("invalid ip:port %q: %q is not an IPv4 address", ipPort, host)
+	}
+	if err := sanity.ValidatePort(port); err != nil {
+		return "", errorx.IllegalArgument.Wrap(err, "invalid ip:port %q", ipPort)
+	}
+	p, _ := strconv.Atoi(port) // safe: ValidatePort already parsed and range-checked it
+	return addr.String() + compoundSep + strconv.Itoa(p), nil
+}
+
+// SetDelta is the membership change to transform a policy's live nft set into
+// its desired state: elements to add and elements to delete, each canonicalized
+// and numerically ordered.
+type SetDelta struct {
+	Adds    []string
+	Deletes []string
+}
+
+// Empty reports whether the delta is a no-op (live already matches desired).
+func (d SetDelta) Empty() bool {
+	return len(d.Adds) == 0 && len(d.Deletes) == 0
+}
+
+// DiffElements computes the SetDelta that turns live membership into desired
+// membership. Both inputs are canonicalized first, so the result is independent
+// of input order or spelling: Adds are canonical elements present in desired but
+// not live; Deletes are present in live but not desired.
+func DiffElements(desired, live []string) SetDelta {
+	desiredCanon := CanonicalizeElements(desired)
+	liveCanon := CanonicalizeElements(live)
+
+	liveSet := make(map[string]struct{}, len(liveCanon))
+	for _, e := range liveCanon {
+		liveSet[e] = struct{}{}
+	}
+	desiredSet := make(map[string]struct{}, len(desiredCanon))
+	for _, e := range desiredCanon {
+		desiredSet[e] = struct{}{}
+	}
+
+	var adds, deletes []string
+	for _, e := range desiredCanon {
+		if _, ok := liveSet[e]; !ok {
+			adds = append(adds, e)
+		}
+	}
+	for _, e := range liveCanon {
+		if _, ok := desiredSet[e]; !ok {
+			deletes = append(deletes, e)
+		}
+	}
+	return SetDelta{Adds: adds, Deletes: deletes}
+}
+
+// CanonicalizeElements normalizes a list of nft set element tokens into a stable,
+// deduplicated, numerically-sorted slice. It accepts both plain IPv4 elements
+// (bare "10.1.0.2" or CIDR "10.4.0.0/24") and compound "<ip> . <port>" keys, and
+// renders each in the form `nft list set` prints for an interval ipv4_addr set:
+// a single host as a bare address (a /32 is collapsed), a wider range as
+// "<network>/<bits>". Passing both the desired membership and the live
+// membership through this before diffing guarantees the two agree on spelling
+// and order regardless of how the caller or the kernel originally wrote them, so
+// the same normalized form drives both the comparison and the apply args.
+//
+// Tokens that don't parse are preserved as-is and sorted after the parseable
+// ones, so an unexpected kernel rendering surfaces as a diff rather than being
+// silently dropped.
+func CanonicalizeElements(elements []string) []string {
+	keys := make([]elemKey, 0, len(elements))
+	seen := make(map[string]struct{}, len(elements))
+	for _, e := range elements {
+		k := parseElement(e)
+		if _, dup := seen[k.canon]; dup {
+			continue
+		}
+		seen[k.canon] = struct{}{}
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].less(keys[j]) })
+	out := make([]string, len(keys))
+	for i, k := range keys {
+		out[i] = k.canon
+	}
+	return out
+}
+
+// elemKey is the parsed, sortable form of one nft set element.
+type elemKey struct {
+	canon  string     // canonical rendering used for comparison and apply
+	addr   netip.Addr // zero value when unparseable
+	bits   int        // prefix length; -1 for compound elements
+	port   int        // port for compound elements; -1 otherwise
+	parsed bool       // false when the token could not be parsed
+}
+
+// parseElement normalizes one nft set element token into an elemKey.
+func parseElement(tok string) elemKey {
+	tok = strings.TrimSpace(tok)
+
+	// These are ipv4_addr(. inet_service) sets, so only IPv4 hosts and in-range
+	// ports count as parsed/authoritative; anything else falls through to the
+	// unparseable path (preserved as-is, sorted last) rather than being ordered
+	// among valid elements.
+	if host, port, ok := splitCompound(tok); ok {
+		if addr, err := netip.ParseAddr(host); err == nil && addr.Is4() {
+			if p, err := strconv.Atoi(port); err == nil && p >= 1 && p <= maxPort {
+				return elemKey{
+					canon:  addr.String() + compoundSep + strconv.Itoa(p),
+					addr:   addr,
+					bits:   -1,
+					port:   p,
+					parsed: true,
+				}
+			}
+		}
+		return elemKey{canon: tok, bits: -1, port: -1}
+	}
+
+	if strings.Contains(tok, "/") {
+		if pfx, err := netip.ParsePrefix(tok); err == nil && pfx.Addr().Is4() {
+			pfx = pfx.Masked()
+			// A full-length prefix is a single host; nft prints an interval
+			// set's /32 as the bare address, so collapse it to match.
+			if pfx.Bits() == pfx.Addr().BitLen() {
+				return elemKey{canon: pfx.Addr().String(), addr: pfx.Addr(), bits: pfx.Bits(), port: -1, parsed: true}
+			}
+			return elemKey{canon: pfx.String(), addr: pfx.Addr(), bits: pfx.Bits(), port: -1, parsed: true}
+		}
+		return elemKey{canon: tok, bits: -1, port: -1}
+	}
+
+	if addr, err := netip.ParseAddr(tok); err == nil && addr.Is4() {
+		return elemKey{canon: addr.String(), addr: addr, bits: addr.BitLen(), port: -1, parsed: true}
+	}
+	return elemKey{canon: tok, bits: -1, port: -1}
+}
+
+// splitCompound splits an nft compound element "<ip> . <port>" into its ip and
+// port halves. It reports ok=false for plain (non-compound) tokens.
+func splitCompound(tok string) (host, port string, ok bool) {
+	i := strings.Index(tok, compoundSep)
+	if i < 0 {
+		return "", "", false
+	}
+	return strings.TrimSpace(tok[:i]), strings.TrimSpace(tok[i+len(compoundSep):]), true
+}
+
+// less orders elements numerically: by address, then prefix length, then port.
+// Unparseable tokens sort last and lexically among themselves.
+func (k elemKey) less(o elemKey) bool {
+	if k.parsed != o.parsed {
+		return k.parsed
+	}
+	if !k.parsed {
+		return k.canon < o.canon
+	}
+	if c := k.addr.Compare(o.addr); c != 0 {
+		return c < 0
+	}
+	if k.bits != o.bits {
+		return k.bits < o.bits
+	}
+	return k.port < o.port
+}

--- a/internal/network/policy/diff_test.go
+++ b/internal/network/policy/diff_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompoundElement(t *testing.T) {
+	tok, err := CompoundElement("10.30.5.7:43473")
+	require.NoError(t, err)
+	require.Equal(t, "10.30.5.7 . 43473", tok)
+
+	// Port leading zeros are normalized away.
+	tok, err = CompoundElement("10.30.5.7:00080")
+	require.NoError(t, err)
+	require.Equal(t, "10.30.5.7 . 80", tok)
+
+	for _, bad := range []string{
+		"not-an-ip-port",   // no port
+		"10.30.5.7",        // missing port
+		"10.30.5.7:-1",     // negative port
+		"10.30.5.7:0",      // port below range
+		"10.30.5.7:99999",  // port above range
+		"10.30.5.7:http",   // non-numeric port
+		"::1:80",           // IPv6 host
+		"[2001:db8::1]:80", // IPv6 host
+	} {
+		_, err := CompoundElement(bad)
+		require.Error(t, err, "expected %q to be rejected", bad)
+	}
+}
+
+func TestCanonicalizeElements(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "numeric order, not lexical",
+			in:   []string{"10.1.0.10/32", "10.1.0.2/32", "10.1.0.1/32"},
+			want: []string{"10.1.0.1", "10.1.0.2", "10.1.0.10"},
+		},
+		{
+			name: "single-host /32 collapses to bare, wider mask kept",
+			in:   []string{"10.4.0.0/24", "10.1.0.5/32", "10.1.0.5"},
+			want: []string{"10.1.0.5", "10.4.0.0/24"},
+		},
+		{
+			name: "dedup after normalization",
+			in:   []string{"10.1.0.2/32", "10.1.0.2", "10.1.0.2/32"},
+			want: []string{"10.1.0.2"},
+		},
+		{
+			name: "compound sorted by ip then port",
+			in:   []string{"10.30.5.7 . 500", "10.30.5.7 . 100", "10.30.5.2 . 900"},
+			want: []string{"10.30.5.2 . 900", "10.30.5.7 . 100", "10.30.5.7 . 500"},
+		},
+		{
+			name: "prefix mask is canonicalized to network address",
+			in:   []string{"10.4.0.5/24"},
+			want: []string{"10.4.0.0/24"},
+		},
+		{
+			name: "unparseable tokens preserved and sorted last",
+			in:   []string{"garbage", "10.1.0.2/32"},
+			want: []string{"10.1.0.2", "garbage"},
+		},
+		{
+			name: "out-of-range compound port is not authoritative, sorts last",
+			in:   []string{"10.30.5.7 . 99999", "10.1.0.2/32"},
+			want: []string{"10.1.0.2", "10.30.5.7 . 99999"},
+		},
+		{
+			name: "IPv6 element is not IPv4, treated as unparseable",
+			in:   []string{"2001:db8::1", "10.1.0.2/32"},
+			want: []string{"10.1.0.2", "2001:db8::1"},
+		},
+		{
+			name: "empty input",
+			in:   nil,
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CanonicalizeElements(tt.in)
+			require.Equal(t, tt.want, got)
+			// Idempotent: canonicalizing the output changes nothing.
+			require.Equal(t, got, CanonicalizeElements(got))
+		})
+	}
+}
+
+func TestDiffElements(t *testing.T) {
+	tests := []struct {
+		name        string
+		desired     []string
+		live        []string
+		wantAdds    []string
+		wantDeletes []string
+	}{
+		{
+			name:     "adds only",
+			desired:  []string{"10.1.0.1/32", "10.1.0.2/32"},
+			live:     nil,
+			wantAdds: []string{"10.1.0.1", "10.1.0.2"},
+		},
+		{
+			name:        "deletes only (empty desired clears set)",
+			desired:     nil,
+			live:        []string{"10.1.0.1/32"},
+			wantDeletes: []string{"10.1.0.1"},
+		},
+		{
+			name:        "mixed add and delete",
+			desired:     []string{"10.1.0.2/32", "10.1.0.3/32"},
+			live:        []string{"10.1.0.1/32", "10.1.0.2/32"},
+			wantAdds:    []string{"10.1.0.3"},
+			wantDeletes: []string{"10.1.0.1"},
+		},
+		{
+			name:    "no-op despite spelling difference (/32 vs bare, unsorted)",
+			desired: []string{"10.1.0.10/32", "10.1.0.2"},
+			live:    []string{"10.1.0.2/32", "10.1.0.10"},
+		},
+		{
+			name:     "compound elements diff",
+			desired:  []string{"10.30.5.8 . 43473"},
+			live:     []string{"10.30.5.7 . 43473"},
+			wantAdds: []string{"10.30.5.8 . 43473"},
+			wantDeletes: []string{
+				"10.30.5.7 . 43473",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := DiffElements(tt.desired, tt.live)
+			require.Equal(t, tt.wantAdds, d.Adds)
+			require.Equal(t, tt.wantDeletes, d.Deletes)
+			require.Equal(t, len(tt.wantAdds) == 0 && len(tt.wantDeletes) == 0, d.Empty())
+		})
+	}
+}

--- a/internal/network/policy/policy.go
+++ b/internal/network/policy/policy.go
@@ -197,15 +197,18 @@ func validateIPPort(s string) error {
 
 // setElements converts initial --cidrs entries into nft element tokens for the
 // policy's set: `<ip> . <port>` compound keys for --reply-stamp policies, plain
-// CIDRs otherwise. The input is assumed already validated.
+// CIDRs otherwise. The input is assumed already validated, so the compound
+// conversion's error (only possible on a malformed ip:port) cannot fire here;
+// it shares CompoundElement so the CLI apply path and the daemon poll loop's
+// diff render compound elements identically.
 func setElements(p *Policy, cidrs []string) []string {
 	if !p.isCompoundSet() {
 		return cidrs
 	}
 	out := make([]string, 0, len(cidrs))
 	for _, c := range cidrs {
-		host, port, _ := net.SplitHostPort(c)
-		out = append(out, host+" . "+port)
+		tok, _ := CompoundElement(c)
+		out = append(out, tok)
 	}
 	return out
 }


### PR DESCRIPTION
## Description

The traffic-shaper monitor keeps the block node's nftables `inet weaver` policy
sets in sync with the categories the BN reports over statusz. This PR adds the
pure middle stage of that reconciliation: the internal category→policy mapping
and the diff that compares desired membership against the **live** kernel sets to
produce per-policy add/delete deltas. It deliberately owns neither the statusz
fetch (#751) nor the delta apply (#754) — those wrap this deterministic core.

The diff reads live membership back from the kernel every time rather than
trusting a remembered hash, so it is stateless across daemon restarts and
self-correcting against drift. Both the desired list and the live list are run
through one canonicalizer before comparison, and the same normalized form is what
the apply path consumes, so compare and apply can never disagree on spelling or
order. A single-host `/32` is collapsed to the bare address nft prints for an
interval `ipv4_addr` set (so `10.1.0.2/32` and `10.1.0.2` are the same element),
and elements sort numerically (`10.1.0.2` before `10.1.0.10`). The compound
`ip:port` conversion for the outbound `bn-backfill` set is now a single exported
helper shared with the `network policy set` apply path, so both render `ip . port`
keys byte-for-byte identically.

Category semantics follow the acceptance criteria precisely: a category present
with an empty endpoint list clears its set; a category absent entirely from the
response leaves its set untouched (and its live set is never even read);
categories with no mapping — the operator-curated mgmt sets — are never touched.

The full poll loop is not wired yet, but `runStatuszPoll` now drives a
not-yet-live `reconcilePolicies` seam (with an empty view, so zero deltas and no
kernel writes) so #751/#754 can plug in fetch and apply without further plumbing.

### Files changed

| File | Change |
|---|---|
| `internal/network/policy/diff.go` | New. `CompoundElement` (exported, shared conversion), `CanonicalizeElements` (numeric sort, `/32` collapse, dedup, unparseable-preserving), `DiffElements` → `SetDelta{Adds,Deletes}`. |
| `internal/network/policy/policy.go` | `setElements` now calls the shared `CompoundElement` instead of inlining the `ip . port` conversion. |
| `internal/daemon/blocknode/statusz_policy.go` | New. Fixed category→policy map, `CategoryEndpoints` input type (present-empty vs absent), `computePolicyDeltas` (build desired, read live via the `Runner` seam, diff). |
| `internal/daemon/blocknode/traffic_shaper_monitor.go` | Monitor holds an `elementLister` (defaults to the policy exec Runner); `runStatuszPoll` drives the new `reconcilePolicies` seam. |
| `internal/network/policy/diff_test.go` | New. Canonicalization ordering / `/32` collapse / dedup / compound / idempotency; diff add/delete/no-op/compound cases. |
| `internal/daemon/blocknode/statusz_policy_test.go` | New. Mapping, empty-clears vs absent-untouched, unmapped-ignored, compound conversion, live-read error propagation, nil-lister guard. |

### Review guide

- **Live read is per-set, not `list table`.** `computePolicyDeltas` reads each
  policy's membership with the existing `Runner.ListElements` (`nft list set inet
  weaver <set>`), which is equivalent to parsing the whole `list table` document
  but reuses the already-tested `parseElementsLine`. Worth a look:
  `internal/daemon/blocknode/statusz_policy.go` `computePolicyDeltas`.
- **Canonicalization matches nft's interval-set rendering.** The `/32`→bare
  collapse in `diff.go` `parseElement` is what makes desired vs live agree; if
  nft rendered single hosts differently this would churn. These sets are
  daemon-owned (sole writer), so the round-trip is self-consistent.
- **Present-empty vs absent** is modeled by map-key presence in
  `CategoryEndpoints`, not an empty slice — verify the two paths in
  `computePolicyDeltas` and their tests.

Test commands:

```bash
go test -tags='!integration' ./internal/network/policy/... ./internal/daemon/blocknode/...
task lint:check
```

No CLI-flag or template changes, so no `docs/quickstart.md` update. Rollback is
dropping the two new files; nothing changes observable behavior until #754 wires
apply into the poll loop.

### Manual UAT

There is no operator-facing runtime path in this PR (the poll loop is stubbed and
writes nothing), so the acceptance criteria are covered by unit tests. The one
thing unit tests can't prove is that the canonical element spelling this PR
produces matches what **real nft** prints back — the assumption the diff's
correctness rests on. Verify that round-trip on a Linux host with `nft` (e.g. the
UTM VM), using throwaway policies so no real BN state is touched:

```bash
# Plain interval ipv4_addr set: a /32 must read back as a bare host, numerically ordered.
sudo solo-provisioner network policy create --name uat-plain \
  --stamp publisher --ports 40840 --pod-cidr 10.4.0.0/24
sudo solo-provisioner network policy set --name uat-plain --cidrs 10.1.0.10/32,10.1.0.2/32
sudo nft list set inet weaver uat-plain
#   expect: elements = { 10.1.0.2, 10.1.0.10 }   ← /32 collapsed, .2 before .10

# Compound ipv4_addr . inet_service set: an ip:port must read back as "<ip> . <port>".
sudo solo-provisioner network policy create --name uat-compound \
  --stamp reserve-egress --reply-stamp backfill-response --pod-cidr 10.4.0.0/24
sudo solo-provisioner network policy set --name uat-compound --cidrs 10.30.5.7:43473
sudo nft list set inet weaver uat-compound
#   expect: elements = { 10.30.5.7 . 43473 }

# cleanup
sudo solo-provisioner network policy delete --name uat-plain
sudo solo-provisioner network policy delete --name uat-compound
```

Both readbacks must match, byte for byte, what `CanonicalizeElements` produces for
the same inputs. If nft spells either form differently, the diff would churn and
`parseElement`'s canonicalization needs to follow nft's rendering.

### Related Issues

* Closes #752
