### PR TITLE
feat(alloy): add --profile flag and ops-profile instance label

### DIFF
--- a/cmd/cli/commands/alloy/cluster/cluster.go
+++ b/cmd/cli/commands/alloy/cluster/cluster.go
@@ -14,6 +14,7 @@ var (
 	flagContinueOnError bool
 
 	// Alloy configuration flags
+	flagProfile            string
 	flagMonitorBlockNode   bool
 	flagClusterName        string
 	flagClusterSecretStore string
@@ -49,6 +50,7 @@ func init() {
 	)
 
 	// Core configuration flags
+	common.FlagProfile().SetVarP(clusterCmd, &flagProfile, false)
 	common.FlagClusterName().SetVarP(clusterCmd, &flagClusterName, false)
 	common.FlagMonitorBlockNode().SetVarP(clusterCmd, &flagMonitorBlockNode, false)
 

--- a/cmd/cli/commands/alloy/cluster/cluster_test.go
+++ b/cmd/cli/commands/alloy/cluster/cluster_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProfileFlagRegistered pins the wiring for #847: `alloy cluster` must expose a
+// visible, persistent `--profile`/`-p` flag (mirroring the block command tree) so the
+// deploy profile reaches config.Profile and the ops label profile can emit the
+// `environment` label. Unlike kube's deprecated flag, this one must NOT be hidden.
+func TestProfileFlagRegistered(t *testing.T) {
+	root := GetCmd()
+
+	profile := root.PersistentFlags().Lookup(common.FlagProfile().Name)
+	require.NotNil(t, profile, "--profile must be registered on the alloy cluster command")
+	require.False(t, profile.Hidden, "--profile must be visible in --help for alloy")
+	require.Equal(t, common.FlagProfile().ShortName, profile.Shorthand, "--profile must keep its -p shorthand")
+
+	// install inherits the persistent flag from its parent.
+	install := findSubcommand(t, root, "install")
+	root.SetArgs([]string{"install"})
+	require.NoError(t, install.InheritedFlags().Parse(nil))
+	require.NotNil(t, install.InheritedFlags().Lookup(common.FlagProfile().Name),
+		"install must inherit --profile from the cluster command")
+}
+
+func findSubcommand(t *testing.T, parent *cobra.Command, name string) *cobra.Command {
+	t.Helper()
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	require.Failf(t, "subcommand not found", "%q under %q", name, parent.Name())
+	return nil
+}

--- a/cmd/cli/commands/alloy/cluster/install.go
+++ b/cmd/cli/commands/alloy/cluster/install.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/workflows"
 	"github.com/hashgraph/solo-weaver/pkg/config"
+	"github.com/hashgraph/solo-weaver/pkg/hardware"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 )
 
@@ -45,6 +46,24 @@ Examples:
   solo-provisioner alloy cluster install \
     --cluster-name=my-cluster`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Resolve the deployment profile. Unlike block/kube this flag is optional:
+		// when omitted we leave config.Profile as loaded via the root --config flag
+		// (viper) so the environment label still resolves. Only override the global
+		// config when a non-empty --profile is explicitly provided, and validate it.
+		flagProfile, err := common.FlagProfile().Value(cmd, args)
+		if err != nil {
+			return errorx.IllegalArgument.Wrap(err, "failed to get profile flag")
+		}
+		if flagProfile != "" {
+			if !hardware.IsValidProfile(flagProfile) {
+				return errorx.IllegalArgument.New("unsupported profile: %q. Supported profiles: %v",
+					flagProfile, models.SupportedProfiles())
+			}
+			// Set the profile in the global config so the label profile can emit
+			// the environment label on scraped metrics and logs.
+			config.SetProfile(flagProfile)
+		}
+
 		// Parse multi-remote flags
 		prometheusRemotes, err := parseRemoteFlags(flagPrometheusRemotes)
 		if err != nil {

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -805,6 +805,7 @@ kubectl create secret generic grafana-alloy-secrets \
 # Step 2: Install Alloy with remotes
 sudo solo-provisioner alloy cluster install \
   --cluster-name=mainnet-block-01 \
+  --profile=mainnet \
   --add-prometheus-remote=name=primary,url=https://prom1.example.com/api/v1/write,username=user1 \
   --add-loki-remote=name=primary,url=https://loki1.example.com/loki/api/v1/push,username=user1 \
   --monitor-block-node
@@ -819,6 +820,7 @@ sudo solo-provisioner alloy cluster install \
 | Flag                      | Description                                                                                                                       |
 |---------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | `--cluster-name`          | Cluster name for metrics/logs labels                                                                                              |
+| `--profile`, `-p`         | Deployment profile (`local`, `perfnet`, `testnet`, `previewnet`, `mainnet`); sets the `environment` label for the `ops` profile. Optional; if omitted, the value from `--config` is used |
 | `--monitor-block-node`    | Enable Block Node specific monitoring                                                                                             |
 | `--add-prometheus-remote` | Add a Prometheus remote (format: `name=<name>,url=<url>,username=<username>[,labelProfile=eng\|ops]`). Repeatable. Default: `eng` |
 | `--add-loki-remote`       | Add a Loki remote (format: `name=<name>,url=<url>,username=<username>[,labelProfile=eng\|ops]`). Repeatable. Default: `eng`       |
@@ -924,7 +926,7 @@ remote activates a profile.
 | Profile           | Labels Added                                                                 |
 |-------------------|------------------------------------------------------------------------------|
 | `eng` *(default)* | `cluster`                                                                    |
-| `ops`             | `cluster`, `environment`, `instance_type`, `inventory_name`, `ip` (optional) |
+| `ops`             | `cluster`, `environment`, `instance`, `instance_type`, `inventory_name`, `ip` (optional) |
 
 **Example** — install with the `ops` label profile:
 
@@ -942,6 +944,7 @@ With `--cluster-name=lfh02-previewnet-blocknode` and `--profile=previewnet`, the
 |------------------|------------------------------|------------------------------------------------------------------|
 | `cluster`        | `lfh02-previewnet-blocknode` | Always set (from `--cluster-name`)                               |
 | `environment`    | `previewnet`                 | From `--profile` (deploy profile)                                |
+| `instance`       | `lfh02-previewnet-blocknode` | Full cluster name; overrides the auto-scraped `IP:port`          |
 | `instance_type`  | `lfh`                        | Alphabetic prefix of the first segment of cluster name           |
 | `inventory_name` | `lfh02-previewnet-blocknode` | Full cluster name                                                |
 | `ip`             | `<ip>`                       | Optional; set when an IP address label is available for the node |

--- a/internal/alloy/labels/ops.go
+++ b/internal/alloy/labels/ops.go
@@ -22,6 +22,7 @@ func (OpsProfile) Name() string { return "ops" }
 // Labels added (from LabelInput):
 //   - cluster        = ClusterName
 //   - environment    = DeployProfile
+//   - instance       = ClusterName (human-readable override of the scrape IP:port)
 //   - instance_type  = alphabetic prefix of first cluster name segment (e.g. "lfh")
 //   - inventory_name = full cluster name (for DevOps inventory systems)
 //   - ip             = MachineIP (when available)
@@ -31,6 +32,12 @@ func (OpsProfile) Labels(input LabelInput) map[string]string {
 	if input.ClusterName != "" {
 		labels["cluster"] = input.ClusterName
 		labels["inventory_name"] = input.ClusterName
+		// Override the auto-populated instance (IP:port) with the cluster name so
+		// dashboards show human-readable names (e.g. "lfh00-testnet"). This mirrors
+		// inventory_name; a static replacement is used rather than a source_labels
+		// copy because RenderLabelRules sorts rules alphabetically and cannot
+		// guarantee inventory_name is set before an instance rule would read it.
+		labels["instance"] = input.ClusterName
 	}
 
 	if input.DeployProfile != "" {

--- a/internal/alloy/labels/ops_test.go
+++ b/internal/alloy/labels/ops_test.go
@@ -83,7 +83,7 @@ func TestExtractAlphaPrefix(t *testing.T) {
 }
 
 func TestOpsProfile_Labels(t *testing.T) {
-	t.Run("returns all labels including cluster, inventory_name, and ip", func(t *testing.T) {
+	t.Run("returns all labels including cluster, instance, inventory_name, and ip", func(t *testing.T) {
 		result := OpsProfile{}.Labels(LabelInput{
 			ClusterName:   "lfh02-previewnet-blocknode",
 			DeployProfile: "previewnet",
@@ -92,6 +92,7 @@ func TestOpsProfile_Labels(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			"cluster":        "lfh02-previewnet-blocknode",
 			"environment":    "previewnet",
+			"instance":       "lfh02-previewnet-blocknode",
 			"instance_type":  "lfh",
 			"inventory_name": "lfh02-previewnet-blocknode",
 			"ip":             "10.0.0.1",
@@ -107,10 +108,20 @@ func TestOpsProfile_Labels(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			"cluster":        "mycluster",
 			"environment":    "mainnet",
+			"instance":       "mycluster",
 			"instance_type":  "mycluster",
 			"inventory_name": "mycluster",
 			"ip":             "192.168.1.100",
 		}, result)
+	})
+
+	t.Run("instance mirrors cluster name for human-readable dashboards", func(t *testing.T) {
+		result := OpsProfile{}.Labels(LabelInput{
+			ClusterName:   "lfh00-testnet",
+			DeployProfile: "testnet",
+		})
+		assert.Equal(t, "lfh00-testnet", result["instance"])
+		assert.Equal(t, result["inventory_name"], result["instance"])
 	})
 
 	t.Run("returns empty map when cluster name is empty", func(t *testing.T) {

--- a/internal/alloy/render_test.go
+++ b/internal/alloy/render_test.go
@@ -232,8 +232,8 @@ func TestRenderModularConfigs_WithOpsLabelProfile_AllModules(t *testing.T) {
 		assert.Contains(t, content, `target_label = "ip"`, "module %s should contain ip rule", moduleName)
 		// ops profile should include inventory_name
 		assert.Contains(t, content, `target_label = "inventory_name"`, "module %s should contain inventory_name", moduleName)
-		// instance label should NOT be present
-		assert.NotContains(t, content, `target_label = "instance"`, "module %s should not contain instance rule", moduleName)
+		// ops profile should override instance with the human-readable cluster name
+		assert.Contains(t, content, `target_label = "instance"`, "module %s should contain instance rule", moduleName)
 	}
 }
 


### PR DESCRIPTION
## Description

Two independent DevOps-observability fixes to the Alloy ops label profile, both surfaced while setting up the ops profile for testnet.

**1. `alloy cluster install` had no `--profile` flag.** The ops label profile sources the `environment` label from `config.Get().Profile` → `LabelInput.DeployProfile`, but the alloy command tree never called `config.SetProfile()` and registered no `--profile`/`-p` flag. As a result `DeployProfile` was always `""` and the `environment` label was silently omitted from every metric and log Alloy scraped. `block` and `kube` already wire this up; alloy now gets the same treatment. The flag is **optional** and only overrides the global config when explicitly set to a non-empty value, so the existing `--config` workaround (`profile: testnet` loaded via viper) keeps working.

**2. The ops profile emitted no `instance` label.** Prometheus auto-sets `instance` to `IP:port` on ServiceMonitor targets. The ops profile injected `cluster`, `environment`, `instance_type`, `inventory_name`, and `ip` but never overrode `instance`, so dashboards showed raw IPs instead of human-readable names like `lfh00-testnet`. The ops profile now emits `instance = <cluster-name>`.

> **Design note (deviation from the issue's suggested fix):** the issue proposed a `source_labels = ["inventory_name"]` → `target_label = "instance"` copy rule. This PR instead emits a **static** `instance = ClusterName` label. `inventory_name` is itself just a static copy of `ClusterName`, so the resulting value is identical; and `RenderLabelRules` sorts rules alphabetically (`"instance"` < `"inventory_name"`), so a genuine copy rule would execute *before* `inventory_name` is set and read empty. The static form is functionally equivalent, needs no renderer/struct changes, and has no ordering hazard.

### Upgrade / compatibility

Backward compatible. The CLI surface is purely additive — `--profile` is new and optional, nothing was removed or renamed, so existing scripts and the `--config profile: <env>` workaround keep working unchanged.

The Alloy configmap is rendered **only** by `alloy cluster install` (via `SetupAlloyStack`); **no startup migration touches Alloy**, so upgrading the `solo-provisioner` binary alone changes nothing — the existing `grafana-alloy-cm` and running DaemonSet are untouched until the operator re-runs install.

On the next `alloy cluster install` **without** `--profile`, behavior for an existing cluster is:

| Label | Effect |
|---|---|
| `environment` | **Unchanged.** `config.SetProfile()` only fires on a non-empty `--profile`, so a viper-loaded `Profile` (from `--config`) is preserved; empty stays empty. |
| `instance` (ops-profile remotes only) | **Changes** from the auto-scraped `IP:port` to the cluster name (e.g. `lfh00-testnet`) — this is the fix. |
| `eng` (default) remotes | **Unchanged** — no ops labels are emitted, so there is no `instance` override. |

So the only observable change on a no-flag re-run is the `instance` value on `labelProfile=ops` remotes. Operators with dashboards/alerts keyed on the old IP-based `instance` should expect it to switch to the cluster name after their next install (see Risks/rollback).

### Files changed

| File | Change |
|---|---|
| `cmd/cli/commands/alloy/cluster/cluster.go` | Register `--profile`/`-p` as a visible persistent flag on the `cluster` command |
| `cmd/cli/commands/alloy/cluster/install.go` | Read the profile in `RunE`; validate via `hardware.IsValidProfile` and call `config.SetProfile()` only when non-empty |
| `internal/alloy/labels/ops.go` | Emit `instance = ClusterName` in `OpsProfile.Labels()` |
| `cmd/cli/commands/alloy/cluster/cluster_test.go` *(new)* | Pin the flag contract (registered, visible, `-p` shorthand, inherited by `install`) |
| `internal/alloy/labels/ops_test.go` | Expect the new `instance` label |
| `internal/alloy/render_test.go` | Flip the rendered `instance`-rule assertion from absent → present |
| `docs/quickstart.md` | Document `--profile` and the `instance` label |

### Review guide

**Code-review checklist**

- [ ] `install.go` — `config.SetProfile()` is guarded by `flagProfile != ""` so an omitted `--profile` does **not** clobber a `Profile` loaded from `--config` via viper.
- [ ] `install.go` — invalid non-empty profiles are rejected with `errorx.IllegalArgument` before any workflow runs.
- [ ] `cluster.go` — the flag is **visible** (not `SetVarPHidden`, unlike kube's deprecated flag) and persistent so `install` inherits it.
- [ ] `ops.go:31-40` — `instance` is only set inside `if input.ClusterName != ""`, so an empty cluster name still yields an empty label map (asserted in `ops_test.go`).
- [ ] `render_test.go` — `target_label = "instance"` (trailing quote) does not falsely match `target_label = "instance_type"`.

**Unit tests**

```bash
# Host (no Linux-only deps):
go test -tags='!integration' ./internal/alloy/...

# CLI package pulls in Linux-only internal/mount, so run it in the VM:
task vm:sync
# then over SSH:
#   cd /mnt/solo-weaver && sudo -E PATH="$PATH" go test -tags='!integration' ./cmd/cli/commands/alloy/...
```

**Manual UAT** (UTM VM + local observability stack, per `test/alloy` quickstart)

Setup:

```bash
task build
task alloy:start                 # Prometheus + Loki + Grafana on the host
task alloy:create-secret         # grafana-alloy-secrets in the grafana-alloy namespace
NODE_IP=$(...)                   # host IP reachable from the VM
```

---

**UAT-1 — `--profile` emits the `environment` label (the primary fix)**

```bash
sudo solo-provisioner alloy cluster install \
  --cluster-name=lfh00-testnet \
  --profile=testnet \
  --add-prometheus-remote=name=local,url=http://$NODE_IP:9090/api/v1/write,username=admin,labelProfile=ops \
  --add-loki-remote=name=local,url=http://$NODE_IP:3100/loki/api/v1/push,username=admin,labelProfile=ops \
  --monitor-block-node

kubectl -n grafana-alloy get cm grafana-alloy-cm -o yaml | grep -A1 'target_label = "environment"'
```

Expected — the rendered relabel block contains:

```
    target_label = "environment"
    replacement  = "testnet"
```

In Grafana (`http://localhost:3000`), a query like `up{environment="testnet"}` returns series (previously `environment` was absent entirely).

---

**UAT-2 — `instance` label overrides the raw IP:port (the second fix)**

Using the same install as UAT-1:

```bash
kubectl -n grafana-alloy get cm grafana-alloy-cm -o yaml | grep -A1 'target_label = "instance"'
```

Expected:

```
    target_label = "instance"
    replacement  = "lfh00-testnet"
```

In Grafana, scraped metrics carry `instance="lfh00-testnet"` instead of `instance="10.x.x.x:9100"`. This holds for every ops-profile module (agent-metrics, kubelet, node-exporter, block-node, syslog).

---

**UAT-3 — backward compatibility: the `--config profile:` path still works**

```bash
printf 'profile: testnet\n' | sudo tee /tmp/weaver.yaml >/dev/null

sudo solo-provisioner alloy cluster install \
  --config /tmp/weaver.yaml \
  --cluster-name=lfh00-testnet \
  --add-prometheus-remote=name=local,url=http://$NODE_IP:9090/api/v1/write,username=admin,labelProfile=ops

kubectl -n grafana-alloy get cm grafana-alloy-cm -o yaml | grep -A1 'target_label = "environment"'
```

Expected — `environment` is still `testnet` (the empty `--profile` must **not** overwrite the viper-loaded value):

```
    target_label = "environment"
    replacement  = "testnet"
```

---

**UAT-4 — invalid profile is rejected early**

```bash
sudo solo-provisioner alloy cluster install --cluster-name=lfh00-testnet --profile=bogus
```

Expected — non-zero exit, no workflow started:

```
unsupported profile: "bogus". Supported profiles: [local perfnet testnet previewnet mainnet]
```

---

**UAT-5 — `--profile` and shorthand appear in help; eng default unaffected**

```bash
solo-provisioner alloy cluster install --help | grep -- '--profile'
```

Expected — a visible line: `-p, --profile string   Deployment profiles [local perfnet testnet previewnet mainnet]`.

Installing without `labelProfile=ops` (default `eng`) still emits only the `cluster` label — no `environment`/`instance` rules — confirming the change is scoped to the ops profile.

**Risks / rollback**

Both changes are additive. The `instance` override changes the label *value* for ops-profile installs (raw IP → cluster name) — that is the intended fix, but any dashboard/alert keyed on the old IP-based `instance` will shift to the cluster name. Rollback is a straight revert of the two source edits; no state or migrations involved.

### Related Issues

* Closes #847

