### PR TITLE
feat(traffic-shaper): install $VETH ingress HTB on BN pod create (#748)

### DIFF
--- a/cmd/cli/commands/block/node/node.go
+++ b/cmd/cli/commands/block/node/node.go
@@ -99,7 +99,7 @@ func init() {
 	// LoadBalancer / MetalLB annotation flag
 	common.FlagLoadBalancerEnabled().SetVarP(nodeCmd, &flagLoadBalancerEnabled, false)
 
-	nodeCmd.AddCommand(checkCmd, installCmd, upgradeCmd, reconfigureCmd, resetCmd, uninstallCmd, reconcileShaperCmd)
+	nodeCmd.AddCommand(checkCmd, installCmd, upgradeCmd, reconfigureCmd, resetCmd, uninstallCmd, reconcileShaperCmd, tcAttachCmd)
 }
 
 func GetCmd() *cobra.Command {

--- a/cmd/cli/commands/block/node/tc_attach.go
+++ b/cmd/cli/commands/block/node/tc_attach.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package node
+
+import (
+	"fmt"
+
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
+)
+
+var (
+	flagTCAttachVeth   string
+	flagTCAttachDetach bool
+
+	tcAttachCmd = &cobra.Command{
+		Use:   "tc-attach",
+		Short: "Install or tear down the ingress traffic-shaper HTB hierarchy on a block node pod's host-side veth",
+		Long: "Install the $VETH ingress HTB hierarchy (classes 1:10/1:20/1:30, default reserve-ingress, " +
+			"fq_codel leaves, no tc filters) on the given host-side veth, using the per-class ingress " +
+			"budgets recorded by `network shape`.\n\n" +
+			"This is a privileged worker (root). The solo-provisioner-daemon's pod-lifecycle watcher execs " +
+			"it via sudo on each block node pod create, passing the veth it resolved for the pod; an " +
+			"operator can also run it by hand for debugging. With --detach it tears the hierarchy down " +
+			"instead (best-effort — the kernel auto-removes veth-attached qdiscs when the pod's veth " +
+			"disappears).",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if flagTCAttachVeth == "" {
+				return errorx.IllegalArgument.New("--veth is required")
+			}
+
+			m := shape.NewManager()
+			if flagTCAttachDetach {
+				if err := m.RemoveIngressVeth(cmd.Context(), flagTCAttachVeth); err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "detached ingress HTB from %s\n", flagTCAttachVeth)
+				return nil
+			}
+			if err := m.ApplyIngressVeth(cmd.Context(), flagTCAttachVeth); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "attached ingress HTB to %s\n", flagTCAttachVeth)
+			return nil
+		},
+	}
+)
+
+func init() {
+	// Narrow privileged worker (the daemon watcher execs it via sudo, or an
+	// operator runs it by hand): it only touches the recorded shape config and
+	// the live veth qdisc, so it needs neither the weaver-installation check nor
+	// startup migrations (both read root-owned state via RunPersistentPreRun).
+	// root.go's superuser gate still independently requires root — unlike
+	// reconcile-shaper, tc-attach has no unprivileged --check path.
+	common.SkipGlobalChecks(tcAttachCmd)
+
+	tcAttachCmd.Flags().StringVar(&flagTCAttachVeth, "veth", "",
+		"Host-side veth interface to (de)install the ingress HTB hierarchy on, e.g. lxc1a2b3c (required)")
+	tcAttachCmd.Flags().BoolVar(&flagTCAttachDetach, "detach", false,
+		"Tear down the ingress HTB hierarchy on the veth instead of installing it (best-effort)")
+	_ = tcAttachCmd.MarkFlagRequired("veth")
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -215,6 +215,15 @@ sudo solo-provisioner block node install \
 > it. An empty management allowlist skips the firewall to avoid locking the host
 > out of SSH; `--firewall-enabled=false` opts out of it entirely.
 
+> **Traffic-shaper defaults**: `block node install` records both the `$EGRESS`
+> (physical NIC) and the `$VETH` (per-pod ingress) HTB shapes using the design's
+> default per-class budgets, so the daemon can install the ingress hierarchy on
+> the next pod create without any manual `network shape` step. The `$EGRESS` shape
+> is persisted for reboot replay (`solo-provisioner-tc-egress.service`); the
+> ingress shape is recorded as config only (the `$VETH` is ephemeral and replayed
+> per-pod). Ingress bandwidth defaults to the egress `--link-rate`. Tune any class
+> afterward with `network shape set --class <name> --rate/--ceil/--prio`.
+
 #### Upgrade Block Node
 
 Upgrade an existing Block Node deployment:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -396,6 +396,35 @@ sudo solo-provisioner block node reconcile-shaper \
 > path (no `--check`) reads and writes the live `inet weaver` sets and must run as
 > root; the daemon invokes it via sudo.
 
+#### Attach Ingress Traffic Shaper (`tc-attach`)
+
+Install the `$VETH` ingress HTB hierarchy (classes `1:10`/`1:20`/`1:30`, default
+`reserve-ingress`, `fq_codel` leaves, no tc filters) on a block node pod's
+host-side veth, using the per-class ingress budgets recorded by
+`network shape`. The solo-provisioner-daemon's pod-lifecycle watcher runs this
+via sudo on each block node pod create, passing the veth it resolved for the
+pod; you can also run it by hand for debugging.
+
+```bash
+# Install the ingress HTB hierarchy on a resolved host-side veth (root)
+sudo solo-provisioner block node tc-attach --veth lxc1a2b3c
+
+# Tear it down (best-effort; the kernel also removes it when the pod's veth disappears)
+sudo solo-provisioner block node tc-attach --veth lxc1a2b3c --detach
+```
+
+**Additional Flags**:
+
+| Flag       | Description                                                                                 | Default |
+|------------|---------------------------------------------------------------------------------------------|---------|
+| `--veth`   | Host-side veth interface to (de)install the ingress HTB hierarchy on, e.g. `lxc1a2b3c` (required) | —       |
+| `--detach` | Tear down the ingress HTB hierarchy on the veth instead of installing it (best-effort)      | `false` |
+
+> **Privilege**: `tc-attach` always mutates live kernel tc state and must run as
+> root (the daemon invokes it via sudo). Unlike `reconcile-shaper`, it has no
+> unprivileged `--check` mode. It requires the ingress shape to have been
+> recorded first (normally by `block node install` via `network shape`).
+
 ---
 
 ### Kubernetes Commands

--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -71,27 +71,16 @@ func (h *InstallHandler) BuildWorkflow(
 				// verifies the binary exists, not the user account. This step is
 				// idempotent and safe to repeat on up-to-date installations.
 				steps.EnsureWeaverOwnerStep(),
-				// The node-level host firewall (inet host table) is owned by the
-				// block-node workflow, not the generic kube cluster install — nftables
-				// is already installed/enabled from that prior cluster provisioning,
-				// so it's safe to apply here.
-				steps.NetworkFirewallCreate(),
-				// Re-render network-weaver.nft from the policy registry and restart
-				// the shared oneshot so systemd's RemainAfterExit state reflects both
-				// the host and weaver tables.
-				steps.NftWeaverPersist(),
-				// Render and install the $EGRESS HTB boot-persistence script and
-				// oneshot unit.
-				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
-				// Record the $VETH ingress HTB shape (publisher/backfill-response/
-				// reserve-ingress) so the daemon replays it on each pod create.
-				// Ingress bandwidth defaults to egress (--link-rate); not persisted
-				// across reboot (the veth is ephemeral).
-				steps.TcIngressRecord(ins.EgressInterface, ins.LinkRate),
+				// Static network plane (host firewall + weaver policy persistence +
+				// $EGRESS/$VETH tc shape config), grouped as the "Network Setup" phase.
+				// The host firewall is owned by the block-node workflow (not the generic
+				// kube cluster install); nftables is already installed/enabled by prior
+				// cluster provisioning, so it's safe to apply here.
+				workflows.NetworkSetupWorkflow(ins.EgressInterface, ins.LinkRate),
 				steps.SetupBlockNode(ins),
 				// Enable the traffic-shaper monitor in daemon.yaml so it starts
 				// reconciling statusz-driven nft membership once the daemon runs.
-				steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace),
+				workflows.BlockNodeDaemonConfigWorkflow(ins.Namespace),
 			)
 	} else {
 		wb = automa.NewWorkflowBuilder().WithId("block-node-install").
@@ -106,26 +95,16 @@ func (h *InstallHandler) BuildWorkflow(
 				// only the substrate floor, which is weaker than the block-node floor.
 				workflows.NodeSetupWorkflow(models.NodeTypeBlock, ins.Profile, ins.PluginPreset, ins.SkipHardwareChecks),
 				workflows.KubernetesSetupWorkflow(h.mr),
+				// Static network plane (host firewall + weaver policy persistence +
+				// $EGRESS/$VETH tc shape config), grouped as the "Network Setup" phase.
 				// nftables was just installed/enabled by NodeSetupWorkflow's
-				// systemSetupWorkflow; apply the host firewall here rather than in
-				// that generic (node-type-agnostic) workflow.
-				steps.NetworkFirewallCreate(),
-				// Re-render network-weaver.nft from the policy registry and restart
-				// the shared oneshot so systemd's RemainAfterExit state reflects both
-				// the host and weaver tables.
-				steps.NftWeaverPersist(),
-				// Render and install the $EGRESS HTB boot-persistence script and
-				// oneshot unit.
-				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
-				// Record the $VETH ingress HTB shape (publisher/backfill-response/
-				// reserve-ingress) so the daemon replays it on each pod create.
-				// Ingress bandwidth defaults to egress (--link-rate); not persisted
-				// across reboot (the veth is ephemeral).
-				steps.TcIngressRecord(ins.EgressInterface, ins.LinkRate),
+				// systemSetupWorkflow, so applying the host firewall here (rather than
+				// in that generic, node-type-agnostic workflow) is safe.
+				workflows.NetworkSetupWorkflow(ins.EgressInterface, ins.LinkRate),
 				steps.SetupBlockNode(ins),
 				// Enable the traffic-shaper monitor in daemon.yaml so it starts
 				// reconciling statusz-driven nft membership once the daemon runs.
-				steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace),
+				workflows.BlockNodeDaemonConfigWorkflow(ins.Namespace),
 			)
 	}
 	return wb, nil

--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -83,6 +83,11 @@ func (h *InstallHandler) BuildWorkflow(
 				// Render and install the $EGRESS HTB boot-persistence script and
 				// oneshot unit.
 				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
+				// Record the $VETH ingress HTB shape (publisher/backfill-response/
+				// reserve-ingress) so the daemon replays it on each pod create.
+				// Ingress bandwidth defaults to egress (--link-rate); not persisted
+				// across reboot (the veth is ephemeral).
+				steps.TcIngressRecord(ins.EgressInterface, ins.LinkRate),
 				steps.SetupBlockNode(ins),
 				// Enable the traffic-shaper monitor in daemon.yaml so it starts
 				// reconciling statusz-driven nft membership once the daemon runs.
@@ -112,6 +117,11 @@ func (h *InstallHandler) BuildWorkflow(
 				// Render and install the $EGRESS HTB boot-persistence script and
 				// oneshot unit.
 				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
+				// Record the $VETH ingress HTB shape (publisher/backfill-response/
+				// reserve-ingress) so the daemon replays it on each pod create.
+				// Ingress bandwidth defaults to egress (--link-rate); not persisted
+				// across reboot (the veth is ephemeral).
+				steps.TcIngressRecord(ins.EgressInterface, ins.LinkRate),
 				steps.SetupBlockNode(ins),
 				// Enable the traffic-shaper monitor in daemon.yaml so it starts
 				// reconciling statusz-driven nft membership once the daemon runs.

--- a/internal/daemon/blocknode/component.go
+++ b/internal/daemon/blocknode/component.go
@@ -4,6 +4,9 @@ package blocknode
 
 import (
 	"github.com/automa-saga/daemonkit"
+	"github.com/joomcode/errorx"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // ComponentConfig holds inputs needed to build the block-node component.
@@ -46,7 +49,11 @@ func NewComponent(cfg ComponentConfig) (ComponentResult, error) {
 		if err != nil {
 			return ComponentResult{}, err
 		}
-		tsm = NewTrafficShaperMonitor(resolver)
+		client, err := newKubeClient(cfg.KubeconfigPath)
+		if err != nil {
+			return ComponentResult{}, err
+		}
+		tsm = NewTrafficShaperMonitor(resolver, client, cfg.Namespace)
 		monitors = append(monitors, tsm)
 	}
 
@@ -54,4 +61,19 @@ func NewComponent(cfg ComponentConfig) (ComponentResult, error) {
 		Monitors:             monitors,
 		TrafficShaperMonitor: tsm,
 	}, nil
+}
+
+// newKubeClient builds a typed Kubernetes client from the BN-scoped kubeconfig.
+// The pod watcher uses it to list/watch BN pods; the veth resolver builds its
+// own client from the same kubeconfig for the SPDY exec path.
+func newKubeClient(kubeconfigPath string) (kubernetes.Interface, error) {
+	restCfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return nil, errorx.ExternalError.Wrap(err, "load kubeconfig %s", kubeconfigPath)
+	}
+	client, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return nil, errorx.ExternalError.Wrap(err, "build k8s client for pod watcher")
+	}
+	return client, nil
 }

--- a/internal/daemon/blocknode/handler_test.go
+++ b/internal/daemon/blocknode/handler_test.go
@@ -19,7 +19,7 @@ import (
 // returns 200 with the supervisor-reported monitor state when the monitor is
 // enabled.
 func TestBlockNodeHandler_TrafficShaperStatus_Enabled(t *testing.T) {
-	mon := NewTrafficShaperMonitor(nil)
+	mon := NewTrafficShaperMonitor(nil, nil, "")
 	stateFn := func() daemonkit.MonitorState { return daemonkit.MonitorState{State: "running"} }
 	h := NewBlockNodeHandler(mon, stateFn)
 

--- a/internal/daemon/blocknode/pod_watcher.go
+++ b/internal/daemon/blocknode/pod_watcher.go
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package blocknode
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// bnPodLabelSelector selects the block-node server pods the traffic-shaper
+// watches. Mirrors internal/blocknode.PodLabelSelector; duplicated (not
+// imported) to keep the daemon's import closure free of the provisioning
+// packages (helm/mount/etc.), which it deliberately never pulls in.
+const bnPodLabelSelector = "app.kubernetes.io/name=block-node-server"
+
+// vethResolver is the subset of *VethResolver the pod watcher needs, extracted
+// so the watcher can be unit-tested with a fake.
+type vethResolver interface {
+	Resolve(ctx context.Context, pod *corev1.Pod) (string, error)
+}
+
+// Veth-resolution retry bounds for a pod that is ContainersReady but whose
+// host-side veth is not yet visible (Cilium is still wiring the veth pair).
+// Vars, not consts, so tests can shrink them to avoid real-time waits.
+var (
+	vethResolveAttempts = 15
+	vethResolveInterval = 2 * time.Second
+)
+
+// runPodWatcher is the pod-lifecycle watcher responsibility (design §8.1.1). It
+// lists the current BN pods, installs the $VETH ingress HTB on any that are
+// already ContainersReady, then watches for create/update/delete events and
+// (re)installs or tears down the hierarchy as pods come and go.
+//
+// A watch-channel close or error returns an error so the supervisor reconnects
+// with back-off; the initial re-list on reconnect re-attaches idempotently
+// (tc-attach tears down and rebuilds), so no state is lost across reconnects.
+func (m *TrafficShaperMonitor) runPodWatcher(ctx context.Context) error {
+	if m.client == nil {
+		// Unconfigured (unit-test scaffolding only — NewComponent always wires a
+		// client in production). Nothing to watch; block until shutdown.
+		logx.As().Warn().
+			Str("reason", "TrafficShaperPodWatcherNoClient").
+			Str("monitor", m.Name()).
+			Msg("pod-lifecycle watcher has no kube client — idle")
+		<-ctx.Done()
+		return nil
+	}
+
+	pods := m.client.CoreV1().Pods(m.namespace)
+	list, err := pods.List(ctx, metav1.ListOptions{LabelSelector: bnPodLabelSelector})
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "list block-node pods in namespace %s", m.namespace)
+	}
+	for i := range list.Items {
+		m.dispatchUpsert(ctx, &list.Items[i])
+	}
+
+	watcher, err := pods.Watch(ctx, metav1.ListOptions{
+		LabelSelector:   bnPodLabelSelector,
+		ResourceVersion: list.ResourceVersion,
+	})
+	if err != nil {
+		return errorx.ExternalError.Wrap(err, "watch block-node pods in namespace %s", m.namespace)
+	}
+	defer watcher.Stop()
+
+	logx.As().Info().
+		Str("reason", "TrafficShaperPodWatcherStarted").
+		Str("monitor", m.Name()).
+		Str("namespace", m.namespace).
+		Msg("block-node pod-lifecycle watcher started")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev, ok := <-watcher.ResultChan():
+			if !ok {
+				// Channel closed (idle timeout / apiserver hiccup): fault so the
+				// supervisor reconnects and re-lists.
+				return errorx.ExternalError.New("block-node pod watch channel closed")
+			}
+			if err := m.handleWatchEvent(ctx, ev); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// handleWatchEvent dispatches a single watch event to the upsert/delete handlers.
+// It returns an error only for a watch-level Error event, which the caller turns
+// into a reconnect.
+func (m *TrafficShaperMonitor) handleWatchEvent(ctx context.Context, ev watch.Event) error {
+	if ev.Type == watch.Error {
+		return errorx.ExternalError.New("block-node pod watch error event: %v", ev.Object)
+	}
+	pod, ok := ev.Object.(*corev1.Pod)
+	if !ok {
+		// Bookmark or an unexpected object — nothing to do.
+		return nil
+	}
+	switch ev.Type {
+	case watch.Added, watch.Modified:
+		m.dispatchUpsert(ctx, pod)
+	case watch.Deleted:
+		m.handlePodDelete(ctx, pod)
+	}
+	return nil
+}
+
+// dispatchUpsert runs handlePodUpsert in a goroutine so a pod whose veth is slow
+// to resolve (resolveVethWithRetry can retry for tens of seconds) never blocks
+// the watch loop from draining subsequent pod events. An in-flight guard keyed by
+// pod UID ensures at most one attach runs per pod at a time; repeated Added/
+// Modified events for a pod already being attached are dropped (the eventual
+// handlePodUpsert re-reads the pod state on the next event anyway). Delete
+// handling stays synchronous — it is a quick map lookup plus a best-effort exec.
+func (m *TrafficShaperMonitor) dispatchUpsert(ctx context.Context, pod *corev1.Pod) {
+	uid := pod.UID
+	m.mu.Lock()
+	if m.inflight[uid] {
+		m.mu.Unlock()
+		return
+	}
+	m.inflight[uid] = true
+	m.mu.Unlock()
+
+	go func() {
+		defer func() {
+			m.mu.Lock()
+			delete(m.inflight, uid)
+			m.mu.Unlock()
+		}()
+		m.handlePodUpsert(ctx, pod)
+	}()
+}
+
+// handlePodUpsert installs the $VETH ingress HTB on a pod that has reached
+// ContainersReady. It is idempotent and deduped: a pod whose veth is already
+// installed is skipped, and tc-attach itself rebuilds the hierarchy cleanly, so
+// repeated Modified events are cheap. Pods that are not yet ready are ignored;
+// a later Modified event (fired when they become ready) picks them up.
+func (m *TrafficShaperMonitor) handlePodUpsert(ctx context.Context, pod *corev1.Pod) {
+	if !podContainersReady(pod) {
+		return
+	}
+
+	veth, err := m.resolveVethWithRetry(ctx, pod)
+	if err != nil {
+		logx.As().Warn().Err(err).
+			Str("reason", "TrafficShaperVethResolveFailed").
+			Str("pod", pod.Namespace+"/"+pod.Name).
+			Msg("could not resolve host-side veth for BN pod — leaving ingress unprioritised until next event")
+		return
+	}
+
+	m.mu.Lock()
+	already := m.attached[pod.UID] == veth
+	m.mu.Unlock()
+	if already {
+		return
+	}
+
+	if err := m.delegator.TCAttach(ctx, veth); err != nil {
+		logx.As().Warn().Err(err).
+			Str("reason", "TrafficShaperTCAttachFailed").
+			Str("pod", pod.Namespace+"/"+pod.Name).
+			Str("veth", veth).
+			Msg("failed to install $VETH ingress HTB")
+		return
+	}
+
+	m.mu.Lock()
+	m.attached[pod.UID] = veth
+	m.mu.Unlock()
+
+	logx.As().Info().
+		Str("reason", "TrafficShaperVethAttached").
+		Str("pod", pod.Namespace+"/"+pod.Name).
+		Str("veth", veth).
+		Msg("installed $VETH ingress HTB on BN pod")
+}
+
+// handlePodDelete tears down the $VETH ingress HTB for a deleted pod. It is
+// best-effort and mostly observational: the kernel auto-removes veth-attached
+// qdiscs when the veth disappears, so this only fires the detach for the veth we
+// recorded at attach time (a deleted pod can no longer be exec'd to re-resolve).
+func (m *TrafficShaperMonitor) handlePodDelete(ctx context.Context, pod *corev1.Pod) {
+	m.mu.Lock()
+	veth, ok := m.attached[pod.UID]
+	delete(m.attached, pod.UID)
+	m.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	if err := m.delegator.TCDetach(ctx, veth); err != nil {
+		logx.As().Warn().Err(err).
+			Str("reason", "TrafficShaperTCDetachFailed").
+			Str("pod", pod.Namespace+"/"+pod.Name).
+			Str("veth", veth).
+			Msg("best-effort $VETH ingress HTB teardown failed (kernel removes it with the veth)")
+		return
+	}
+	logx.As().Info().
+		Str("reason", "TrafficShaperVethDetached").
+		Str("pod", pod.Namespace+"/"+pod.Name).
+		Str("veth", veth).
+		Msg("tore down $VETH ingress HTB for deleted BN pod")
+}
+
+// resolveVethWithRetry resolves the pod's host-side veth, retrying while the
+// veth is not yet visible or the container is not yet exec-capable. It stops on
+// success, on a non-retryable error, or on ctx cancellation.
+func (m *TrafficShaperMonitor) resolveVethWithRetry(ctx context.Context, pod *corev1.Pod) (string, error) {
+	var lastErr error
+	for attempt := 0; attempt < vethResolveAttempts; attempt++ {
+		veth, err := m.resolver.Resolve(ctx, pod)
+		if err == nil {
+			return veth, nil
+		}
+		if !errors.Is(err, ErrVethNotFound) && !errors.Is(err, ErrVethNotReady) {
+			// A genuinely non-retryable error — e.g. a malformed iflink value or
+			// an unreadable /sys/class/net. Note the resolver wraps exec failures
+			// (including RBAC) as ErrVethNotReady, so those are retried above, not
+			// here.
+			return "", err
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(vethResolveInterval):
+		}
+	}
+	return "", lastErr
+}
+
+// podContainersReady reports whether the pod's ContainersReady condition is
+// True. Binding on ContainersReady (rather than PodReady) shrinks the window
+// during which ingress is unprioritised after a pod (re)start.
+func podContainersReady(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.ContainersReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// ensure *VethResolver satisfies the vethResolver seam.
+var _ vethResolver = (*VethResolver)(nil)

--- a/internal/daemon/blocknode/pod_watcher_test.go
+++ b/internal/daemon/blocknode/pod_watcher_test.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package blocknode
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// fakeResolver returns queued (veth, err) results in order, repeating the last
+// one once exhausted, so tests can model transient not-found → success retries.
+type fakeResolver struct {
+	results []resolveResult
+	calls   int
+}
+
+type resolveResult struct {
+	veth string
+	err  error
+}
+
+func (f *fakeResolver) Resolve(_ context.Context, _ *corev1.Pod) (string, error) {
+	i := f.calls
+	if i >= len(f.results) {
+		i = len(f.results) - 1
+	}
+	f.calls++
+	r := f.results[i]
+	return r.veth, r.err
+}
+
+// fakeDelegator records TCAttach/TCDetach invocations; the poll-loop methods are
+// unused here.
+type fakeDelegator struct {
+	attached  []string
+	detached  []string
+	attachErr error
+}
+
+func (f *fakeDelegator) Run(context.Context, ...string) ([]byte, error) { return nil, nil }
+func (f *fakeDelegator) NetworkPolicySet(context.Context, string, []string) error {
+	return nil
+}
+func (f *fakeDelegator) TCAttach(_ context.Context, veth string) error {
+	f.attached = append(f.attached, veth)
+	return f.attachErr
+}
+func (f *fakeDelegator) TCDetach(_ context.Context, veth string) error {
+	f.detached = append(f.detached, veth)
+	return nil
+}
+
+func newTestMonitor(r vethResolver, d *fakeDelegator) *TrafficShaperMonitor {
+	return &TrafficShaperMonitor{
+		resolver:  r,
+		delegator: d,
+		attached:  make(map[types.UID]string),
+		inflight:  make(map[types.UID]bool),
+	}
+}
+
+func readyPod(uid, name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID(uid), Name: name, Namespace: "bn"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.ContainersReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func notReadyPod(uid, name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID(uid), Name: name, Namespace: "bn"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.ContainersReady, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+}
+
+func shrinkResolveRetries(t *testing.T) {
+	t.Helper()
+	origAttempts, origInterval := vethResolveAttempts, vethResolveInterval
+	vethResolveAttempts = 3
+	vethResolveInterval = time.Millisecond
+	t.Cleanup(func() {
+		vethResolveAttempts = origAttempts
+		vethResolveInterval = origInterval
+	})
+}
+
+func TestHandlePodUpsert_NotReady_NoAttach(t *testing.T) {
+	d := &fakeDelegator{}
+	m := newTestMonitor(&fakeResolver{results: []resolveResult{{veth: "lxc1"}}}, d)
+
+	m.handlePodUpsert(context.Background(), notReadyPod("u1", "bn-0"))
+	require.Empty(t, d.attached, "must not attach a pod that is not ContainersReady")
+}
+
+func TestHandlePodUpsert_Ready_AttachesResolvedVeth(t *testing.T) {
+	d := &fakeDelegator{}
+	m := newTestMonitor(&fakeResolver{results: []resolveResult{{veth: "lxcAAA"}}}, d)
+
+	m.handlePodUpsert(context.Background(), readyPod("u1", "bn-0"))
+	require.Equal(t, []string{"lxcAAA"}, d.attached)
+	require.Equal(t, "lxcAAA", m.attached["u1"])
+}
+
+func TestHandlePodUpsert_DedupesSameVeth(t *testing.T) {
+	d := &fakeDelegator{}
+	m := newTestMonitor(&fakeResolver{results: []resolveResult{{veth: "lxcAAA"}}}, d)
+
+	pod := readyPod("u1", "bn-0")
+	m.handlePodUpsert(context.Background(), pod)
+	m.handlePodUpsert(context.Background(), pod)
+	require.Equal(t, []string{"lxcAAA"}, d.attached, "second identical upsert must not re-attach")
+}
+
+func TestHandlePodUpsert_RetriesUntilVethVisible(t *testing.T) {
+	shrinkResolveRetries(t)
+	d := &fakeDelegator{}
+	r := &fakeResolver{results: []resolveResult{
+		{err: ErrVethNotFound},
+		{veth: "lxcAAA"},
+	}}
+	m := newTestMonitor(r, d)
+
+	m.handlePodUpsert(context.Background(), readyPod("u1", "bn-0"))
+	require.Equal(t, []string{"lxcAAA"}, d.attached)
+	require.GreaterOrEqual(t, r.calls, 2, "should retry after ErrVethNotFound")
+}
+
+func TestHandlePodUpsert_HardResolveErrorDoesNotRetryOrAttach(t *testing.T) {
+	shrinkResolveRetries(t)
+	d := &fakeDelegator{}
+	// A genuinely non-retryable error (not ErrVethNotFound / ErrVethNotReady).
+	// Note RBAC is deliberately NOT used here: the resolver wraps RBAC/exec
+	// failures as ErrVethNotReady, which is retryable.
+	r := &fakeResolver{results: []resolveResult{{err: errors.New("malformed iflink output")}}}
+	m := newTestMonitor(r, d)
+
+	m.handlePodUpsert(context.Background(), readyPod("u1", "bn-0"))
+	require.Empty(t, d.attached)
+	require.Equal(t, 1, r.calls, "a non-retryable error must not be retried")
+}
+
+func TestHandlePodUpsert_AttachFailureNotRecorded(t *testing.T) {
+	d := &fakeDelegator{attachErr: errors.New("tc: operation not permitted")}
+	m := newTestMonitor(&fakeResolver{results: []resolveResult{{veth: "lxcAAA"}}}, d)
+
+	m.handlePodUpsert(context.Background(), readyPod("u1", "bn-0"))
+	require.Equal(t, []string{"lxcAAA"}, d.attached, "attach was attempted")
+	_, tracked := m.attached["u1"]
+	require.False(t, tracked, "a failed attach must not be recorded, so a later event retries it")
+}
+
+func TestHandlePodDelete_DetachesRecordedVeth(t *testing.T) {
+	d := &fakeDelegator{}
+	m := newTestMonitor(&fakeResolver{results: []resolveResult{{veth: "lxcAAA"}}}, d)
+
+	pod := readyPod("u1", "bn-0")
+	m.handlePodUpsert(context.Background(), pod)
+	m.handlePodDelete(context.Background(), pod)
+
+	require.Equal(t, []string{"lxcAAA"}, d.detached)
+	_, stillTracked := m.attached["u1"]
+	require.False(t, stillTracked, "deleted pod must be dropped from the attached map")
+}
+
+func TestHandlePodDelete_UnknownPodIsNoOp(t *testing.T) {
+	d := &fakeDelegator{}
+	m := newTestMonitor(&fakeResolver{results: []resolveResult{{veth: "lxcAAA"}}}, d)
+
+	m.handlePodDelete(context.Background(), readyPod("never-attached", "bn-9"))
+	require.Empty(t, d.detached, "deleting an untracked pod must not call detach")
+}
+
+// blockingResolver blocks in Resolve until gate is closed, so a test can hold a
+// dispatch goroutine "in flight" and assert the guard.
+type blockingResolver struct {
+	veth string
+	gate chan struct{}
+}
+
+func (b *blockingResolver) Resolve(ctx context.Context, _ *corev1.Pod) (string, error) {
+	select {
+	case <-b.gate:
+		return b.veth, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func TestDispatchUpsert_InFlightGuardAndAsyncAttach(t *testing.T) {
+	release := make(chan struct{})
+	d := &fakeDelegator{}
+	m := newTestMonitor(&blockingResolver{veth: "lxcAAA", gate: release}, d)
+	pod := readyPod("u1", "bn-0")
+
+	m.dispatchUpsert(context.Background(), pod)
+
+	// The first goroutine is blocked inside Resolve; the pod is marked in-flight.
+	require.Eventually(t, func() bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return m.inflight["u1"]
+	}, time.Second, time.Millisecond, "pod should be marked in-flight while resolving")
+
+	// A second dispatch while the first is in-flight must not launch another attach.
+	m.dispatchUpsert(context.Background(), pod)
+
+	close(release) // let the single in-flight goroutine finish
+
+	require.Eventually(t, func() bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return len(m.inflight) == 0
+	}, time.Second, time.Millisecond, "in-flight entry should clear after attach completes")
+
+	require.Equal(t, []string{"lxcAAA"}, d.attached, "exactly one attach despite two dispatches")
+}
+
+func TestPodContainersReady(t *testing.T) {
+	require.True(t, podContainersReady(readyPod("u1", "bn-0")))
+	require.False(t, podContainersReady(notReadyPod("u1", "bn-0")))
+	require.False(t, podContainersReady(&corev1.Pod{}), "no condition → not ready")
+	require.False(t, podContainersReady(nil))
+}

--- a/internal/daemon/blocknode/traffic_shaper_monitor.go
+++ b/internal/daemon/blocknode/traffic_shaper_monitor.go
@@ -8,6 +8,9 @@ import (
 	"time"
 
 	"github.com/automa-saga/logx"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/hashgraph/solo-weaver/internal/daemon/privexec"
 )
 
@@ -41,28 +44,46 @@ const responsibilityBackoffFactor = 2.0
 // Each responsibility is independently retried with exponential back-off so a
 // fault in one cannot stop the other or crash the daemon.
 type TrafficShaperMonitor struct {
-	// resolver resolves the host-side veth name for a BN pod (story #747).
-	// Used by runPodWatcher once the real watch loop lands in #748.
-	resolver *VethResolver
+	// resolver resolves the host-side veth name for a BN pod (story #747). Held
+	// as an interface so the pod watcher can be unit-tested with a fake.
+	resolver vethResolver
 	// delegator runs privileged solo-provisioner subcommands under sudo. The
 	// daemon is unprivileged (User=weaver), so both responsibilities delegate
 	// their privileged work through it: the poll loop applies membership via
 	// `network policy set` and the watcher installs veth qdiscs via `block node
-	// tc-attach`. Held here so the poll loop and watcher can consume it once
-	// their apply/attach paths are wired, without a constructor change.
+	// tc-attach`.
 	delegator privexec.Delegator
+	// client watches BN pods in namespace. Nil only in unit tests that exercise
+	// the supervisor loop without a real cluster (runPodWatcher degrades to an
+	// idle block in that case).
+	client kubernetes.Interface
+	// namespace is the BN orbit namespace the pod watcher scopes its list/watch
+	// to.
+	namespace string
+
+	// mu guards attached and inflight.
+	mu sync.Mutex
+	// attached maps pod UID → installed veth, used to dedupe redundant attaches
+	// and to know which veth to detach on pod delete.
+	attached map[types.UID]string
+	// inflight tracks pods with an attach goroutine currently running, so the
+	// watch loop never launches a second concurrent attach for the same pod
+	// while its (retrying) resolve is still in progress.
+	inflight map[types.UID]bool
 }
 
-// NewTrafficShaperMonitor constructs a TrafficShaperMonitor with the given
-// VethResolver. The resolver is wired into runPodWatcher by #748; it is held
-// here so #748 can use it without further constructor changes. The delegator
-// defaults to the sudo-backed privileged-exec seam so the poll loop and watcher
-// can perform their privileged work without the unprivileged daemon holding
-// root itself.
-func NewTrafficShaperMonitor(resolver *VethResolver) *TrafficShaperMonitor {
+// NewTrafficShaperMonitor constructs a TrafficShaperMonitor. resolver and client
+// are built from the BN-scoped kubeconfig by NewComponent; namespace is the BN
+// orbit. The delegator defaults to the sudo-backed privileged-exec seam so the
+// watcher can install veth qdiscs without the unprivileged daemon holding root.
+func NewTrafficShaperMonitor(resolver *VethResolver, client kubernetes.Interface, namespace string) *TrafficShaperMonitor {
 	return &TrafficShaperMonitor{
 		resolver:  resolver,
 		delegator: privexec.New(),
+		client:    client,
+		namespace: namespace,
+		attached:  make(map[types.UID]string),
+		inflight:  make(map[types.UID]bool),
 	}
 }
 
@@ -131,17 +152,6 @@ func (m *TrafficShaperMonitor) superviseResponsibility(ctx context.Context, name
 		}
 		backoff = minDuration(time.Duration(float64(backoff)*responsibilityBackoffFactor), responsibilityBackoffMax)
 	}
-}
-
-// runPodWatcher is the pod-lifecycle watcher responsibility. Stub replaced by
-// the real watch loop in #748; m.resolver is ready for use there.
-func (m *TrafficShaperMonitor) runPodWatcher(ctx context.Context) error {
-	logx.As().Info().
-		Str("reason", "TrafficShaperPodWatcherStub").
-		Str("monitor", m.Name()).
-		Msg("pod-lifecycle watcher not yet implemented — stub running")
-	<-ctx.Done()
-	return nil
 }
 
 // runStatuszPoll is the statusz poll-loop responsibility. The reconciliation

--- a/internal/daemon/blocknode/traffic_shaper_monitor_test.go
+++ b/internal/daemon/blocknode/traffic_shaper_monitor_test.go
@@ -17,7 +17,7 @@ import (
 // TestTrafficShaperMonitor_RunReturnsOnContextCancel verifies Run starts both
 // responsibilities and returns nil promptly once ctx is cancelled.
 func TestTrafficShaperMonitor_RunReturnsOnContextCancel(t *testing.T) {
-	m := NewTrafficShaperMonitor(nil)
+	m := NewTrafficShaperMonitor(nil, nil, "")
 	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan error, 1)
@@ -46,7 +46,7 @@ func TestSuperviseResponsibility_RetriesFaultsWithoutPropagating(t *testing.T) {
 		responsibilityBackoffMax = origMax
 	})
 
-	m := NewTrafficShaperMonitor(nil)
+	m := NewTrafficShaperMonitor(nil, nil, "")
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var calls atomic.Int32
@@ -77,7 +77,7 @@ func TestSuperviseResponsibility_RetriesFaultsWithoutPropagating(t *testing.T) {
 // path: a responsibility that returns without error (and without ctx being
 // cancelled) is re-entered immediately, and the loop exits once ctx is done.
 func TestSuperviseResponsibility_ResetsBackoffAndExitsOnCancel(t *testing.T) {
-	m := NewTrafficShaperMonitor(nil)
+	m := NewTrafficShaperMonitor(nil, nil, "")
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var calls atomic.Int32

--- a/internal/daemon/privexec/delegate.go
+++ b/internal/daemon/privexec/delegate.go
@@ -65,6 +65,16 @@ type Delegator interface {
 	// atomically replaces the named policy's live nft set with cidrs; an empty
 	// (or nil) cidrs slice clears the set (the --cidrs flag is omitted).
 	NetworkPolicySet(ctx context.Context, name string, cidrs []string) error
+
+	// TCAttach delegates `block node tc-attach --veth <veth>` — the pod-lifecycle
+	// watcher's ingress-HTB install path. It installs the $VETH HTB hierarchy on
+	// the given host-side veth from the recorded ingress shape config.
+	TCAttach(ctx context.Context, veth string) error
+
+	// TCDetach delegates `block node tc-attach --veth <veth> --detach` — the
+	// best-effort teardown of the $VETH HTB hierarchy on pod delete or before a
+	// clean re-attach.
+	TCDetach(ctx context.Context, veth string) error
 }
 
 // execDelegator is the production Delegator. Its resolution and exec seams are
@@ -143,6 +153,34 @@ func (d *execDelegator) NetworkPolicySet(ctx context.Context, name string, cidrs
 	args := []string{"network", "policy", "set", "--name", name}
 	if len(cidrs) > 0 {
 		args = append(args, "--cidrs", strings.Join(cidrs, ","))
+	}
+	_, err := d.Run(ctx, args...)
+	return err
+}
+
+func (d *execDelegator) TCAttach(ctx context.Context, veth string) error {
+	return d.tcAttach(ctx, veth, false)
+}
+
+func (d *execDelegator) TCDetach(ctx context.Context, veth string) error {
+	return d.tcAttach(ctx, veth, true)
+}
+
+// tcAttach delegates the `block node tc-attach --veth <veth> [--detach]` exec.
+// The veth-name format is validated by the CLI/shape layer the exec reaches;
+// here we only guard against an empty name so a daemon bug surfaces as a clear
+// ProbeError rather than a malformed argv.
+func (d *execDelegator) tcAttach(ctx context.Context, veth string, detach bool) error {
+	if strings.TrimSpace(veth) == "" {
+		return &daemonkit.ProbeError{
+			Reason:     "VethNameEmpty",
+			Message:    "block node tc-attach requires a non-empty veth name",
+			Resolution: "this is a daemon bug; report it with the daemon logs",
+		}
+	}
+	args := []string{"block", "node", "tc-attach", "--veth", veth}
+	if detach {
+		args = append(args, "--detach")
 	}
 	_, err := d.Run(ctx, args...)
 	return err

--- a/internal/daemon/privexec/delegate_test.go
+++ b/internal/daemon/privexec/delegate_test.go
@@ -100,6 +100,48 @@ func TestNetworkPolicySet_EmptyNameIsGuarded(t *testing.T) {
 	require.Empty(t, call.name, "exec must not run when the name is invalid")
 }
 
+func TestTCAttach_BuildsSudoArgv(t *testing.T) {
+	d, call := fakeDelegator(
+		[]string{"/usr/bin/sudo", "/opt/solo/weaver/bin/solo-provisioner"},
+		"/opt/solo/weaver/bin/solo-provisioner-daemon",
+		nil, nil,
+	)
+
+	require.NoError(t, d.TCAttach(context.Background(), "lxc1a2b3c"))
+	require.Equal(t, "/usr/bin/sudo", call.name)
+	require.Equal(t, []string{
+		"-n",
+		"/opt/solo/weaver/bin/solo-provisioner",
+		"block", "node", "tc-attach", "--veth", "lxc1a2b3c",
+	}, call.args)
+}
+
+func TestTCDetach_AppendsDetachFlag(t *testing.T) {
+	d, call := fakeDelegator(
+		[]string{"/usr/bin/sudo", "/opt/solo/weaver/bin/solo-provisioner"},
+		"/opt/solo/weaver/bin/solo-provisioner-daemon",
+		nil, nil,
+	)
+
+	require.NoError(t, d.TCDetach(context.Background(), "lxc1a2b3c"))
+	require.Equal(t, []string{
+		"-n",
+		"/opt/solo/weaver/bin/solo-provisioner",
+		"block", "node", "tc-attach", "--veth", "lxc1a2b3c", "--detach",
+	}, call.args)
+}
+
+func TestTCAttach_EmptyVethIsGuarded(t *testing.T) {
+	d, call := fakeDelegator([]string{"/usr/bin/sudo", "/usr/local/bin/solo-provisioner"}, "", nil, nil)
+
+	err := d.TCAttach(context.Background(), "  ")
+	require.Error(t, err)
+	var pe *daemonkit.ProbeError
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, "VethNameEmpty", pe.Reason)
+	require.Empty(t, call.name, "exec must not run when the veth name is empty")
+}
+
 func TestResolveCLI_PrefersDaemonSibling(t *testing.T) {
 	// Both the sibling and a granted path exist; the sibling wins.
 	d, _ := fakeDelegator(

--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -641,6 +641,74 @@ func ProvisionDefaultEgressShape(ctx context.Context, nicName, trunkRate string)
 	return NewManager().ProvisionDefaultEgress(ctx, nicName, trunkRate)
 }
 
+// defaultIngressConfig returns the ingress device root and three default ingress
+// classes at proportions derived from trunkRate (publisher 80%, backfill-response
+// 10%, reserve-ingress 10%; all ceil 100% of trunk). Mirrors defaultEgressConfig;
+// exposed as a package-internal helper so tests can verify the computation
+// without disk I/O.
+func defaultIngressConfig(trunkRate string) (*DeviceConfig, []*ClassConfig, error) {
+	bps, err := parseBandwidthBps(trunkRate)
+	if err != nil {
+		return nil, nil, errorx.IllegalArgument.Wrap(err, "invalid trunk rate %q", trunkRate)
+	}
+	mbps := bps / 1_000_000
+	now := time.Now().UTC()
+	dev := &DeviceConfig{
+		Dir:          DirIngress,
+		Rate:         trunkRate,
+		DefaultClass: "reserve-ingress",
+		CreatedAt:    now,
+	}
+	classes := []*ClassConfig{
+		{Name: "publisher", Rate: fmt.Sprintf("%dmbit", mbps*80/100), Ceil: trunkRate, Prio: 0, CreatedAt: now},
+		{Name: "backfill-response", Rate: fmt.Sprintf("%dmbit", mbps*10/100), Ceil: trunkRate, Prio: 7, CreatedAt: now},
+		{Name: "reserve-ingress", Rate: fmt.Sprintf("%dmbit", mbps*10/100), Ceil: trunkRate, Prio: 1, CreatedAt: now},
+	}
+	return dev, classes, nil
+}
+
+// ProvisionDefaultIngress records the ingress ($VETH) device root and three
+// default HTB classes at proportions derived from trunkRate (publisher 80%,
+// backfill-response 10%, reserve-ingress 10%; all ceil 100%). trunkRate may be
+// "auto", resolved to the detected link speed at record time (see
+// resolveAutoRateString). Unlike ProvisionDefaultEgress this writes config only
+// and renders NO boot script: the $VETH HTB is deliberately not persisted across
+// reboot — the daemon pod-lifecycle watcher replays it on each pod create from
+// the stored class configs. Called by block node install so ApplyIngressVeth
+// finds concrete ingress config on the first pod create (the per-pod replay has
+// no sysfs fallback, so the recorded rates must always be concrete).
+func (m *Manager) ProvisionDefaultIngress(_ context.Context, trunkRate string) error {
+	trunkRate = m.resolveAutoRateString(trunkRate)
+	dev, classes, err := defaultIngressConfig(trunkRate)
+	if err != nil {
+		return err
+	}
+	return m.withLock(func() error {
+		if err := writeDevice(dev); err != nil {
+			return err
+		}
+		for _, cls := range classes {
+			if err := writeClass(cls); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// ProvisionDefaultIngressShape records the ingress shape registry with the three
+// default HTB classes at proportions derived from trunkRate. Convenience wrapper
+// over ProvisionDefaultIngress. When nicName is non-empty it pins the resolution
+// of a "auto" trunkRate to the operator-chosen NIC (parity with the egress path
+// on multi-NIC hosts); ingress bandwidth defaults to egress.
+func ProvisionDefaultIngressShape(ctx context.Context, nicName, trunkRate string) error {
+	cfg := Config{}
+	if nicName != "" {
+		cfg.NICDetect = func() (string, error) { return nicName, nil }
+	}
+	return NewManagerWithConfig(cfg).ProvisionDefaultIngress(ctx, trunkRate)
+}
+
 // RenderAndApplyDefaultEgress renders the tc-egress script for nic from the
 // shape registry (or sysfs fallback when no config exists) and applies it.
 // Used when no trunk rate is supplied (e.g. block node reconfigure without

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -434,6 +434,88 @@ func TestDefaultEgressConfig_100mbit_ProportionalRates(t *testing.T) {
 	}
 }
 
+// --- Ingress default config tests ---
+
+// findClass returns the ClassConfig with the given name, failing the test when
+// it is absent.
+func findClass(t *testing.T, classes []*ClassConfig, name string) *ClassConfig {
+	t.Helper()
+	for _, c := range classes {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("class %q not found in %+v", name, classes)
+	return nil
+}
+
+func TestDefaultIngressConfig_1gbit(t *testing.T) {
+	dev, classes, err := defaultIngressConfig("1gbit")
+	if err != nil {
+		t.Fatalf("defaultIngressConfig(1gbit): %v", err)
+	}
+	if dev.Dir != DirIngress {
+		t.Errorf("dev.Dir = %q, want %q", dev.Dir, DirIngress)
+	}
+	if dev.Rate != "1gbit" {
+		t.Errorf("dev.Rate = %q, want 1gbit", dev.Rate)
+	}
+	if dev.DefaultClass != "reserve-ingress" {
+		t.Errorf("dev.DefaultClass = %q, want reserve-ingress", dev.DefaultClass)
+	}
+
+	// 80% / 10% / 10% of 1000mbit; all ceil = 100% (trunk = 1gbit); §1 prios.
+	for _, tc := range []struct {
+		name string
+		rate string
+		prio int
+	}{
+		{"publisher", "800mbit", 0},
+		{"backfill-response", "100mbit", 7},
+		{"reserve-ingress", "100mbit", 1},
+	} {
+		c := findClass(t, classes, tc.name)
+		if c.Rate != tc.rate {
+			t.Errorf("%s rate = %q, want %q", tc.name, c.Rate, tc.rate)
+		}
+		if c.Ceil != "1gbit" {
+			t.Errorf("%s ceil = %q, want 1gbit (100%%)", tc.name, c.Ceil)
+		}
+		if c.Prio != tc.prio {
+			t.Errorf("%s prio = %d, want %d", tc.name, c.Prio, tc.prio)
+		}
+	}
+}
+
+func TestDefaultIngressConfig_100mbit(t *testing.T) {
+	_, classes, err := defaultIngressConfig("100mbit")
+	if err != nil {
+		t.Fatalf("defaultIngressConfig(100mbit): %v", err)
+	}
+	// 80% / 10% / 10% of 100mbit.
+	if c := findClass(t, classes, "publisher"); c.Rate != "80mbit" || c.Ceil != "100mbit" {
+		t.Errorf("publisher = %s/%s, want 80mbit/100mbit", c.Rate, c.Ceil)
+	}
+	if c := findClass(t, classes, "backfill-response"); c.Rate != "10mbit" || c.Ceil != "100mbit" {
+		t.Errorf("backfill-response = %s/%s, want 10mbit/100mbit", c.Rate, c.Ceil)
+	}
+	if c := findClass(t, classes, "reserve-ingress"); c.Rate != "10mbit" || c.Ceil != "100mbit" {
+		t.Errorf("reserve-ingress = %s/%s, want 10mbit/100mbit", c.Rate, c.Ceil)
+	}
+}
+
+func TestDefaultIngressConfig_UnparseableRateErrors(t *testing.T) {
+	// "auto" is resolved to a concrete rate before defaultIngressConfig is called
+	// (see ProvisionDefaultIngress); the pure helper rejects it, matching the
+	// egress helper's contract.
+	if _, _, err := defaultIngressConfig("auto"); err == nil {
+		t.Error("expected defaultIngressConfig(\"auto\") to error, got nil")
+	}
+	if _, _, err := defaultIngressConfig("500mbit"); err != nil {
+		t.Errorf("defaultIngressConfig(\"500mbit\"): unexpected error: %v", err)
+	}
+}
+
 // --- Validation tests ---
 
 func TestValidateDir(t *testing.T) {

--- a/internal/network/shape/tc_linux.go
+++ b/internal/network/shape/tc_linux.go
@@ -6,39 +6,95 @@ package shape
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/joomcode/errorx"
 )
 
-// TCRunner abstracts live kernel tc class operations for testability.
+// tcBin is the absolute path to the tc binary. Absolute (never bare "tc" off
+// PATH) so a caller cannot hijack the privileged invocation via an
+// attacker-controlled directory (see docs/dev/security-model.md).
+const tcBin = "/sbin/tc"
+
+// TCRunner abstracts live kernel tc qdisc/class operations for testability. The
+// egress path drives ClassChange (live tuning of an already-installed
+// hierarchy); the ingress path drives the qdisc/class add verbs to install the
+// per-veth HTB hierarchy from scratch on each BN pod create.
 type TCRunner interface {
 	// ClassChange runs `tc class change dev <nic> parent 1:1 classid 1:<minor>
 	// htb rate <rate> ceil <ceil> prio <prio>` on the live kernel.
 	ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error
+
+	// QdiscDelRoot runs `tc qdisc del dev <nic> root`, tearing down any existing
+	// hierarchy (cascading to all classes and leaf qdiscs). It is best-effort: a
+	// missing root qdisc (a fresh veth) is not an error, so the caller can
+	// unconditionally rebuild — matching the tc-egress boot script's `|| true`.
+	QdiscDelRoot(ctx context.Context, nic string) error
+
+	// QdiscAddRoot runs `tc qdisc add dev <nic> root handle 1: htb default
+	// <defaultMinor>`, installing the root HTB qdisc whose unmatched traffic
+	// falls to class 1:<defaultMinor>.
+	QdiscAddRoot(ctx context.Context, nic, defaultMinor string) error
+
+	// ClassAddRoot runs `tc class add dev <nic> parent 1: classid 1:1 htb rate
+	// <rate> ceil <ceil>`, the trunk class every per-class leaf attaches to.
+	ClassAddRoot(ctx context.Context, nic, rate, ceil string) error
+
+	// ClassAdd runs `tc class add dev <nic> parent 1:1 classid 1:<minor> htb
+	// rate <rate> ceil <ceil> prio <prio>`, a per-class leaf under the trunk.
+	ClassAdd(ctx context.Context, nic, minor, rate, ceil string, prio int) error
+
+	// QdiscAddFqCodel runs `tc qdisc add dev <nic> parent 1:<minor> handle
+	// <handle>: fq_codel`, the leaf qdisc for a class.
+	QdiscAddFqCodel(ctx context.Context, nic, minor, handle string) error
 }
 
 type execTCRunner struct{}
 
-func (r *execTCRunner) ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error {
-	cmd := exec.CommandContext(ctx, "/sbin/tc",
-		"class", "change",
-		"dev", nic,
-		"parent", "1:1",
-		"classid", "1:"+minor,
-		"htb",
-		"rate", rate,
-		"ceil", ceil,
-		"prio", fmt.Sprintf("%d", prio),
-	)
-	out, err := cmd.CombinedOutput()
+// run execs `tc <args...>` and wraps any non-zero exit with the combined output.
+func (r *execTCRunner) run(ctx context.Context, args ...string) error {
+	out, err := exec.CommandContext(ctx, tcBin, args...).CombinedOutput()
 	if err != nil {
 		return errorx.ExternalError.Wrap(err,
-			"tc class change dev %s classid 1:%s failed: %s", nic, minor, strings.TrimSpace(string(out)))
+			"tc %s failed: %s", strings.Join(args, " "), strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+func (r *execTCRunner) ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error {
+	return r.run(ctx, "class", "change",
+		"dev", nic, "parent", "1:1", "classid", "1:"+minor,
+		"htb", "rate", rate, "ceil", ceil, "prio", strconv.Itoa(prio))
+}
+
+func (r *execTCRunner) QdiscDelRoot(ctx context.Context, nic string) error {
+	// Best-effort: swallow the error so a fresh veth (no root qdisc yet) or a
+	// recycled veth name both start from a clean rebuild.
+	_ = exec.CommandContext(ctx, tcBin, "qdisc", "del", "dev", nic, "root").Run()
+	return nil
+}
+
+func (r *execTCRunner) QdiscAddRoot(ctx context.Context, nic, defaultMinor string) error {
+	return r.run(ctx, "qdisc", "add",
+		"dev", nic, "root", "handle", "1:", "htb", "default", defaultMinor)
+}
+
+func (r *execTCRunner) ClassAddRoot(ctx context.Context, nic, rate, ceil string) error {
+	return r.run(ctx, "class", "add",
+		"dev", nic, "parent", "1:", "classid", "1:1", "htb", "rate", rate, "ceil", ceil)
+}
+
+func (r *execTCRunner) ClassAdd(ctx context.Context, nic, minor, rate, ceil string, prio int) error {
+	return r.run(ctx, "class", "add",
+		"dev", nic, "parent", "1:1", "classid", "1:"+minor,
+		"htb", "rate", rate, "ceil", ceil, "prio", strconv.Itoa(prio))
+}
+
+func (r *execTCRunner) QdiscAddFqCodel(ctx context.Context, nic, minor, handle string) error {
+	return r.run(ctx, "qdisc", "add",
+		"dev", nic, "parent", "1:"+minor, "handle", handle+":", "fq_codel")
 }
 
 // newExecTCRunner returns the production TC runner that shells out to /sbin/tc.

--- a/internal/network/shape/tc_other.go
+++ b/internal/network/shape/tc_other.go
@@ -10,15 +10,40 @@ import (
 	"github.com/joomcode/errorx"
 )
 
-// TCRunner abstracts live kernel tc class operations for testability.
+// TCRunner abstracts live kernel tc qdisc/class operations for testability.
 type TCRunner interface {
 	ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error
+	QdiscDelRoot(ctx context.Context, nic string) error
+	QdiscAddRoot(ctx context.Context, nic, defaultMinor string) error
+	ClassAddRoot(ctx context.Context, nic, rate, ceil string) error
+	ClassAdd(ctx context.Context, nic, minor, rate, ceil string, prio int) error
+	QdiscAddFqCodel(ctx context.Context, nic, minor, handle string) error
 }
 
 type noopTCRunner struct{}
 
-func (r *noopTCRunner) ClassChange(_ context.Context, _, _, _, _ string, _ int) error {
+func errUnsupported() error {
 	return errorx.IllegalState.New("tc operations not supported on this platform")
+}
+
+func (r *noopTCRunner) ClassChange(_ context.Context, _, _, _, _ string, _ int) error {
+	return errUnsupported()
+}
+
+// QdiscDelRoot is best-effort even on unsupported platforms: teardown must never
+// block the caller, matching the Linux runner's swallow-and-continue semantics.
+func (r *noopTCRunner) QdiscDelRoot(_ context.Context, _ string) error { return nil }
+
+func (r *noopTCRunner) QdiscAddRoot(_ context.Context, _, _ string) error { return errUnsupported() }
+
+func (r *noopTCRunner) ClassAddRoot(_ context.Context, _, _, _ string) error { return errUnsupported() }
+
+func (r *noopTCRunner) ClassAdd(_ context.Context, _, _, _, _ string, _ int) error {
+	return errUnsupported()
+}
+
+func (r *noopTCRunner) QdiscAddFqCodel(_ context.Context, _, _, _ string) error {
+	return errUnsupported()
 }
 
 // newExecTCRunner returns a no-op runner on non-Linux platforms.

--- a/internal/network/shape/veth.go
+++ b/internal/network/shape/veth.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"context"
+
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+)
+
+// validateVethName rejects a veth name that could inject into the privileged tc
+// invocation. The name originates from the daemon's runtime veth resolution but
+// is an untrusted argument at the command boundary, so it passes through the
+// same IFNAMSIZ-bounded funnel (nicNameRe) as the egress NIC name.
+func validateVethName(veth string) error {
+	if !nicNameRe.MatchString(veth) {
+		return errorx.IllegalArgument.New(
+			"veth name %q is invalid: must match %s", veth, nicNameRe.String())
+	}
+	return nil
+}
+
+// effectiveIngressRootRate resolves the concrete HTB trunk rate for the ingress
+// veth hierarchy. By design the ingress root rate mirrors the egress root rate
+// (the install's `--ingress-bandwidth` defaults to `--egress-bandwidth`), so a
+// recorded ingress rate that is not a concrete bandwidth — e.g. left as "auto",
+// which has no meaning for a per-pod veth that has no sysfs link speed — falls
+// back to the recorded egress rate. It errors only when neither is concrete.
+func effectiveIngressRootRate(ingressRate, egressRate string) (string, error) {
+	if validateRate(ingressRate) == nil {
+		return ingressRate, nil
+	}
+	if validateRate(egressRate) == nil {
+		return egressRate, nil
+	}
+	return "", errorx.IllegalState.New(
+		"ingress shape rate %q is not a concrete bandwidth and no egress rate is available to mirror; "+
+			"run `network shape create --device ingress --rate <bandwidth>` (or configure the egress device)", ingressRate)
+}
+
+// ApplyIngressVeth installs the $VETH ingress HTB hierarchy (design §5.1) on the
+// given host-side veth, using the ingress device root and per-class budgets
+// recorded by `network shape` (under DeviceConfigDir / ClassConfigDir). It is
+// the privileged operation the daemon's pod-lifecycle watcher delegates via
+// `block node tc-attach` on each BN pod create.
+//
+// The hierarchy is: root HTB qdisc (default → the ingress default class), a
+// trunk class 1:1 at the device root rate, one leaf class per recorded ingress
+// class (1:10 / 1:20 / 1:30) with an fq_codel qdisc, and no tc filters — HTB
+// classifies natively on skb->priority set by the nft classification rules.
+//
+// The apply is idempotent: the root qdisc is torn down first (cascading to all
+// classes and leaf qdiscs), so a rebind on a recycled veth name starts clean.
+func (m *Manager) ApplyIngressVeth(ctx context.Context, veth string) error {
+	if err := validateVethName(veth); err != nil {
+		return err
+	}
+
+	dev, err := readDevice(DirIngress)
+	if err != nil {
+		return err
+	}
+	if dev == nil {
+		return errorx.IllegalState.New(
+			"no ingress shape recorded; run `network shape create --device ingress --rate <bandwidth> --default reserve-ingress` first (normally done by `block node install`)")
+	}
+	defInfo, err := lookupClassInfo(dev.DefaultClass)
+	if err != nil {
+		return err
+	}
+
+	egress, err := readDevice(DirEgress)
+	if err != nil {
+		return err
+	}
+	egressRate := ""
+	if egress != nil {
+		egressRate = egress.Rate
+	}
+	rootRate, err := effectiveIngressRootRate(dev.Rate, egressRate)
+	if err != nil {
+		return err
+	}
+
+	classes, err := loadClassesForDir(DirIngress)
+	if err != nil {
+		return err
+	}
+	if len(classes) == 0 {
+		return errorx.IllegalState.New(
+			"no ingress shape classes recorded; run `network shape create --class <name> --rate <bandwidth>` for the ingress classes first (normally done by `block node install`)")
+	}
+
+	if err := m.applyVethHierarchy(ctx, veth, defInfo.Minor, rootRate, classes); err != nil {
+		return err
+	}
+
+	logx.As().Info().
+		Str("veth", veth).
+		Str("default_class", dev.DefaultClass).
+		Int("classes", len(classes)).
+		Msg("installed $VETH ingress HTB hierarchy")
+	return nil
+}
+
+// applyVethHierarchy installs the §5.1 HTB hierarchy on veth under the tc lock:
+// tear down any existing root qdisc, add the root HTB qdisc (default →
+// defaultMinor), the trunk class 1:1 at rootRate, then one leaf class + fq_codel
+// per recorded class. Split from ApplyIngressVeth (which does the disk reads and
+// validation) so the tc-call sequence is unit-testable with a fake TCRunner.
+func (m *Manager) applyVethHierarchy(ctx context.Context, veth, defaultMinor, rootRate string, classes []*ClassConfig) error {
+	return m.withLock(func() error {
+		// Tear down any existing hierarchy so a rebind on a recycled veth name
+		// (or a partially-applied prior attempt) starts from a clean slate.
+		if err := m.tcRunner.QdiscDelRoot(ctx, veth); err != nil {
+			return err
+		}
+		if err := m.tcRunner.QdiscAddRoot(ctx, veth, defaultMinor); err != nil {
+			return err
+		}
+		if err := m.tcRunner.ClassAddRoot(ctx, veth, rootRate, rootRate); err != nil {
+			return err
+		}
+		for _, cls := range classes {
+			ci, err := lookupClassInfo(cls.Name)
+			if err != nil {
+				return err
+			}
+			if err := m.tcRunner.ClassAdd(ctx, veth, ci.Minor, cls.Rate, cls.effectiveCeil(), cls.Prio); err != nil {
+				return err
+			}
+			if err := m.tcRunner.QdiscAddFqCodel(ctx, veth, ci.Minor, ci.Handle); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// RemoveIngressVeth tears down the $VETH ingress HTB hierarchy on the given
+// veth. It is best-effort: the kernel auto-removes veth-attached qdiscs when the
+// veth disappears on pod delete, so this is mostly for the proactive
+// (re)attach-time cleanup path and never fails on an already-absent qdisc.
+func (m *Manager) RemoveIngressVeth(ctx context.Context, veth string) error {
+	if err := validateVethName(veth); err != nil {
+		return err
+	}
+	return m.withLock(func() error {
+		return m.tcRunner.QdiscDelRoot(ctx, veth)
+	})
+}

--- a/internal/network/shape/veth_test.go
+++ b/internal/network/shape/veth_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// recordingTCRunner records each tc operation as an ordered, human-readable line
+// so tests can assert the exact §5.1 install sequence. An operation whose line
+// prefix is in failOn returns an error, to exercise mid-sequence failure.
+type recordingTCRunner struct {
+	calls  []string
+	failOn map[string]bool
+}
+
+func (r *recordingTCRunner) record(line string) error {
+	r.calls = append(r.calls, line)
+	verb := strings.SplitN(line, " ", 2)[0]
+	if r.failOn[verb] {
+		return fmt.Errorf("forced failure on %q", verb)
+	}
+	return nil
+}
+
+func (r *recordingTCRunner) ClassChange(_ context.Context, nic, minor, rate, ceil string, prio int) error {
+	return r.record(fmt.Sprintf("class-change %s 1:%s %s %s prio=%d", nic, minor, rate, ceil, prio))
+}
+func (r *recordingTCRunner) QdiscDelRoot(_ context.Context, nic string) error {
+	return r.record(fmt.Sprintf("qdisc-del-root %s", nic))
+}
+func (r *recordingTCRunner) QdiscAddRoot(_ context.Context, nic, defaultMinor string) error {
+	return r.record(fmt.Sprintf("qdisc-add-root %s default=1:%s", nic, defaultMinor))
+}
+func (r *recordingTCRunner) ClassAddRoot(_ context.Context, nic, rate, ceil string) error {
+	return r.record(fmt.Sprintf("class-add-root %s 1:1 %s %s", nic, rate, ceil))
+}
+func (r *recordingTCRunner) ClassAdd(_ context.Context, nic, minor, rate, ceil string, prio int) error {
+	return r.record(fmt.Sprintf("class-add %s 1:%s %s %s prio=%d", nic, minor, rate, ceil, prio))
+}
+func (r *recordingTCRunner) QdiscAddFqCodel(_ context.Context, nic, minor, handle string) error {
+	return r.record(fmt.Sprintf("qdisc-fqcodel %s 1:%s handle=%s", nic, minor, handle))
+}
+
+func newRecordingManager(t *testing.T, tc TCRunner) *Manager {
+	t.Helper()
+	return NewManagerWithConfig(Config{
+		LockPath: filepath.Join(t.TempDir(), ".tc-applying"),
+		TCRunner: tc,
+	})
+}
+
+// ingressClasses returns the three §5.1 ingress classes in the sorted order
+// loadClassesForDir would yield (alphabetical by name).
+func ingressClasses() []*ClassConfig {
+	return []*ClassConfig{
+		{Name: "backfill-response", Rate: "100mbit", Ceil: "1gbit", Prio: 7},
+		{Name: "publisher", Rate: "800mbit", Ceil: "1gbit", Prio: 0},
+		{Name: "reserve-ingress", Rate: "100mbit", Ceil: "1gbit", Prio: 1},
+	}
+}
+
+func TestApplyVethHierarchy_InstallsSection51Sequence(t *testing.T) {
+	tc := &recordingTCRunner{}
+	m := newRecordingManager(t, tc)
+
+	// default class reserve-ingress → minor 30.
+	if err := m.applyVethHierarchy(context.Background(), "lxc1a2b3c", "30", "1gbit", ingressClasses()); err != nil {
+		t.Fatalf("applyVethHierarchy: %v", err)
+	}
+
+	want := []string{
+		"qdisc-del-root lxc1a2b3c",
+		"qdisc-add-root lxc1a2b3c default=1:30",
+		"class-add-root lxc1a2b3c 1:1 1gbit 1gbit",
+		// backfill-response → 1:20 / handle 120
+		"class-add lxc1a2b3c 1:20 100mbit 1gbit prio=7",
+		"qdisc-fqcodel lxc1a2b3c 1:20 handle=120",
+		// publisher → 1:10 / handle 110
+		"class-add lxc1a2b3c 1:10 800mbit 1gbit prio=0",
+		"qdisc-fqcodel lxc1a2b3c 1:10 handle=110",
+		// reserve-ingress → 1:30 / handle 130
+		"class-add lxc1a2b3c 1:30 100mbit 1gbit prio=1",
+		"qdisc-fqcodel lxc1a2b3c 1:30 handle=130",
+	}
+	if len(tc.calls) != len(want) {
+		t.Fatalf("call count = %d, want %d\ngot:  %v\nwant: %v", len(tc.calls), len(want), tc.calls, want)
+	}
+	for i := range want {
+		if tc.calls[i] != want[i] {
+			t.Errorf("call[%d] = %q, want %q", i, tc.calls[i], want[i])
+		}
+	}
+}
+
+func TestApplyVethHierarchy_DefaultCeilFallsBackToRate(t *testing.T) {
+	tc := &recordingTCRunner{}
+	m := newRecordingManager(t, tc)
+
+	// A class with an empty Ceil should render ceil == rate.
+	classes := []*ClassConfig{{Name: "publisher", Rate: "800mbit", Ceil: "", Prio: 0}}
+	if err := m.applyVethHierarchy(context.Background(), "lxc9", "30", "1gbit", classes); err != nil {
+		t.Fatalf("applyVethHierarchy: %v", err)
+	}
+	found := false
+	for _, c := range tc.calls {
+		if c == "class-add lxc9 1:10 800mbit 800mbit prio=0" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected ceil to default to rate (800mbit); calls: %v", tc.calls)
+	}
+}
+
+func TestApplyVethHierarchy_StopsOnMidSequenceFailure(t *testing.T) {
+	tc := &recordingTCRunner{failOn: map[string]bool{"class-add": true}}
+	m := newRecordingManager(t, tc)
+
+	err := m.applyVethHierarchy(context.Background(), "lxc1", "30", "1gbit", ingressClasses())
+	if err == nil {
+		t.Fatal("expected error when a class-add fails, got nil")
+	}
+	// Should have run del-root, add-root, class-add-root, then the first leaf
+	// class-add (which fails) — and stopped before its fq_codel.
+	if got := tc.calls[len(tc.calls)-1]; !strings.HasPrefix(got, "class-add ") {
+		t.Errorf("expected to stop on the failing class-add, last call = %q", got)
+	}
+	for _, c := range tc.calls {
+		if strings.HasPrefix(c, "qdisc-fqcodel") {
+			t.Errorf("must not proceed to fq_codel after a class-add failure; calls: %v", tc.calls)
+		}
+	}
+}
+
+func TestEffectiveIngressRootRate(t *testing.T) {
+	// Concrete ingress rate is used as-is.
+	got, err := effectiveIngressRootRate("500mbit", "1gbit")
+	require.NoError(t, err)
+	require.Equal(t, "500mbit", got)
+
+	// Non-concrete ingress rate ("auto" has no meaning for a per-pod veth) mirrors
+	// the egress rate.
+	got, err = effectiveIngressRootRate("auto", "1gbit")
+	require.NoError(t, err)
+	require.Equal(t, "1gbit", got)
+
+	// Empty ingress rate also falls back to egress.
+	got, err = effectiveIngressRootRate("", "800mbit")
+	require.NoError(t, err)
+	require.Equal(t, "800mbit", got)
+
+	// Neither concrete → error.
+	_, err = effectiveIngressRootRate("auto", "")
+	require.Error(t, err)
+}
+
+func TestValidateVethName(t *testing.T) {
+	for _, ok := range []string{"lxc1a2b3c4d", "eth0", "veth_abc", "a"} {
+		if err := validateVethName(ok); err != nil {
+			t.Errorf("validateVethName(%q): unexpected error %v", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "lxc; rm -rf /", "veth abc", "toolonginterfacename", "lxc/../etc"} {
+		if err := validateVethName(bad); err == nil {
+			t.Errorf("validateVethName(%q): expected error, got nil", bad)
+		}
+	}
+}
+
+func TestRemoveIngressVeth_BestEffortDelRoot(t *testing.T) {
+	tc := &recordingTCRunner{}
+	m := newRecordingManager(t, tc)
+
+	if err := m.RemoveIngressVeth(context.Background(), "lxc1a2b3c"); err != nil {
+		t.Fatalf("RemoveIngressVeth: %v", err)
+	}
+	if len(tc.calls) != 1 || tc.calls[0] != "qdisc-del-root lxc1a2b3c" {
+		t.Errorf("expected a single qdisc-del-root call, got %v", tc.calls)
+	}
+}
+
+func TestRemoveIngressVeth_RejectsBadName(t *testing.T) {
+	tc := &recordingTCRunner{}
+	m := newRecordingManager(t, tc)
+	if err := m.RemoveIngressVeth(context.Background(), "bad name"); err == nil {
+		t.Error("expected error for invalid veth name, got nil")
+	}
+	if len(tc.calls) != 0 {
+		t.Errorf("expected no tc calls for an invalid name, got %v", tc.calls)
+	}
+}

--- a/internal/templates/files/weaver/solo-provisioner-daemon.service
+++ b/internal/templates/files/weaver/solo-provisioner-daemon.service
@@ -17,6 +17,15 @@ RestartSec=5s
 PrivateTmp=true
 ProtectSystem=strict
 ReadWritePaths=/opt/solo{{range .ExtraReadWritePaths}} {{.}}{{end}}
+# The daemon delegates privileged tc/nft work by exec'ing `sudo solo-provisioner`
+# children, which inherit this unit's mount namespace. Those children acquire a
+# flock under /run/solo-provisioner/network to serialise tc/nft applies with the
+# operator CLI. Under ProtectSystem=strict that path is read-only, so grant it a
+# managed runtime dir: RuntimeDirectory creates and RW-mounts /run/solo-provisioner
+# on every start (recreating it after reboot, since /run is tmpfs); Preserve=yes
+# keeps it across daemon restarts so a concurrent operator flock is never yanked.
+RuntimeDirectory=solo-provisioner
+RuntimeDirectoryPreserve=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/internal/templates/weaver_privilege_test.go
+++ b/internal/templates/weaver_privilege_test.go
@@ -76,3 +76,22 @@ func TestDaemonServiceRunsUnprivileged(t *testing.T) {
 		t.Errorf("daemon service unit sets a NoNewPrivileges directive; it must be omitted so sudo delegation works\n--- unit ---\n%s", unit)
 	}
 }
+
+// TestDaemonServiceGrantsRuntimeDir locks the invariant that the daemon's
+// privileged-exec children can write their tc/nft flock under
+// /run/solo-provisioner. ProtectSystem=strict makes /run read-only, so without a
+// RuntimeDirectory the exec'd `block node tc-attach` / `network policy set` fail
+// with "read-only file system" when opening /run/solo-provisioner/network/.*
+// lock files.
+func TestDaemonServiceGrantsRuntimeDir(t *testing.T) {
+	unit := directiveLines(t, "files/weaver/solo-provisioner-daemon.service")
+
+	if !strings.Contains(unit, "ProtectSystem=strict") {
+		t.Fatalf("expected ProtectSystem=strict (the reason the runtime dir grant is required)\n--- unit ---\n%s", unit)
+	}
+	// RuntimeDirectory=solo-provisioner makes /run/solo-provisioner writable inside
+	// the sandbox (and recreates it after reboot, since /run is tmpfs).
+	if !strings.Contains(unit, "RuntimeDirectory=solo-provisioner") {
+		t.Errorf("daemon service unit must set RuntimeDirectory=solo-provisioner so exec'd tc/nft workers can write their flock under /run/solo-provisioner\n--- unit ---\n%s", unit)
+	}
+}

--- a/internal/workflows/network_setup.go
+++ b/internal/workflows/network_setup.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package workflows
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+)
+
+// NetworkSetupWorkflow lays down the block node's static network plane: the
+// node-level host firewall (inet host), the weaver policy-table persistence
+// (inet weaver), and the $EGRESS / $VETH tc HTB shape config. It is rendered as
+// the "Network Setup" phase so these steps group under their own header in the
+// TUI instead of dangling as loose sub-steps after the "Kubernetes Setup" phase.
+//
+// Ordering note preserved from the caller: this must run after the Kubernetes
+// setup, since nftables is installed/enabled by the system-setup phase before the
+// host firewall is applied here.
+func NetworkSetupWorkflow(egressInterface, linkRate string) *automa.WorkflowBuilder {
+	return automa.NewWorkflowBuilder().
+		WithId("block-node-network-setup").
+		Steps(
+			steps.NetworkFirewallCreate(),
+			steps.NftWeaverPersist(),
+			steps.TcEgressPersist(egressInterface, linkRate),
+			steps.TcIngressRecord(egressInterface, linkRate),
+		).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().PhaseStart(ctx, stp, "Network Setup")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().PhaseFailure(ctx, stp, rpt, "Network Setup")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().PhaseCompletion(ctx, stp, rpt, "Network Setup")
+		})
+}
+
+// BlockNodeDaemonConfigWorkflow enables the block-node traffic-shaper monitor in
+// daemon.yaml. It wraps the single config step in a "Traffic-shaper Monitor" phase
+// so it renders under its own header rather than dangling after the "Block Node
+// Deployment" phase. It runs last, after the deployment it watches is in place.
+func BlockNodeDaemonConfigWorkflow(namespace string) *automa.WorkflowBuilder {
+	return automa.NewWorkflowBuilder().
+		WithId("block-node-daemon-config").
+		Steps(
+			steps.WriteBlockNodeDaemonConfigStep(models.Paths(), namespace),
+		).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().PhaseStart(ctx, stp, "Traffic-shaper Monitor")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().PhaseFailure(ctx, stp, rpt, "Traffic-shaper Monitor")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().PhaseCompletion(ctx, stp, rpt, "Traffic-shaper Monitor")
+		})
+}

--- a/internal/workflows/steps/step_network_tc_ingress.go
+++ b/internal/workflows/steps/step_network_tc_ingress.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// TcIngressRecordStepId is the step ID for TcIngressRecord.
+const TcIngressRecordStepId = "tc-ingress-record"
+
+// TcIngressRecord records the ingress ($VETH) HTB shape config so the daemon
+// pod-lifecycle watcher can replay it on each block-node pod create. It writes
+// the ingress device root and the three default classes (publisher/backfill-
+// response/reserve-ingress) at proportional rates into the shape registry, but —
+// unlike TcEgressPersist — renders NO boot script: the $VETH qdisc is ephemeral
+// (Cilium recreates the veth per pod) and is deliberately not persisted across
+// reboot.
+//
+// Ingress bandwidth defaults to egress: linkRate is the operator's --link-rate
+// (the $EGRESS trunk). When empty it resolves "auto" — the NIC's detected link
+// speed at install time — so the recorded class rates are always concrete, since
+// the per-pod replay has no sysfs fallback. nicName pins auto-resolution to the
+// operator-chosen NIC on multi-NIC hosts.
+func TcIngressRecord(nicName string, linkRate string) *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(TcIngressRecordStepId).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Recording tc-ingress ($VETH) HTB shape for per-pod replay")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to record tc-ingress shape")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "tc-ingress shape recorded")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			rate := linkRate
+			if rate == "" {
+				rate = "auto"
+			}
+			if err := shape.ProvisionDefaultIngressShape(ctx, nicName, rate); err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to record default ingress shape").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Inspect the recorded ingress config: ls /etc/solo-provisioner/network/shape/devices /etc/solo-provisioner/network/shape/classes",
+							"Verify --link-rate is a valid tc-style rate (e.g. 1gbit, 100mbit) or \"auto\"",
+							"Re-run the install: block node install --link-rate <rate>",
+						})))
+			}
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			// Rollback is a no-op: the recorded config is an idempotent artifact and
+			// is not applied to the kernel here (the daemon replays it per pod).
+			// Teardown is handled by block node uninstall.
+			return automa.SkippedReport(stp,
+				automa.WithDetail("tc-ingress rollback is a no-op; teardown is handled by block node uninstall"))
+		})
+}


### PR DESCRIPTION
## Description

The traffic-shaper monitor's pod-lifecycle watcher was a stub, and the host-side
veth resolver from the prior story was wired in but never called. This PR closes
that gap: when a block node pod becomes ready, the daemon now installs the
per-pod ingress HTB hierarchy on its host-side veth, so ingress traffic to the
pod is prioritised by class within single-digit seconds of the pod starting.

The privileged `tc` work is **not** exposed as a `network` subcommand. Per-host tc
hierarchies already live under `block node` (the `$EGRESS` HTB is installed by
`block node install`), and — unlike every `network shape` verb, which persists a
boot script for reboot replay — the `$VETH` qdisc is deliberately ephemeral (the
veth doesn't survive a pod restart; Cilium recreates it). So the applier is a
`block node tc-attach` worker the unprivileged daemon (`User=weaver`) execs via
sudo, reusing the existing `privexec` delegation seam. The reconcile "brain"
(which veths should exist, resolved from the k8s watch) stays in the daemon;
`tc-attach` is a dumb per-veth applier, which also keeps the blast radius small
for the eventual Cilium veth→netkit migration.

The installed hierarchy is exactly the design's ingress shape: root HTB qdisc with
`default reserve-ingress`, a trunk class `1:1`, three leaf classes `1:10`
(publisher) / `1:20` (backfill-response) / `1:30` (reserve-ingress) with `fq_codel`
leaves, and **no tc filters** — HTB classifies natively on `skb->priority` set by
the nft classification rules. The rate/ceil/prio come from the budgets
`network shape` recorded under `/etc/solo-provisioner/network/shape`. The apply is
idempotent (tear down the root qdisc, then rebuild), so a rebind on a recycled
veth name starts clean.

Scope of the applier is install-on-ready only. Orphan-qdisc GC on monitor restart,
the rebind window, and richer delete-cleanup semantics are the follow-up story's
concern; this PR does a best-effort detach on pod delete (the kernel also drops the
qdisc with the veth).

Two adjacent pieces are folded in (surfaced during end-to-end testing):

- **#764 — record the ingress shape at `block node install`.** Install now records
  the `$VETH` ingress device + the three ingress classes (ingress rate defaults to
  `--link-rate`), so the daemon's `tc-attach` has a shape to read without a manual
  step.
- **Install TUI grouping + daemon sandbox.** The loose static-plane install steps
  (host firewall, weaver-nft persist, tc-egress/ingress, daemon-enable) are wrapped
  in named phases ("Network Setup", "Traffic-shaper Daemon") so they no longer
  dangle under the previous phase in `-VV` output; and the daemon unit gets
  `RuntimeDirectory=solo-provisioner` so the sudo-exec'd `tc-attach` can write its
  flock under `ProtectSystem=strict`.

### Files changed

| File | Change |
|---|---|
| `internal/network/shape/veth.go` | New. `ApplyIngressVeth`/`RemoveIngressVeth` load the recorded ingress device+classes and apply/tear down the §5.1 hierarchy under the tc lock; `validateVethName` guards the privileged tc argv via the existing `nicNameRe` funnel. |
| `internal/network/shape/tc_linux.go` | Extend `TCRunner` beyond `ClassChange` with `QdiscDelRoot`/`QdiscAddRoot`/`ClassAddRoot`/`ClassAdd`/`QdiscAddFqCodel`; add a shared `run` exec helper. |
| `internal/network/shape/tc_other.go` | Mirror the new `TCRunner` methods for the non-Linux stub. |
| `internal/network/shape/veth_test.go` | New. Asserts the exact §5.1 tc-call sequence via a recording runner, ceil-defaults-to-rate, mid-sequence failure stop, veth-name validation, best-effort detach. |
| `internal/daemon/privexec/delegate.go` | Add typed `TCAttach`/`TCDetach` (`block node tc-attach --veth <v> [--detach]`) alongside `NetworkPolicySet`. |
| `internal/daemon/privexec/delegate_test.go` | Argv + empty-veth-guard tests for the new delegation. |
| `internal/daemon/blocknode/pod_watcher.go` | New. Real pod-lifecycle watcher: list+watch BN pods, resolve the host-side veth with a bounded retry, install on `ContainersReady`, dedupe, best-effort detach on delete. |
| `internal/daemon/blocknode/traffic_shaper_monitor.go` | Monitor holds the kube client + namespace + `attached` map; `resolver` is now an interface for testability; the `runPodWatcher` stub is gone. |
| `internal/daemon/blocknode/component.go` | Build the pod-watch kube client from the BN kubeconfig and pass namespace into the monitor. |
| `internal/daemon/blocknode/pod_watcher_test.go` | New. Ready-gating, attach, dedupe, resolve-retry, hard-error-no-retry, attach-failure-not-recorded, delete-detach, unknown-pod no-op. |
| `cmd/cli/commands/block/node/tc_attach.go` | New. Visible `block node tc-attach --veth <name> [--detach]` worker (root; `SkipGlobalChecks`), thin wrapper over the shape applier. |
| `cmd/cli/commands/block/node/node.go` | Register `tc-attach`. |
| `docs/quickstart.md` | Document `block node tc-attach`. |
| `internal/templates/files/weaver/solo-provisioner-daemon.service` | Add `RuntimeDirectory=solo-provisioner` (+ `Preserve=yes`) so the daemon's sudo-exec'd `tc-attach` child can write its `/run/solo-provisioner/network` flock under `ProtectSystem=strict` (otherwise the apply fails "read-only file system"). |
| `internal/templates/weaver_privilege_test.go` | Assert the daemon unit grants the runtime dir under `ProtectSystem=strict`. |
| `internal/workflows/steps/step_network_tc_ingress.go` | New (#764). `TcIngressRecord` step → records the ingress device + classes at install. |
| `internal/network/shape/manager.go` | Add `ProvisionDefaultIngressShape` (#764). |
| `internal/network/shape/shape_test.go` | Tests for ingress-shape provisioning (#764). |
| `internal/workflows/network_setup.go` | New. `NetworkSetupWorkflow` ("Network Setup") + `BlockNodeDaemonConfigWorkflow` ("Traffic-shaper Daemon") group the loose static-plane steps into named TUI phases. |
| `internal/bll/blocknode/install_handler.go` | Record the ingress shape (#764) and route the static-plane + daemon-enable steps through the phased sub-workflows. |

### Test plan

Unit coverage is green on the host for the three host-buildable packages
(`internal/network/shape`, `internal/daemon/privexec`, `internal/daemon/blocknode`):

```bash
go test -tags='!integration' ./internal/network/shape/... ./internal/daemon/privexec/... ./internal/daemon/blocknode/...
```

The `cmd/cli/commands/block/node` package is Linux-only (transitive `mount`
import); it was verified to compile via `GOOS=linux GOARCH=arm64 go build` of the
full CLI binary. Full `task vm:test:unit` should be run on the reviewer's Linux VM.

### Manual UAT

> **Note:** the daemon-side dependencies have landed on `main` — #905 (provisions
> the block-node RBAC + `daemon-bn.kubeconfig`) and #902 (graceful degradation) —
> and this branch is rebased on top of them, so the UAT below is runnable
> end-to-end.

Run on a Linux host (e.g. the UTM VM) as root/sudo. **Prerequisites:** a
Kubernetes cluster reachable via `kubectl` whose admin kubeconfig can create
ServiceAccounts/ClusterRoles/ClusterRoleBindings/Secrets (step 0 provisions RBAC
via #905), and a block node already installed and Ready
(`solo-provisioner block node install …`) so there is a BN pod on the host and both
the egress and ingress tc shapes are recorded (install records both now — the
ingress-shape recording, #764, is folded into this PR). **The primary path is fully daemon-driven**:
the daemon watches BN pods, resolves the host-side veth *itself* (pod `iflink` →
host `ifindex`, from story #747), and execs `tc-attach` via sudo on
`ContainersReady` — no manual veth handling. Steps 3–4 verify the daemon resolved
the *correct* veth; the by-hand `tc-attach` (step 6) is only for debugging.

First build the two binaries (the debian UTM VM is `linux/arm64` on Apple Silicon;
use the target host's `GOOS`/`GOARCH`):

```bash
task build:cli    GOOS=linux GOARCH=arm64   # → bin/solo-provisioner-linux-arm64
task build:daemon GOOS=linux GOARCH=arm64   # → bin/solo-provisioner-daemon-linux-arm64
# or build both (CLI + daemon) for all configured platforms at once:
task build
```

Deploy them the normal way: `sudo solo-provisioner install` self-installs the CLI
into `/opt/solo/weaver/bin`, and step 0 below installs + starts the daemon from the
built daemon binary. (On the UTM VM the repo's `task vm:*` helpers sync the repo
and run these for you.)

```bash
NS=<bn-namespace>

# 0. Install the daemon with the block-node component. Via #905 this now
#    provisions the block-node ServiceAccount + RBAC and writes the BN-scoped
#    kubeconfig, installs + starts the systemd unit, and enables the traffic_shaper
#    monitor by default (BlockNodeMonitors{TrafficShaper: true}). If a PRIOR install
#    left the daemon in a failed/partial state, clear it first:
sudo solo-provisioner daemon service uninstall     # only when re-running after a failed install
sudo solo-provisioner daemon service install --components block-node --bn-orbit "$NS"
#    Progress should now include (skipped before #905): Checking K8s cluster
#    reachability → Creating daemon RBAC resources → Writing daemon kubeconfigs →
#    Installing systemd service. This (re)render of the unit also grants
#    RuntimeDirectory=solo-provisioner, so the sudo-exec'd tc-attach can write its
#    /run/solo-provisioner/network flock under ProtectSystem=strict (an existing
#    daemon must be reinstalled to pick up the new unit).

# Verify provisioning landed and the monitor is running:
ls -l /opt/solo/weaver/config/daemon-bn.kubeconfig                       # written by #905
kubectl auth can-i --as=system:serviceaccount:"$NS":solo-provisioner-daemon-bn get pods
kubectl auth can-i --as=system:serviceaccount:"$NS":solo-provisioner-daemon-bn create pods/exec
systemctl status solo-provisioner-daemon --no-pager
sudo journalctl -u solo-provisioner-daemon -n 50 --no-pager | grep -iE "traffic|block.?node|monitor|DaemonComponentSkipped"
#   expect: "block-node traffic-shaper monitor starting" and NO "DaemonComponentSkipped".
#   NOTE (#902): if daemon-bn.kubeconfig is missing the daemon no longer crashes —
#   it logs "DaemonComponentSkipped" and stays active WITHOUT the traffic-shaper.
#   So an "active" unit alone is not proof; confirm the monitor-starting log above.

# 1. Verify the ingress shape is recorded. `block node install` now records BOTH
#    the egress and ingress shapes (the "Network Setup" phase runs TcIngressRecord,
#    #764), so this is a CHECK — confirm both devices and the ingress classes:
sudo solo-provisioner network shape show
#   expect an egress device AND an ingress device (default reserve-ingress) with
#   classes publisher (1:10), backfill-response (1:20), reserve-ingress (1:30).
#
#   Only if the ingress side is missing (e.g. a block node installed before #764),
#   record it explicitly. `create` is create-if-missing (a no-op that warns
#   "already configured" if present; --force to change):
sudo solo-provisioner network shape create --device ingress --rate 1gbit --default reserve-ingress
sudo solo-provisioner network shape create --class publisher         --rate 800mbit --ceil 1gbit --prio 0
sudo solo-provisioner network shape create --class backfill-response --rate 100mbit --ceil 1gbit --prio 7
sudo solo-provisioner network shape create --class reserve-ingress   --rate 100mbit --ceil 1gbit --prio 1

# 2. PRIMARY — daemon auto-detects the veth and attaches on pod readiness.
#    Restart the BN pod and watch the daemon resolve + attach entirely on its own.
kubectl delete pod -n "$NS" -l app.kubernetes.io/name=block-node-server
sudo journalctl -u solo-provisioner-daemon -f | grep -iE "veth|ingress HTB"
#   expect, within seconds of the new pod reaching ContainersReady:
#     "installed $VETH ingress HTB on BN pod"  pod=<ns>/<pod>  veth=lxc...
#   The veth in the log line is the one the DAEMON resolved — no manual step.

# 2b. See the wired veth purely from tc (independent of the log). tc qdisc show
#     with no `dev` lists every interface's qdiscs; filter to the HTB roots:
sudo tc qdisc show | grep 'qdisc htb 1:'
#   expect TWO htb roots: the $EGRESS NIC (default 0x60) and the BN veth
#   (default 0x30 = the ingress hierarchy). The "dev lxc..." on the 0x30 line is
#   the wired veth — it must match the daemon log above and $DAEMON_VETH in step 3.
#   (On older iproute2 the default may render decimal, e.g. "default 30".)

# 3. Verify the daemon auto-detected the CORRECT veth. Independently resolve the
#    new pod's host veth and confirm it equals the veth the daemon logged.
POD=$(kubectl get pod -n "$NS" -l app.kubernetes.io/name=block-node-server -o name | head -1)
IFLINK=$(kubectl exec -n "$NS" "$POD" -- cat /sys/class/net/eth0/iflink)
DAEMON_VETH=$(for d in /sys/class/net/*; do [ "$(cat $d/ifindex 2>/dev/null)" = "$IFLINK" ] && basename "$d"; done)
echo "independently-resolved veth: $DAEMON_VETH"   # MUST match the daemon's log line

# 4. Confirm the §5.1 hierarchy the daemon installed on that veth.
sudo tc -s class show dev "$DAEMON_VETH"
#   expect: 1:1 trunk, 1:10 (800Mbit), 1:20 (100Mbit prio 7), 1:30 (100Mbit)
sudo tc qdisc show dev "$DAEMON_VETH"
#   expect: root htb default 30, plus fq_codel leaves 110:/120:/130:, no tc filters

# 5. Restart resilience — a NEW pod gets a NEW veth auto-detected and attached.
kubectl delete "$POD" -n "$NS"
#   watch the daemon log a DIFFERENT veth name and re-attach; repeat steps 3–4 on it.

# 6. DEBUGGING ONLY — the same install/teardown by hand (what the daemon execs).
sudo solo-provisioner block node tc-attach --veth "$DAEMON_VETH"          # idempotent rebuild
sudo solo-provisioner block node tc-attach --veth "$DAEMON_VETH" --detach # best-effort teardown
```

Expected: the daemon resolves and attaches with **no manual veth handling**; the
veth it logs matches the independent `iflink`→`ifindex` resolution (step 3); the
three ingress classes carry the configured rates/prios; unmatched ingress falls to
`1:30` (reserve-ingress); no tc filters (classification is native on
`skb->priority`). On pod restart the daemon auto-detects the *new* veth and
re-attaches. A by-hand attach on an already-attached veth is a clean rebuild (no
error, no duplicate classes).

### Risks / rollback

- **Cilium veth→netkit migration** invalidates the veth attach point; `tc-attach`
  is deliberately isolated so that migration stays cheap. Tracked by the
  veth-elimination spike.
- **New privileged tc surface**: `tc-attach` runs `tc` as root on a caller-supplied
  device name; `nicNameRe` validation is the injection guard (unit-tested).
- The veth qdisc is ephemeral and non-persisted, so reverting this change leaves no
  host state to unwind beyond qdiscs the kernel drops with the veth.
- **Daemon unit change (upgrade path):** the `RuntimeDirectory` grant only reaches a
  host when the daemon service unit is re-rendered — i.e. an already-installed
  daemon must be reinstalled (`daemon service install`) to pick it up. There is no
  startup migration for the unit; without the reinstall, the exec'd `tc-attach`
  keeps failing "read-only file system" (surfaced as `TrafficShaperTCAttachFailed`,
  which #902 keeps non-fatal to the daemon).

### Related Issues

* Closes #748
* Closes #764
