### PR TITLE
feat(daemon): local-fallback statusz config, install-time enablement, and mock statusz server

### DIFF
--- a/docs/dev/daemon/traffic-shaper-statusz.md
+++ b/docs/dev/daemon/traffic-shaper-statusz.md
@@ -1,0 +1,180 @@
+# Block Node traffic-shaper: statusz poll loop & configuration
+
+This document describes how the `solo-provisioner-daemon` block-node
+traffic-shaper monitor consumes the Block Node's `statusz` REST endpoints, how
+the statusz categories map to network policies, the local-fallback statusz
+configuration schema in `daemon.yaml`, and the mock statusz server used for
+daemon development and tests.
+
+> **The statusz contract is provisional.** The request/response shape below
+> mirrors the Block Node's `network-data.proto`. Confirming the contract with
+> the Block Node team is a blocking dependency; treat this document as the
+> current best understanding, not a frozen interface.
+
+> **Implementation status.** This story delivers the pieces the loop *consumes* —
+> the `daemon.yaml` local-fallback config schema, the install-time monitor
+> enablement, and the mock statusz server. The poll loop *itself* (fetch → diff →
+> apply) lands in a follow-up TS_3 story: it applies nft membership through the
+> daemon's `privexec` sudo-delegation (the daemon is unprivileged and never calls
+> `nft` directly), not the in-process path this doc's prose describes.
+
+## What the poll loop does
+
+The traffic-shaper monitor runs a poll loop that, on a fixed cadence
+(default 5s):
+
+1. fetches the BN's `inbound-clients` and `outbound-clients` statusz endpoints,
+2. buckets the returned endpoints by category,
+3. diffs the desired membership against the live nftables sets, and
+4. applies the per-policy membership deltas.
+
+The loop reconciles **nftables set membership only** — the dynamic plane. The
+tc HTB class hierarchy is static (installed once); traffic lands in the correct
+class via nftables `skb->priority` marking, not via runtime tc changes.
+
+### Outage behaviour
+
+A failed poll (statusz unreachable, diff error, or apply error) is logged and
+retried on the next tick, leaving the **last-good** nftables state in place. A
+BN outage therefore never drops existing rules; once the BN's statusz is
+reachable again, membership re-converges within one poll cycle. During initial
+BN bootstrap the sets simply stay empty until statusz responds.
+
+## statusz endpoints
+
+Both endpoints are REST/JSON, resolved relative to the configured base URL:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET statusz/inbound-clients` | Sources allowed to connect **to** the BN, by category |
+| `GET statusz/outbound-clients` | Destinations the BN connects **out** to (peer-BN backfill) |
+
+### Response shape (`NetworkData`)
+
+```json
+{
+  "active_endpoints": [
+    {
+      "local":  { "address": "0.0.0.0",      "port": "40840" },
+      "remote": { "address": "10.10.1.0/24", "port": "*" },
+      "category": "publisher",
+      "tls_required": true
+    }
+  ]
+}
+```
+
+- `remote.address` is the source (inbound) or destination (outbound) host or
+  CIDR. It is the value written into the nft set.
+- `remote.port` is only meaningful for the outbound `peer_bn` category, where
+  the backfill set is keyed on `address . port`. Inbound categories ignore the
+  port (it is the BN's listener port, not part of the source allowlist).
+- Fields the shaper does not consume (`scheme`, `protocol`, `certificate`) are
+  omitted from the decode.
+
+## Category to policy mapping
+
+The statusz-category to policy-name mapping is **internal to the monitor** and
+not operator-configurable. The policy name is also the nftables set name, in the
+`inet weaver` table. These are the same names `block node install` uses when it
+creates the policies, so install and the monitor agree on the namespace without
+a shared config file.
+
+| statusz endpoint | category | policy / nft set | key shape |
+|---|---|---|---|
+| inbound-clients | `publisher` | `bn-publisher` | ipv4 host/CIDR |
+| inbound-clients | `partner` | `bn-partner` | ipv4 host/CIDR |
+| inbound-clients | `restricted` | `bn-restricted` | ipv4 host/CIDR |
+| outbound-clients | `peer_bn` | `bn-backfill` | compound `ip . port` |
+
+Categories not in this table (for example `public`, or the operator-curated
+management set) are **never touched** by the monitor. A `public` source is
+expressed as the absence of a source-match on its rule, not as a set element, so
+it is intentionally dropped during bucketing.
+
+Each owned category is reconciled on every successful poll: an address that
+drops out of statusz is removed from its set, not left stale. A poll that
+reports no endpoints for an owned category clears that set.
+
+## Local-fallback statusz configuration
+
+The monitor needs to know **where** to poll statusz. This is configured with an
+optional `statusz` block on the block-node component in `daemon.yaml`:
+
+```yaml
+components:
+  block_node:
+    enabled: true
+    kubeconfig: /opt/solo/weaver/config/daemon-bn.kubeconfig
+    orbit: block-node
+    monitors:
+      traffic_shaper: true
+    statusz:                          # optional
+      base_url: http://127.0.0.1:8080 # where the poll loop fetches statusz
+      poll_interval: 5s               # optional; defaults to 5s
+```
+
+| Field | Required | Meaning |
+|---|---|---|
+| `base_url` | no | Root URL the `statusz/...` paths resolve against. Must be `http(s)` with a host. |
+| `poll_interval` | no | Poll cadence as a Go duration (e.g. `5s`, `10s`). Defaults to `5s`. |
+
+When `base_url` is empty (or the `statusz` block is absent), the poll loop
+**idles** — there is no source to poll. In-cluster discovery of statusz on the
+BN pod is a later story; until then, `base_url` is how the monitor is pointed at
+a statusz source, whether that is the mock server, a port-forward, or a
+directly reachable BN.
+
+### Enablement at install time
+
+`block node install` writes/merges the `block_node` block above into
+`daemon.yaml` (enabled, the scoped `daemon-bn.kubeconfig`, the BN orbit, and
+`monitors.traffic_shaper: true`), preserving any operator-set `statusz` block
+and the `consensus_node` block. It does **not** set `base_url` — the
+local-fallback source is an operator/deploy concern, added separately. The
+daemon binary and service are installed by `daemon service install`; the install
+step only records the enablement so the monitor starts when the daemon runs.
+
+Disable the monitor at any time with `monitors.traffic_shaper: false` and a
+daemon restart.
+
+## Mock statusz server (dev & tests)
+
+`internal/daemon/blocknode/statuszmock` is a minimal mock of the two statusz
+endpoints, served from a JSON roster file that is **re-read on every request**,
+so editing the file changes what the daemon's poll loop sees on its next tick.
+It is used by daemon tests and by the UTM-VM traffic-shaper demo.
+
+Run it:
+
+```bash
+go run ./internal/daemon/blocknode/statuszmock/cmd --addr :8080 --roster roster.json
+```
+
+Roster file shape:
+
+```json
+{
+  "inbound": [
+    { "remote": {"address": "10.10.1.0/24", "port": "*"}, "category": "publisher" },
+    { "remote": {"address": "10.20.1.0/24", "port": "*"}, "category": "partner" }
+  ],
+  "outbound": [
+    { "remote": {"address": "10.30.5.7", "port": "43473"}, "category": "peer_bn" }
+  ]
+}
+```
+
+A missing roster file is served as an empty roster (the BN "no clients yet"
+bootstrap state) rather than an error, so the server can be started before the
+roster exists. Point `daemon.yaml`'s `block_node.statusz.base_url` at this
+server's address to drive the poll loop from it.
+
+See `docs/dev/traffic-shaper-demo.md` for the end-to-end UTM-VM walkthrough.
+
+## Related
+
+- `docs/dev/daemon/daemon-architecture.md` — the daemon's overall architecture
+  (components, monitors, supervision, `daemon.yaml` schema and versioning).
+- The Block Node QoS multi-class priority design (unified nft priority) —
+  the authoritative design for the traffic-shaper's nft/tc model.

--- a/docs/dev/traffic-shaper-demo.md
+++ b/docs/dev/traffic-shaper-demo.md
@@ -1,0 +1,319 @@
+# Traffic-shaper MVP demo (UTM VM)
+
+This runbook drives the block-node traffic-shaper end to end on a UTM VM: a
+mock statusz server feeds a roster to the `solo-provisioner-daemon` poll loop,
+and you watch the live nftables set membership follow roster edits. It then
+extends to multiple VMs to observe per-category traffic shaping.
+
+**What you will observe:** nftables set *membership* changing within one poll
+interval (default 5s) as the roster changes. The tc HTB class hierarchy is
+static (installed once); traffic is classified into those classes by nftables
+`skb->priority` marking, so you will not see tc rules change at runtime — you
+will see traffic land in different classes as set membership changes.
+
+> **Status.** Steps 1-3 (static-plane policies, mock server, daemon.yaml config +
+> daemon install) work with the current stories. The live convergence in Step 4
+> and the shaping in Step 5 depend on the **daemon poll loop**, which lands in a
+> follow-up TS_3 story (it applies nft via the daemon's `privexec`
+> sudo-delegation). Until that lands, the mock server + config are in place but
+> the sets are not yet reconciled automatically.
+
+## Prerequisites
+
+- A provisioned block-node VM: `sudo solo-provisioner block node install`. Note
+  this lays down the **host firewall** (`inet host`), the **egress tc** HTB root,
+  and the **daemon.yaml enablement** — but **not** the `inet weaver` policies.
+  Those are created in Step 1 below with `network policy create` (the install-time
+  orchestration that would chain them automatically is not yet implemented).
+- The daemon binary and the mock statusz server built for the VM's arch.
+
+```bash
+task build:cli GOOS=linux GOARCH=arm64      # solo-provisioner + daemon
+GOOS=linux GOARCH=arm64 go build -o bin/statuszmock \
+  ./internal/daemon/blocknode/statuszmock/cmd
+```
+
+## Step 1 - create the BN policies (static plane)
+
+`block node install` does not create the `inet weaver` policies yet, so create
+the four the monitor drives. The names must match the monitor's category mapping
+exactly, and each `--stamp` references one of the fixed class names (`publisher`,
+`partner`, `reserve-egress`, `backfill-response`, ...). The first `create` also
+creates the `inet weaver` table:
+
+```bash
+sudo solo-provisioner network policy create --name bn-publisher  --stamp publisher --ports 40840
+sudo solo-provisioner network policy create --name bn-partner    --stamp partner   --ports 40980,40981
+sudo solo-provisioner network policy create --name bn-restricted --deny
+sudo solo-provisioner network policy create --name bn-backfill    --stamp reserve-egress --reply-stamp backfill-response
+```
+
+| category (statusz) | policy / nft set | create flags |
+|---|---|---|
+| publisher | bn-publisher | `--stamp publisher --ports 40840` |
+| partner | bn-partner | `--stamp partner --ports 40980,40981` |
+| restricted | bn-restricted | `--deny` |
+| peer_bn | bn-backfill | `--stamp reserve-egress --reply-stamp backfill-response` (compound ip:port) |
+
+Confirm the table and its sets exist and are empty (no roster applied yet):
+
+```bash
+sudo nft list table inet weaver
+# expect sets: bn-publisher, bn-partner, bn-restricted, bn-backfill (empty)
+```
+
+## Step 2 - start the mock statusz server
+
+Create a roster and serve it:
+
+```bash
+cat > roster.json <<'JSON'
+{
+  "inbound": [
+    { "remote": {"address": "10.10.1.0/24", "port": "*"}, "category": "publisher" },
+    { "remote": {"address": "10.20.1.0/24", "port": "*"}, "category": "partner" }
+  ],
+  "outbound": [
+    { "remote": {"address": "10.30.5.7", "port": "43473"}, "category": "peer_bn" }
+  ]
+}
+JSON
+
+./bin/statuszmock --addr 127.0.0.1:8080 --roster roster.json &
+```
+
+Sanity check:
+
+```bash
+curl -s 127.0.0.1:8080/statusz/inbound-clients | jq .
+curl -s 127.0.0.1:8080/statusz/outbound-clients | jq .
+```
+
+## Step 3 - install the daemon, point it at the mock, and start it
+
+`daemon.yaml` lives at **`/opt/solo/weaver/config/daemon.yaml`**. `block node
+install` already wrote its `block_node` block (enabled, kubeconfig, orbit,
+`traffic_shaper: true`) — but the daemon **binary and systemd service are
+installed separately**; `block node install` does not install them.
+
+### 3.1 Install the daemon service
+
+```bash
+sudo solo-provisioner daemon service install --components block-node --bn-orbit block-node
+```
+
+> **Prerequisite — `daemon-bn.kubeconfig`.** The traffic-shaper monitor builds a
+> Kubernetes client from `/opt/solo/weaver/config/daemon-bn.kubeconfig` at
+> startup; if that file is missing, the daemon fails to start the block-node
+> component. Provisioning it automatically at install is a known gap, so for the
+> demo provide one manually — the cluster's admin kubeconfig works:
+>
+> ```bash
+> sudo cp <cluster-admin-kubeconfig> /opt/solo/weaver/config/daemon-bn.kubeconfig
+> ```
+>
+> The pod-lifecycle watcher may still fault without real pod access — that's
+> absorbed and retried; the statusz poll loop against the local-fallback URL runs
+> independently of it.
+
+### 3.2 Add the statusz source
+
+Edit `/opt/solo/weaver/config/daemon.yaml` and add the `statusz` block under
+`block_node` so the monitor polls the mock (the rest of the block is already
+there):
+
+```yaml
+components:
+  block_node:
+    enabled: true
+    kubeconfig: /opt/solo/weaver/config/daemon-bn.kubeconfig
+    orbit: block-node
+    monitors:
+      traffic_shaper: true
+    statusz:                        # add this
+      base_url: http://127.0.0.1:8080
+      poll_interval: 5s
+```
+
+### 3.3 Restart and verify it's up
+
+```bash
+sudo systemctl restart solo-provisioner-daemon
+solo-provisioner daemon service check          # health + component status (alias: status)
+systemctl status solo-provisioner-daemon       # or plain systemd status
+journalctl -u solo-provisioner-daemon -f       # watch the poll loop log
+```
+
+You should see `statusz poll loop starting` and, once the first tick applies,
+`applied membership deltas`. If the service is **not active**, `journalctl` shows
+why — most commonly the missing `daemon-bn.kubeconfig` from the prerequisite above.
+
+## Step 4 - watch membership converge
+
+In another shell on the VM:
+
+```bash
+watch -n1 'sudo nft list table inet weaver | sed -n "/set bn-/,/}/p"'
+```
+
+Within one poll interval the sets fill from the roster:
+
+- `bn-publisher` -> `10.10.1.0/24`
+- `bn-partner`   -> `10.20.1.0/24`
+- `bn-backfill`  -> `10.30.5.7 . 43473`
+
+Now edit `roster.json` (no restart needed - the mock re-reads it, the daemon
+re-polls it):
+
+```bash
+# e.g. add a publisher CIDR and drop the partner
+cat > roster.json <<'JSON'
+{
+  "inbound": [
+    { "remote": {"address": "10.10.1.0/24", "port": "*"}, "category": "publisher" },
+    { "remote": {"address": "10.11.0.0/16", "port": "*"}, "category": "publisher" }
+  ],
+  "outbound": []
+}
+JSON
+```
+
+Within ~5s: `bn-publisher` gains `10.11.0.0/16`, `bn-partner` empties, and
+`bn-backfill` empties. Stop the mock server (or block its port) and confirm the
+sets are **left as-is** - an outage keeps the last-good state, it does not drop
+rules.
+
+## Step 5 - traffic shaping across the category VMs (optional)
+
+Steps 1-4 prove the statusz -> nft membership loop. This step proves the payoff:
+traffic from each category lands in the right HTB class at the rate the profile
+budgets for it. It mirrors the v4 companion POC
+(`bn-qos-multiclass-priority-poc-v4-nft-priority.md` in the traffic-shaper repo),
+scaled here to a **100 Mbit** link so the ratios read as round numbers.
+
+### Bandwidth budget at `--link-rate 100mbit`
+
+The per-class floors and ceilings are the design's profile ratios applied to a
+100 Mbit parent. Install the static plane with `block node install
+--link-rate 100mbit` so these classes exist:
+
+| Attach point | Class | Role | floor | ceil | prio |
+|---|---|---|---|---|---|
+| `$VETH` (ingress) | 1:10 | Publisher | 80 Mbit | 100 Mbit | 0 |
+| `$VETH` (ingress) | 1:20 | Backfill response | 10 Mbit | 100 Mbit | 7 |
+| `$VETH` (ingress) | 1:30 | Reserve (subscribe req, mgmt) | 10 Mbit | 100 Mbit | 1 |
+| `$EGRESS` (egress) | 1:40 | Partner subscriber | 40 Mbit | 70 Mbit | 0 |
+| `$EGRESS` (egress) | 1:50 | Public subscriber / status | 30 Mbit | 70 Mbit | 5 |
+| `$EGRESS` (egress) | 1:60 | Reserve (backfill req, ACKs) | 30 Mbit | 100 Mbit | 1 |
+
+Sanity-check the ratios: **each direction's floors sum to exactly the 100 Mbit
+parent** (ingress 80+10+10; egress 40+30+30), so guaranteed capacity is fully
+allocated — none over- or under-subscribed — and every `ceil >= floor` lets an
+otherwise-idle class be borrowed against. Consequences to look for:
+
+- Under full concurrent load in one direction, each class is pinned to its floor
+  (the floors already sum to the parent, so there is nothing left to borrow).
+- When a higher-priority class goes idle, a lower one borrows up to its ceil.
+
+> The `$EGRESS` HTB is installed by `block node install` (the egress tc plane),
+> so the egress checks (1:40/1:50/1:60) work with what this PR + install provide.
+> The `$VETH` ingress HTB is installed by the daemon's pod-lifecycle watcher — a
+> later story — so until that lands, set up the ingress classes manually per the
+> POC (Stage 2) to exercise the 1:10/1:20/1:30 checks.
+
+### Category VMs and roster
+
+| VM | Roster category | Exercises |
+|---|---|---|
+| `solo-weaver-cn` | `publisher` | ingress publisher class 1:10 |
+| `solo-weaver-partner` | `partner` | egress partner class 1:40 |
+| `solo-weaver-public` | (unmapped `public`) | egress public class 1:50 |
+| `solo-weaver-peer` | `peer_bn` | backfill: egress 1:60 req / ingress 1:20 resp |
+
+Put each VM's address in `roster.json` under its category (publisher/partner/
+peer_bn); the public VM stays **unmapped** (a `public` source is any-source, not
+a set member, so it falls through to the public class). Reload is automatic — the
+mock re-reads the file, the daemon re-polls it.
+
+### iperf3 setup
+
+```bash
+# on each category VM
+sudo apt-get install -y iperf3
+
+# four listeners in the BN pod (one per BN port), plus the peer backfill target
+for p in 40840 40980 40981 40982; do kubectl exec deploy/bn -- iperf3 -s -p $p -D; done
+# on the peer VM:
+iperf3 -s -p 43473 -D
+```
+
+On the BN host resolve the attach points (`$EGRESS` from the default route;
+`$VETH` per the POC "discover the pod's host-side veth" step). Per-class Mbit/s is
+computed by diffing each class's `Sent` bytes over time — use the streaming
+`tc_rates` helper from the v4 POC, or diff by hand:
+
+```bash
+export EGRESS=$(ip route | awk '/default/{print $5; exit}')
+sudo tc -s class show dev $EGRESS classid 1:40   # note "Sent N bytes", wait 5s, repeat
+# Mbit/s = (N2 - N1) * 8 / (5 * 1e6)
+```
+
+### Per-category baseline (no contention)
+
+Run one category at a time for ~20s; ≥95% of the bytes should land in that
+category's class, the others idle.
+
+| Driver VM | Command | Bytes land in |
+|---|---|---|
+| cn (publisher) | `iperf3 -c $BN_LB_IP -p 40840 -t 20` | `$VETH` 1:10 |
+| partner | `iperf3 -c $BN_LB_IP -p 40980 -t 20 -R` | `$EGRESS` 1:40 |
+| public | `iperf3 -c $BN_LB_IP -p 40981 -t 20 -R` | `$EGRESS` 1:50 |
+
+Check after each: `sudo tc -s class show dev <DEV> classid <CLASS>`.
+
+### Contention (floors hold, priority preempts)
+
+Start all categories at once for 90s and watch the rates converge to the floors:
+
+```bash
+# cn:      iperf3 -c $BN_LB_IP -p 40840 -t 90 &                              # publisher -> 1:10
+# partner: iperf3 -c $BN_LB_IP -p 40980 -t 90 -R &                           # partner   -> 1:40
+# public:  iperf3 -c $BN_LB_IP -p 40981 -t 90 -R &                           # public    -> 1:50
+# BN pod:  kubectl exec deploy/bn -- iperf3 -c $PEER_VM_IP -p 43473 -t 90 -R & # backfill
+
+# BN host, two terminals (tc_rates from the v4 POC):
+tc_rates $VETH   1:10,1:20,1:30 2
+tc_rates $EGRESS 1:40,1:50,1:60 2
+```
+
+Expected steady-state during the overlap window (100 Mbit link):
+
+| Class | Expected | Why |
+|---|---|---|
+| `$VETH` 1:10 | ~80 Mbit/s | publisher floor, prio 0 |
+| `$VETH` 1:20 | ~10 Mbit/s | backfill response, prio 7 yields |
+| `$VETH` 1:30 | ~10 Mbit/s | reserve |
+| `$EGRESS` 1:40 | ~40 Mbit/s | partner floor, prio 0 |
+| `$EGRESS` 1:50 | ~30 Mbit/s | public floor, prio 5 |
+| `$EGRESS` 1:60 | ~30 Mbit/s | reserve |
+
+Each device's classes sum to ~100 Mbit/s and no class exceeds its ceil. Now kill
+the publisher (`kill %1` on the cn VM): 1:20 should ramp toward ~100 Mbit/s within
+~5s as it borrows the freed prio-0 capacity up to its ceil — the borrowing proof.
+
+There are **no tc filters** anywhere (`tc filter show dev $VETH` / `$EGRESS` are
+empty); classification is entirely by nft `skb->priority`. Finally, move a source
+between categories in `roster.json` and confirm new connections reclassify on the
+next poll interval (existing flows keep their class until they close).
+
+## Cleanup
+
+```bash
+kill %1                                   # stop the mock server
+sudo systemctl restart solo-provisioner-daemon   # or set traffic_shaper: false
+```
+
+## See also
+
+- `docs/dev/daemon/traffic-shaper-statusz.md` - statusz endpoints, category
+  mapping, config schema, and the mock server reference.

--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -84,6 +84,9 @@ func (h *InstallHandler) BuildWorkflow(
 				// oneshot unit.
 				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 				steps.SetupBlockNode(ins),
+				// Enable the traffic-shaper monitor in daemon.yaml so it starts
+				// reconciling statusz-driven nft membership once the daemon runs.
+				steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace),
 			)
 	} else {
 		wb = automa.NewWorkflowBuilder().WithId("block-node-install").
@@ -110,6 +113,9 @@ func (h *InstallHandler) BuildWorkflow(
 				// oneshot unit.
 				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
 				steps.SetupBlockNode(ins),
+				// Enable the traffic-shaper monitor in daemon.yaml so it starts
+				// reconciling statusz-driven nft membership once the daemon runs.
+				steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace),
 			)
 	}
 	return wb, nil

--- a/internal/daemon/blocknode/statusz_client_mock_test.go
+++ b/internal/daemon/blocknode/statusz_client_mock_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package blocknode_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/internal/daemon/blocknode"
+	"github.com/hashgraph/solo-weaver/internal/daemon/blocknode/statuszmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatuszClient_DecodesMockServer proves the mock statusz server's wire
+// shape is exactly what the production StatuszClient decodes — the contract both
+// sides depend on. This is the read half of the MVP loop (fetch + decode);
+// applying the reconciled membership to nft is Linux-only and covered by the
+// VM integration test.
+func TestStatuszClient_DecodesMockServer(t *testing.T) {
+	roster := statuszmock.Roster{
+		Inbound: []statuszmock.Connection{
+			{Remote: statuszmock.Endpoint{Address: "10.10.1.0/24", Port: "*"}, Category: "publisher", TLSRequired: true},
+			{Remote: statuszmock.Endpoint{Address: "10.20.1.0/24", Port: "*"}, Category: "partner", TLSRequired: true},
+		},
+		Outbound: []statuszmock.Connection{
+			{Remote: statuszmock.Endpoint{Address: "10.30.5.7", Port: "43473"}, Category: "peer_bn"},
+		},
+	}
+	srv := httptest.NewServer(statuszmock.Handler(statuszmock.StaticRoster(roster)))
+	defer srv.Close()
+
+	client := blocknode.NewStatuszClient(srv.URL)
+
+	inbound, err := client.InboundClients(context.Background())
+	require.NoError(t, err)
+	require.Len(t, inbound.ActiveEndpoints, 2)
+	assert.Equal(t, "publisher", inbound.ActiveEndpoints[0].Category)
+	assert.Equal(t, "10.10.1.0/24", inbound.ActiveEndpoints[0].Remote.Address)
+	assert.True(t, inbound.ActiveEndpoints[0].TLSRequired)
+	assert.Equal(t, "partner", inbound.ActiveEndpoints[1].Category)
+
+	outbound, err := client.OutboundClients(context.Background())
+	require.NoError(t, err)
+	require.Len(t, outbound.ActiveEndpoints, 1)
+	assert.Equal(t, "peer_bn", outbound.ActiveEndpoints[0].Category)
+	assert.Equal(t, "10.30.5.7", outbound.ActiveEndpoints[0].Remote.Address)
+	assert.Equal(t, "43473", outbound.ActiveEndpoints[0].Remote.Port)
+}

--- a/internal/daemon/blocknode/statuszmock/cmd/main.go
+++ b/internal/daemon/blocknode/statuszmock/cmd/main.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Command statuszmock runs the mock Block Node statusz REST server for daemon
+// development and the UTM-VM traffic-shaper demo. It serves
+// `statusz/inbound-clients` and `statusz/outbound-clients` from a JSON roster
+// file that is re-read on every request, so editing the file changes what the
+// daemon's poll loop sees on its next tick.
+//
+// Usage:
+//
+//	go run ./internal/daemon/blocknode/statuszmock/cmd --addr :8080 --roster roster.json
+//
+// The roster JSON shape is:
+//
+//	{
+//	  "inbound":  [ { "remote": {"address":"10.10.1.0/24","port":"*"}, "category":"publisher" } ],
+//	  "outbound": [ { "remote": {"address":"10.30.5.7","port":"43473"}, "category":"peer_bn" } ]
+//	}
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+
+	"github.com/hashgraph/solo-weaver/internal/daemon/blocknode/statuszmock"
+)
+
+func main() {
+	addr := flag.String("addr", ":8080", "listen address")
+	roster := flag.String("roster", "roster.json", "path to the JSON roster file (re-read on every request)")
+	flag.Parse()
+
+	handler := statuszmock.Handler(statuszmock.FileRoster(*roster))
+
+	log.Printf("mock statusz server listening on %s, serving roster %s", *addr, *roster)
+	log.Printf("  GET %s/statusz/inbound-clients", *addr)
+	log.Printf("  GET %s/statusz/outbound-clients", *addr)
+
+	srv := &http.Server{Addr: *addr, Handler: handler}
+	if err := srv.ListenAndServe(); err != nil {
+		log.Fatalf("mock statusz server stopped: %v", err)
+	}
+}

--- a/internal/daemon/blocknode/statuszmock/server.go
+++ b/internal/daemon/blocknode/statuszmock/server.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package statuszmock provides a minimal mock of a Block Node's statusz REST
+// endpoints for daemon development and tests. It serves the two endpoints the
+// traffic-shaper monitor polls — `statusz/inbound-clients` and
+// `statusz/outbound-clients` — from an editable roster, so a developer can point
+// the daemon's local-fallback statusz source at it and watch the nft set
+// membership follow roster edits.
+//
+// The wire contract mirrors block-node/api/network-data.proto (a `NetworkData`
+// with `active_endpoints`). It is defined independently here so the mock stays
+// decoupled from the daemon's decode types and can serve the contract on its
+// own. The contract is PROVISIONAL — confirming it with the BN team is a
+// blocking dependency.
+package statuszmock
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+
+	"github.com/joomcode/errorx"
+)
+
+// Endpoint is one side (local or remote) of a Connection. Port is a string
+// because the BN reports "*" (any) alongside numeric ports.
+type Endpoint struct {
+	Address string `json:"address"`
+	Port    string `json:"port"`
+}
+
+// Connection is one active endpoint the BN reports.
+type Connection struct {
+	Local       Endpoint `json:"local"`
+	Remote      Endpoint `json:"remote"`
+	Category    string   `json:"category"`
+	TLSRequired bool     `json:"tls_required"`
+}
+
+// networkData is the JSON envelope both endpoints return.
+type networkData struct {
+	ActiveEndpoints []Connection `json:"active_endpoints"`
+}
+
+// Roster is the mock's full view: the endpoints served by each statusz endpoint.
+type Roster struct {
+	Inbound  []Connection `json:"inbound"`
+	Outbound []Connection `json:"outbound"`
+}
+
+// RosterProvider returns the roster to serve for a given request. A static
+// provider returns a fixed roster; a file provider re-reads a JSON file so edits
+// are picked up live between polls.
+type RosterProvider func() (Roster, error)
+
+// StaticRoster returns a provider that always serves r.
+func StaticRoster(r Roster) RosterProvider {
+	return func() (Roster, error) { return r, nil }
+}
+
+// FileRoster returns a provider that reads and decodes the JSON roster at path
+// on every call, so external edits take effect on the next poll without a
+// restart. A missing file yields an empty roster (the BN "has no clients yet"
+// bootstrap state) rather than an error.
+func FileRoster(path string) RosterProvider {
+	return func() (Roster, error) {
+		data, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			return Roster{}, nil
+		}
+		if err != nil {
+			return Roster{}, errorx.ExternalError.Wrap(err, "read mock statusz roster %s", path)
+		}
+		var r Roster
+		if err := json.Unmarshal(data, &r); err != nil {
+			return Roster{}, errorx.IllegalFormat.Wrap(err, "decode mock statusz roster %s", path)
+		}
+		return r, nil
+	}
+}
+
+// Handler returns an http.Handler serving the two statusz endpoints from the
+// given provider. Paths are matched with and without a leading `statusz/` prefix
+// so it works whether mounted at the root or behind a `statusz/` mount.
+func Handler(provider RosterProvider) http.Handler {
+	mux := http.NewServeMux()
+	inbound := func(w http.ResponseWriter, _ *http.Request) {
+		serve(w, provider, func(r Roster) []Connection { return r.Inbound })
+	}
+	outbound := func(w http.ResponseWriter, _ *http.Request) {
+		serve(w, provider, func(r Roster) []Connection { return r.Outbound })
+	}
+	mux.HandleFunc("/statusz/inbound-clients", inbound)
+	mux.HandleFunc("/statusz/outbound-clients", outbound)
+	mux.HandleFunc("/inbound-clients", inbound)
+	mux.HandleFunc("/outbound-clients", outbound)
+	return mux
+}
+
+func serve(w http.ResponseWriter, provider RosterProvider, pick func(Roster) []Connection) {
+	roster, err := provider()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	endpoints := pick(roster)
+	if endpoints == nil {
+		endpoints = []Connection{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	// Encoding a small, in-memory struct does not fail in practice; if it did,
+	// the header is already sent, so there is nothing further to signal.
+	_ = json.NewEncoder(w).Encode(networkData{ActiveEndpoints: endpoints})
+}

--- a/internal/daemon/blocknode/statuszmock/server_test.go
+++ b/internal/daemon/blocknode/statuszmock/server_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package statuszmock_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/internal/daemon/blocknode/statuszmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func decode(t *testing.T, srv *httptest.Server, path string) []map[string]any {
+	t.Helper()
+	resp, err := srv.Client().Get(srv.URL + path)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	var body struct {
+		ActiveEndpoints []map[string]any `json:"active_endpoints"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	return body.ActiveEndpoints
+}
+
+func TestHandler_StaticRoster(t *testing.T) {
+	roster := statuszmock.Roster{
+		Inbound: []statuszmock.Connection{
+			{Remote: statuszmock.Endpoint{Address: "10.10.1.0/24", Port: "*"}, Category: "publisher"},
+		},
+		Outbound: []statuszmock.Connection{
+			{Remote: statuszmock.Endpoint{Address: "10.30.5.7", Port: "43473"}, Category: "peer_bn"},
+		},
+	}
+	srv := httptest.NewServer(statuszmock.Handler(statuszmock.StaticRoster(roster)))
+	defer srv.Close()
+
+	in := decode(t, srv, "/statusz/inbound-clients")
+	require.Len(t, in, 1)
+	assert.Equal(t, "publisher", in[0]["category"])
+
+	out := decode(t, srv, "/statusz/outbound-clients")
+	require.Len(t, out, 1)
+	assert.Equal(t, "peer_bn", out[0]["category"])
+}
+
+func TestHandler_EmptyRosterReturnsEmptyArray(t *testing.T) {
+	srv := httptest.NewServer(statuszmock.Handler(statuszmock.StaticRoster(statuszmock.Roster{})))
+	defer srv.Close()
+
+	// active_endpoints must be [] not null so the client always decodes a slice.
+	resp, err := srv.Client().Get(srv.URL + "/statusz/inbound-clients")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&raw))
+	assert.Equal(t, "[]", string(raw["active_endpoints"]))
+}
+
+func TestFileRoster_ReReadsBetweenRequests(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "roster.json")
+
+	srv := httptest.NewServer(statuszmock.Handler(statuszmock.FileRoster(path)))
+	defer srv.Close()
+
+	// Missing file → empty roster, not an error.
+	assert.Empty(t, decode(t, srv, "/statusz/inbound-clients"))
+
+	write := func(category string) {
+		r := statuszmock.Roster{Inbound: []statuszmock.Connection{
+			{Remote: statuszmock.Endpoint{Address: "10.1.0.1/32"}, Category: category},
+		}}
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, data, 0o600))
+	}
+
+	write("publisher")
+	in := decode(t, srv, "/statusz/inbound-clients")
+	require.Len(t, in, 1)
+	assert.Equal(t, "publisher", in[0]["category"])
+
+	// Edit the file; the next request must reflect it (live re-read).
+	write("partner")
+	in = decode(t, srv, "/statusz/inbound-clients")
+	require.Len(t, in, 1)
+	assert.Equal(t, "partner", in[0]["category"])
+}
+
+func TestFileRoster_MalformedJSONErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "roster.json")
+	require.NoError(t, os.WriteFile(path, []byte("{ not json"), 0o600))
+
+	srv := httptest.NewServer(statuszmock.Handler(statuszmock.FileRoster(path)))
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL + "/statusz/inbound-clients")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -3,8 +3,10 @@
 package daemon
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -16,6 +18,11 @@ const (
 	// Increment this constant whenever a breaking structural change is made to
 	// DaemonConfig so that LoadDaemonConfig can detect and migrate old files.
 	CurrentSchemaVersion = 1
+
+	// DefaultStatuszPollInterval is the steady-state cadence at which the
+	// traffic-shaper monitor polls statusz when statusz.poll_interval is unset.
+	// The design specifies a 5-second poll loop.
+	DefaultStatuszPollInterval = 5 * time.Second
 )
 
 // DaemonConfig is parsed from daemon.yaml at startup.
@@ -38,7 +45,10 @@ const (
 //	    kubeconfig: /opt/solo/weaver/config/daemon-bn.kubeconfig
 //	    orbit: hedera-block-node
 //	    monitors:
-//	      upgrade: true
+//	      traffic_shaper: true
+//	    statusz:                     # optional local-fallback statusz source
+//	      base_url: http://127.0.0.1:8080
+//	      poll_interval: 5s
 type DaemonConfig struct {
 	// SchemaVersion identifies the config file format. Always written as
 	// CurrentSchemaVersion by WriteDaemonConfig. A value of 0 means the file
@@ -99,11 +109,73 @@ type BlockNodeComponentConfig struct {
 	Orbit string `yaml:"orbit"`
 
 	Monitors BlockNodeMonitors `yaml:"monitors"`
+
+	// Statusz is the optional local-fallback statusz source for the
+	// traffic-shaper poll loop. When nil or with an empty BaseURL, the monitor
+	// has no statusz source to poll (BN-pod statusz discovery is a future story)
+	// and the poll loop idles. When set, the monitor polls that fixed REST
+	// endpoint — a mock statusz server in dev/test, or a directly reachable BN
+	// statusz.
+	Statusz *StatuszConfig `yaml:"statusz,omitempty"`
 }
 
 // BlockNodeMonitors toggles individual monitors for the block-node component.
 type BlockNodeMonitors struct {
 	TrafficShaper bool `yaml:"traffic_shaper"`
+}
+
+// StatuszConfig is the local-fallback statusz source polled by the block-node
+// traffic-shaper monitor. The monitor reads `statusz/inbound-clients` and
+// `statusz/outbound-clients` relative to BaseURL and reconciles the returned
+// roster into the live nft set membership.
+type StatuszConfig struct {
+	// BaseURL is the root the statusz REST endpoints resolve against, e.g.
+	// http://127.0.0.1:8080. Empty means "no local-fallback source configured";
+	// the poll loop then idles rather than polling.
+	BaseURL string `yaml:"base_url,omitempty"`
+
+	// PollInterval is the poll cadence in Go duration form (e.g. "5s"). Empty
+	// defaults to DefaultStatuszPollInterval.
+	PollInterval string `yaml:"poll_interval,omitempty"`
+}
+
+// EffectivePollInterval returns the configured poll interval, or the 5-second
+// default when unset. It assumes the value has already passed Validate, and
+// falls back to the default for any residual parse failure rather than erroring.
+func (s StatuszConfig) EffectivePollInterval() time.Duration {
+	if s.PollInterval == "" {
+		return DefaultStatuszPollInterval
+	}
+	d, err := time.ParseDuration(s.PollInterval)
+	if err != nil || d <= 0 {
+		return DefaultStatuszPollInterval
+	}
+	return d
+}
+
+// Validate checks the statusz block's fields: BaseURL, when set, must be an
+// http(s) URL with a host, and PollInterval, when set, must be a positive Go
+// duration.
+func (s StatuszConfig) Validate() error {
+	if s.BaseURL != "" {
+		u, err := url.Parse(s.BaseURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return ErrConfigMalformed.New(
+				"components.block_node.statusz.base_url must be an http(s) URL with a host, got %q", s.BaseURL)
+		}
+	}
+	if s.PollInterval != "" {
+		d, err := time.ParseDuration(s.PollInterval)
+		if err != nil {
+			return ErrConfigMalformed.Wrap(err,
+				"components.block_node.statusz.poll_interval %q is not a valid Go duration", s.PollInterval)
+		}
+		if d <= 0 {
+			return ErrConfigMalformed.New(
+				"components.block_node.statusz.poll_interval must be positive, got %q", s.PollInterval)
+		}
+	}
+	return nil
 }
 
 // Validate checks that all required fields within the block-node block are present.
@@ -114,6 +186,11 @@ func (bn BlockNodeComponentConfig) Validate() error {
 		}
 		if bn.Orbit == "" {
 			return ErrConfigMalformed.New("components.block_node.orbit is required when monitors.traffic_shaper is true")
+		}
+	}
+	if bn.Statusz != nil {
+		if err := bn.Statusz.Validate(); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -200,13 +277,23 @@ func LoadDaemonConfig(path string) (DaemonConfig, error) {
 	if err != nil {
 		return DaemonConfig{}, ErrConfigNotFound.Wrap(err, "daemon config not found at %s", path)
 	}
+	return ParseDaemonConfig(data, path)
+}
 
+// ParseDaemonConfig parses daemon config bytes that have already been read from
+// source (a path, used only in error messages). It is the file-read-free core of
+// LoadDaemonConfig: callers that have already captured the raw bytes — e.g. an
+// install step that snapshots daemon.yaml for rollback — parse from those exact
+// bytes so the parsed config and the snapshot can never diverge across a second
+// read. It applies the same two-phase probe + migration + Validate as
+// LoadDaemonConfig (see that function's doc for version rules).
+func ParseDaemonConfig(data []byte, source string) (DaemonConfig, error) {
 	// Phase 1: probe the schema version only.
 	var probe struct {
 		SchemaVersion int `yaml:"schemaVersion"`
 	}
 	if err := yaml.Unmarshal(data, &probe); err != nil {
-		return DaemonConfig{}, ErrConfigMalformed.Wrap(err, "invalid daemon config at %s", path)
+		return DaemonConfig{}, ErrConfigMalformed.Wrap(err, "invalid daemon config at %s", source)
 	}
 	version := probe.SchemaVersion
 	if version == 0 {
@@ -216,7 +303,7 @@ func LoadDaemonConfig(path string) (DaemonConfig, error) {
 		return DaemonConfig{}, ErrConfigMalformed.New(
 			"daemon config %s was written by a newer binary (schemaVersion %d > supported %d); "+
 				"upgrade solo-provisioner-daemon to a compatible version",
-			path, version, CurrentSchemaVersion)
+			source, version, CurrentSchemaVersion)
 	}
 
 	// Phase 2: unmarshal into the versioned struct and walk the migration chain.
@@ -229,17 +316,17 @@ func LoadDaemonConfig(path string) (DaemonConfig, error) {
 	case 1:
 		var raw daemonConfigV1
 		if err := yaml.Unmarshal(data, &raw); err != nil {
-			return DaemonConfig{}, ErrConfigMalformed.Wrap(err, "invalid v1 daemon config at %s", path)
+			return DaemonConfig{}, ErrConfigMalformed.Wrap(err, "invalid v1 daemon config at %s", source)
 		}
 		cfg = raw.migrateToLatest()
 	default:
 		// Should never reach here given the version > CurrentSchemaVersion guard above.
 		return DaemonConfig{}, ErrConfigMalformed.New(
-			"unsupported daemon config schemaVersion %d at %s", version, path)
+			"unsupported daemon config schemaVersion %d at %s", version, source)
 	}
 
 	if err := cfg.Validate(); err != nil {
-		return DaemonConfig{}, ErrConfigMalformed.Wrap(err, "daemon config %s", path)
+		return DaemonConfig{}, ErrConfigMalformed.Wrap(err, "daemon config %s", source)
 	}
 
 	return cfg, nil

--- a/internal/daemon/config_statusz_test.go
+++ b/internal/daemon/config_statusz_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package daemon_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashgraph/solo-weaver/internal/daemon"
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadDaemonConfig_BlockNodeStatuszBlock(t *testing.T) {
+	content := `schemaVersion: 1
+components:
+  block_node:
+    enabled: true
+    kubeconfig: /opt/solo/weaver/config/daemon-bn.kubeconfig
+    orbit: block-node
+    monitors:
+      traffic_shaper: true
+    statusz:
+      base_url: http://127.0.0.1:8080
+      poll_interval: 3s
+`
+	path := writeTempConfig(t, content)
+
+	cfg, err := daemon.LoadDaemonConfig(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Components.BlockNode)
+	require.NotNil(t, cfg.Components.BlockNode.Statusz)
+	assert.Equal(t, "http://127.0.0.1:8080", cfg.Components.BlockNode.Statusz.BaseURL)
+	assert.Equal(t, 3*time.Second, cfg.Components.BlockNode.Statusz.EffectivePollInterval())
+}
+
+func TestStatuszConfig_EffectivePollInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want time.Duration
+	}{
+		{"empty defaults to 5s", "", daemon.DefaultStatuszPollInterval},
+		{"parses value", "10s", 10 * time.Second},
+		{"unparseable falls back to default", "banana", daemon.DefaultStatuszPollInterval},
+		{"non-positive falls back to default", "0s", daemon.DefaultStatuszPollInterval},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := daemon.StatuszConfig{PollInterval: tt.in}
+			assert.Equal(t, tt.want, s.EffectivePollInterval())
+		})
+	}
+}
+
+func TestStatuszConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     daemon.StatuszConfig
+		wantErr bool
+	}{
+		{"empty is valid", daemon.StatuszConfig{}, false},
+		{"http url + interval", daemon.StatuszConfig{BaseURL: "http://127.0.0.1:8080", PollInterval: "5s"}, false},
+		{"https url", daemon.StatuszConfig{BaseURL: "https://bn.example:9000"}, false},
+		{"missing scheme", daemon.StatuszConfig{BaseURL: "127.0.0.1:8080"}, true},
+		{"non-http scheme", daemon.StatuszConfig{BaseURL: "ftp://host/x"}, true},
+		{"no host", daemon.StatuszConfig{BaseURL: "http://"}, true},
+		{"bad interval", daemon.StatuszConfig{PollInterval: "5"}, true},
+		{"negative interval", daemon.StatuszConfig{PollInterval: "-5s"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, errorx.IsOfType(err, daemon.ErrConfigMalformed),
+					"want ErrConfigMalformed, got %v", err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestLoadDaemonConfig_RejectsBadStatuszURL(t *testing.T) {
+	content := `schemaVersion: 1
+components:
+  block_node:
+    enabled: true
+    kubeconfig: /k
+    orbit: block-node
+    monitors:
+      traffic_shaper: true
+    statusz:
+      base_url: "not a url with spaces"
+`
+	path := writeTempConfig(t, content)
+
+	_, err := daemon.LoadDaemonConfig(path)
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, daemon.ErrConfigMalformed), "got %v", err)
+}
+
+func TestParseDaemonConfig_MatchesLoadFromFile(t *testing.T) {
+	content := `schemaVersion: 1
+components:
+  block_node:
+    enabled: true
+    kubeconfig: /k
+    orbit: block-node
+    monitors:
+      traffic_shaper: true
+    statusz:
+      base_url: http://127.0.0.1:8080
+`
+	path := writeTempConfig(t, content)
+
+	fromFile, err := daemon.LoadDaemonConfig(path)
+	require.NoError(t, err)
+	fromBytes, err := daemon.ParseDaemonConfig([]byte(content), "in-memory")
+	require.NoError(t, err)
+	assert.Equal(t, fromFile, fromBytes)
+
+	// Same validation as the file path: a malformed newer version is rejected.
+	_, err = daemon.ParseDaemonConfig([]byte("schemaVersion: 99\ncomponents: {}\n"), "in-memory")
+	require.Error(t, err)
+	assert.True(t, errorx.IsOfType(err, daemon.ErrConfigMalformed), "got %v", err)
+}
+
+func TestWriteDaemonConfig_RoundTripsStatusz(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/daemon.yaml"
+
+	cfg := daemon.DaemonConfig{
+		Components: daemon.DaemonComponents{
+			BlockNode: &daemon.BlockNodeComponentConfig{
+				Enabled:    true,
+				Kubeconfig: "/opt/solo/weaver/config/daemon-bn.kubeconfig",
+				Orbit:      "block-node",
+				Monitors:   daemon.BlockNodeMonitors{TrafficShaper: true},
+				Statusz:    &daemon.StatuszConfig{BaseURL: "http://127.0.0.1:8080", PollInterval: "5s"},
+			},
+		},
+	}
+	require.NoError(t, daemon.WriteDaemonConfig(path, cfg))
+
+	got, err := daemon.LoadDaemonConfig(path)
+	require.NoError(t, err)
+	require.NotNil(t, got.Components.BlockNode.Statusz)
+	assert.Equal(t, "http://127.0.0.1:8080", got.Components.BlockNode.Statusz.BaseURL)
+	assert.Equal(t, "5s", got.Components.BlockNode.Statusz.PollInterval)
+}

--- a/internal/daemon/config_v1.go
+++ b/internal/daemon/config_v1.go
@@ -46,10 +46,16 @@ type blockNodeConfigV1 struct {
 	Kubeconfig string              `yaml:"kubeconfig"`
 	Orbit      string              `yaml:"orbit"`
 	Monitors   blockNodeMonitorsV1 `yaml:"monitors"`
+	Statusz    *statuszConfigV1    `yaml:"statusz,omitempty"`
 }
 
 type blockNodeMonitorsV1 struct {
 	TrafficShaper bool `yaml:"traffic_shaper"`
+}
+
+type statuszConfigV1 struct {
+	BaseURL      string `yaml:"base_url,omitempty"`
+	PollInterval string `yaml:"poll_interval,omitempty"`
 }
 
 // migrateToLatest is the terminal step of the migration chain at v1.
@@ -75,7 +81,7 @@ func (v daemonConfigV1) migrateToLatest() DaemonConfig {
 		}
 	}
 	if bn := v.Components.BlockNode; bn != nil {
-		cfg.Components.BlockNode = &BlockNodeComponentConfig{
+		blockNode := &BlockNodeComponentConfig{
 			Enabled:    bn.Enabled,
 			Kubeconfig: bn.Kubeconfig,
 			Orbit:      bn.Orbit,
@@ -83,6 +89,13 @@ func (v daemonConfigV1) migrateToLatest() DaemonConfig {
 				TrafficShaper: bn.Monitors.TrafficShaper,
 			},
 		}
+		if s := bn.Statusz; s != nil {
+			blockNode.Statusz = &StatuszConfig{
+				BaseURL:      s.BaseURL,
+				PollInterval: s.PollInterval,
+			}
+		}
+		cfg.Components.BlockNode = blockNode
 	}
 	return cfg
 }

--- a/internal/workflows/steps/step_daemon_block_node.go
+++ b/internal/workflows/steps/step_daemon_block_node.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+	"os"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/daemon"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// This file holds the block-node-specific daemon wiring step. The generic daemon
+// lifecycle steps (binary/service install, config removal, start/stop/check) live
+// in step_daemon.go and are shared across the daemon's components; block-node and
+// (future) consensus-node component-config steps are kept in their own files.
+
+// BlockNodeDaemonConfigStepId is the step ID for WriteBlockNodeDaemonConfigStep.
+const BlockNodeDaemonConfigStepId = "write-block-node-daemon-config"
+
+// defaultBlockNodeOrbit mirrors deps.BLOCK_NODE_NAMESPACE. It is used only as a
+// last-resort default so an enabled block_node config still validates when the
+// resolved BN namespace is somehow empty.
+const defaultBlockNodeOrbit = "block-node"
+
+// State keys used by WriteBlockNodeDaemonConfigStep to reverse its write on
+// rollback: whether daemon.yaml existed before the step, and its prior content.
+const (
+	daemonConfigPriorExistedKey = "daemon-config-prior-existed"
+	daemonConfigPriorContentKey = "daemon-config-prior-content"
+)
+
+// WriteBlockNodeDaemonConfigStep enables the block-node traffic-shaper monitor
+// in daemon.yaml at install time. It loads the existing config (or starts a
+// fresh one), merges in the block_node component block — enabled, the scoped
+// daemon-bn.kubeconfig, the BN orbit (namespace), and monitors.traffic_shaper —
+// while preserving any operator-set statusz block and the consensus_node block,
+// then writes it back.
+//
+// The daemon binary and systemd service are installed separately by `daemon
+// service install`; this step only records the enablement so the traffic-shaper
+// monitor starts once the daemon runs. The write is fully reversed on rollback
+// (the file is restored to its prior content, or removed if it did not exist).
+func WriteBlockNodeDaemonConfigStep(paths models.WeaverPaths, orbit string) *automa.StepBuilder {
+	cfgPath := paths.DaemonConfigPath
+	kubeconfig := paths.DaemonBNKubeconfigPath
+	if orbit == "" {
+		orbit = defaultBlockNodeOrbit
+	}
+
+	return automa.NewStepBuilder().WithId(BlockNodeDaemonConfigStepId).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Enabling traffic-shaper monitor in daemon.yaml")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to enable traffic-shaper monitor in daemon.yaml")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Traffic-shaper monitor enabled in daemon.yaml")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			prior, err := os.ReadFile(cfgPath)
+			existed := true
+			if os.IsNotExist(err) {
+				existed = false
+				prior = nil
+			} else if err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.ExternalError.Wrap(err, "failed to read daemon config at %s", cfgPath).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Check permissions on " + cfgPath,
+						})))
+			}
+
+			var cfg daemon.DaemonConfig
+			if existed {
+				// Parse the same bytes captured for rollback (not a second read
+				// of the file), so the merged config and the rollback snapshot
+				// can never diverge if the file changes mid-install.
+				loaded, lerr := daemon.ParseDaemonConfig(prior, cfgPath)
+				if lerr != nil {
+					return automa.FailureReport(stp, automa.WithError(
+						errorx.Decorate(lerr, "existing daemon config at %s is invalid", cfgPath).
+							WithProperty(models.ErrPropertyResolution, []string{
+								"Fix or remove " + cfgPath + " and re-run",
+							})))
+				}
+				cfg = loaded
+			}
+
+			// Preserve an operator-set statusz block (local-fallback source) if
+			// one already exists; this step only owns the enablement fields.
+			bn := &daemon.BlockNodeComponentConfig{
+				Enabled:    true,
+				Kubeconfig: kubeconfig,
+				Orbit:      orbit,
+				Monitors:   daemon.BlockNodeMonitors{TrafficShaper: true},
+			}
+			if cfg.Components.BlockNode != nil {
+				bn.Statusz = cfg.Components.BlockNode.Statusz
+			}
+			cfg.Components.BlockNode = bn
+
+			if err := cfg.Validate(); err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "daemon config is invalid after enabling block-node monitor").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Inspect " + cfgPath,
+						})))
+			}
+			if err := daemon.WriteDaemonConfig(cfgPath, cfg); err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to write daemon config").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Check permissions on " + cfgPath,
+						})))
+			}
+
+			stp.State().Local().Set(daemonConfigPriorExistedKey, existed)
+			stp.State().Local().Set(daemonConfigPriorContentKey, string(prior))
+			logx.As().Info().
+				Str("path", cfgPath).
+				Str("orbit", orbit).
+				Msg("Enabled block-node traffic-shaper monitor in daemon.yaml")
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			existed, _ := stp.State().Local().Bool(daemonConfigPriorExistedKey)
+			if !existed {
+				if err := os.Remove(cfgPath); err != nil && !os.IsNotExist(err) {
+					return automa.FailureReport(stp, automa.WithError(
+						errorx.ExternalError.Wrap(err, "failed to remove daemon config at %s on rollback", cfgPath)))
+				}
+				return automa.SuccessReport(stp)
+			}
+			prior, _ := stp.State().Local().String(daemonConfigPriorContentKey)
+			if err := os.WriteFile(cfgPath, []byte(prior), 0o644); err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.ExternalError.Wrap(err, "failed to restore daemon config at %s on rollback", cfgPath)))
+			}
+			return automa.SuccessReport(stp)
+		})
+}

--- a/internal/workflows/steps/step_daemon_block_node_test.go
+++ b/internal/workflows/steps/step_daemon_block_node_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/automa-saga/automa"
+	"github.com/hashgraph/solo-weaver/internal/daemon"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func blockNodeConfigPaths(t *testing.T) models.WeaverPaths {
+	t.Helper()
+	dir := t.TempDir()
+	return models.WeaverPaths{
+		DaemonConfigPath:       filepath.Join(dir, "daemon.yaml"),
+		DaemonBNKubeconfigPath: "/opt/solo/weaver/config/daemon-bn.kubeconfig",
+	}
+}
+
+func TestWriteBlockNodeDaemonConfig_FreshFile(t *testing.T) {
+	paths := blockNodeConfigPaths(t)
+
+	step, err := WriteBlockNodeDaemonConfigStep(paths, "block-node").Build()
+	require.NoError(t, err)
+
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+
+	cfg, err := daemon.LoadDaemonConfig(paths.DaemonConfigPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Components.BlockNode)
+	assert.True(t, cfg.Components.BlockNode.Enabled)
+	assert.True(t, cfg.Components.BlockNode.Monitors.TrafficShaper)
+	assert.Equal(t, "block-node", cfg.Components.BlockNode.Orbit)
+	assert.Equal(t, paths.DaemonBNKubeconfigPath, cfg.Components.BlockNode.Kubeconfig)
+
+	// Rollback must remove the file it created.
+	rb := step.Rollback(context.Background())
+	require.NoError(t, rb.Error)
+	_, statErr := os.Stat(paths.DaemonConfigPath)
+	assert.True(t, os.IsNotExist(statErr), "rollback should remove the created daemon.yaml")
+}
+
+func TestWriteBlockNodeDaemonConfig_EmptyOrbitDefaults(t *testing.T) {
+	paths := blockNodeConfigPaths(t)
+
+	step, err := WriteBlockNodeDaemonConfigStep(paths, "").Build()
+	require.NoError(t, err)
+	require.NoError(t, step.Execute(context.Background()).Error)
+
+	cfg, err := daemon.LoadDaemonConfig(paths.DaemonConfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, defaultBlockNodeOrbit, cfg.Components.BlockNode.Orbit)
+}
+
+func TestWriteBlockNodeDaemonConfig_PreservesExistingBlocks(t *testing.T) {
+	paths := blockNodeConfigPaths(t)
+
+	// Seed an existing config: a consensus_node block plus a block_node with an
+	// operator-set statusz local-fallback source.
+	seed := daemon.DaemonConfig{
+		Components: daemon.DaemonComponents{
+			ConsensusNode: &daemon.ConsensusNodeComponentConfig{
+				Enabled:    true,
+				Kubeconfig: "/opt/solo/weaver/config/daemon-cn.kubeconfig",
+				NodeID:     "3",
+				Orbit:      "hedera-network",
+				Monitors:   daemon.ConsensusNodeMonitors{Upgrade: true},
+			},
+			BlockNode: &daemon.BlockNodeComponentConfig{
+				Statusz: &daemon.StatuszConfig{BaseURL: "http://127.0.0.1:8080", PollInterval: "3s"},
+			},
+		},
+	}
+	require.NoError(t, daemon.WriteDaemonConfig(paths.DaemonConfigPath, seed))
+	priorBytes, err := os.ReadFile(paths.DaemonConfigPath)
+	require.NoError(t, err)
+
+	step, err := WriteBlockNodeDaemonConfigStep(paths, "block-node").Build()
+	require.NoError(t, err)
+	require.NoError(t, step.Execute(context.Background()).Error)
+
+	cfg, err := daemon.LoadDaemonConfig(paths.DaemonConfigPath)
+	require.NoError(t, err)
+	// consensus_node preserved.
+	require.NotNil(t, cfg.Components.ConsensusNode)
+	assert.Equal(t, "3", cfg.Components.ConsensusNode.NodeID)
+	// block_node enablement set, operator statusz preserved.
+	require.NotNil(t, cfg.Components.BlockNode)
+	assert.True(t, cfg.Components.BlockNode.Monitors.TrafficShaper)
+	require.NotNil(t, cfg.Components.BlockNode.Statusz)
+	assert.Equal(t, "http://127.0.0.1:8080", cfg.Components.BlockNode.Statusz.BaseURL)
+	assert.Equal(t, "3s", cfg.Components.BlockNode.Statusz.PollInterval)
+
+	// Rollback restores the exact prior file content.
+	require.NoError(t, step.Rollback(context.Background()).Error)
+	gotBytes, err := os.ReadFile(paths.DaemonConfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(priorBytes), string(gotBytes))
+}


### PR DESCRIPTION
## Summary

Delivers the block-node traffic-shaper's **static configuration surface** in
`solo-provisioner-daemon`: the `daemon.yaml` local-fallback statusz config schema,
install-time enablement of the monitor, and a mock statusz server for dev/tests —
the pieces the (separately-landing) poll loop consumes.

Builds on the merged statusz REST client (#751), category→policy diff engine
(#752), batched membership apply (#754), and the privileged exec-delegation
mechanism (#774 / `internal/daemon/privexec`). The **poll loop itself** (fetch →
diff → apply) is a follow-up **TS_3** story: per the daemon's unprivileged model
it applies nft membership through `privexec` (`sudo solo-provisioner network
policy set`), never in-process `nft`. This PR deliberately does not wire that loop.

Closes #765.

### What's included

- **Local-fallback statusz config** — optional `statusz` block (`base_url`,
  `poll_interval`) on `block_node` in `daemon.yaml`, with validation, the sealed
  v1 on-disk mirror + migration, an `EffectivePollInterval()` accessor (default
  5s), and a `ParseDaemonConfig([]byte, source)` seam. Backward-compatible:
  existing configs load unchanged.
- **Install-time enablement** — `block node install` writes/merges the
  `block_node` block into `daemon.yaml` (enabled, scoped `daemon-bn.kubeconfig`,
  BN orbit, `monitors.traffic_shaper: true`), preserving any operator-set
  `statusz` block and the `consensus_node` block; fully reversed on rollback.
- **Mock statusz server** — `internal/daemon/blocknode/statuszmock`: a
  file-backed, live-editable roster server + a `go run` entrypoint, and a test
  proving the production `StatuszClient` decodes its wire shape.
- **Docs** — `docs/dev/daemon/traffic-shaper-statusz.md` (endpoints, category
  mapping, config schema, mock server) and `docs/dev/traffic-shaper-demo.md`
  (UTM-VM runbook), both flagged with what lands here vs. in the TS_3 poll-loop
  story.

### Scope boundaries

- **The poll loop is out of scope** — it lands in a TS_3 story on `privexec`.
  This PR provides the config/mock/enablement it will consume.
- Install does **not** set `statusz.base_url` — that local-fallback source is an
  operator/deploy concern (documented in the demo runbook).
- The `inet weaver` policies (`bn-*`) are created by `network policy create`; the
  install-time orchestration that chains them is #762 (separate, blocked on the
  BN multi-port model). The demo runbook creates them manually.
- BN kubeconfig/RBAC provisioning nuances are handled by `daemon service install`.
- The statusz contract is **provisional** pending Block Node team confirmation.

## Test plan

- [x] Unit (`-race`, host): config load/validate/migrate/round-trip;
  `ParseDaemonConfig` parity; install-step write/merge/rollback (Linux VM);
  mock server incl. live file re-read; `StatuszClient` ↔ mock contract.
- [x] `gofmt` clean; cross-compiles for `linux/arm64` including the Linux-only
  `internal/workflows/steps` test; rebased onto `main` (with #774) — no monitor
  changes, so no conflict with the delegator work.
- [ ] Manual UAT — see below.

## Manual UAT

Follow **`docs/dev/traffic-shaper-demo.md`** on a UTM VM. This PR's slice:

1. `block node install` writes the `block_node` block into
   `/opt/solo/weaver/config/daemon.yaml` (verify the block + `traffic_shaper: true`).
2. `daemon service install`; add a `statusz.base_url` pointing at the mock server;
   confirm the daemon loads the config and starts.
3. Run the mock server (`go run ./internal/daemon/blocknode/statuszmock/cmd`) and
   confirm it serves `inbound-clients`/`outbound-clients` and re-reads the roster
   live.

Steps 4-5 (live nft convergence, traffic shaping) exercise the poll loop and
require the TS_3 follow-up.

## Risks

- The install-time daemon.yaml write is confined to the `block node install`
  workflow (not upgrade/reconfigure/migrations), so it does not leak onto
  already-provisioned clusters. Rollback restores the exact prior file.
- The statusz config is landed ahead of its consumer (the poll loop), mirroring
  how #774 landed the delegator ahead of its call sites.

