### PR TITLE
feat(network): reject overlapping specific policies and tiebreak tier order by created_at (#772)

### DIFF
--- a/internal/network/policy/manager.go
+++ b/internal/network/policy/manager.go
@@ -127,6 +127,14 @@ func (m *Manager) Create(ctx context.Context, p *Policy, cidrs []string, podCIDR
 			}
 		}
 
+		// Reject a specific --stamp policy that would share its
+		// (Direction, Ports) group with another already-registered
+		// specific policy -- checked up front, for both the
+		// create-if-missing and --force paths.
+		if err := checkNoOverlap(policies, p); err != nil {
+			return err
+		}
+
 		existing := findByName(policies, p.Name)
 		target, newCIDRs := p, cidrs
 		if existing != nil && !force {

--- a/internal/network/policy/policy.go
+++ b/internal/network/policy/policy.go
@@ -4,6 +4,7 @@ package policy
 
 import (
 	"net"
+	"sort"
 	"strings"
 	"time"
 
@@ -217,4 +218,57 @@ func setElements(p *Policy, cidrs []string) []string {
 // clause.
 func portElements(ports []string) string {
 	return strings.Join(ports, ", ")
+}
+
+// isSpecific reports whether p is a "specific" stamp policy for tier-3/4
+// grouping and overlap purposes: an --stamp policy that is not --from-entity
+// world (i.e. one that renders an IP-set clause). Deny policies and
+// fallthrough stamp policies are never "specific".
+func isSpecific(p *Policy) bool {
+	return p.Action == ActionStamp && !p.FromEntityWorld
+}
+
+// portsKey returns a canonical, order-insensitive key for a --ports value, so
+// two policies naming the same ports in a different flag order still compare
+// equal for grouping/overlap purposes.
+func portsKey(ports []string) string {
+	sorted := append([]string(nil), ports...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ",")
+}
+
+// groupKey returns the (Direction, Ports) grouping key used both by
+// renderChain's tier-3/4 ordering and by the overlap check below.
+func groupKey(p *Policy) string {
+	return string(p.Direction) + "|" + portsKey(p.Ports)
+}
+
+// checkNoOverlap rejects candidate if it is a "specific" stamp policy that
+// shares its (Direction, Ports) group with another existing specific policy.
+// Two specific policies claiming the same traffic would have an ambiguous
+// classification outcome, since set membership -- and therefore which
+// policy's CIDR actually matches a given packet -- can change independently
+// after create via the daemon/element verbs (Add/Remove/Set), so the check
+// is on the group key alone, not on the initial --cidrs values. Fallthrough
+// (--from-entity world) policies are exempt: they intentionally match
+// anything, and creation order (see renderChain) already gives them a
+// deterministic position.
+//
+// existing entries matching candidate.Name are skipped so a --force
+// re-create of the same policy never self-rejects.
+func checkNoOverlap(existing []*Policy, candidate *Policy) error {
+	if !isSpecific(candidate) {
+		return nil
+	}
+	for _, p := range existing {
+		if p.Name == candidate.Name {
+			continue
+		}
+		if isSpecific(p) && groupKey(p) == groupKey(candidate) {
+			return errorx.IllegalArgument.New(
+				"policy %q overlaps with existing policy %q: both are specific --stamp policies for direction=%s ports=%v",
+				candidate.Name, p.Name, candidate.Direction, candidate.Ports)
+		}
+	}
+	return nil
 }

--- a/internal/network/policy/policy_test.go
+++ b/internal/network/policy/policy_test.go
@@ -193,6 +193,28 @@ func TestRender_WorkedExamples(t *testing.T) {
 	require.Contains(t, doc, "set bn-backfill { type ipv4_addr . inet_service; }")
 }
 
+func TestRender_CreatedAtTiebreakWithinDirPortsGroup(t *testing.T) {
+	older := fixedTime()
+	newer := older.Add(time.Hour)
+
+	// Both policies are egress fallthrough with the same --ports, so they
+	// land in the same tier-4 group. Name order ("aaa" < "zzz") disagrees
+	// with CreatedAt order here on purpose, so the assertion below can only
+	// pass if renderChain is ordering by CreatedAt, not by name.
+	policies := []*Policy{
+		{Name: "aaa-newer", Action: ActionStamp, Stamp: "public", Direction: DirectionEgress, FromEntityWorld: true, Ports: []string{"9000"}, CreatedAt: newer},
+		{Name: "zzz-older", Action: ActionStamp, Stamp: "reserve-egress", Direction: DirectionEgress, FromEntityWorld: true, Ports: []string{"9000"}, CreatedAt: older},
+	}
+	doc, err := Render(policies, "10.4.0.0/24")
+	require.NoError(t, err)
+
+	zzzIdx := strings.Index(doc, "@zzz-older_ports")
+	aaaIdx := strings.Index(doc, "@aaa-newer_ports")
+	require.NotEqual(t, -1, zzzIdx, "zzz-older's rule must be present")
+	require.NotEqual(t, -1, aaaIdx, "aaa-newer's rule must be present")
+	require.Less(t, zzzIdx, aaaIdx, "the older policy must render first despite sorting after the newer one by name")
+}
+
 func TestRender_RequiresPodCIDR(t *testing.T) {
 	_, err := Render(sampleBNPolicies(), "")
 	require.Error(t, err)
@@ -437,6 +459,58 @@ func TestCreate_CorruptSiblingRegistryRejected(t *testing.T) {
 	_, err := m.Create(context.Background(), &Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}}, nil, "10.4.0.0/24", false)
 	require.ErrorContains(t, err, "corrupt policy registry entry")
 	require.Empty(t, r.applied, "a corrupt sibling entry must fail before the kernel is touched")
+}
+
+func TestCreate_OverlappingSpecificPoliciesRejected(t *testing.T) {
+	r := newFakeRunner()
+	m, _, regDir := newTestManager(t, r)
+
+	// publisher and reserve-ingress are both DirectionIngress; same --ports
+	// makes the two policies claim the same (Direction, Ports) group.
+	a := &Policy{Name: "bn-a", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}}
+	changed, err := m.Create(context.Background(), a, []string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+	require.True(t, changed)
+	firstApplyCount := r.applyCount
+
+	b := &Policy{Name: "bn-b", Action: ActionStamp, Stamp: "reserve-ingress", Ports: []string{"40840"}}
+	_, err = m.Create(context.Background(), b, []string{"10.1.0.2/32"}, "10.4.0.0/24", false)
+	require.ErrorContains(t, err, "overlaps with existing policy")
+
+	require.Equal(t, firstApplyCount, r.applyCount, "a rejected overlap must never reach the kernel")
+	require.NoFileExists(t, filepath.Join(regDir, "bn-b.json"))
+}
+
+func TestCreate_OverlapCheckExcludesSelfOnForce(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	a := &Policy{Name: "bn-a", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}}
+	_, err := m.Create(context.Background(), a, []string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+	require.NoError(t, err)
+
+	// Re-creating the SAME name with --force must not trip the overlap check
+	// against its own prior registry entry.
+	changed, err := m.Create(context.Background(), a, []string{"10.1.0.2/32"}, "10.4.0.0/24", true)
+	require.NoError(t, err)
+	require.True(t, changed)
+}
+
+func TestCreate_FromEntityWorldNotSubjectToOverlapCheck(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+
+	a := &Policy{Name: "bn-a", Action: ActionStamp, Stamp: "public", FromEntityWorld: true, Ports: []string{"9000"}}
+	_, err := m.Create(context.Background(), a, nil, "10.4.0.0/24", false)
+	require.NoError(t, err)
+
+	b := &Policy{Name: "bn-b", Action: ActionStamp, Stamp: "reserve-egress", FromEntityWorld: true, Ports: []string{"9000"}}
+	changed, err := m.Create(context.Background(), b, nil, "10.4.0.0/24", false)
+	require.NoError(t, err, "fallthrough policies sharing direction+ports are not overlap-checked")
+	require.True(t, changed)
+
+	require.Contains(t, r.applied, "@bn-a_ports")
+	require.Contains(t, r.applied, "@bn-b_ports")
 }
 
 func TestRegistry_RoundTrip(t *testing.T) {

--- a/internal/network/policy/render.go
+++ b/internal/network/policy/render.go
@@ -154,21 +154,40 @@ func renderChain(policies []*Policy, podCIDR string) ([]string, error) {
 		lines = append(lines, restore...)
 	}
 
-	// Tiers 3 and 4: stamp classification, specific before fallthrough.
-	var specific, fallthr []string
+	// Tiers 3 and 4: stamp classification, specific before fallthrough. Within
+	// each tier, policies are grouped by (Direction, Ports) and ordered by
+	// CreatedAt within a group -- a stable tiebreaker for the cases that can
+	// still share a group (fallthrough policies, which the overlap check in
+	// Manager.Create doesn't apply to; or specific policies loaded from
+	// registry data written before that check existed).
+	var specificPolicies, fallthrPolicies []*Policy
 	for _, p := range policies {
 		if p.Action != ActionStamp {
 			continue
 		}
+		if p.FromEntityWorld {
+			fallthrPolicies = append(fallthrPolicies, p)
+		} else {
+			specificPolicies = append(specificPolicies, p)
+		}
+	}
+	specificPolicies = orderByGroupThenCreatedAt(specificPolicies)
+	fallthrPolicies = orderByGroupThenCreatedAt(fallthrPolicies)
+
+	var specific, fallthr []string
+	for _, p := range specificPolicies {
 		rule, err := renderStampRule(p, podCIDR)
 		if err != nil {
 			return nil, err
 		}
-		if p.FromEntityWorld {
-			fallthr = append(fallthr, rule)
-		} else {
-			specific = append(specific, rule)
+		specific = append(specific, rule)
+	}
+	for _, p := range fallthrPolicies {
+		rule, err := renderStampRule(p, podCIDR)
+		if err != nil {
+			return nil, err
 		}
+		fallthr = append(fallthr, rule)
 	}
 	if len(specific) > 0 {
 		lines = append(lines, "", "\t\t# Classification — specific matches.")
@@ -183,6 +202,40 @@ func renderChain(policies []*Policy, podCIDR string) ([]string, error) {
 		"\t\tct state established,related accept",
 		"\t\tdrop")
 	return lines, nil
+}
+
+// orderByGroupThenCreatedAt returns policies reordered so that members of the
+// same (Direction, Ports) group (see groupKey) are contiguous and sorted by
+// CreatedAt ascending, while groups themselves keep the relative order of
+// their first member in the input. The per-group sort is stable, so policies
+// with equal CreatedAt (e.g. an unpopulated field in older test fixtures)
+// retain their input order rather than being shuffled.
+func orderByGroupThenCreatedAt(policies []*Policy) []*Policy {
+	type group struct {
+		key     string
+		members []*Policy
+	}
+	var groups []*group
+	byKey := make(map[string]*group, len(policies))
+	for _, p := range policies {
+		k := groupKey(p)
+		g, ok := byKey[k]
+		if !ok {
+			g = &group{key: k}
+			byKey[k] = g
+			groups = append(groups, g)
+		}
+		g.members = append(g.members, p)
+	}
+
+	out := make([]*Policy, 0, len(policies))
+	for _, g := range groups {
+		sort.SliceStable(g.members, func(i, j int) bool {
+			return g.members[i].CreatedAt.Before(g.members[j].CreatedAt)
+		})
+		out = append(out, g.members...)
+	}
+	return out
 }
 
 // renderReplyRestoreRule renders the ingress restore rule for a --reply-stamp


### PR DESCRIPTION
## Description

Story 1.5 of epic TS_1 (#738) — "Policy registry and tier-order chain re-render." Most of the acceptance criteria already shipped as part of Story 1.2 (`network policy create`, PR #803): the JSON registry at `/etc/solo-provisioner/policies/<name>.json`, the atomic full-chain re-render of `inet weaver` in tier order (deny → reply-restore → stamp-specific → stamp-fallthrough → est/rel → drop) applied via `nft -f`, and the daemon poll loop never writing the registry. This PR closes the two acceptance criteria that weren't yet implemented:

- **Overlap rejection** — `network policy create` now rejects a "specific" `--stamp` policy (one that is not `--from-entity world`) that shares its `(Direction, Ports)` with another already-registered specific policy. Two such policies would have an ambiguous classification outcome, since set membership can diverge independently after create via the daemon/element verbs (Story 1.3), so the check is on the group key alone, not the initial `--cidrs` values.
- **`created_at` tiebreak** — within tiers 3/4, rules for policies that share a `(Direction, Ports)` group now render in creation order (`CreatedAt` ascending) instead of falling back to alphabetical-by-name order.

Fallthrough (`--from-entity world`) policies are exempt from the overlap check by design — they intentionally match anything, and the `created_at` tiebreak already gives them a deterministic position.

### Files changed

| File | Change |
|---|---|
| `internal/network/policy/policy.go` | Add `isSpecific`, `portsKey`, `groupKey`, `checkNoOverlap` helpers |
| `internal/network/policy/manager.go` | Wire `checkNoOverlap` into `Manager.Create`, before any render/kernel/disk mutation |
| `internal/network/policy/render.go` | `renderChain`'s tier-3/4 loop groups by `(Direction, Ports)` and stably sorts each group by `CreatedAt` via new `orderByGroupThenCreatedAt` |
| `internal/network/policy/policy_test.go` | New tests: overlap rejection, self-exclusion on `--force`, fallthrough exemption, `created_at` tiebreak |

### Review guide

**Code review checklist**

- `checkNoOverlap` only fires for `Action == ActionStamp && !FromEntityWorld` pairs — a `--deny` policy or a `--from-entity world` policy sharing the same direction+ports as another policy is never rejected.
- `checkNoOverlap` skips the registry entry whose `Name` matches the candidate, so a `--force` re-create of the same policy never self-rejects.
- `portsKey` sorts a copy of `--ports` before joining, so port order in the flag doesn't affect either overlap detection or tier grouping.
- `orderByGroupThenCreatedAt`'s per-group sort is `sort.SliceStable` — verified against the existing golden fixture (`TestRender_GoldenMatchesBNInstallSet`): none of its specific policies share a `(Direction, Ports)` tuple today, so the new grouping is a no-op there and the test passes unmodified.
- The overlap-rejection error uses `errorx.IllegalArgument` (operator-actionable — rename or adjust one of the two conflicting policies).
- `checkNoOverlap` runs before `snapshotMembership`/`Render`/`Apply` in `Manager.Create` — a rejected overlap never touches the kernel or the registry file.

**Test commands**

```bash
# Unit tests (macOS OK — no Linux-only deps in internal/network/policy)
go test -race -cover -tags='!integration' ./internal/network/policy/...

# Just the new/changed tests
go test ./internal/network/policy/... -run 'TestCreate_Overlap|TestCreate_FromEntityWorldNotSubjectToOverlapCheck|TestRender_CreatedAtTiebreak' -v

# Lint
task lint:check
```

**Manual UAT** (Linux box/VM with `nft` and an existing `inet weaver` table)

1. Create two specific policies with the same direction+ports:
   ```bash
   solo-provisioner network policy create --name test-a --stamp publisher --ports 40840 --cidrs 10.1.0.1/32
   solo-provisioner network policy create --name test-b --stamp reserve-ingress --ports 40840 --cidrs 10.1.0.2/32
   ```
   Expected: the second command fails with `policy "test-b" overlaps with existing policy "test-a": both are specific --stamp policies for direction=ingress ports=[40840]`; `nft list table inet weaver` shows no `test-b` set.

2. Create two fallthrough policies with the same direction+ports (should succeed):
   ```bash
   solo-provisioner network policy create --name test-c --stamp public --from-entity world --ports 9000
   solo-provisioner network policy create --name test-d --stamp reserve-egress --from-entity world --ports 9000
   ```
   Expected: both succeed; `cat /etc/solo-provisioner/network-weaver.nft` shows `test-c`'s rule before `test-d`'s in the fallthrough block.

**Risks / rollback**

- The overlap check is scoped narrowly (`Action == ActionStamp && !FromEntityWorld`); if a legitimate use case surfaces that it wrongly blocks, it can be relaxed in `checkNoOverlap`/`isSpecific` without touching `renderChain` or the `Manager.Create` call site.
- The tier-3/4 grouping change and the overlap check are independent and can be reverted separately.
- No registry file format change — existing registry JSON parses unchanged; the tiebreak only affects in-memory render ordering.

### Related Issues

* Closes #772
