### PR TITLE
feat(daemon): delegate privileged ops via sudo solo-provisioner exec

### DIFF
--- a/docs/dev/daemon/daemon-architecture.md
+++ b/docs/dev/daemon/daemon-architecture.md
@@ -166,10 +166,18 @@ systemd unit), never as root. It holds no Linux capabilities of its own.
 
 **Privilege via exec-delegation, not raw tools.** When the daemon needs to perform a
 privileged action it execs the root `solo-provisioner` CLI (see "CLI invocation & the import
-boundary" above) — it does **not** invoke `kubectl`/`helm`/`kubeadm`/`systemctl` directly.
-This is verified, not aspirational: the daemon binary imports `os/exec` nowhere in its
-transitive closure, talks to Kubernetes via client-go, and talks to systemd via the
-go-systemd dbus API. Its only privileged-escalation path is the sudoers grant below.
+boundary" above) — it does **not** invoke `kubectl`/`helm`/`kubeadm`/`systemctl`/`nft`/`tc`
+directly. It talks to Kubernetes via client-go and to systemd via the go-systemd dbus API;
+its only privileged-escalation path is the sudoers grant below. The exec-delegation itself is
+confined to a single package, `internal/daemon/privexec`, which is the **only** place in the
+daemon's import closure that reaches for `os/exec`. It execs nothing but `sudo` +
+`solo-provisioner`, so the "no raw tools" guarantee holds even though `os/exec` is now present.
+The delegation is synchronous (run, wait, capture stdout) and execs `sudo -n` so a
+missing or expired grant fails fast instead of blocking on a prompt the daemon has no
+tty for. Any failure is returned as a `*daemonkit.ProbeError` carrying an operator-facing
+reason/resolution, which the daemon boundary converts into a `daemonkit.StatusError` so
+`/status` explains it. The self-upgrade protocol's detached child spawn is a separate exec
+mechanism with different lifecycle semantics.
 
 **Sudoers grant (`internal/templates/files/weaver/sudoers`).** Weaver is granted passwordless
 sudo to the `solo-provisioner` binary as a whole (any subcommand), at both its install paths:

--- a/internal/daemon/blocknode/traffic_shaper_monitor.go
+++ b/internal/daemon/blocknode/traffic_shaper_monitor.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/daemon/privexec"
 	"github.com/hashgraph/solo-weaver/internal/network/policy"
 	"github.com/joomcode/errorx"
 )
@@ -47,17 +48,27 @@ type TrafficShaperMonitor struct {
 	// statusz-derived membership against the kernel. Satisfied by the network
 	// policy Runner; a fake is injected in tests.
 	lister elementLister
+	// delegator runs privileged solo-provisioner subcommands under sudo. The
+	// daemon is unprivileged (User=weaver), so both responsibilities delegate
+	// their privileged work through it: the poll loop applies membership via
+	// `network policy set` and the watcher installs veth qdiscs via `block node
+	// tc-attach`. Held here so the poll loop and watcher can consume it once
+	// their apply/attach paths are wired, without a constructor change.
+	delegator privexec.Delegator
 }
 
 // NewTrafficShaperMonitor constructs a TrafficShaperMonitor with the given
 // VethResolver. The resolver is wired into runPodWatcher by #748; it is held
 // here so #748 can use it without further constructor changes. The live-set
 // reader defaults to the network policy exec Runner, which reads the `inet
-// weaver` sets via `nft list set`.
+// weaver` sets via `nft list set`. The delegator defaults to the sudo-backed
+// privileged-exec seam so the poll loop and watcher can perform their
+// privileged work without the unprivileged daemon holding root itself.
 func NewTrafficShaperMonitor(resolver *VethResolver) *TrafficShaperMonitor {
 	return &TrafficShaperMonitor{
-		resolver: resolver,
-		lister:   policy.NewExecRunner(),
+		resolver:  resolver,
+		lister:    policy.NewExecRunner(),
+		delegator: privexec.New(),
 	}
 }
 

--- a/internal/daemon/privexec/delegate.go
+++ b/internal/daemon/privexec/delegate.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package privexec is the daemon's privileged-exec delegation seam.
+//
+// The solo-provisioner-daemon runs unprivileged (systemd `User=weaver`) and
+// performs every privileged operation by exec'ing the root solo-provisioner CLI
+// under sudo — the privilege-by-exec-delegation model documented in
+// docs/dev/daemon/daemon-architecture.md and the BN traffic-shaper design's
+// daemon-vs-CLI separation. This package is the ONLY place in the daemon's
+// import closure that reaches for os/exec, and it execs nothing but sudo +
+// solo-provisioner: never kubectl/helm/systemctl/nft/tc directly. The sudoers
+// grant (internal/templates/files/weaver/sudoers) is the single escalation path
+// and is restricted to the solo-provisioner binary.
+//
+// The delegation is synchronous (run, wait, capture output) — distinct from the
+// self-upgrade protocol's detached child spawn, which is a separate mechanism.
+package privexec
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/automa-saga/daemonkit"
+)
+
+// cliBinName is the solo-provisioner CLI binary's file name. The daemon execs
+// the sibling CLI installed alongside its own binary.
+const cliBinName = "solo-provisioner"
+
+// sudoBinCandidates are the absolute locations we look for the system sudo
+// binary, in order. We never exec a bare "sudo" off PATH so a caller cannot
+// hijack the escalation via an attacker-controlled directory (the same
+// hardening the network exec runners apply to nft/tc — see
+// docs/dev/security-model.md).
+var sudoBinCandidates = []string{"/usr/bin/sudo", "/bin/sudo", "/usr/sbin/sudo"}
+
+// cliBinCandidates are the solo-provisioner install paths the weaver sudoers
+// grant permits, in resolution order. The daemon's own sibling path (resolved
+// via os.Executable) is tried before these so a non-standard install stays
+// self-consistent.
+var cliBinCandidates = []string{
+	"/opt/solo/weaver/bin/" + cliBinName,
+	"/usr/local/bin/" + cliBinName,
+}
+
+// Delegator runs privileged solo-provisioner subcommands under sudo on behalf
+// of the unprivileged daemon. Failures carry an operator-facing Reason and
+// Resolution (via *daemonkit.ProbeError) so the caller can surface them through
+// the component's /status endpoint.
+type Delegator interface {
+	// Run execs `sudo <solo-provisioner> <args...>`, waits for completion, and
+	// returns the command's stdout. A missing sudo/CLI binary, a denied sudo
+	// grant, or a non-zero exit returns a *daemonkit.ProbeError describing the
+	// failure and how to resolve it; on success err is nil and the returned
+	// bytes are stdout only (stderr is folded into the error, never stdout, so
+	// callers can parse `--output json`).
+	Run(ctx context.Context, args ...string) ([]byte, error)
+
+	// NetworkPolicySet delegates `network policy set --name <name>
+	// [--cidrs <csv>]` — the statusz poll loop's membership write path. It
+	// atomically replaces the named policy's live nft set with cidrs; an empty
+	// (or nil) cidrs slice clears the set (the --cidrs flag is omitted).
+	NetworkPolicySet(ctx context.Context, name string, cidrs []string) error
+}
+
+// execDelegator is the production Delegator. Its resolution and exec seams are
+// injectable so unit tests can assert the constructed argv and the failure
+// mapping without a real sudo or CLI binary on the host.
+type execDelegator struct {
+	// executable resolves the running daemon binary's path so the sibling CLI
+	// can be preferred. Defaults to os.Executable.
+	executable func() (string, error)
+	// stat reports whether a candidate binary path exists. Defaults to os.Stat.
+	stat func(string) (os.FileInfo, error)
+	// output runs name+args and returns stdout; on a non-zero exit the returned
+	// error is an *exec.ExitError whose Stderr carries the CLI's stderr.
+	// Defaults to exec.CommandContext(...).Output().
+	output func(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// New returns a Delegator wired to the host's sudo and solo-provisioner
+// binaries.
+func New() Delegator {
+	return &execDelegator{
+		executable: os.Executable,
+		stat:       os.Stat,
+		output: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			return exec.CommandContext(ctx, name, args...).Output()
+		},
+	}
+}
+
+func (d *execDelegator) Run(ctx context.Context, args ...string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, &daemonkit.ProbeError{
+			Reason:     "PrivilegedExecNoArgs",
+			Message:    "privileged delegation called with no solo-provisioner arguments",
+			Resolution: "this is a daemon bug; report it with the daemon logs",
+		}
+	}
+
+	sudoBin, err := d.resolve(sudoBinCandidates, "SudoBinaryNotFound",
+		"install sudo, or verify it exists at one of: "+strings.Join(sudoBinCandidates, ", "))
+	if err != nil {
+		return nil, err
+	}
+
+	cliBin, err := d.resolveCLI()
+	if err != nil {
+		return nil, err
+	}
+
+	// argv is `sudo -n <cli> <args...>`. -n makes sudo non-interactive: a missing
+	// or expired grant exits immediately (a daemon has no tty to prompt on)
+	// rather than blocking, and surfaces as the ProbeError below. The CLI path is
+	// passed as an explicit argument (not via PATH) so it matches the absolute
+	// paths the sudoers grant authorizes.
+	argv := append([]string{"-n", cliBin}, args...)
+	out, err := d.output(ctx, sudoBin, argv...)
+	if err != nil {
+		return out, &daemonkit.ProbeError{
+			Reason:     "PrivilegedExecFailed",
+			Message:    privilegedExecMessage(cliBin, args, err),
+			Resolution: "verify the weaver sudoers grant (/etc/sudoers.d/solo-provisioner) permits `sudo " + cliBinName + "`, then reproduce manually: sudo " + cliBin + " " + strings.Join(args, " "),
+			Err:        err,
+		}
+	}
+	return out, nil
+}
+
+func (d *execDelegator) NetworkPolicySet(ctx context.Context, name string, cidrs []string) error {
+	if strings.TrimSpace(name) == "" {
+		return &daemonkit.ProbeError{
+			Reason:     "PolicyNameEmpty",
+			Message:    "network policy set requires a non-empty policy name",
+			Resolution: "this is a daemon bug; report it with the daemon logs",
+		}
+	}
+	args := []string{"network", "policy", "set", "--name", name}
+	if len(cidrs) > 0 {
+		args = append(args, "--cidrs", strings.Join(cidrs, ","))
+	}
+	_, err := d.Run(ctx, args...)
+	return err
+}
+
+// resolve returns the first candidate that exists on disk, or a ProbeError with
+// the given reason/resolution when none do.
+func (d *execDelegator) resolve(candidates []string, reason, resolution string) (string, error) {
+	for _, c := range candidates {
+		if _, err := d.stat(c); err == nil {
+			return c, nil
+		}
+	}
+	return "", &daemonkit.ProbeError{
+		Reason:     reason,
+		Message:    "no usable binary found in any known path: " + strings.Join(candidates, ", "),
+		Resolution: resolution,
+	}
+}
+
+// resolveCLI resolves the solo-provisioner CLI binary, preferring the sibling of
+// the running daemon binary and falling back to the sudoers-granted install
+// paths.
+func (d *execDelegator) resolveCLI() (string, error) {
+	candidates := cliBinCandidates
+	if exe, err := d.executable(); err == nil {
+		sibling := filepath.Join(filepath.Dir(exe), cliBinName)
+		// Prefer the sibling; keep the granted paths as fallbacks.
+		candidates = append([]string{sibling}, cliBinCandidates...)
+	}
+	return d.resolve(candidates, "CLIBinaryNotFound",
+		"reinstall the solo-provisioner CLI, or verify it exists at one of: "+strings.Join(cliBinCandidates, ", "))
+}
+
+// privilegedExecMessage builds the human-readable failure message, preferring
+// the CLI's stderr (available on a non-zero exit) over the raw exec error.
+func privilegedExecMessage(cliBin string, args []string, err error) string {
+	base := "sudo " + cliBin + " " + strings.Join(args, " ") + " failed"
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if stderr := strings.TrimSpace(string(exitErr.Stderr)); stderr != "" {
+			return base + ": " + stderr
+		}
+	}
+	return base + ": " + err.Error()
+}

--- a/internal/daemon/privexec/delegate_test.go
+++ b/internal/daemon/privexec/delegate_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package privexec
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/automa-saga/daemonkit"
+	"github.com/stretchr/testify/require"
+)
+
+// recordedCall captures one invocation of the exec seam.
+type recordedCall struct {
+	name string
+	args []string
+}
+
+// fakeDelegator builds an execDelegator whose seams are fully in-memory: stat
+// treats existPaths as present, executable returns exePath, and output records
+// the call and returns the canned stdout/err. It never touches the host.
+func fakeDelegator(existPaths []string, exePath string, stdout []byte, runErr error) (*execDelegator, *recordedCall) {
+	exist := map[string]bool{}
+	for _, p := range existPaths {
+		exist[p] = true
+	}
+	call := &recordedCall{}
+	d := &execDelegator{
+		executable: func() (string, error) {
+			if exePath == "" {
+				return "", errors.New("no executable")
+			}
+			return exePath, nil
+		},
+		stat: func(p string) (os.FileInfo, error) {
+			if exist[p] {
+				return nil, nil
+			}
+			return nil, os.ErrNotExist
+		},
+		output: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			call.name = name
+			call.args = args
+			return stdout, runErr
+		},
+	}
+	return d, call
+}
+
+func TestNetworkPolicySet_BuildsSudoArgv(t *testing.T) {
+	// CLI resolves to the daemon's sibling; sudo to its first candidate.
+	d, call := fakeDelegator(
+		[]string{"/usr/bin/sudo", "/opt/solo/weaver/bin/solo-provisioner"},
+		"/opt/solo/weaver/bin/solo-provisioner-daemon",
+		nil, nil,
+	)
+
+	err := d.NetworkPolicySet(context.Background(), "bn-publisher", []string{"10.1.0.2/32", "10.1.0.10/32"})
+	require.NoError(t, err)
+
+	require.Equal(t, "/usr/bin/sudo", call.name)
+	require.Equal(t, []string{
+		"-n",
+		"/opt/solo/weaver/bin/solo-provisioner",
+		"network", "policy", "set",
+		"--name", "bn-publisher",
+		"--cidrs", "10.1.0.2/32,10.1.0.10/32",
+	}, call.args)
+}
+
+func TestNetworkPolicySet_EmptyCIDRsOmitsFlag(t *testing.T) {
+	d, call := fakeDelegator(
+		[]string{"/usr/bin/sudo", "/opt/solo/weaver/bin/solo-provisioner"},
+		"/opt/solo/weaver/bin/solo-provisioner-daemon",
+		nil, nil,
+	)
+
+	require.NoError(t, d.NetworkPolicySet(context.Background(), "bn-partner", nil))
+	require.Equal(t, []string{
+		"-n",
+		"/opt/solo/weaver/bin/solo-provisioner",
+		"network", "policy", "set", "--name", "bn-partner",
+	}, call.args)
+	require.NotContains(t, call.args, "--cidrs")
+}
+
+func TestNetworkPolicySet_EmptyNameIsGuarded(t *testing.T) {
+	d, call := fakeDelegator([]string{"/usr/bin/sudo", "/usr/local/bin/solo-provisioner"}, "", nil, nil)
+
+	err := d.NetworkPolicySet(context.Background(), "   ", []string{"10.0.0.1/32"})
+	require.Error(t, err)
+	var pe *daemonkit.ProbeError
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, "PolicyNameEmpty", pe.Reason)
+	require.Empty(t, call.name, "exec must not run when the name is invalid")
+}
+
+func TestResolveCLI_PrefersDaemonSibling(t *testing.T) {
+	// Both the sibling and a granted path exist; the sibling wins.
+	d, _ := fakeDelegator(
+		[]string{"/custom/install/solo-provisioner", "/usr/local/bin/solo-provisioner"},
+		"/custom/install/solo-provisioner-daemon",
+		nil, nil,
+	)
+	bin, err := d.resolveCLI()
+	require.NoError(t, err)
+	require.Equal(t, "/custom/install/solo-provisioner", bin)
+}
+
+func TestResolveCLI_FallsBackToGrantedPath(t *testing.T) {
+	// No sibling on disk; resolution falls back to the sudoers-granted path.
+	d, _ := fakeDelegator(
+		[]string{"/usr/local/bin/solo-provisioner"},
+		"/custom/install/solo-provisioner-daemon",
+		nil, nil,
+	)
+	bin, err := d.resolveCLI()
+	require.NoError(t, err)
+	require.Equal(t, "/usr/local/bin/solo-provisioner", bin)
+}
+
+func TestRun_CLINotFoundReportsResolution(t *testing.T) {
+	// sudo exists but no CLI binary anywhere.
+	d, call := fakeDelegator([]string{"/usr/bin/sudo"}, "", nil, nil)
+
+	_, err := d.Run(context.Background(), "network", "policy", "set", "--name", "bn-publisher")
+	require.Error(t, err)
+	var pe *daemonkit.ProbeError
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, "CLIBinaryNotFound", pe.Reason)
+	require.Contains(t, pe.Resolution, "reinstall the solo-provisioner CLI")
+	require.Empty(t, call.name, "exec must not run when the CLI binary is missing")
+}
+
+func TestRun_SudoNotFoundReportsResolution(t *testing.T) {
+	d, _ := fakeDelegator([]string{"/opt/solo/weaver/bin/solo-provisioner"}, "", nil, nil)
+
+	_, err := d.Run(context.Background(), "version")
+	require.Error(t, err)
+	var pe *daemonkit.ProbeError
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, "SudoBinaryNotFound", pe.Reason)
+}
+
+func TestRun_NonZeroExitMapsToProbeErrorWithStderr(t *testing.T) {
+	// A real *exec.ExitError so the Stderr-extraction path is exercised.
+	exitErr := runFailingCommand(t)
+	exitErr.Stderr = []byte("sudo: a password is required\n")
+
+	d, _ := fakeDelegator(
+		[]string{"/usr/bin/sudo", "/opt/solo/weaver/bin/solo-provisioner"},
+		"/opt/solo/weaver/bin/solo-provisioner-daemon",
+		nil, exitErr,
+	)
+
+	_, err := d.Run(context.Background(), "network", "policy", "set", "--name", "bn-publisher")
+	require.Error(t, err)
+	var pe *daemonkit.ProbeError
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, "PrivilegedExecFailed", pe.Reason)
+	require.Contains(t, pe.Message, "sudo: a password is required")
+	require.Contains(t, pe.Resolution, "/etc/sudoers.d/solo-provisioner")
+	require.ErrorIs(t, err, exitErr, "underlying exec error must remain unwrappable")
+}
+
+func TestRun_NoArgsIsGuarded(t *testing.T) {
+	d, call := fakeDelegator([]string{"/usr/bin/sudo", "/usr/local/bin/solo-provisioner"}, "", nil, nil)
+	_, err := d.Run(context.Background())
+	require.Error(t, err)
+	var pe *daemonkit.ProbeError
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, "PrivilegedExecNoArgs", pe.Reason)
+	require.Empty(t, call.name)
+}
+
+// runFailingCommand runs a command guaranteed to exit non-zero so the test can
+// obtain a genuine *exec.ExitError (whose Stderr field it then overrides).
+func runFailingCommand(t *testing.T) *exec.ExitError {
+	t.Helper()
+	err := exec.Command("false").Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	return exitErr
+}

--- a/internal/templates/weaver_privilege_test.go
+++ b/internal/templates/weaver_privilege_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package templates
+
+import (
+	"strings"
+	"testing"
+)
+
+// directiveLines returns the non-comment, non-blank lines of an embedded config
+// file. Comment prose is stripped because both the sudoers file and the daemon
+// service unit deliberately *name* things they do NOT do (raw tools that are
+// not granted; NoNewPrivileges that is intentionally omitted), so assertions
+// must run against the effective directives, not the explanatory text.
+func directiveLines(t *testing.T, name string) string {
+	t.Helper()
+	data, err := Read(name)
+	if err != nil {
+		t.Fatalf("read embedded %s: %v", name, err)
+	}
+	var b strings.Builder
+	for _, ln := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(ln)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		b.WriteString(ln)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// TestSudoersGrantsOnlySoloProvisioner locks the privilege model: the daemon's
+// only escalation path is exec'ing the solo-provisioner CLI under sudo, so the
+// grant must cover that binary at both install paths and must NOT hand out any
+// raw tool (kubectl/helm/kubeadm/systemctl/nft/tc/mkdir), which would grant
+// root-equivalent access far beyond the audited CLI surface.
+func TestSudoersGrantsOnlySoloProvisioner(t *testing.T) {
+	grant := directiveLines(t, "files/weaver/sudoers")
+
+	for _, want := range []string{
+		"/opt/solo/weaver/bin/solo-provisioner",
+		"/usr/local/bin/solo-provisioner",
+	} {
+		if !strings.Contains(grant, want) {
+			t.Errorf("sudoers grant missing expected path %q\n--- grant ---\n%s", want, grant)
+		}
+	}
+
+	// No raw-tool grants may leak into the escalation surface.
+	for _, forbidden := range []string{"kubectl", "helm", "kubeadm", "systemctl", "mkdir", "/nft", "/tc"} {
+		if strings.Contains(grant, forbidden) {
+			t.Errorf("sudoers grant unexpectedly references raw tool %q — the daemon must escalate only via solo-provisioner\n--- grant ---\n%s", forbidden, grant)
+		}
+	}
+}
+
+// TestDaemonServiceRunsUnprivileged locks the two systemd invariants the
+// privilege model depends on: the daemon runs as the unprivileged weaver user,
+// and NoNewPrivileges is not enabled (which would block the sudo escalation the
+// delegation model relies on).
+func TestDaemonServiceRunsUnprivileged(t *testing.T) {
+	unit := directiveLines(t, "files/weaver/solo-provisioner-daemon.service")
+
+	for _, want := range []string{"User=weaver", "Group=weaver"} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("daemon service unit missing %q\n--- unit ---\n%s", want, unit)
+		}
+	}
+
+	// NoNewPrivileges must be omitted entirely, not merely set to a false-y
+	// value: any true-ish form (true/yes/1/on) would block the sudo setuid
+	// escalation the delegation model relies on. Assert the directive is absent
+	// altogether rather than matching one spelling of "on".
+	if strings.Contains(unit, "NoNewPrivileges") {
+		t.Errorf("daemon service unit sets a NoNewPrivileges directive; it must be omitted so sudo delegation works\n--- unit ---\n%s", unit)
+	}
+}


### PR DESCRIPTION
## Description

The `solo-provisioner-daemon` runs unprivileged (systemd `User=weaver`) but the
traffic-shaper monitor's work requires root: writing nftables set membership and
attaching tc qdiscs to per-pod veths. Rather than give the daemon capabilities or
run it as root, it delegates each privileged action by exec'ing the root
`solo-provisioner` CLI under `sudo`. This PR implements that privilege mechanism.

`internal/daemon/privexec` is a small `Delegator` that runs
`sudo solo-provisioner <args…>`: it resolves both binaries by absolute path (the
CLI sibling of the running daemon first, then the two sudoers-granted install
paths — never a bare `PATH` lookup), runs synchronously, returns stdout, and maps
every failure — missing `sudo`, missing CLI, denied grant, non-zero exit — to a
`*daemonkit.ProbeError` carrying an operator-facing reason and resolution so the
consumer can surface it through `/status`. A typed `NetworkPolicySet(name, cidrs)`
wraps the poll loop's `network policy set` write path; the generic `Run` seam is
what the pod watcher's `block node tc-attach` will use.

This is intentionally the **mechanism only**. Both call sites live in
not-yet-landed stories (the poll-loop apply and bootstrap/outage policy; the
tc-attach verb), so the monitor merely *holds* the delegator (defaulted in its
constructor, like the existing live-set reader) — those stories consume it with no
constructor change. Two of the story's acceptance criteria — the `User=weaver`
service unit and the whole-binary sudoers grant — already shipped with the
self-upgrade epic; this PR locks them with a regression test rather than
re-authoring them.

`privexec` is the only package in the daemon's import closure that reaches for
`os/exec`, and it execs nothing but `sudo` + `solo-provisioner`, so the "no raw
tools" guarantee in the security model still holds even though `os/exec` is now
present. The daemon architecture doc is updated to say exactly that.

### Files changed

| File | Change |
|---|---|
| `internal/daemon/privexec/delegate.go` | New. `Delegator` interface + `execDelegator`: absolute-path resolution of `sudo` and `solo-provisioner`, `sudo <cli> <args…>` via `exec.CommandContext(...).Output()`, failure → `*daemonkit.ProbeError` (reason + resolution), typed `NetworkPolicySet`. |
| `internal/daemon/privexec/delegate_test.go` | New. 9 macOS-safe tests via injected exec/stat/executable seams: argv shape, resolution order + fallback, empty-cidrs omits `--cidrs`, empty-name / no-arg guards, real `*exec.ExitError` → `ProbeError` (stderr surfaced, underlying error still unwrappable). |
| `internal/daemon/blocknode/traffic_shaper_monitor.go` | `TrafficShaperMonitor` holds a `privexec.Delegator`, defaulted to `privexec.New()` in the constructor. No behavioural change to the stubs. |
| `internal/templates/weaver_privilege_test.go` | New. Locks the two supporting invariants: sudoers grants only the `solo-provisioner` binary (no raw `kubectl`/`helm`/`kubeadm`/`systemctl`/`nft`/`tc`/`mkdir`); the daemon service unit keeps `User=weaver`/`Group=weaver` with no `NoNewPrivileges=true`. Comment prose is stripped so assertions match the effective directives. |
| `docs/dev/daemon/daemon-architecture.md` | Security posture: `os/exec` is now present, scoped to `internal/daemon/privexec`; "no raw tools" guarantee retained; CLI-binary hash/signature verification noted as still pending. |

### Review guide

- **Binary resolution never trusts `PATH`.** `resolveCLI` prefers the CLI
  installed alongside the daemon (`os.Executable()` dir) and falls back to the two
  paths the sudoers file grants (`/opt/solo/weaver/bin`, `/usr/local/bin`); `sudo`
  is resolved from an absolute candidate list the same way the nft/tc runners do.
  Worth confirming the fallback order in `delegate.go` `resolveCLI` /
  `resolve`.
- **stdout stays clean.** `Run` returns stdout only; stderr is folded into the
  `ProbeError` message (via `*exec.ExitError.Stderr`), so a future caller can
  parse `--output json` from stdout without stderr contamination.
- **Failure surfacing.** Every error path returns a `*daemonkit.ProbeError` with a
  stable `Reason` and an actionable `Resolution` (naming the sudoers file and the
  exact reproduce command) — the same reason/resolution shape the upgrade monitor
  feeds into `/status`.
- **Invariant test reads directives, not comments.** Both the sudoers file and the
  service unit deliberately *name* the things they exclude (raw tools;
  `NoNewPrivileges`), so `weaver_privilege_test.go` strips `#` lines before
  asserting — see `directiveLines`.

Test commands:

```bash
go test -tags='!integration' ./internal/daemon/privexec/... ./internal/daemon/blocknode/... ./internal/templates/...
task lint:check
```

No CLI-flag or embedded-template changes, so no `docs/quickstart.md` update and no
upgrade-path concern. Rollback is dropping the new package and reverting the two
one-line edits; nothing changes observable behavior until a later story wires a
call site.

### Manual UAT

The delegator has no live caller yet, so end-to-end shaping isn't observable in
this PR. What *is* verifiable is the escalation path it depends on — that the
unprivileged `weaver` user can exec `sudo solo-provisioner` non-interactively via
the installed sudoers grant. On a provisioned host (or UTM VM):

```bash
# As the weaver user, the whole-binary NOPASSWD grant must let a subcommand run
# as root with no password prompt — this is exactly what privexec.Run performs.
sudo -n -u weaver sudo -n /opt/solo/weaver/bin/solo-provisioner version
#   expect: version output, no password prompt, exit 0

# A denied/absent grant surfaces as the ProbeError resolution the daemon logs:
#   "verify the weaver sudoers grant (/etc/sudoers.d/solo-provisioner) permits
#    `sudo solo-provisioner` …"
sudo cat /etc/sudoers.d/solo-provisioner
#   expect: grants only /opt/solo/weaver/bin/solo-provisioner and
#           /usr/local/bin/solo-provisioner (bare + " *"), no raw tools
```

### Related Issues

* Closes #774
