### PR TITLE
feat(blocknode): add block node reconcile-shaper worker

### DIFF
--- a/cmd/cli/commands/block/node/node.go
+++ b/cmd/cli/commands/block/node/node.go
@@ -99,7 +99,7 @@ func init() {
 	// LoadBalancer / MetalLB annotation flag
 	common.FlagLoadBalancerEnabled().SetVarP(nodeCmd, &flagLoadBalancerEnabled, false)
 
-	nodeCmd.AddCommand(checkCmd, installCmd, upgradeCmd, reconfigureCmd, resetCmd, uninstallCmd)
+	nodeCmd.AddCommand(checkCmd, installCmd, upgradeCmd, reconfigureCmd, resetCmd, uninstallCmd, reconcileShaperCmd)
 }
 
 func GetCmd() *cobra.Command {

--- a/cmd/cli/commands/block/node/reconcile_shaper.go
+++ b/cmd/cli/commands/block/node/reconcile_shaper.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package node
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/internal/blocknode/shaper"
+)
+
+var (
+	flagStatuszURL   string
+	flagReconcileDry bool
+
+	reconcileShaperCmd = &cobra.Command{
+		Use:   "reconcile-shaper",
+		Short: "Reconcile the block node traffic-shaper's nft policy membership from statusz",
+		Long: "Fetch the block node's statusz inbound/outbound active endpoints, map them to the " +
+			"traffic-shaper's nft policy sets, and reconcile live set membership.\n\n" +
+			"With --check (unprivileged) it only fetches and prints a digest of the desired membership " +
+			"and touches no nft state. Without --check (root; the daemon invokes it via sudo) it reads " +
+			"the live nft sets, diffs, and rewrites only the policies whose membership changed.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if flagStatuszURL == "" {
+				return errorx.IllegalArgument.New("--statusz-url is required")
+			}
+
+			r := shaper.NewReconciler(flagStatuszURL)
+
+			if flagReconcileDry {
+				return runReconcileCheck(cmd, r)
+			}
+			return runReconcileApply(cmd, r)
+		},
+	}
+)
+
+// runReconcileCheck runs the unprivileged detect path: fetch statusz, digest the
+// desired membership, and print it.
+func runReconcileCheck(cmd *cobra.Command, r *shaper.Reconciler) error {
+	result, err := r.Check(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	if common.OutputIsJSON() {
+		out, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return errorx.InternalError.Wrap(err, "marshal reconcile-shaper check result")
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "desired-digest: %s\n", result.Digest)
+	return nil
+}
+
+// runReconcileApply runs the privileged apply path: fetch statusz, diff against
+// live nft, rewrite changed policies, and print the summary.
+func runReconcileApply(cmd *cobra.Command, r *shaper.Reconciler) error {
+	result, err := r.Apply(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	if common.OutputIsJSON() {
+		out, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return errorx.InternalError.Wrap(err, "marshal reconcile-shaper result")
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "applied:   %s\n", joinOrNone(result.Applied))
+		fmt.Fprintf(cmd.OutOrStdout(), "skipped:   %s\n", joinOrNone(result.Skipped))
+		fmt.Fprintf(cmd.OutOrStdout(), "unchanged: %s\n", joinOrNone(result.Unchanged))
+		fmt.Fprintf(cmd.OutOrStdout(), "digest:    %s\n", result.Digest)
+	}
+
+	logx.As().Info().
+		Strs("applied", result.Applied).
+		Strs("skipped", result.Skipped).
+		Strs("unchanged", result.Unchanged).
+		Str("digest", result.Digest).
+		Msg("block node traffic-shaper membership reconciled")
+	return nil
+}
+
+// joinOrNone renders a policy-name list for text output, using "(none)" for an
+// empty list so the operator sees an explicit result rather than a blank line.
+func joinOrNone(names []string) string {
+	if len(names) == 0 {
+		return "(none)"
+	}
+	out := names[0]
+	for _, n := range names[1:] {
+		out += ", " + n
+	}
+	return out
+}
+
+func init() {
+	// This is a narrow worker subprocess (the daemon scheduler execs it, or an
+	// operator runs it by hand for debugging), not a provisioning command: it
+	// only talks to statusz and the already-provisioned nft sets, so it needs
+	// neither the weaver-installation check nor startup migrations. Both read
+	// root-owned state (see RunPersistentPreRun), which would otherwise defeat
+	// --check's whole point of running unprivileged. root.go's superuser gate
+	// still independently requires root for the apply path.
+	common.SkipGlobalChecks(reconcileShaperCmd)
+
+	reconcileShaperCmd.Flags().StringVar(&flagStatuszURL, "statusz-url", "",
+		"Base URL of the block node's statusz endpoints (required)")
+	reconcileShaperCmd.Flags().BoolVar(&flagReconcileDry, "check", false,
+		"Only fetch and print the desired-membership digest; read/write no nft state (unprivileged)")
+	_ = reconcileShaperCmd.MarkFlagRequired("statusz-url")
+}

--- a/cmd/cli/commands/block/node/reconcile_shaper_test.go
+++ b/cmd/cli/commands/block/node/reconcile_shaper_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package node
+
+import (
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReconcileShaperCmdSkipsGlobalChecks asserts that `block node
+// reconcile-shaper` opts out of the installation check and startup
+// migrations. Both read root-owned state (see common.RunPersistentPreRun),
+// which would defeat --check's entire point of running unprivileged; the
+// root.go superuser gate independently still requires root for the apply
+// path. Without this annotation, --check fails for a non-root caller with a
+// permission-denied reading /opt/solo/weaver/state/state.yaml rather than
+// ever reaching the reconcile logic.
+func TestReconcileShaperCmdSkipsGlobalChecks(t *testing.T) {
+	require.False(t, common.RequireGlobalChecks(reconcileShaperCmd),
+		"block node reconcile-shaper must opt out of global pre-run checks")
+}

--- a/cmd/cli/commands/root.go
+++ b/cmd/cli/commands/root.go
@@ -279,15 +279,24 @@ func initConfig(ctx context.Context) {
 }
 
 // isPrivilegeExemptInvocation reports whether args represents an invocation
-// that does not require superuser privileges (version output, help text).
+// that does not require superuser privileges: version output, help text, or
+// `block node reconcile-shaper --check`. The latter's entire design point (see
+// #893) is running unprivileged so the daemon scheduler can cheaply detect a
+// real change before ever escalating to sudo for the apply path.
 func isPrivilegeExemptInvocation(args []string) bool {
 	if len(args) == 0 {
 		return true
 	}
+	hasReconcileShaper, hasCheckTrue := false, false
 	for _, arg := range args {
 		switch arg {
 		case "--version", "-v", "--help", "-h":
 			return true
+		case "reconcile-shaper":
+			hasReconcileShaper = true
+		}
+		if isCheckTrueFlag(arg) {
+			hasCheckTrue = true
 		}
 	}
 	// Only the leading subcommand word can be exempt; flag values and nested
@@ -297,7 +306,27 @@ func isPrivilegeExemptInvocation(args []string) bool {
 		return true
 	}
 
-	return false
+	// "reconcile-shaper" is a fixed, unambiguous subcommand name, so pairing it
+	// with a --check flag that resolves true is a safe substitute for full
+	// argument parsing (which Execute() cannot do yet — this guard runs before
+	// Cobra initializes).
+	return hasReconcileShaper && hasCheckTrue
+}
+
+// isCheckTrueFlag reports whether arg is a spelling of --check that resolves
+// to true: the bare flag, or an explicit --check=<truthy> value. --check=false
+// (or any other falsy spelling) is deliberately not exempt, since that
+// invokes the privileged apply path.
+func isCheckTrueFlag(arg string) bool {
+	if arg == "--check" {
+		return true
+	}
+	val, ok := strings.CutPrefix(arg, "--check=")
+	if !ok {
+		return false
+	}
+	b, err := strconv.ParseBool(val)
+	return err == nil && b
 }
 
 func activateProxy(ctx context.Context) {

--- a/cmd/cli/commands/root_test.go
+++ b/cmd/cli/commands/root_test.go
@@ -22,6 +22,10 @@ func TestIsPrivilegeExemptInvocation(t *testing.T) {
 		{"help", "block"},
 		{"--non-interactive", "--help"},
 		{"--log-level", "debug", "-h"},
+		{"block", "node", "reconcile-shaper", "--check", "--statusz-url", "http://127.0.0.1:8080"},
+		{"block", "node", "reconcile-shaper", "--statusz-url=http://127.0.0.1:8080", "--check"},
+		{"block", "node", "reconcile-shaper", "--check=true", "--statusz-url", "http://127.0.0.1:8080"},
+		{"--log-level", "debug", "block", "node", "reconcile-shaper", "--check", "--statusz-url", "http://127.0.0.1:8080"},
 	}
 	for _, args := range exempt {
 		require.True(t, isPrivilegeExemptInvocation(args), "expected exempt: %v", args)
@@ -35,6 +39,8 @@ func TestIsPrivilegeExemptInvocation(t *testing.T) {
 		{"block", "node", "upgrade", "--profile=mainnet"},
 		{"teleport", "node", "install"},
 		{"alloy", "cluster", "install"},
+		{"block", "node", "reconcile-shaper", "--statusz-url", "http://127.0.0.1:8080"},
+		{"block", "node", "reconcile-shaper", "--check=false", "--statusz-url", "http://127.0.0.1:8080"},
 	}
 	for _, args := range notExempt {
 		require.False(t, isPrivilegeExemptInvocation(args), "expected not exempt: %v", args)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -361,6 +361,41 @@ sudo solo-provisioner block node uninstall \
 > targeted way to remove the block-node PVs without tearing down the whole
 > cluster via `kube cluster uninstall`.
 
+#### Reconcile Traffic Shaper
+
+Reconcile the block node traffic-shaper's `inet weaver` nft policy set membership
+from the block node's statusz endpoints. The command fetches the active
+inbound/outbound endpoints, maps them to the owned policy sets
+(`bn-publisher`, `bn-partner`, `bn-restricted`, `bn-backfill`), and applies only
+the policies whose membership changed.
+
+```bash
+# Detect only (unprivileged): print a digest of the desired membership; touches no nft state
+solo-provisioner block node reconcile-shaper \
+  --statusz-url=http://10.0.0.5:8080 \
+  --check
+
+# Apply (root): read live nft, diff, and rewrite the changed policies
+sudo solo-provisioner block node reconcile-shaper \
+  --statusz-url=http://10.0.0.5:8080
+
+# Machine-readable output
+sudo solo-provisioner block node reconcile-shaper \
+  --statusz-url=http://10.0.0.5:8080 \
+  --output=json
+```
+
+**Additional Flags**:
+
+| Flag             | Description                                                                          | Default |
+|------------------|--------------------------------------------------------------------------------------|---------|
+| `--statusz-url`  | Base URL of the block node's statusz endpoints (required)                            | —       |
+| `--check`        | Only fetch and print the desired-membership digest; read/write no nft state (unprivileged) | `false` |
+
+> **Privilege**: `--check` never touches nft and needs no privilege. The apply
+> path (no `--check`) reads and writes the live `inet weaver` sets and must run as
+> root; the daemon invokes it via sudo.
+
 ---
 
 ### Kubernetes Commands

--- a/internal/blocknode/shaper/policy_map.go
+++ b/internal/blocknode/shaper/policy_map.go
@@ -119,6 +119,31 @@ func computePolicyDeltas(ctx context.Context, lister elementLister, ce CategoryE
 	return deltas, nil
 }
 
+// canonicalDesiredMembership maps each owned category present in ce to its nft
+// policy name and the canonical, nft-rendered form of its desired membership:
+// compound "<ip> . <port>" tokens for peer_bn, /32-collapsed and numerically
+// ordered elements otherwise (via policy.CanonicalizeElements). This is exactly
+// the rendering computePolicyDeltas diffs against live nft state, so digesting
+// this form — rather than the raw statusz endpoints desiredMembership carries —
+// means the digest only changes when the actual applied membership would
+// change, regardless of how statusz happens to spell an equivalent host/CIDR
+// across polls.
+func canonicalDesiredMembership(ce CategoryEndpoints) (map[string][]string, error) {
+	m := make(map[string][]string, len(ce))
+	for cat, endpoints := range ce {
+		b, ok := categoryBindings[cat]
+		if !ok {
+			continue
+		}
+		elems, err := desiredElements(b, endpoints)
+		if err != nil {
+			return nil, err
+		}
+		m[b.policyName] = policy.CanonicalizeElements(elems)
+	}
+	return m, nil
+}
+
 // desiredElements converts a category's raw statusz endpoints into nft set
 // element tokens for its policy: compound "<ip> . <port>" keys for the peer_bn
 // category, plain elements otherwise. Canonicalization (ordering, /32 collapse)

--- a/internal/blocknode/shaper/policy_map.go
+++ b/internal/blocknode/shaper/policy_map.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package blocknode
+package shaper
 
 import (
 	"context"

--- a/internal/blocknode/shaper/policy_map_test.go
+++ b/internal/blocknode/shaper/policy_map_test.go
@@ -145,6 +145,26 @@ func TestComputePolicyDeltas_ComputesDeltas(t *testing.T) {
 	}, deltas)
 }
 
+func TestCanonicalDesiredMembership_MatchesDeltaRendering(t *testing.T) {
+	ce := CategoryEndpoints{
+		CategoryPublisher: {"10.1.0.2/32", "10.1.0.1/32"}, // /32 collapse + numeric order
+		CategoryPeerBN:    {"10.30.5.7:43473"},            // compound conversion
+		Category("mgmt"):  {"10.9.0.1"},                   // unmapped → dropped
+	}
+
+	m, err := canonicalDesiredMembership(ce)
+	require.NoError(t, err)
+	require.Equal(t, map[string][]string{
+		"bn-publisher": {"10.1.0.1", "10.1.0.2"},
+		"bn-backfill":  {"10.30.5.7 . 43473"},
+	}, m)
+}
+
+func TestCanonicalDesiredMembership_MalformedCompoundErrors(t *testing.T) {
+	_, err := canonicalDesiredMembership(CategoryEndpoints{CategoryPeerBN: {"not-an-ip-port"}})
+	require.Error(t, err)
+}
+
 // setDelta builds a policy.SetDelta so tests express expectations as an
 // (adds, deletes) pair.
 func setDelta(adds, deletes []string) policy.SetDelta {

--- a/internal/blocknode/shaper/policy_map_test.go
+++ b/internal/blocknode/shaper/policy_map_test.go
@@ -2,7 +2,7 @@
 
 //go:build !integration
 
-package blocknode
+package shaper
 
 import (
 	"context"
@@ -136,17 +136,9 @@ func TestComputePolicyDeltas_LiveReadErrorPropagates(t *testing.T) {
 	require.ErrorContains(t, err, "bn-publisher")
 }
 
-func TestReconcilePolicies_NilListerErrors(t *testing.T) {
-	m := &TrafficShaperMonitor{} // no lister injected
-	_, err := m.reconcilePolicies(context.Background(), CategoryEndpoints{CategoryPublisher: {"10.1.0.1/32"}})
-	require.Error(t, err)
-	require.ErrorContains(t, err, "live-set reader")
-}
-
-func TestReconcilePolicies_ComputesDeltas(t *testing.T) {
+func TestComputePolicyDeltas_ComputesDeltas(t *testing.T) {
 	l := newFakeLister()
-	m := &TrafficShaperMonitor{lister: l}
-	deltas, err := m.reconcilePolicies(context.Background(), CategoryEndpoints{CategoryPublisher: {"10.1.0.1/32"}})
+	deltas, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{CategoryPublisher: {"10.1.0.1/32"}})
 	require.NoError(t, err)
 	require.Equal(t, []PolicyDelta{
 		{Policy: "bn-publisher", SetDelta: setDelta([]string{"10.1.0.1"}, nil)},

--- a/internal/blocknode/shaper/reconciler.go
+++ b/internal/blocknode/shaper/reconciler.go
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shaper
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+
+	"github.com/hashgraph/solo-weaver/internal/network/policy"
+	"github.com/joomcode/errorx"
+)
+
+// endpointFetcher reads the block node's inbound/outbound active endpoints from
+// its statusz REST endpoints. Satisfied by *StatuszClient; a fake is injected in
+// tests so the reconcile logic can be exercised without a live BN.
+type endpointFetcher interface {
+	InboundClients(ctx context.Context) (NetworkData, error)
+	OutboundClients(ctx context.Context) (NetworkData, error)
+}
+
+// membershipApplier writes desired per-policy nft set membership to the kernel.
+// Satisfied by *policy.Manager; a fake is injected in tests. The bool return
+// distinguishes "applied" from "skipped because the operator apply lock was
+// held" (see policy.Manager.ApplyMembership).
+type membershipApplier interface {
+	ApplyMembership(ctx context.Context, desired map[string][]string) (bool, error)
+}
+
+// Reconciler drives one reconcile of the block node traffic-shaper's nft policy
+// set membership from statusz. It is the engine behind the
+// `block node reconcile-shaper` worker: Check derives the desired membership and
+// digests it (no privilege, no nft), while Apply additionally reads the live nft
+// sets, diffs, and writes only the changed policies (root).
+//
+// The three collaborators are seams so the orchestration is testable off-host:
+// fetcher reads statusz, lister reads live nft membership, applier writes it.
+type Reconciler struct {
+	fetcher endpointFetcher
+	lister  elementLister
+	applier membershipApplier
+}
+
+// NewReconciler wires the production Reconciler: statusz is read over HTTP from
+// statuszURL, live nft sets are read via the exec Runner, and membership is
+// written via the network policy Manager.
+func NewReconciler(statuszURL string) *Reconciler {
+	return &Reconciler{
+		fetcher: NewStatuszClient(statuszURL),
+		lister:  policy.NewExecRunner(),
+		applier: policy.NewManager(),
+	}
+}
+
+// Result summarizes one Apply: the owned policies whose live membership was
+// rewritten, those skipped because the operator apply lock was held (still out
+// of sync, not yet reconciled), those left unchanged (already in the desired
+// state), and the digest of the full desired membership (identical to what
+// Check reports for the same statusz snapshot).
+type Result struct {
+	Applied   []string `json:"applied"`
+	Skipped   []string `json:"skipped"`
+	Unchanged []string `json:"unchanged"`
+	Digest    string   `json:"digest"`
+}
+
+// CheckResult is the unprivileged detect path's output: the sha256 digest of
+// the desired policy membership, and the canonical desired membership itself
+// (policy name -> nft-rendered elements) so `--check --output json` is useful
+// for daemon-side introspection and debugging, not just change detection.
+type CheckResult struct {
+	Digest  string              `json:"desired-digest"`
+	Desired map[string][]string `json:"desired"`
+}
+
+// Check fetches both statusz endpoints, buckets them into the desired
+// per-category membership, and returns the sha256 digest of the canonical
+// desired policy membership alongside that canonical membership. It reads no
+// nft state and requires no privilege — it is the unprivileged detect path.
+func (r *Reconciler) Check(ctx context.Context) (CheckResult, error) {
+	ce, err := r.fetchEndpoints(ctx)
+	if err != nil {
+		return CheckResult{}, err
+	}
+	canon, err := canonicalDesiredMembership(ce)
+	if err != nil {
+		return CheckResult{}, err
+	}
+	return CheckResult{Digest: membershipDigest(canon), Desired: canon}, nil
+}
+
+// Apply fetches both statusz endpoints, buckets them into the desired
+// membership, reads the live nft sets to find which owned policies actually
+// changed, and rewrites only those. Policies already in the desired state are
+// not touched. The returned Result records the applied/unchanged split and the
+// desired-membership digest.
+func (r *Reconciler) Apply(ctx context.Context) (Result, error) {
+	ce, err := r.fetchEndpoints(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+	desired := desiredMembership(ce)
+	canon, err := canonicalDesiredMembership(ce)
+	if err != nil {
+		return Result{}, err
+	}
+	digest := membershipDigest(canon)
+
+	deltas, err := computePolicyDeltas(ctx, r.lister, ce)
+	if err != nil {
+		return Result{}, err
+	}
+
+	changed := make(map[string][]string, len(deltas))
+	changedNames := make([]string, 0, len(deltas))
+	for _, d := range deltas {
+		changed[d.Policy] = desired[d.Policy]
+		changedNames = append(changedNames, d.Policy)
+	}
+	sort.Strings(changedNames)
+
+	res := Result{Digest: digest, Unchanged: unchangedPolicyNames(changedNames)}
+	if len(changed) == 0 {
+		return res, nil
+	}
+
+	applied, err := r.applier.ApplyMembership(ctx, changed)
+	if err != nil {
+		return Result{}, errorx.ExternalError.Wrap(err, "apply reconciled traffic-shaper membership")
+	}
+	if applied {
+		res.Applied = changedNames
+	} else {
+		// The operator apply lock was held: nothing was written, so these
+		// policies are still out of sync — report them as skipped rather than
+		// silently dropping them from both Applied and Unchanged.
+		res.Skipped = changedNames
+	}
+	return res, nil
+}
+
+// fetchEndpoints reads both statusz endpoints and buckets them into the desired
+// per-category membership view.
+func (r *Reconciler) fetchEndpoints(ctx context.Context) (CategoryEndpoints, error) {
+	inbound, err := r.fetcher.InboundClients(ctx)
+	if err != nil {
+		return nil, err
+	}
+	outbound, err := r.fetcher.OutboundClients(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return bucketizeEndpoints(inbound, outbound), nil
+}
+
+// bucketizeEndpoints folds one statusz snapshot into the desired per-category
+// membership. Inbound categories (publisher/partner/restricted) contribute their
+// remote host/CIDR; the outbound peer_bn category contributes compound
+// "remote.Address:remote.Port" pairs, skipping any endpoint whose port is empty
+// or "*" (a wildcard port cannot key a compound set).
+//
+// Every owned category is seeded present with an empty slice, so a category the
+// BN no longer reports collapses to an empty membership that clears its set
+// rather than leaving stale members behind — each owned set is fully reconciled
+// every tick. Categories outside categoryBindings (e.g. the public category, or
+// operator-curated mgmt sets) are ignored.
+func bucketizeEndpoints(inbound, outbound NetworkData) CategoryEndpoints {
+	ce := make(CategoryEndpoints, len(categoryBindings))
+	for c := range categoryBindings {
+		ce[c] = []string{}
+	}
+
+	for _, conn := range inbound.ActiveEndpoints {
+		cat := Category(conn.Category)
+		b, ok := categoryBindings[cat]
+		if !ok || b.compound {
+			continue
+		}
+		ce[cat] = append(ce[cat], conn.Remote.Address)
+	}
+
+	for _, conn := range outbound.ActiveEndpoints {
+		cat := Category(conn.Category)
+		b, ok := categoryBindings[cat]
+		if !ok || !b.compound {
+			continue
+		}
+		if conn.Remote.Port == "" || conn.Remote.Port == "*" {
+			continue
+		}
+		ce[cat] = append(ce[cat], conn.Remote.Address+":"+conn.Remote.Port)
+	}
+
+	return ce
+}
+
+// desiredMembership maps each owned category present in ce to its nft policy
+// name, carrying the raw statusz endpoints through unchanged (the policy Manager
+// and the diff engine canonicalize them on the way to the kernel). Categories
+// with no policy binding are dropped.
+func desiredMembership(ce CategoryEndpoints) map[string][]string {
+	m := make(map[string][]string, len(ce))
+	for cat, endpoints := range ce {
+		b, ok := categoryBindings[cat]
+		if !ok {
+			continue
+		}
+		m[b.policyName] = endpoints
+	}
+	return m
+}
+
+// membershipDigest returns a sha256 hex digest over a canonical serialization of
+// the desired membership: policy names sorted, each membership list sorted and
+// de-duplicated, rendered as `name\n<comma-joined members>\n` per policy. The
+// digest depends only on the membership content, not on map iteration order or
+// endpoint spelling order, so an unchanged desired state always digests the same.
+func membershipDigest(m map[string][]string) string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	for _, name := range names {
+		b.WriteString(name)
+		b.WriteByte('\n')
+		b.WriteString(strings.Join(sortedUnique(m[name]), ","))
+		b.WriteByte('\n')
+	}
+
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+// sortedUnique returns the input sorted with duplicates removed. The input is not
+// mutated.
+func sortedUnique(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	cp := make([]string, len(in))
+	copy(cp, in)
+	sort.Strings(cp)
+	out := cp[:0]
+	var prev string
+	for i, s := range cp {
+		if i == 0 || s != prev {
+			out = append(out, s)
+		}
+		prev = s
+	}
+	return out
+}
+
+// ownedPolicyNames returns every nft policy name the traffic-shaper owns, sorted.
+func ownedPolicyNames() []string {
+	names := make([]string, 0, len(categoryBindings))
+	for _, b := range categoryBindings {
+		names = append(names, b.policyName)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// unchangedPolicyNames returns the owned policy names not present in changed,
+// sorted.
+func unchangedPolicyNames(changed []string) []string {
+	changedSet := make(map[string]struct{}, len(changed))
+	for _, c := range changed {
+		changedSet[c] = struct{}{}
+	}
+	var out []string
+	for _, name := range ownedPolicyNames() {
+		if _, ok := changedSet[name]; !ok {
+			out = append(out, name)
+		}
+	}
+	return out
+}

--- a/internal/blocknode/shaper/reconciler_test.go
+++ b/internal/blocknode/shaper/reconciler_test.go
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package shaper
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFetcher returns seeded statusz payloads and records how many times each
+// endpoint was read. A configured err is returned instead of the payload.
+type fakeFetcher struct {
+	inbound      NetworkData
+	outbound     NetworkData
+	inboundErr   error
+	outboundErr  error
+	inboundHits  int
+	outboundHits int
+}
+
+func (f *fakeFetcher) InboundClients(context.Context) (NetworkData, error) {
+	f.inboundHits++
+	if f.inboundErr != nil {
+		return NetworkData{}, f.inboundErr
+	}
+	return f.inbound, nil
+}
+
+func (f *fakeFetcher) OutboundClients(context.Context) (NetworkData, error) {
+	f.outboundHits++
+	if f.outboundErr != nil {
+		return NetworkData{}, f.outboundErr
+	}
+	return f.outbound, nil
+}
+
+// fakeApplier records the membership it was asked to apply and returns a
+// configurable (applied, err).
+type fakeApplier struct {
+	got     map[string][]string
+	applied bool
+	err     error
+	calls   int
+}
+
+func (a *fakeApplier) ApplyMembership(_ context.Context, desired map[string][]string) (bool, error) {
+	a.calls++
+	a.got = desired
+	if a.err != nil {
+		return false, a.err
+	}
+	return a.applied, nil
+}
+
+// conn is a small helper to build an inbound/outbound NetworkConnection.
+func conn(category, addr, port string) NetworkConnection {
+	return NetworkConnection{Remote: Endpoint{Address: addr, Port: port}, Category: category}
+}
+
+func TestMembershipDigest_Deterministic(t *testing.T) {
+	m := map[string][]string{
+		"bn-publisher": {"10.1.0.1", "10.1.0.2"},
+		"bn-partner":   {"10.2.0.1"},
+	}
+	require.Equal(t, membershipDigest(m), membershipDigest(m))
+}
+
+func TestMembershipDigest_OrderIndependent(t *testing.T) {
+	a := map[string][]string{
+		"bn-publisher": {"10.1.0.2", "10.1.0.1"},
+		"bn-partner":   {"10.2.0.1"},
+	}
+	b := map[string][]string{
+		"bn-partner":   {"10.2.0.1"},
+		"bn-publisher": {"10.1.0.1", "10.1.0.2"},
+	}
+	require.Equal(t, membershipDigest(a), membershipDigest(b))
+}
+
+func TestMembershipDigest_DedupesMembership(t *testing.T) {
+	withDup := map[string][]string{"bn-publisher": {"10.1.0.1", "10.1.0.1", "10.1.0.2"}}
+	noDup := map[string][]string{"bn-publisher": {"10.1.0.2", "10.1.0.1"}}
+	require.Equal(t, membershipDigest(noDup), membershipDigest(withDup))
+}
+
+func TestMembershipDigest_DistinguishesContent(t *testing.T) {
+	a := map[string][]string{"bn-publisher": {"10.1.0.1"}}
+	b := map[string][]string{"bn-publisher": {"10.1.0.2"}}
+	require.NotEqual(t, membershipDigest(a), membershipDigest(b))
+
+	// A present-but-empty set differs from an absent one.
+	empty := map[string][]string{"bn-publisher": {}}
+	absent := map[string][]string{}
+	require.NotEqual(t, membershipDigest(empty), membershipDigest(absent))
+}
+
+func TestBucketizeEndpoints_CategorizesAndSeedsAllOwned(t *testing.T) {
+	inbound := NetworkData{ActiveEndpoints: []NetworkConnection{
+		conn("publisher", "10.10.1.0/24", "*"),
+		conn("partner", "10.20.1.0/24", "*"),
+		conn("public", "0.0.0.0/0", "*"), // unmapped → skipped
+	}}
+	outbound := NetworkData{ActiveEndpoints: []NetworkConnection{
+		conn("peer_bn", "10.30.5.7", "43473"),
+	}}
+
+	ce := bucketizeEndpoints(inbound, outbound)
+
+	// All four owned categories present.
+	require.Len(t, ce, 4)
+	require.Contains(t, ce, CategoryPublisher)
+	require.Contains(t, ce, CategoryPartner)
+	require.Contains(t, ce, CategoryRestricted)
+	require.Contains(t, ce, CategoryPeerBN)
+
+	assert.Equal(t, []string{"10.10.1.0/24"}, ce[CategoryPublisher])
+	assert.Equal(t, []string{"10.20.1.0/24"}, ce[CategoryPartner])
+	// restricted reported nothing → present but empty (clears its set).
+	assert.Empty(t, ce[CategoryRestricted])
+	// peer_bn folds to a compound ip:port raw endpoint.
+	assert.Equal(t, []string{"10.30.5.7:43473"}, ce[CategoryPeerBN])
+
+	// The unmapped public category never appears.
+	require.NotContains(t, ce, Category("public"))
+}
+
+func TestBucketizeEndpoints_SkipsWildcardAndEmptyPeerPort(t *testing.T) {
+	outbound := NetworkData{ActiveEndpoints: []NetworkConnection{
+		conn("peer_bn", "10.30.5.7", "43473"), // kept
+		conn("peer_bn", "10.30.5.8", "*"),     // wildcard port → skipped
+		conn("peer_bn", "10.30.5.9", ""),      // empty port → skipped
+	}}
+
+	ce := bucketizeEndpoints(NetworkData{}, outbound)
+	assert.Equal(t, []string{"10.30.5.7:43473"}, ce[CategoryPeerBN])
+}
+
+func TestBucketizeEndpoints_EmptySnapshotSeedsAllOwnedEmpty(t *testing.T) {
+	ce := bucketizeEndpoints(NetworkData{}, NetworkData{})
+	require.Len(t, ce, 4)
+	for c := range categoryBindings {
+		assert.Empty(t, ce[c], "category %s should be present but empty", c)
+	}
+}
+
+func TestDesiredMembership_MapsOwnedCategoriesToPolicies(t *testing.T) {
+	ce := CategoryEndpoints{
+		CategoryPublisher: {"10.1.0.1"},
+		CategoryPeerBN:    {"10.30.5.7:43473"},
+		Category("mgmt"):  {"10.9.0.1"}, // unmapped → dropped
+	}
+	m := desiredMembership(ce)
+	require.Equal(t, map[string][]string{
+		"bn-publisher": {"10.1.0.1"},
+		"bn-backfill":  {"10.30.5.7:43473"},
+	}, m)
+}
+
+func TestReconciler_Check_DigestsDesired(t *testing.T) {
+	f := &fakeFetcher{
+		inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+			conn("publisher", "10.10.1.0/24", "*"),
+		}},
+		outbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+			conn("peer_bn", "10.30.5.7", "43473"),
+		}},
+	}
+	r := &Reconciler{fetcher: f}
+
+	result, err := r.Check(context.Background())
+	require.NoError(t, err)
+
+	// The digest is exactly the digest of the canonical desired membership
+	// derived from the same snapshot — no nft read/write happened (nil
+	// lister/applier untouched).
+	ce := bucketizeEndpoints(f.inbound, f.outbound)
+	wantCanon, err := canonicalDesiredMembership(ce)
+	require.NoError(t, err)
+	require.Equal(t, membershipDigest(wantCanon), result.Digest)
+	require.Equal(t, wantCanon, result.Desired)
+}
+
+func TestReconciler_Check_DigestIgnoresSpellingEquivalence(t *testing.T) {
+	// A /32-suffixed host and its bare-address spelling are canonically
+	// identical, and so are the two "compound" spellings statusz vs. the nft
+	// rendering would use — the digest must not distinguish them, since the
+	// actual applied membership would be identical either way.
+	bare := &fakeFetcher{inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+		conn("publisher", "10.1.0.1", "*"),
+	}}}
+	slash32 := &fakeFetcher{inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+		conn("publisher", "10.1.0.1/32", "*"),
+	}}}
+
+	rBare := &Reconciler{fetcher: bare}
+	rSlash32 := &Reconciler{fetcher: slash32}
+
+	resBare, err := rBare.Check(context.Background())
+	require.NoError(t, err)
+	resSlash32, err := rSlash32.Check(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, resBare.Digest, resSlash32.Digest)
+}
+
+func TestReconciler_Check_PropagatesFetchError(t *testing.T) {
+	r := &Reconciler{fetcher: &fakeFetcher{inboundErr: errors.New("statusz down")}}
+	_, err := r.Check(context.Background())
+	require.Error(t, err)
+}
+
+func TestReconciler_Apply_AppliesOnlyChangedPolicies(t *testing.T) {
+	f := &fakeFetcher{
+		inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+			conn("publisher", "10.1.0.1/32", "*"), // will change
+			conn("partner", "10.2.0.1/32", "*"),   // already live → unchanged
+		}},
+		outbound: NetworkData{},
+	}
+	lister := newFakeLister()
+	// bn-partner already matches desired; bn-publisher differs; bn-restricted and
+	// bn-backfill are seeded empty and live-empty → no change.
+	lister.elements["bn-partner"] = []string{"10.2.0.1"}
+	lister.elements["bn-publisher"] = []string{"10.9.9.9"}
+
+	applier := &fakeApplier{applied: true}
+	r := &Reconciler{fetcher: f, lister: lister, applier: applier}
+
+	res, err := r.Apply(context.Background())
+	require.NoError(t, err)
+
+	// Only bn-publisher changed; it is the only policy handed to the applier.
+	require.Equal(t, 1, applier.calls)
+	require.Equal(t, map[string][]string{"bn-publisher": {"10.1.0.1/32"}}, applier.got)
+
+	assert.Equal(t, []string{"bn-publisher"}, res.Applied)
+	// The other three owned policies are reported unchanged.
+	assert.Equal(t, []string{"bn-backfill", "bn-partner", "bn-restricted"}, res.Unchanged)
+	assert.NotEmpty(t, res.Digest)
+}
+
+func TestReconciler_Apply_NoChangesTakesNoApply(t *testing.T) {
+	f := &fakeFetcher{} // empty snapshot → all owned sets desired-empty
+	lister := newFakeLister()
+	applier := &fakeApplier{applied: true}
+	r := &Reconciler{fetcher: f, lister: lister, applier: applier}
+
+	res, err := r.Apply(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, applier.calls, "no deltas → applier must not be called")
+	assert.Empty(t, res.Applied)
+	assert.Equal(t, ownedPolicyNames(), res.Unchanged)
+}
+
+func TestReconciler_Apply_LockHeldReportsNothingApplied(t *testing.T) {
+	f := &fakeFetcher{inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+		conn("publisher", "10.1.0.1/32", "*"),
+	}}}
+	lister := newFakeLister()
+	lister.elements["bn-publisher"] = []string{"10.9.9.9"}
+	applier := &fakeApplier{applied: false} // operator lock held → skipped
+	r := &Reconciler{fetcher: f, lister: lister, applier: applier}
+
+	res, err := r.Apply(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, applier.calls)
+	assert.Empty(t, res.Applied, "lock held → nothing reported applied")
+	// The changed policy must not silently vanish from the result: it is
+	// reported skipped (still out of sync), not folded into unchanged.
+	assert.Equal(t, []string{"bn-publisher"}, res.Skipped)
+	assert.Equal(t, []string{"bn-backfill", "bn-partner", "bn-restricted"}, res.Unchanged)
+}
+
+func TestReconciler_Apply_PropagatesApplyError(t *testing.T) {
+	f := &fakeFetcher{inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+		conn("publisher", "10.1.0.1/32", "*"),
+	}}}
+	lister := newFakeLister()
+	lister.elements["bn-publisher"] = []string{"10.9.9.9"}
+	applier := &fakeApplier{err: errors.New("nft boom")}
+	r := &Reconciler{fetcher: f, lister: lister, applier: applier}
+
+	_, err := r.Apply(context.Background())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "nft boom")
+}

--- a/internal/blocknode/shaper/statusz_client.go
+++ b/internal/blocknode/shaper/statusz_client.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package blocknode
+package shaper
 
 import (
 	"context"

--- a/internal/blocknode/shaper/statusz_client_mock_test.go
+++ b/internal/blocknode/shaper/statusz_client_mock_test.go
@@ -2,14 +2,14 @@
 
 //go:build !integration
 
-package blocknode_test
+package shaper_test
 
 import (
 	"context"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hashgraph/solo-weaver/internal/daemon/blocknode"
+	"github.com/hashgraph/solo-weaver/internal/blocknode/shaper"
 	"github.com/hashgraph/solo-weaver/internal/daemon/blocknode/statuszmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,7 +33,7 @@ func TestStatuszClient_DecodesMockServer(t *testing.T) {
 	srv := httptest.NewServer(statuszmock.Handler(statuszmock.StaticRoster(roster)))
 	defer srv.Close()
 
-	client := blocknode.NewStatuszClient(srv.URL)
+	client := shaper.NewStatuszClient(srv.URL)
 
 	inbound, err := client.InboundClients(context.Background())
 	require.NoError(t, err)

--- a/internal/blocknode/shaper/statusz_client_test.go
+++ b/internal/blocknode/shaper/statusz_client_test.go
@@ -2,7 +2,7 @@
 
 //go:build !integration
 
-package blocknode
+package shaper
 
 import (
 	"context"

--- a/internal/daemon/blocknode/traffic_shaper_monitor.go
+++ b/internal/daemon/blocknode/traffic_shaper_monitor.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/daemon/privexec"
-	"github.com/hashgraph/solo-weaver/internal/network/policy"
-	"github.com/joomcode/errorx"
 )
 
 // Per-responsibility back-off bounds. A fault in one subsystem (pod watcher or
@@ -35,8 +33,10 @@ const responsibilityBackoffFactor = 2.0
 //
 //   - the pod-lifecycle watcher (resolves host-side veths and installs/rebinds
 //     ingress HTB qdiscs — implemented in #748/#749), and
-//   - the statusz poll loop (diffs statusz membership against live nft sets and
-//     applies deltas — implemented in #751/#752/#754/#755).
+//   - the statusz poll loop, which reconciles the nft policy membership from
+//     statusz. Its reconcile logic now lives in the `block node reconcile-shaper`
+//     CLI worker; the daemon-side scheduler that execs that worker is not yet
+//     wired, so this responsibility is currently an idle stub.
 //
 // Each responsibility is independently retried with exponential back-off so a
 // fault in one cannot stop the other or crash the daemon.
@@ -44,10 +44,6 @@ type TrafficShaperMonitor struct {
 	// resolver resolves the host-side veth name for a BN pod (story #747).
 	// Used by runPodWatcher once the real watch loop lands in #748.
 	resolver *VethResolver
-	// lister reads live nft set membership so the poll loop can diff desired
-	// statusz-derived membership against the kernel. Satisfied by the network
-	// policy Runner; a fake is injected in tests.
-	lister elementLister
 	// delegator runs privileged solo-provisioner subcommands under sudo. The
 	// daemon is unprivileged (User=weaver), so both responsibilities delegate
 	// their privileged work through it: the poll loop applies membership via
@@ -59,15 +55,13 @@ type TrafficShaperMonitor struct {
 
 // NewTrafficShaperMonitor constructs a TrafficShaperMonitor with the given
 // VethResolver. The resolver is wired into runPodWatcher by #748; it is held
-// here so #748 can use it without further constructor changes. The live-set
-// reader defaults to the network policy exec Runner, which reads the `inet
-// weaver` sets via `nft list set`. The delegator defaults to the sudo-backed
-// privileged-exec seam so the poll loop and watcher can perform their
-// privileged work without the unprivileged daemon holding root itself.
+// here so #748 can use it without further constructor changes. The delegator
+// defaults to the sudo-backed privileged-exec seam so the poll loop and watcher
+// can perform their privileged work without the unprivileged daemon holding
+// root itself.
 func NewTrafficShaperMonitor(resolver *VethResolver) *TrafficShaperMonitor {
 	return &TrafficShaperMonitor{
 		resolver:  resolver,
-		lister:    policy.NewExecRunner(),
 		delegator: privexec.New(),
 	}
 }
@@ -150,35 +144,17 @@ func (m *TrafficShaperMonitor) runPodWatcher(ctx context.Context) error {
 	return nil
 }
 
-// runStatuszPoll is the statusz poll-loop responsibility. The category→policy
-// diff engine is in place; the surrounding loop is not yet wired — statusz fetch
-// lands in #751, delta apply in #754, and bootstrap/outage policy in #755. It
-// exercises the diff seam once with an empty desired view so the plumbing (the
-// live-set reader and reconcilePolicies) is ready for #754 to drive from real
-// statusz data. An empty view maps to zero deltas and touches no set.
+// runStatuszPoll is the statusz poll-loop responsibility. The reconciliation
+// logic now lives in the `solo-provisioner block node reconcile-shaper` worker;
+// the daemon-side scheduler that execs it is not yet wired. Until then this is a
+// pure idle stub that blocks until ctx is cancelled and touches no set.
 func (m *TrafficShaperMonitor) runStatuszPoll(ctx context.Context) error {
-	deltas, err := m.reconcilePolicies(ctx, nil)
-	if err != nil {
-		return err
-	}
 	logx.As().Info().
 		Str("reason", "TrafficShaperStatuszPollStub").
 		Str("monitor", m.Name()).
-		Int("policy_deltas", len(deltas)).
-		Msg("statusz poll loop not yet wired — diff engine ready, awaiting statusz client")
+		Msg("statusz poll loop not yet wired — reconcile-shaper scheduler pending")
 	<-ctx.Done()
 	return nil
-}
-
-// reconcilePolicies computes the per-policy membership deltas between the desired
-// category endpoints and the live nft sets. It does NOT apply them — applying is
-// #754's responsibility. It is the seam the poll loop drives once the statusz
-// client (#751) supplies real endpoints.
-func (m *TrafficShaperMonitor) reconcilePolicies(ctx context.Context, ce CategoryEndpoints) ([]PolicyDelta, error) {
-	if m.lister == nil {
-		return nil, errorx.IllegalState.New("traffic-shaper monitor has no live-set reader")
-	}
-	return computePolicyDeltas(ctx, m.lister, ce)
 }
 
 // minDuration returns the smaller of a and b.


### PR DESCRIPTION
## Summary

Adds the `solo-provisioner block node reconcile-shaper` worker — the CLI subcommand that reconciles the BN traffic-shaper's nft policy set membership from statusz. It is the worker the daemon scheduler (#755) execs; isolating this logic in a short-lived subprocess keeps the long-lived daemon resilient (a reconcile-path panic dies with the subprocess) and statusz-schema-agnostic. Design: automa-saga/traffic-shaper#3.

Two commits:

1. **`refactor(daemon)`** — pure relocation (`git mv`) of the statusz REST client (#751) and the category→policy mapping/diff (#752) from `internal/daemon/blocknode` into a new `internal/blocknode/shaper` package, so the CLI can own statusz and the daemon stops importing it. The daemon's `runStatuszPoll` becomes an idle stub (the scheduler that drives the worker lands in #755).
2. **`feat(blocknode)`** — the `reconcile-shaper` command + the `internal/blocknode/shaper` reconcile engine.

### The command

One subcommand, two modes:

| | `--check` | apply (default) |
|---|---|---|
| privilege | unprivileged | root (daemon invokes via sudo) |
| reads statusz | yes | yes |
| reads live nft | no | yes |
| writes nft | no | yes (changed policies only) |
| output | `desired-digest: <sha256>` | applied/unchanged summary |

`--check` fetches statusz, buckets endpoints by category, and prints a sha256 digest of the desired membership (only shaper-relevant changes alter it) — the daemon uses this to detect change without privilege, so `sudo` fires only on a real change. apply reads the live `inet weaver` sets, diffs (reusing the merged `network policy` diff), and rewrites only the changed policies via `ApplyMembership`.

## Scope boundaries

- The **daemon scheduler** (cadence, in-memory digest compare, outage/resync policy) is **#755**, not this PR — the daemon stub stays idle here.
- `privexec.RunUnprivileged` (the daemon's non-sudo exec seam) lands with #755.
- The `bn-partner`→`bn-partner-out` rename / install policy orchestration is #762 — category names unchanged here.

## Test plan

- [x] Unit (`-race`, host): shaper package (digest determinism/normalization, bucketize, `Check`, `Apply` with fake fetch/list/apply seams) — 31 tests; full daemon + `network/policy` suites pass.
- [x] `gofmt` clean; `task lint` 0 issues; cross-compiles for `linux/arm64` (incl. the CLI); commit 1 verified to build independently (`package shaper`, daemon stub).
- [ ] Integration (UTM VM): `sudo block node reconcile-shaper` against a mock statusz + seeded `inet weaver`; assert membership converges; `--check` prints a stable digest and touches nothing.

## Manual UAT (UTM VM)

Scoped to the `reconcile-shaper` worker itself — no daemon scheduler involved (that's #755). Reuses the mock statusz server and the four `inet weaver` policies from `docs/dev/traffic-shaper-demo.md` (Steps 1-2), driving the command directly instead of the daemon poll loop.

> **If you use `task vm:sync`:** it rsyncs with `--delete`, so anything you create under `/mnt/solo-weaver` that isn't in the git tree (the roster file, ad hoc binaries) gets wiped the next time you sync from the host. Do your UAT scratch work in a directory outside the synced tree, e.g. `~/reconcile-shaper-uat/`, so a mid-session `task vm:sync` can't silently reset your roster back to "empty" (a missing roster file is treated as an empty one — see `FileRoster` in `internal/daemon/blocknode/statuszmock/server.go` — so this fails quietly, not loudly).

### Setup

```bash
# host: cross-compile the CLI and the mock statusz server for the VM
task build:cli GOOS=linux GOARCH=arm64
GOOS=linux GOARCH=arm64 go build -o bin/statuszmock ./internal/daemon/blocknode/statuszmock/cmd
# copy bin/solo-provisioner-linux-arm64 and bin/statuszmock into the VM

# in the VM: keep scratch files outside the synced tree
mkdir -p ~/reconcile-shaper-uat && cd ~/reconcile-shaper-uat
```

Create the four owned policies (matches `categoryBindings` in `internal/blocknode/shaper/policy_map.go`). `create` is idempotent and self-healing: if you ever run `sudo nft delete table inet weaver` by hand to reset state, re-running these four restores the whole table (including previously-registered policies) from the registry, even though only the not-yet-registered ones log "network policy created" — the others log "already exists" but still trigger the same re-render:

```bash
sudo solo-provisioner network policy create --name bn-publisher  --stamp publisher --ports 40840
sudo solo-provisioner network policy create --name bn-partner    --stamp partner   --ports 40980,40981
sudo solo-provisioner network policy create --name bn-restricted --deny
sudo solo-provisioner network policy create --name bn-backfill   --stamp reserve-egress --reply-stamp backfill-response

sudo nft list table inet weaver   # expect the 4 sets above, all empty
```

Start the mock statusz server with a roster covering 3 of the 4 categories (leave `restricted` unreported, to exercise "category absent → policy untouched"). Use an absolute `--roster` path so it survives regardless of the server's working directory:

```bash
cat > ~/reconcile-shaper-uat/roster.json <<'JSON'
{
  "inbound": [
    { "remote": {"address": "10.10.1.0/24", "port": "*"}, "category": "publisher" },
    { "remote": {"address": "10.20.1.0/24", "port": "*"}, "category": "partner" }
  ],
  "outbound": [
    { "remote": {"address": "10.30.5.7", "port": "43473"}, "category": "peer_bn" }
  ]
}
JSON

~/reconcile-shaper-uat/statuszmock --addr 127.0.0.1:8080 --roster ~/reconcile-shaper-uat/roster.json &

# sanity check before proceeding — both should echo the roster back, not `{"active_endpoints":null}`
curl -s 127.0.0.1:8080/statusz/inbound-clients
curl -s 127.0.0.1:8080/statusz/outbound-clients
```

### 1. `--check` is unprivileged and touches no nft state

```bash
solo-provisioner block node reconcile-shaper --check --statusz-url http://127.0.0.1:8080
```

Expect `desired-digest: <64-char sha256>` printed as a non-root user (confirm with `whoami` if unsure), and:

```bash
sudo nft list table inet weaver   # still all 4 sets empty — check must not have written anything
```

`--check --output json` additionally returns the desired membership map, so you can see exactly what the digest covers before ever touching nft:

```bash
solo-provisioner --output json block node reconcile-shaper --check --statusz-url http://127.0.0.1:8080
```

```json
{
  "desired-digest": "<sha256>",
  "desired": {
    "bn-backfill": ["10.30.5.7 . 43473"],
    "bn-partner": ["10.20.1.0/24"],
    "bn-publisher": ["10.10.1.0/24"],
    "bn-restricted": []
  }
}
```

### 2. apply converges membership and reports applied/skipped/unchanged

```bash
sudo solo-provisioner block node reconcile-shaper --statusz-url http://127.0.0.1:8080
```

Expect:

```
applied:   bn-backfill, bn-partner, bn-publisher
skipped:   (none)
unchanged: bn-restricted
digest:    <same digest as step 1>
```

(`skipped` lists policies that had a real delta but weren't written because a hand-run `network policy` command held the apply lock — it should be empty in this walkthrough.)

```bash
sudo nft list table inet weaver | sed -n '/set bn-/,/}/p'
```

- `bn-publisher` → `10.10.1.0/24`
- `bn-partner` → `10.20.1.0/24`
- `bn-backfill` → `10.30.5.7 . 43473`
- `bn-restricted` → still empty (category was absent from the roster, so it's untouched, not cleared)

### 3. re-running apply with no roster change is a no-op

```bash
sudo solo-provisioner block node reconcile-shaper --statusz-url http://127.0.0.1:8080
```

Expect `applied: (none)`, `unchanged: bn-backfill, bn-partner, bn-publisher, bn-restricted`, and the same digest as steps 1-2.

### 4. only the changed policy is rewritten

Edit `roster.json` to change only the partner CIDR (mock re-reads on every request, no restart needed):

```bash
# bump 10.20.1.0/24 -> 10.21.0.0/16 in the "partner" entry, leave publisher/peer_bn untouched
```

```bash
solo-provisioner block node reconcile-shaper --check --statusz-url http://127.0.0.1:8080   # digest changes vs step 3
sudo solo-provisioner block node reconcile-shaper --statusz-url http://127.0.0.1:8080
```

Expect `applied:   bn-partner` only, `unchanged: bn-backfill, bn-publisher, bn-restricted`, and the digest matching the `--check` run just above — this is the contract the daemon scheduler (#755) will rely on to gate `sudo` on a real change.

### 5. `--output json` on both modes

```bash
solo-provisioner --output json block node reconcile-shaper --check --statusz-url http://127.0.0.1:8080
sudo solo-provisioner --output json block node reconcile-shaper --statusz-url http://127.0.0.1:8080
```

Expect valid JSON: `{"desired-digest": "..."}` for check, `{"applied": [...], "unchanged": [...], "digest": "..."}` for apply.

### 6. error paths

```bash
solo-provisioner block node reconcile-shaper --check   # missing --statusz-url
```

Expect a cobra "required flag(s) \"statusz-url\" not set" error, non-zero exit, no panic.

```bash
solo-provisioner block node reconcile-shaper --check --statusz-url http://127.0.0.1:9   # nothing listening
```

Expect a wrapped connection-refused error with a non-zero exit, no panic.

### 7. non-empty desired membership against a missing table fails loudly (no silent drift)

A missing/deleted nft table is only silently tolerated when there's genuinely nothing to reconcile (empty desired membership diffs to empty-from-a-missing-table as a no-op — that's not a bug, just "nothing to do either way"). Confirm the other case: a real delta against a missing table must error, not silently skip:

```bash
sudo nft delete table inet weaver
sudo solo-provisioner block node reconcile-shaper --statusz-url http://127.0.0.1:8080
```

Expect a non-zero exit and `policy table not found; run \`network policy create\` with --name and the original policy flags to restore` in the error output (from `internal/network/policy/manager.go`'s `requireTableExists` — pre-existing code, not part of this PR, but worth confirming the interaction). Restore by re-running the four `network policy create` commands from Setup, then re-run apply to confirm it converges again.

### Cleanup

```bash
kill %1   # stop the mock server
for p in bn-publisher bn-partner bn-restricted bn-backfill; do
  sudo solo-provisioner network policy delete --name "$p"
done
```

## Closes

* Closes #893

