### PR TITLE
fix: absent state yaml silent migration

### DIFF
--- a/cmd/cli/commands/common/run.go
+++ b/cmd/cli/commands/common/run.go
@@ -348,21 +348,23 @@ func RunPersistentPreRun(cmd *cobra.Command, args []string) error {
 func RunStartupMigrations(ctx context.Context) error {
 	// Read the provisioner version last written to disk — this is the "installed"
 	// CLI version before the current binary ran for the first time.
-	installedCLIVersion, err := state.ReadProvisionerVersionFromDisk()
+	onDiskCLIVersion, err := state.ReadProvisionerVersionFromDisk()
 	if err != nil {
 		return err
 	}
+	currentCLIVersion := version.Get().Version
 
-	// Absent state.yaml reads back as ""; treat it as the baseline so boundary
-	// migrations still run instead of being skipped as a fresh install.
-	installedCLIVersion = migration.ResolveInstalledCLIVersion(installedCLIVersion)
+	// An absent state.yaml (pre-state-tracking cluster) reads back as "". Treat it as the
+	// 0.0.0 baseline so pending migrations still run instead of being skipped as a fresh
+	// install
+	installedCLIVersion := migration.ResolveInstalledCLIVersion(onDiskCLIVersion)
 
 	mctx := &migration.Context{
 		Component: migration.ScopeStartup,
 		Data:      &automa.SyncStateBag{},
 	}
 	mctx.Data.Set(migration.CtxKeyInstalledCLIVersion, installedCLIVersion)
-	mctx.Data.Set(migration.CtxKeyCurrentCLIVersion, version.Get().Version)
+	mctx.Data.Set(migration.CtxKeyCurrentCLIVersion, currentCLIVersion)
 
 	migrations, err := migration.GetApplicableMigrations(migration.ScopeStartup, mctx)
 	if err != nil {
@@ -386,6 +388,20 @@ func RunStartupMigrations(ctx context.Context) error {
 		return report.Error
 	}
 	logx.As().Info().Msg("Startup migrations completed successfully")
+
+	// Record the version we just migrated to so these boundary migrations are not
+	// re-evaluated — and non-idempotent ones (e.g. the Cilium agent restart) not
+	// re-run — on the next invocation. Gate on an actual version change and on a
+	// provisioned host so a genuinely fresh machine keeps having no state file.
+	// Best-effort: a persistence failure must not fail the user's command; the
+	// worst case is the next run re-evaluates the same boundary (prior behaviour).
+	// See #789 / #781.
+	if onDiskCLIVersion != currentCLIVersion && workflows.KubernetesInstalled() {
+		if err := state.PersistProvisionerVersion(); err != nil {
+			logx.As().Warn().Err(err).
+				Msg("Failed to record provisioner version after startup migrations; boundary migrations may re-run next invocation")
+		}
+	}
 	return nil
 }
 

--- a/cmd/cli/commands/common/run.go
+++ b/cmd/cli/commands/common/run.go
@@ -353,6 +353,10 @@ func RunStartupMigrations(ctx context.Context) error {
 		return err
 	}
 
+	// Absent state.yaml reads back as ""; treat it as the baseline so boundary
+	// migrations still run instead of being skipped as a fresh install.
+	installedCLIVersion = migration.ResolveInstalledCLIVersion(installedCLIVersion)
+
 	mctx := &migration.Context{
 		Component: migration.ScopeStartup,
 		Data:      &automa.SyncStateBag{},

--- a/cmd/cli/commands/common/run.go
+++ b/cmd/cli/commands/common/run.go
@@ -343,6 +343,11 @@ func RunPersistentPreRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// persistProvisionerVersion records the running binary's version to the on-disk
+// state file. A var so tests can stub it to exercise the best-effort swallow in
+// RunStartupMigrations without a writable state dir.
+var persistProvisionerVersion = state.PersistProvisionerVersion
+
 // RunStartupMigrations runs a single ordered pass over all startup-scoped migrations.
 // It is a no-op when no migrations apply.
 func RunStartupMigrations(ctx context.Context) error {
@@ -371,33 +376,30 @@ func RunStartupMigrations(ctx context.Context) error {
 		return err
 	}
 
-	if len(migrations) == 0 {
+	if len(migrations) > 0 {
+		migrationWf := migration.MigrationsToWorkflow(migrations, mctx)
+		wf, err := migrationWf.Build()
+		if err != nil {
+			return err
+		}
+
+		logx.As().Info().Msg("Running startup migrations...")
+		report := wf.Execute(ctx)
+		if report.Error != nil {
+			return report.Error
+		}
+		logx.As().Info().Msg("Startup migrations completed successfully")
+	} else {
 		logx.As().Debug().Msg("No startup migrations needed")
-		return nil
 	}
 
-	migrationWf := migration.MigrationsToWorkflow(migrations, mctx)
-	wf, err := migrationWf.Build()
-	if err != nil {
-		return err
-	}
-
-	logx.As().Info().Msg("Running startup migrations...")
-	report := wf.Execute(ctx)
-	if report.Error != nil {
-		return report.Error
-	}
-	logx.As().Info().Msg("Startup migrations completed successfully")
-
-	// Record the version we just migrated to so these boundary migrations are not
-	// re-evaluated — and non-idempotent ones (e.g. the Cilium agent restart) not
-	// re-run — on the next invocation. Gate on an actual version change and on a
-	// provisioned host so a genuinely fresh machine keeps having no state file.
-	// Best-effort: a persistence failure must not fail the user's command; the
-	// worst case is the next run re-evaluates the same boundary (prior behaviour).
-	// See #789 / #781.
+	// Record the running version so boundary migrations aren't re-run next time and
+	// pre-state-tracking clusters get a state.yaml. Persist regardless of whether a
+	// migration applied — coupling it to that would stop backfilling once nothing
+	// crosses the baseline. Gate on a version change and a provisioned host so a
+	// fresh machine keeps no state file. Best-effort.
 	if onDiskCLIVersion != currentCLIVersion && workflows.KubernetesInstalled() {
-		if err := state.PersistProvisionerVersion(); err != nil {
+		if err := persistProvisionerVersion(); err != nil {
 			logx.As().Warn().Err(err).
 				Msg("Failed to record provisioner version after startup migrations; boundary migrations may re-run next invocation")
 		}

--- a/cmd/cli/commands/common/run_startup_migrations_test.go
+++ b/cmd/cli/commands/common/run_startup_migrations_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/automa-saga/version"
+	"github.com/hashgraph/solo-weaver/internal/migration"
+	"github.com/hashgraph/solo-weaver/internal/state"
+	"github.com/hashgraph/solo-weaver/internal/workflows"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStartupMigration applies only at the 0.0.0 baseline and counts each Execute.
+type fakeStartupMigration struct {
+	id      string
+	applied *int
+}
+
+func (m *fakeStartupMigration) ID() string          { return m.id }
+func (m *fakeStartupMigration) Description() string { return "fake startup migration" }
+func (m *fakeStartupMigration) Applies(mctx *migration.Context) (bool, error) {
+	installed, _ := mctx.Data.String(migration.CtxKeyInstalledCLIVersion)
+	return installed == migration.BaselineCLIVersion, nil
+}
+func (m *fakeStartupMigration) Execute(_ context.Context, _ *migration.Context) error {
+	*m.applied++
+	return nil
+}
+func (m *fakeStartupMigration) Rollback(_ context.Context, _ *migration.Context) error { return nil }
+
+// registerFakeStartupMigration isolates the registry to one fake migration under a temp state path; returns the execute counter.
+func registerFakeStartupMigration(t *testing.T) *int {
+	t.Helper()
+
+	migration.ClearRegistry()
+	t.Cleanup(migration.ClearRegistry)
+
+	home := t.TempDir()
+	t.Cleanup(models.SetPaths(home))
+	// Provisioned host: state dir exists but no state.yaml → reader returns "".
+	require.NoError(t, os.MkdirAll(models.Paths().StateDir, 0o755))
+
+	applied := 0
+	migration.Register(migration.ScopeStartup, &fakeStartupMigration{id: "fake-startup-v1", applied: &applied})
+	return &applied
+}
+
+// TestRunStartupMigrations_PersistsVersionAndStopsRerun: run 1 (no state.yaml) crosses the baseline and records the version; run 2 reads it back, so the migration runs exactly once
+func TestRunStartupMigrations_PersistsVersionAndStopsRerun(t *testing.T) {
+	applied := registerFakeStartupMigration(t)
+
+	// Force the provisioned-host gate true; the real probe checks
+	// /etc/kubernetes/admin.conf, which is absent on a CI/test host.
+	origK8s := workflows.KubernetesInstalled
+	t.Cleanup(func() { workflows.KubernetesInstalled = origK8s })
+	workflows.KubernetesInstalled = func() bool { return true }
+
+	ctx := context.Background()
+
+	// Run 1: absent state.yaml → "" → 0.0.0 baseline → boundary applies → runs once.
+	require.NoError(t, RunStartupMigrations(ctx))
+	assert.Equal(t, 1, *applied, "run 1 must execute the boundary migration once")
+
+	// The orchestrator recorded the running version at the reader's path.
+	recorded, err := state.ReadProvisionerVersionFromDisk()
+	require.NoError(t, err)
+	assert.Equal(t, version.Get().Version, recorded, "run 1 must persist the running version")
+
+	// Run 2: the reader now returns the recorded version → not the baseline → the
+	// boundary no longer applies, so the migration is not re-run.
+	require.NoError(t, RunStartupMigrations(ctx))
+	assert.Equal(t, 1, *applied, "run 2 must NOT re-execute the migration")
+}
+
+// TestRunStartupMigrations_SkipsPersistWhenKubernetesAbsent: without Kubernetes the version is not recorded, so the boundary re-runs next time.
+func TestRunStartupMigrations_SkipsPersistWhenKubernetesAbsent(t *testing.T) {
+	applied := registerFakeStartupMigration(t)
+
+	origK8s := workflows.KubernetesInstalled
+	t.Cleanup(func() { workflows.KubernetesInstalled = origK8s })
+	workflows.KubernetesInstalled = func() bool { return false }
+
+	ctx := context.Background()
+
+	require.NoError(t, RunStartupMigrations(ctx))
+	assert.Equal(t, 1, *applied, "run 1 still runs the migration")
+
+	// Gate closed: nothing recorded, so the reader still sees an empty version.
+	recorded, err := state.ReadProvisionerVersionFromDisk()
+	require.NoError(t, err)
+	assert.Empty(t, recorded, "version must NOT be persisted on a non-provisioned host")
+
+	// Without a recorded version the boundary applies again on the next run.
+	require.NoError(t, RunStartupMigrations(ctx))
+	assert.Equal(t, 2, *applied, "without a recorded version the migration re-runs")
+}
+
+// TestRunStartupMigrations_PersistsVersionWhenNoMigrationApplies: the version is backfilled even when no migration applies — recording it must not depend on a migration running.
+func TestRunStartupMigrations_PersistsVersionWhenNoMigrationApplies(t *testing.T) {
+	// Isolate an empty registry at a temp home with a state dir but no state.yaml.
+	migration.ClearRegistry()
+	t.Cleanup(migration.ClearRegistry)
+	home := t.TempDir()
+	t.Cleanup(models.SetPaths(home))
+	require.NoError(t, os.MkdirAll(models.Paths().StateDir, 0o755))
+
+	origK8s := workflows.KubernetesInstalled
+	t.Cleanup(func() { workflows.KubernetesInstalled = origK8s })
+	workflows.KubernetesInstalled = func() bool { return true }
+
+	// Precondition: no applicable migrations and an absent version on disk.
+	before, err := state.ReadProvisionerVersionFromDisk()
+	require.NoError(t, err)
+	require.Empty(t, before)
+
+	require.NoError(t, RunStartupMigrations(context.Background()))
+
+	recorded, err := state.ReadProvisionerVersionFromDisk()
+	require.NoError(t, err)
+	assert.Equal(t, version.Get().Version, recorded,
+		"version must be backfilled even when no migration applied")
+}
+
+// TestRunStartupMigrations_PersistFailureIsNonFatal: recording the version is
+// best-effort — if it fails (e.g. a corrupt state.yaml or an unwritable state dir
+// on a long-lived host), startup must still succeed. Regression guard: turning the
+// swallowed Warn into a returned error would abort every CLI invocation on such a
+// host, and quietly re-run boundary migrations forever. See #789.
+func TestRunStartupMigrations_PersistFailureIsNonFatal(t *testing.T) {
+	applied := registerFakeStartupMigration(t)
+
+	origK8s := workflows.KubernetesInstalled
+	t.Cleanup(func() { workflows.KubernetesInstalled = origK8s })
+	workflows.KubernetesInstalled = func() bool { return true }
+
+	// Force the version record to fail the way a wonky state dir would.
+	origPersist := persistProvisionerVersion
+	t.Cleanup(func() { persistProvisionerVersion = origPersist })
+	persistCalled := 0
+	persistProvisionerVersion = func(_ ...state.ManagerOption) error {
+		persistCalled++
+		return errors.New("simulated persist failure")
+	}
+
+	// The migration applies (baseline crosses the boundary) and the persist fails —
+	// RunStartupMigrations must swallow the error and still return nil.
+	require.NoError(t, RunStartupMigrations(context.Background()),
+		"a failed version record must not fail startup")
+	assert.Equal(t, 1, persistCalled, "the version record must have been attempted")
+	assert.Equal(t, 1, *applied, "the migration must still have executed despite the persist failure")
+}

--- a/internal/migration/cli_version_migration.go
+++ b/internal/migration/cli_version_migration.go
@@ -13,6 +13,20 @@ const (
 	CtxKeyCurrentCLIVersion   = "currentCLIVersion"
 )
 
+// BaselineCLIVersion is the assumed installed version when none was recorded on
+// disk. It makes every version-boundary migration eligible; each migration's
+// Execute() guard keeps it a no-op on a fresh machine.
+const BaselineCLIVersion = "0.0.0"
+
+// ResolveInstalledCLIVersion maps an absent (empty) version to BaselineCLIVersion;
+// non-empty is returned as-is.
+func ResolveInstalledCLIVersion(raw string) string {
+	if raw == "" {
+		return BaselineCLIVersion
+	}
+	return raw
+}
+
 // CLIVersionMigration provides a base implementation for CLI-version-boundary startup migrations.
 // Embed this in concrete migrations to get ID(), Description(), and Applies() behaviour
 // that gates on the CLI binary version rather than a deployed chart version.
@@ -34,7 +48,9 @@ func (v *CLIVersionMigration) ID() string          { return v.id }
 func (v *CLIVersionMigration) Description() string { return v.description }
 
 // Applies returns true if the CLI is upgrading across the version boundary.
-// Returns false when installedCLIVersion is empty (fresh install).
+//
+// An empty installedCLIVersion returns false; the startup path supplies
+// BaselineCLIVersion instead, so this is only a fallback for direct callers.
 func (v *CLIVersionMigration) Applies(mctx *Context) (bool, error) {
 	var installedCLIVersion string
 	if s, ok := mctx.Data.String(CtxKeyInstalledCLIVersion); ok {

--- a/internal/migration/cli_version_migration_test.go
+++ b/internal/migration/cli_version_migration_test.go
@@ -161,13 +161,7 @@ func TestResolveInstalledCLIVersion(t *testing.T) {
 	}
 }
 
-// TestCLIVersionMigration_PersistedVersionStopsRerun proves the #789/#781 fix
-// end-to-end at the version layer: on the first run a pre-state-tracking host
-// (no recorded version) crosses the boundary and the migration applies; after the
-// startup path persists the current version (PersistProvisionerVersion), the next
-// run reads that version back and the SAME boundary no longer applies — so a
-// non-idempotent migration (e.g. the Cilium agent restart) runs exactly once
-// instead of on every invocation.
+// TestCLIVersionMigration_PersistedVersionStopsRerun: an absent version crosses the boundary; once persisted, it no longer applies — so the migration runs once
 func TestCLIVersionMigration_PersistedVersionStopsRerun(t *testing.T) {
 	m := &CLIVersionMigration{id: "cilium-agent-restart-v0.19.2", minVersion: "0.19.2"}
 	const currentVersion = "0.21.0"

--- a/internal/migration/cli_version_migration_test.go
+++ b/internal/migration/cli_version_migration_test.go
@@ -161,6 +161,34 @@ func TestResolveInstalledCLIVersion(t *testing.T) {
 	}
 }
 
+// TestCLIVersionMigration_PersistedVersionStopsRerun proves the #789/#781 fix
+// end-to-end at the version layer: on the first run a pre-state-tracking host
+// (no recorded version) crosses the boundary and the migration applies; after the
+// startup path persists the current version (PersistProvisionerVersion), the next
+// run reads that version back and the SAME boundary no longer applies — so a
+// non-idempotent migration (e.g. the Cilium agent restart) runs exactly once
+// instead of on every invocation.
+func TestCLIVersionMigration_PersistedVersionStopsRerun(t *testing.T) {
+	m := &CLIVersionMigration{id: "cilium-agent-restart-v0.19.2", minVersion: "0.19.2"}
+	const currentVersion = "0.21.0"
+
+	applies := func(onDiskVersion string) bool {
+		installed := ResolveInstalledCLIVersion(onDiskVersion)
+		mctx := &Context{Data: &automa.SyncStateBag{}}
+		mctx.Data.Set(CtxKeyInstalledCLIVersion, installed)
+		mctx.Data.Set(CtxKeyCurrentCLIVersion, currentVersion)
+		got, err := m.Applies(mctx)
+		require.NoError(t, err)
+		return got
+	}
+
+	// Run 1: absent state.yaml → "" → 0.0.0 baseline → boundary applies (migration runs).
+	assert.True(t, applies(""), "first run on a pre-state-tracking host must apply the boundary")
+
+	// Run 2: PersistProvisionerVersion recorded the current version → boundary no longer applies.
+	assert.False(t, applies(currentVersion), "after the version is recorded the boundary must not re-apply")
+}
+
 func TestCLIVersionMigration_Applies_InvalidMinVersion(t *testing.T) {
 	// A migration constructed with a bad minVersion should surface an error
 	// in Applies() rather than silently misrouting.

--- a/internal/migration/cli_version_migration_test.go
+++ b/internal/migration/cli_version_migration_test.go
@@ -48,6 +48,13 @@ func TestCLIVersionMigration_Applies(t *testing.T) {
 			currentVersion:   "2.0.0",
 			expectApplies:    true,
 		},
+		{
+			// Baseline is below the boundary, so it applies.
+			name:             "baseline installed version crosses boundary should apply",
+			installedVersion: BaselineCLIVersion,
+			currentVersion:   "1.0.0",
+			expectApplies:    true,
+		},
 		// ── does not apply ───────────────────────────────────────────────────
 		{
 			name:             "upgrade within old versions should NOT apply",
@@ -120,6 +127,36 @@ func TestCLIVersionMigration_Applies(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectApplies, applies)
 			}
+		})
+	}
+}
+
+func TestResolveInstalledCLIVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "empty version defaults to the baseline",
+			raw:  "",
+			want: BaselineCLIVersion,
+		},
+		{
+			name: "non-empty version is returned unchanged",
+			raw:  "0.19.0",
+			want: "0.19.0",
+		},
+		{
+			name: "explicit baseline is returned unchanged",
+			raw:  "0.0.0",
+			want: "0.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ResolveInstalledCLIVersion(tt.raw))
 		})
 	}
 }

--- a/internal/state/provisioner_version_test.go
+++ b/internal/state/provisioner_version_test.go
@@ -8,15 +8,12 @@ import (
 	"testing"
 
 	"github.com/automa-saga/version"
+	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// readProvisionerVersionFrom parses the provisioner version out of a state file
-// at an arbitrary path using the EXACT same doc struct and unmarshaller that the
-// production reader (ReadProvisionerVersionFromDisk) uses. This lets the test
-// assert the round-trip a real second invocation would observe, without the
-// reader's fixed models.Paths() path.
+// readProvisionerVersionFrom parses the provisioner version from a state file at an arbitrary path (unlike the reader's fixed models.Paths() path).
 func readProvisionerVersionFrom(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)
@@ -26,10 +23,7 @@ func readProvisionerVersionFrom(t *testing.T, path string) string {
 	return doc.State.Provisioner.Version
 }
 
-// TestPersistProvisionerVersion_CreatesFileWhenAbsent proves that on a
-// pre-state-tracking host (no state.yaml) PersistProvisionerVersion writes a
-// state file whose provisioner.version is the running binary's version — which
-// is exactly what ReadProvisionerVersionFromDisk returns on the next invocation.
+// TestPersistProvisionerVersion_CreatesFileWhenAbsent: with no state.yaml, the write creates one holding the running binary's version.
 func TestPersistProvisionerVersion_CreatesFileWhenAbsent(t *testing.T) {
 	tmp := filepath.Join(t.TempDir(), "state.yaml")
 
@@ -48,9 +42,7 @@ func TestPersistProvisionerVersion_CreatesFileWhenAbsent(t *testing.T) {
 	assert.Equal(t, version.Get().Version, readProvisionerVersionFrom(t, tmp))
 }
 
-// TestPersistProvisionerVersion_PreservesExistingState proves the write is a
-// merge, not a clobber: reality-detected fields already on disk (here a software
-// entry) survive, and only provisioner.version is advanced to the current binary.
+// TestPersistProvisionerVersion_PreservesExistingState: the write merges — an existing software entry survives; only provisioner.version advances.
 func TestPersistProvisionerVersion_PreservesExistingState(t *testing.T) {
 	tmp := filepath.Join(t.TempDir(), "state.yaml")
 	fm := newTestFileManager(t)
@@ -87,9 +79,7 @@ func TestPersistProvisionerVersion_PreservesExistingState(t *testing.T) {
 	assert.Equal(t, "1.30.0", sw.Version)
 }
 
-// TestPersistProvisionerVersion_Idempotent proves repeated calls are safe (the
-// optimistic-concurrency baseline is set on each call), so a per-command hook
-// never errors on the second run.
+// TestPersistProvisionerVersion_Idempotent: repeated calls succeed (the concurrency baseline resets each call).
 func TestPersistProvisionerVersion_Idempotent(t *testing.T) {
 	tmp := filepath.Join(t.TempDir(), "state.yaml")
 	fm := newTestFileManager(t)
@@ -99,4 +89,35 @@ func TestPersistProvisionerVersion_Idempotent(t *testing.T) {
 		require.NoErrorf(t, err, "call %d should succeed", i)
 	}
 	assert.Equal(t, version.Get().Version, readProvisionerVersionFrom(t, tmp))
+}
+
+// TestPersistThenReadProvisionerVersion_RoundTrip: writer and reader agree on the state-file path and shape — the round-trip #789 depends on.
+func TestPersistThenReadProvisionerVersion_RoundTrip(t *testing.T) {
+	home := t.TempDir()
+	restore := models.SetPaths(home)
+	t.Cleanup(restore)
+
+	stateFile := filepath.Join(models.Paths().StateDir, StateFileName)
+
+	// Precondition: state dir exists but no state.yaml — the reader returns "".
+	require.NoError(t, os.MkdirAll(models.Paths().StateDir, 0o755))
+	_, statErr := os.Stat(stateFile)
+	require.True(t, os.IsNotExist(statErr), "precondition: state file must not exist yet")
+
+	absent, err := ReadProvisionerVersionFromDisk()
+	require.NoError(t, err)
+	assert.Empty(t, absent, "absent state.yaml must read back as an empty version")
+
+	// Write the running version at the default path (no opts → the reader's path).
+	require.NoError(t, PersistProvisionerVersion())
+
+	_, statErr = os.Stat(stateFile)
+	require.NoError(t, statErr, "state file should now exist at the reader's path")
+
+	// The reader observes exactly the version just written (non-empty).
+	readBack, err := ReadProvisionerVersionFromDisk()
+	require.NoError(t, err)
+	assert.NotEmpty(t, readBack, "recorded version must read back non-empty, unlike the absent case")
+	assert.Equal(t, version.Get().Version, readBack,
+		"the reader must observe the version the writer persisted")
 }

--- a/internal/state/provisioner_version_test.go
+++ b/internal/state/provisioner_version_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/automa-saga/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readProvisionerVersionFrom parses the provisioner version out of a state file
+// at an arbitrary path using the EXACT same doc struct and unmarshaller that the
+// production reader (ReadProvisionerVersionFromDisk) uses. This lets the test
+// assert the round-trip a real second invocation would observe, without the
+// reader's fixed models.Paths() path.
+func readProvisionerVersionFrom(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var doc ProvisionerVersionDoc
+	require.NoError(t, unmarshalStateDoc(data, &doc))
+	return doc.State.Provisioner.Version
+}
+
+// TestPersistProvisionerVersion_CreatesFileWhenAbsent proves that on a
+// pre-state-tracking host (no state.yaml) PersistProvisionerVersion writes a
+// state file whose provisioner.version is the running binary's version — which
+// is exactly what ReadProvisionerVersionFromDisk returns on the next invocation.
+func TestPersistProvisionerVersion_CreatesFileWhenAbsent(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "state.yaml")
+
+	_, err := os.Stat(tmp)
+	require.True(t, os.IsNotExist(err), "precondition: state file must not exist")
+
+	err = PersistProvisionerVersion(
+		WithState(newTestState(tmp)),
+		WithFileManager(newTestFileManager(t)),
+	)
+	require.NoError(t, err)
+
+	_, err = os.Stat(tmp)
+	require.NoError(t, err, "state file should now exist")
+
+	assert.Equal(t, version.Get().Version, readProvisionerVersionFrom(t, tmp))
+}
+
+// TestPersistProvisionerVersion_PreservesExistingState proves the write is a
+// merge, not a clobber: reality-detected fields already on disk (here a software
+// entry) survive, and only provisioner.version is advanced to the current binary.
+func TestPersistProvisionerVersion_PreservesExistingState(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "state.yaml")
+	fm := newTestFileManager(t)
+
+	const oldVersion = "0.0.0-pre-existing"
+	const swKey = "crio"
+
+	// Seed a rich state file the way a provisioned cluster would have one.
+	seed := newTestState(tmp)
+	seed.ProvisionerState.Version = oldVersion
+	seed.MachineState.Software[swKey] = SoftwareState{Name: "cri-o", Version: "1.30.0", Installed: true}
+
+	seedMgr, err := NewStateManager(WithState(seed), WithFileManager(fm))
+	require.NoError(t, err)
+	require.NoError(t, seedMgr.Refresh())
+	require.NoError(t, seedMgr.FlushState())
+	require.NotEqual(t, oldVersion, version.Get().Version, "sentinel must differ from current version")
+
+	// Record the provisioner version against the existing file.
+	err = PersistProvisionerVersion(
+		WithState(newTestState(tmp)),
+		WithFileManager(fm),
+	)
+	require.NoError(t, err)
+
+	// Version advanced; the pre-existing software entry is untouched.
+	assert.Equal(t, version.Get().Version, readProvisionerVersionFrom(t, tmp))
+
+	reloaded, err := NewStateManager(WithState(newTestState(tmp)), WithFileManager(fm))
+	require.NoError(t, err)
+	require.NoError(t, reloaded.Refresh())
+	sw, ok := reloaded.State().MachineState.Software[swKey]
+	require.True(t, ok, "pre-existing software entry must be preserved")
+	assert.Equal(t, "1.30.0", sw.Version)
+}
+
+// TestPersistProvisionerVersion_Idempotent proves repeated calls are safe (the
+// optimistic-concurrency baseline is set on each call), so a per-command hook
+// never errors on the second run.
+func TestPersistProvisionerVersion_Idempotent(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "state.yaml")
+	fm := newTestFileManager(t)
+
+	for i := range 3 {
+		err := PersistProvisionerVersion(WithState(newTestState(tmp)), WithFileManager(fm))
+		require.NoErrorf(t, err, "call %d should succeed", i)
+	}
+	assert.Equal(t, version.Get().Version, readProvisionerVersionFrom(t, tmp))
+}

--- a/internal/state/state_manager.go
+++ b/internal/state/state_manager.go
@@ -136,6 +136,32 @@ func NewStateManager(opts ...ManagerOption) (Manager, error) {
 	return m, nil
 }
 
+// PersistProvisionerVersion records the running binary's version in the on-disk
+// state file so version-boundary startup migrations are not re-evaluated — and
+// non-idempotent ones (e.g. the Cilium agent restart) not re-run — on the next
+// invocation.
+//
+// It Refresh()es first, so any existing reality-detected software/cluster/
+// block-node fields are preserved and the optimistic-concurrency baseline is set;
+// on a host with no state file it writes a minimal one from NewState defaults. A
+// missing file is not an error. Call only after a successful startup-migration
+// pass and only on a provisioned host, so a genuinely fresh machine keeps having
+// no state file.
+func PersistProvisionerVersion(opts ...ManagerOption) error {
+	sm, err := NewStateManager(opts...)
+	if err != nil {
+		return err
+	}
+
+	if err := sm.Refresh(); err != nil && !errorx.IsOfType(err, NotFoundError) {
+		return err
+	}
+
+	s := sm.State()
+	s.ProvisionerState.Version = version.Get().Version
+	return sm.Set(s).FlushState()
+}
+
 // State returns a copy of the current in-memory state (thread-safe).
 // Returns a value copy so callers cannot mutate the manager's internals
 // through the returned value.

--- a/internal/workflows/cluster.go
+++ b/internal/workflows/cluster.go
@@ -33,6 +33,8 @@ func InstallClusterWorkflow(skipHardwareChecks bool, mr software.MachineRuntime)
 		Steps(
 			SubstrateSetupWorkflow(skipHardwareChecks),
 			KubernetesSetupWorkflow(mr),
+			// Record the CLI version so a fresh cluster has a state.yaml; without it the next invocation synthesises the 0.0.0 baseline and re-runs historical startup migrations.
+			steps.RecordProvisionerVersion(),
 		)
 }
 

--- a/internal/workflows/migration_cilium_acceleration.go
+++ b/internal/workflows/migration_cilium_acceleration.go
@@ -142,6 +142,13 @@ func (m *CiliumAccelerationMigration) Rollback(ctx context.Context, mctx *migrat
 	return nil
 }
 
+// KubernetesInstalled reports whether Kubernetes has been provisioned on this
+// host, using the same probe the Cilium startup migrations gate their Execute()
+// on. The startup orchestrator uses it to decide whether to record the
+// provisioner version after a migration pass, so a genuinely fresh machine keeps
+// having no state file.
+func KubernetesInstalled() bool { return kubernetesInstalled() }
+
 // defaultKubernetesInstalled reports whether Kubernetes has been provisioned on
 // this host (the kubeadm admin kubeconfig exists).
 func defaultKubernetesInstalled() bool {

--- a/internal/workflows/migration_cilium_acceleration.go
+++ b/internal/workflows/migration_cilium_acceleration.go
@@ -142,12 +142,12 @@ func (m *CiliumAccelerationMigration) Rollback(ctx context.Context, mctx *migrat
 	return nil
 }
 
-// KubernetesInstalled reports whether Kubernetes has been provisioned on this
-// host, using the same probe the Cilium startup migrations gate their Execute()
-// on. The startup orchestrator uses it to decide whether to record the
-// provisioner version after a migration pass, so a genuinely fresh machine keeps
-// having no state file.
-func KubernetesInstalled() bool { return kubernetesInstalled() }
+// KubernetesInstalled reports whether Kubernetes is provisioned on this host,
+// using the same probe the Cilium migrations gate Execute() on. The startup
+// orchestrator uses it to decide whether to record the provisioner version, so a
+// fresh machine keeps having no state file. A var so tests can stub the probe
+// (which reads /etc/kubernetes/admin.conf, absent on a CI host).
+var KubernetesInstalled = func() bool { return kubernetesInstalled() }
 
 // defaultKubernetesInstalled reports whether Kubernetes has been provisioned on
 // this host (the kubeadm admin kubeconfig exists).

--- a/internal/workflows/migration_startup_persist_test.go
+++ b/internal/workflows/migration_startup_persist_test.go
@@ -12,23 +12,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestStartupPersist_AgentRestartRunsOnceAcrossRuns is the end-to-end proof for
-// #789/#781: it drives the REAL, non-idempotent CiliumAgentRestartMigration the
-// way RunStartupMigrations does, across two invocations, and shows the disruptive
-// agent restart fires exactly once — because the first run records the CLI
-// version, so the second run no longer crosses the boundary.
-//
-// Runs under `task vm:test:unit` (the workflows package is Linux-only).
+// TestStartupPersist_AgentRestartRunsOnceAcrossRuns: the real restart migration fires once across two runs because run 1 records the version (#789/#781). Linux-only: `task vm:test:unit`.
 func TestStartupPersist_AgentRestartRunsOnceAcrossRuns(t *testing.T) {
 	origK8s, origRead, origRestart := kubernetesInstalled, readCiliumState, restartCiliumAgents
 	t.Cleanup(func() {
 		kubernetesInstalled, readCiliumState, restartCiliumAgents = origK8s, origRead, origRestart
 	})
 
-	// A provisioned cluster whose acceleration is already "disabled": the restart
-	// migration's Execute() has no "already restarted" guard, so it WILL restart
-	// the agents every time it is allowed to run. The version gate is the only
-	// thing that stops repeated restarts.
+	// Acceleration already "disabled": Execute() has no "already restarted" guard,
+	// so it restarts every time it runs — the version gate is what stops repeats.
 	kubernetesInstalled = func() bool { return true }
 	readCiliumState = func(_ context.Context) (bool, string, error) {
 		return true, disabledAcceleration, nil
@@ -40,8 +32,7 @@ func TestStartupPersist_AgentRestartRunsOnceAcrossRuns(t *testing.T) {
 
 	m := NewCiliumAgentRestartMigration()
 
-	// runStartupPass mirrors RunStartupMigrations for one invocation: resolve the
-	// on-disk version, evaluate Applies(), and Execute() only if it applies.
+	// runStartupPass mirrors one RunStartupMigrations invocation: resolve version, check Applies(), Execute() if so.
 	runStartupPass := func(onDiskCLIVersion string) {
 		mctx := &migration.Context{Data: &automa.SyncStateBag{}}
 		mctx.Data.Set(migration.CtxKeyInstalledCLIVersion, migration.ResolveInstalledCLIVersion(onDiskCLIVersion))
@@ -54,15 +45,13 @@ func TestStartupPersist_AgentRestartRunsOnceAcrossRuns(t *testing.T) {
 		}
 	}
 
-	// Run 1 — pre-state-tracking host: no state.yaml → "" → 0.0.0 baseline → the
-	// boundary applies → the agents are restarted. RunStartupMigrations then
-	// persists currentCLIVersion.
+	// Run 1 — no state.yaml → "" → 0.0.0 baseline → boundary applies → restart.
+	// RunStartupMigrations then persists currentCLIVersion.
 	runStartupPass("")
 	assert.Equal(t, 1, restarts, "first run on a pre-state-tracking host restarts the agents once")
 
-	// Run 2 — the recorded version is read back: the boundary no longer applies,
-	// so Execute() (and the restart) is skipped. Without the persisted version the
-	// on-disk value would still be "" and this would restart the agents again.
+	// Run 2 — the recorded version is read back: boundary no longer applies, so the
+	// restart is skipped. Without the persist it would still be "" and restart again.
 	runStartupPass(currentCLIVersion)
 	assert.Equal(t, 1, restarts, "second run must not restart the agents again")
 }

--- a/internal/workflows/migration_startup_persist_test.go
+++ b/internal/workflows/migration_startup_persist_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package workflows
+
+import (
+	"context"
+	"testing"
+
+	"github.com/automa-saga/automa"
+	"github.com/hashgraph/solo-weaver/internal/migration"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartupPersist_AgentRestartRunsOnceAcrossRuns is the end-to-end proof for
+// #789/#781: it drives the REAL, non-idempotent CiliumAgentRestartMigration the
+// way RunStartupMigrations does, across two invocations, and shows the disruptive
+// agent restart fires exactly once — because the first run records the CLI
+// version, so the second run no longer crosses the boundary.
+//
+// Runs under `task vm:test:unit` (the workflows package is Linux-only).
+func TestStartupPersist_AgentRestartRunsOnceAcrossRuns(t *testing.T) {
+	origK8s, origRead, origRestart := kubernetesInstalled, readCiliumState, restartCiliumAgents
+	t.Cleanup(func() {
+		kubernetesInstalled, readCiliumState, restartCiliumAgents = origK8s, origRead, origRestart
+	})
+
+	// A provisioned cluster whose acceleration is already "disabled": the restart
+	// migration's Execute() has no "already restarted" guard, so it WILL restart
+	// the agents every time it is allowed to run. The version gate is the only
+	// thing that stops repeated restarts.
+	kubernetesInstalled = func() bool { return true }
+	readCiliumState = func(_ context.Context) (bool, string, error) {
+		return true, disabledAcceleration, nil
+	}
+	restarts := 0
+	restartCiliumAgents = func(_ context.Context) error { restarts++; return nil }
+
+	const currentCLIVersion = "0.21.0" // >= the 0.19.2 restart boundary
+
+	m := NewCiliumAgentRestartMigration()
+
+	// runStartupPass mirrors RunStartupMigrations for one invocation: resolve the
+	// on-disk version, evaluate Applies(), and Execute() only if it applies.
+	runStartupPass := func(onDiskCLIVersion string) {
+		mctx := &migration.Context{Data: &automa.SyncStateBag{}}
+		mctx.Data.Set(migration.CtxKeyInstalledCLIVersion, migration.ResolveInstalledCLIVersion(onDiskCLIVersion))
+		mctx.Data.Set(migration.CtxKeyCurrentCLIVersion, currentCLIVersion)
+
+		applies, err := m.Applies(mctx)
+		require.NoError(t, err)
+		if applies {
+			require.NoError(t, m.Execute(context.Background(), mctx))
+		}
+	}
+
+	// Run 1 — pre-state-tracking host: no state.yaml → "" → 0.0.0 baseline → the
+	// boundary applies → the agents are restarted. RunStartupMigrations then
+	// persists currentCLIVersion.
+	runStartupPass("")
+	assert.Equal(t, 1, restarts, "first run on a pre-state-tracking host restarts the agents once")
+
+	// Run 2 — the recorded version is read back: the boundary no longer applies,
+	// so Execute() (and the restart) is skipped. Without the persisted version the
+	// on-disk value would still be "" and this would restart the agents again.
+	runStartupPass(currentCLIVersion)
+	assert.Equal(t, 1, restarts, "second run must not restart the agents again")
+}

--- a/internal/workflows/steps/step_provisioner_version.go
+++ b/internal/workflows/steps/step_provisioner_version.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/state"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+)
+
+// persistProvisionerVersion records the running CLI version to the on-disk state
+// file. A var so tests can stub it to exercise the step's best-effort swallow
+// without a writable state dir.
+var persistProvisionerVersion = state.PersistProvisionerVersion
+
+// RecordProvisionerVersion persists the running CLI version to state.yaml at the
+// end of cluster install. `kube cluster install` does not flush state via the
+// BaseHandler path (unlike `block node install`), so without this a fresh cluster
+// has no state.yaml and the next invocation synthesises the 0.0.0 baseline and
+// re-runs historical migrations.
+func RecordProvisionerVersion() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId("record-provisioner-version").
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if err := persistProvisionerVersion(); err != nil {
+				logx.As().Warn().Err(err).
+					Msg("Failed to record provisioner version after cluster install; " +
+						"startup migrations may re-evaluate historical boundaries on the next invocation")
+			}
+			return automa.StepSuccessReport(stp.Id())
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Recording provisioner version")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to record provisioner version")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Provisioner version recorded")
+		})
+}

--- a/internal/workflows/steps/step_provisioner_version_test.go
+++ b/internal/workflows/steps/step_provisioner_version_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/automa-saga/version"
+	"github.com/hashgraph/solo-weaver/internal/state"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// the cluster install tail step writes a state.yaml whose provisioner.version is
+// the running binary's version, which the next invocation's reader then observes
+// instead of synthesising the 0.0.0 baseline.
+func TestRecordProvisionerVersion_WritesStateFile(t *testing.T) {
+	home := t.TempDir()
+	t.Cleanup(models.SetPaths(home))
+	// A provisioned host has the state dir (created at install) but no state.yaml.
+	require.NoError(t, os.MkdirAll(models.Paths().StateDir, 0o755))
+
+	stateFile := filepath.Join(models.Paths().StateDir, state.StateFileName)
+	_, statErr := os.Stat(stateFile)
+	require.True(t, os.IsNotExist(statErr), "precondition: state file must not exist yet")
+
+	step, err := RecordProvisionerVersion().Build()
+	require.NoError(t, err)
+	report := step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error, "step must succeed")
+
+	_, statErr = os.Stat(stateFile)
+	require.NoError(t, statErr, "state file should now exist")
+
+	recorded, err := state.ReadProvisionerVersionFromDisk()
+	require.NoError(t, err)
+	assert.Equal(t, version.Get().Version, recorded,
+		"the reader must observe the version the step persisted")
+}
+
+// TestRecordProvisionerVersion_PersistFailureIsNonFatal: recording the version is
+// best-effort — a failure is logged, not fatal. The cluster install must not fail
+// just because state.yaml could not be written. Regression guard: returning the
+// error here (instead of swallowing it) would abort `kube cluster install`.
+func TestRecordProvisionerVersion_PersistFailureIsNonFatal(t *testing.T) {
+	origPersist := persistProvisionerVersion
+	t.Cleanup(func() { persistProvisionerVersion = origPersist })
+	persistCalled := 0
+	persistProvisionerVersion = func(_ ...state.ManagerOption) error {
+		persistCalled++
+		return errors.New("simulated persist failure")
+	}
+
+	step, err := RecordProvisionerVersion().Build()
+	require.NoError(t, err)
+
+	report := step.Execute(context.Background())
+	require.NotNil(t, report)
+	require.NoError(t, report.Error, "a failed version record must not fail the step")
+	assert.Equal(t, 1, persistCalled, "the version record must have been attempted")
+}

--- a/pkg/models/paths.go
+++ b/pkg/models/paths.go
@@ -27,3 +27,16 @@ var (
 func Paths() WeaverPaths {
 	return *pp
 }
+
+// SetPaths re-roots the process-wide Weaver paths at the given home directory and
+// returns a function that restores the previous paths. It exists so tests can
+// redirect path lookups that are hard-wired to Paths() (e.g. the state-file
+// readers in internal/state) at a temporary directory. Not for production use.
+//
+//	restore := models.SetPaths(t.TempDir())
+//	defer restore()
+func SetPaths(home string) func() {
+	prev := pp
+	pp = NewWeaverPaths(home)
+	return func() { pp = prev }
+}


### PR DESCRIPTION
## Description

This pull request changes the following:

- Treat an absent state.yaml (empty on-disk CLI version) as the 0.0.0 baseline in RunStartupMigrations, so pending version-boundary startup migrations run on existing clusters instead of being silently skipped as a fresh install.
- Persist the running CLI version to state.yaml after the startup-migration pass — gated on a version change and a provisioned host (KubernetesInstalled()), and recorded regardless of whether a migration applied — so boundary migrations (notably the non-idempotent Cilium agent restart) don't re-run on every subsequent invocation.
- Add a RecordProvisionerVersion step at the end of kube cluster install so freshly provisioned clusters write a state.yaml with the current version, instead of relying on the 0.0.0 fallback.
- Add state.PersistProvisionerVersion (Refresh-then-flush, preserving existing state) and models.SetPaths test helper; keep version recording best-effort (warn, never fail startup).

### Related Issues

- Closes #789
- Closes #790