### PR TITLE
feat(cli): add eso operator uninstall command

### DIFF
--- a/cmd/cli/commands/common/flags_common.go
+++ b/cmd/cli/commands/common/flags_common.go
@@ -106,7 +106,7 @@ func FlagESONamespace() FlagDefinition[string] {
 	return FlagDefinition[string]{
 		Name:        "namespace",
 		ShortName:   "",
-		Description: "Kubernetes namespace to install the External Secrets Operator into",
+		Description: "Kubernetes namespace for the External Secrets Operator",
 		Default:     "external-secrets",
 	}
 }
@@ -117,15 +117,6 @@ func FlagESOChartVersion() FlagDefinition[string] {
 		ShortName:   "",
 		Description: "External Secrets Operator chart version to install (must be declared in the infrastructure catalog; defaults to the catalog default)",
 		Default:     "",
-	}
-}
-
-func FlagESOUninstallNamespace() FlagDefinition[string] {
-	return FlagDefinition[string]{
-		Name:        "namespace",
-		ShortName:   "",
-		Description: "Kubernetes namespace the External Secrets Operator is installed in",
-		Default:     "external-secrets",
 	}
 }
 

--- a/cmd/cli/commands/common/flags_common.go
+++ b/cmd/cli/commands/common/flags_common.go
@@ -120,6 +120,15 @@ func FlagESOChartVersion() FlagDefinition[string] {
 	}
 }
 
+func FlagESOUninstallNamespace() FlagDefinition[string] {
+	return FlagDefinition[string]{
+		Name:        "namespace",
+		ShortName:   "",
+		Description: "Kubernetes namespace the External Secrets Operator is installed in",
+		Default:     "external-secrets",
+	}
+}
+
 func FlagMetricsServer() FlagDefinition[bool] {
 	return FlagDefinition[bool]{
 		Name:        "metrics-server",

--- a/cmd/cli/commands/eso/operator/install.go
+++ b/cmd/cli/commands/eso/operator/install.go
@@ -10,10 +10,7 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/workflows"
 )
 
-var (
-	flagESONamespace    string
-	flagESOChartVersion string
-)
+var flagESOChartVersion string
 
 var installCmd = &cobra.Command{
 	Use:   "install",

--- a/cmd/cli/commands/eso/operator/operator.go
+++ b/cmd/cli/commands/eso/operator/operator.go
@@ -16,6 +16,7 @@ var operatorCmd = &cobra.Command{
 
 func init() {
 	operatorCmd.AddCommand(installCmd)
+	operatorCmd.AddCommand(uninstallCmd)
 }
 
 func GetCmd() *cobra.Command {

--- a/cmd/cli/commands/eso/operator/operator.go
+++ b/cmd/cli/commands/eso/operator/operator.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var flagESONamespace string
+
 var operatorCmd = &cobra.Command{
 	Use:   "operator",
 	Short: "Manage the External Secrets Operator installation",

--- a/cmd/cli/commands/eso/operator/uninstall.go
+++ b/cmd/cli/commands/eso/operator/uninstall.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package operator
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/spf13/cobra"
+
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/internal/workflows"
+)
+
+var flagESOUninstallNamespace string
+
+var uninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Uninstall the External Secrets Operator",
+	Long: `Uninstall the External Secrets Operator (ESO) Helm release from the cluster.
+
+The command is idempotent: when ESO is not installed in the target namespace, it
+exits cleanly with a skip message.
+
+Warning: uninstalling ESO removes its cluster-scoped CRDs, which deletes every
+ExternalSecret and SecretStore resource in the cluster (and the Kubernetes Secrets
+they sync). Do not run this while other components still rely on synced secrets.
+
+Examples:
+  # Uninstall ESO from the default namespace (external-secrets)
+  solo-provisioner eso operator uninstall
+
+  # Uninstall from a custom namespace
+  solo-provisioner eso operator uninstall --namespace my-eso`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		l := logx.As()
+		l.Debug().
+			Strs("args", args).
+			Str("namespace", flagESOUninstallNamespace).
+			Msg("Uninstalling External Secrets Operator")
+
+		wb := workflows.NewESOUninstallWorkflow(flagESOUninstallNamespace)
+
+		if err := common.RunWorkflowBuilder(cmd.Context(), wb); err != nil {
+			return err
+		}
+
+		l.Info().Msg("Successfully uninstalled External Secrets Operator")
+		return nil
+	},
+}
+
+func init() {
+	common.FlagESOUninstallNamespace().SetVar(uninstallCmd, &flagESOUninstallNamespace, false)
+}

--- a/cmd/cli/commands/eso/operator/uninstall.go
+++ b/cmd/cli/commands/eso/operator/uninstall.go
@@ -10,8 +10,6 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/workflows"
 )
 
-var flagESOUninstallNamespace string
-
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Uninstall the External Secrets Operator",
@@ -34,10 +32,10 @@ Examples:
 		l := logx.As()
 		l.Debug().
 			Strs("args", args).
-			Str("namespace", flagESOUninstallNamespace).
+			Str("namespace", flagESONamespace).
 			Msg("Uninstalling External Secrets Operator")
 
-		wb := workflows.NewESOUninstallWorkflow(flagESOUninstallNamespace)
+		wb := workflows.NewESOUninstallWorkflow(flagESONamespace)
 
 		if err := common.RunWorkflowBuilder(cmd.Context(), wb); err != nil {
 			return err
@@ -49,5 +47,5 @@ Examples:
 }
 
 func init() {
-	common.FlagESOUninstallNamespace().SetVar(uninstallCmd, &flagESOUninstallNamespace, false)
+	common.FlagESONamespace().SetVar(uninstallCmd, &flagESONamespace, false)
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -806,6 +806,26 @@ sudo solo-provisioner eso operator install --chart-version 0.20.2
 | `--namespace`     | `external-secrets` | Kubernetes namespace to install the External Secrets Operator into                                                   |
 | `--chart-version` | _(catalog default)_ | External Secrets Operator chart version to install (must be declared in the infrastructure catalog; defaults to the catalog default) |
 
+#### Uninstall External Secrets Operator
+
+Uninstall the ESO Helm release. The command is idempotent: if ESO is not installed in the target namespace, uninstallation is skipped with a clear message.
+
+> **Warning:** uninstalling ESO removes its cluster-scoped CRDs, which deletes every `ExternalSecret`/`SecretStore` resource in the cluster (and the Kubernetes Secrets they sync). Do not run this while other components still rely on synced secrets.
+
+```bash
+# Uninstall from the default namespace (external-secrets)
+sudo solo-provisioner eso operator uninstall
+
+# Uninstall from a custom namespace
+sudo solo-provisioner eso operator uninstall --namespace my-eso
+```
+
+**Additional Flags**:
+
+| Flag          | Default            | Description                                                        |
+|---------------|--------------------|--------------------------------------------------------------------|
+| `--namespace` | `external-secrets` | Kubernetes namespace the External Secrets Operator is installed in |
+
 ---
 
 ### Alloy Commands
@@ -1414,6 +1434,7 @@ sudo solo-provisioner teleport cluster uninstall
 
 # EXTERNAL SECRETS OPERATOR (ESO)
 sudo solo-provisioner eso operator install    [--namespace=<ns>] [--chart-version=<version>]
+sudo solo-provisioner eso operator uninstall  [--namespace=<ns>]
 
 # ALLOY
 sudo solo-provisioner alloy cluster install   [--monitor-block-node] [--cluster-name=<name>]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -803,7 +803,7 @@ sudo solo-provisioner eso operator install --chart-version 0.20.2
 
 | Flag              | Default            | Description                                                                                                          |
 |-------------------|--------------------|----------------------------------------------------------------------------------------------------------------------|
-| `--namespace`     | `external-secrets` | Kubernetes namespace to install the External Secrets Operator into                                                   |
+| `--namespace`     | `external-secrets` | Kubernetes namespace for the External Secrets Operator                                                               |
 | `--chart-version` | _(catalog default)_ | External Secrets Operator chart version to install (must be declared in the infrastructure catalog; defaults to the catalog default) |
 
 #### Uninstall External Secrets Operator
@@ -824,7 +824,7 @@ sudo solo-provisioner eso operator uninstall --namespace my-eso
 
 | Flag          | Default            | Description                                                        |
 |---------------|--------------------|--------------------------------------------------------------------|
-| `--namespace` | `external-secrets` | Kubernetes namespace the External Secrets Operator is installed in |
+| `--namespace` | `external-secrets` | Kubernetes namespace for the External Secrets Operator |
 
 ---
 

--- a/internal/workflows/eso.go
+++ b/internal/workflows/eso.go
@@ -17,3 +17,9 @@ type ESOInstallOptions = steps.ESOInstallOptions
 func NewESOInstallWorkflow(opts ESOInstallOptions) (*automa.WorkflowBuilder, error) {
 	return steps.SetupExternalSecrets(opts)
 }
+
+// NewESOUninstallWorkflow creates a workflow to uninstall the External Secrets
+// Operator (ESO) Helm release. An empty namespace selects the catalog default.
+func NewESOUninstallWorkflow(namespace string) *automa.WorkflowBuilder {
+	return steps.TeardownExternalSecrets(namespace)
+}

--- a/internal/workflows/steps/step_external_secrets.go
+++ b/internal/workflows/steps/step_external_secrets.go
@@ -4,6 +4,7 @@ package steps
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/automa-saga/automa"
@@ -11,6 +12,8 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/kube"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
 	"github.com/hashgraph/solo-weaver/pkg/helm"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
 	"helm.sh/helm/v3/pkg/cli/values"
 )
 
@@ -204,12 +207,22 @@ func uninstallExternalSecrets(spec *helmChartSpec) automa.Builder {
 			l := logx.As()
 			hm, err := newHelmManager()
 			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+				return automa.StepFailureReport(stp.Id(), automa.WithError(
+					errorx.InternalError.Wrap(err, "failed to initialise Helm manager").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Check the solo-provisioner logs for details: /opt/solo/weaver/logs/solo-provisioner.log",
+						})))
 			}
 
 			uninstalled, err := uninstallESOChart(hm, spec)
 			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+				return automa.StepFailureReport(stp.Id(), automa.WithError(
+					errorx.ExternalError.Wrap(err, "failed to uninstall External Secrets Operator release %q in namespace %q", spec.Release, spec.Namespace).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Verify the cluster is reachable: kubectl cluster-info",
+							fmt.Sprintf("Check the release state: helm list -n %s", spec.Namespace),
+							fmt.Sprintf("Remove it manually if needed: helm uninstall %s -n %s", spec.Release, spec.Namespace),
+						})))
 			}
 
 			if !uninstalled {

--- a/internal/workflows/steps/step_external_secrets.go
+++ b/internal/workflows/steps/step_external_secrets.go
@@ -15,9 +15,11 @@ import (
 )
 
 const (
-	SetupExternalSecretsStepId   = "setup-external-secrets"
-	InstallExternalSecretsStepId = "install-external-secrets"
-	IsExternalSecretsReadyStepId = "is-external-secrets-ready"
+	SetupExternalSecretsStepId     = "setup-external-secrets"
+	InstallExternalSecretsStepId   = "install-external-secrets"
+	IsExternalSecretsReadyStepId   = "is-external-secrets-ready"
+	TeardownExternalSecretsStepId  = "teardown-external-secrets"
+	UninstallExternalSecretsStepId = "uninstall-external-secrets"
 )
 
 // ESOInstallOptions parameterizes the External Secrets Operator install workflow.
@@ -51,6 +53,29 @@ func SetupExternalSecrets(opts ESOInstallOptions) (*automa.WorkflowBuilder, erro
 		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
 			notify.As().StepCompletion(ctx, stp, rpt, "External Secrets Operator setup successfully")
 		}), nil
+}
+
+// TeardownExternalSecrets returns a workflow builder that uninstalls the External
+// Secrets Operator. An empty namespace selects the catalog default namespace.
+func TeardownExternalSecrets(namespace string) *automa.WorkflowBuilder {
+	spec := chartSpec("external-secrets")
+	if namespace != "" {
+		spec.Namespace = namespace
+	}
+
+	return automa.NewWorkflowBuilder().WithId(TeardownExternalSecretsStepId).Steps(
+		uninstallExternalSecrets(spec),
+	).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Tearing down External Secrets Operator")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to tear down External Secrets Operator")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "External Secrets Operator torn down successfully")
+		})
 }
 
 // installESOChart runs the idempotent ESO Helm install and reports whether it
@@ -153,6 +178,56 @@ func installExternalSecrets(spec *helmChartSpec) automa.Builder {
 		}).
 		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
 			notify.As().StepCompletion(ctx, stp, rpt, "External Secrets Operator installed successfully")
+		})
+}
+
+// uninstallESOChart runs the idempotent ESO Helm uninstall and reports whether it
+// uninstalled (false = not installed). Extracted from the step so it can be
+// unit-tested with a mock helm.Manager.
+func uninstallESOChart(hm helm.Manager, spec *helmChartSpec) (bool, error) {
+	isInstalled, err := hm.IsInstalled(spec.Release, spec.Namespace)
+	if err != nil {
+		return false, err
+	}
+	if !isInstalled {
+		return false, nil
+	}
+	if err := hm.UninstallChart(spec.Release, spec.Namespace); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func uninstallExternalSecrets(spec *helmChartSpec) automa.Builder {
+	return automa.NewStepBuilder().WithId(UninstallExternalSecretsStepId).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			l := logx.As()
+			hm, err := newHelmManager()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			uninstalled, err := uninstallESOChart(hm, spec)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+			}
+
+			if !uninstalled {
+				l.Info().Msg("External Secrets Operator is not installed, skipping uninstallation")
+				return automa.StepSkippedReport(stp.Id())
+			}
+
+			return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(map[string]string{"uninstalled": "true"}))
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Uninstalling External Secrets Operator")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to uninstall External Secrets Operator")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "External Secrets Operator uninstalled successfully")
 		})
 }
 

--- a/internal/workflows/steps/step_external_secrets_test.go
+++ b/internal/workflows/steps/step_external_secrets_test.go
@@ -4,6 +4,7 @@ package steps
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -117,6 +118,58 @@ func Test_uninstallESOChart_Idempotent(t *testing.T) {
 
 	uninstalled, err := uninstallESOChart(hm, spec)
 	require.NoError(t, err)
+	assert.False(t, uninstalled)
+}
+
+func Test_uninstallESOChart_NamespaceOverride(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	spec, err := resolveCatalogChart("external-secrets")
+	require.NoError(t, err)
+	const customNS = "my-eso"
+	spec.Namespace = customNS
+
+	hm := helm.NewMockManager(ctrl)
+	hm.EXPECT().IsInstalled(spec.Release, customNS).Return(true, nil)
+	hm.EXPECT().UninstallChart(spec.Release, customNS).Return(nil)
+
+	uninstalled, err := uninstallESOChart(hm, spec)
+	require.NoError(t, err)
+	assert.True(t, uninstalled)
+}
+
+func Test_uninstallESOChart_IsInstalledError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	spec, err := resolveCatalogChart("external-secrets")
+	require.NoError(t, err)
+
+	wantErr := errors.New("is-installed boom")
+	hm := helm.NewMockManager(ctrl)
+	hm.EXPECT().IsInstalled(spec.Release, spec.Namespace).Return(false, wantErr)
+	// No UninstallChart expectation: the IsInstalled error must short-circuit.
+
+	uninstalled, err := uninstallESOChart(hm, spec)
+	require.ErrorIs(t, err, wantErr)
+	assert.False(t, uninstalled)
+}
+
+func Test_uninstallESOChart_UninstallChartError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	spec, err := resolveCatalogChart("external-secrets")
+	require.NoError(t, err)
+
+	wantErr := errors.New("uninstall boom")
+	hm := helm.NewMockManager(ctrl)
+	hm.EXPECT().IsInstalled(spec.Release, spec.Namespace).Return(true, nil)
+	hm.EXPECT().UninstallChart(spec.Release, spec.Namespace).Return(wantErr)
+
+	uninstalled, err := uninstallESOChart(hm, spec)
+	require.ErrorIs(t, err, wantErr)
 	assert.False(t, uninstalled)
 }
 

--- a/internal/workflows/steps/step_external_secrets_test.go
+++ b/internal/workflows/steps/step_external_secrets_test.go
@@ -88,6 +88,38 @@ func Test_installESOChart_NamespaceOverride(t *testing.T) {
 	assert.True(t, installed)
 }
 
+func Test_uninstallESOChart_Uninstalls(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	spec, err := resolveCatalogChart("external-secrets")
+	require.NoError(t, err)
+
+	hm := helm.NewMockManager(ctrl)
+	hm.EXPECT().IsInstalled(spec.Release, spec.Namespace).Return(true, nil)
+	hm.EXPECT().UninstallChart(spec.Release, spec.Namespace).Return(nil)
+
+	uninstalled, err := uninstallESOChart(hm, spec)
+	require.NoError(t, err)
+	assert.True(t, uninstalled)
+}
+
+func Test_uninstallESOChart_Idempotent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	spec, err := resolveCatalogChart("external-secrets")
+	require.NoError(t, err)
+
+	hm := helm.NewMockManager(ctrl)
+	hm.EXPECT().IsInstalled(spec.Release, spec.Namespace).Return(false, nil)
+	// No UninstallChart expectation: not-installed must skip.
+
+	uninstalled, err := uninstallESOChart(hm, spec)
+	require.NoError(t, err)
+	assert.False(t, uninstalled)
+}
+
 func Test_SetupExternalSecrets_VersionResolution(t *testing.T) {
 	t.Run("default version", func(t *testing.T) {
 		def, err := resolveCatalogChart("external-secrets")


### PR DESCRIPTION
## Description

Adds `solo-provisioner eso operator uninstall`, which removes the External Secrets Operator (ESO)
Helm release from the cluster. It completes the `eso operator` sub-group alongside
`install` (#670).

What it does:

* Adds the `eso operator uninstall` command (`cmd/cli/commands/eso/operator/uninstall.go`),
  registered on the `operator` sub-group.
* Adds `--namespace` (default `external-secrets`) to select where ESO is installed.
* Uninstalls via `pkg/helm.Manager` (`IsInstalled` → `UninstallChart`), mirroring the teardown
  pattern in `step_alloy.go`.
* Idempotent: when ESO is not installed in the target namespace, it exits cleanly with an
  "is not installed, skipping uninstallation" message (returns a Skipped step report, like
  `uninstallAlloy`).

### Review guide

* **Mirrors `step_alloy.go` teardown** — `uninstallExternalSecrets` follows `uninstallAlloy`:
  `IsInstalled` → skip (Skipped report) if absent, else `UninstallChart` → success.
* **Idempotency** — not-installed is a clean skip (exit 0), not an error.
* **CRD deletion is intentional and warned about**, not preserved — see the CRD warning above.

### Manual UAT

Run inside a VM/host with a reachable cluster (requires `sudo`). Verified on the UTM VM
(Kubernetes 1.33). The steps below flow top-to-bottom — copy-paste them in order to exercise
every case (`install` is included so the reviewer can set up and see the full lifecycle).

**Setup — install ESO** (from #670; included so this PR is testable standalone)

```bash
sudo solo-provisioner eso operator install
```

**1. Uninstall when installed**

```bash
sudo solo-provisioner eso operator uninstall
```

Expected: an interactive progress run that exits 0, ending in `Completed successfully` (the
visible workflow line is `External Secrets Operator torn down successfully`). Verify the release
**and** its cluster-scoped CRDs are gone:

```bash
sudo KUBECONFIG=/etc/kubernetes/admin.conf helm list -n external-secrets
# → no external-secrets release
sudo KUBECONFIG=/etc/kubernetes/admin.conf kubectl get crd | grep external-secrets.io
# → none (helm uninstall removes the templated CRDs — see the CRD warning above)
```

**2. Idempotency (re-run when not installed)**

```bash
sudo solo-provisioner eso operator uninstall
```

Expected: a no-op that exits 0 — the interactive TUI shows the uninstall step with a **skipped
(⊘)** icon. The `External Secrets Operator is not installed, skipping uninstallation` line is
written to the log file / shown with `--non-interactive` or `-V`.

**3. Custom namespace** (ESO is gone after steps 1–2, so this installs cleanly)

```bash
sudo solo-provisioner eso operator install   --namespace my-eso
sudo solo-provisioner eso operator uninstall --namespace my-eso
```

Expected: install into `my-eso`, then uninstall the release from `my-eso`, both exit 0.

### Related Issues

* Closes #671