### PR TITLE
fix(daemon): skip a component that fails to build instead of crashing the daemon

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -105,7 +105,7 @@ var (
 				if ex := errorx.Cast(err); ex != nil {
 					return ex.WithProperty(models.ErrPropertyResolution, []string{
 						"Check the daemon config: cat " + daemonConfigPath,
-						"Check the kubeconfig: ls -la " + paths.DaemonCNKubeconfigPath,
+						"Check the component kubeconfig(s): ls -la " + paths.DaemonCNKubeconfigPath + " " + paths.DaemonBNKubeconfigPath,
 						"Reinstall the daemon: sudo solo-provisioner daemon service install",
 					})
 				}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -86,9 +86,8 @@ func NewFromConfig(paths models.WeaverPaths, cfg DaemonConfig) (*Daemon, error) 
 			MigrateEventsDir: paths.DaemonConsensusMigrateEventsDir,
 		})
 		if err != nil {
-			return nil, err
-		}
-		if len(result.Monitors) > 0 {
+			logComponentBuildSkipped("consensus-node", cn.Kubeconfig, err)
+		} else if len(result.Monitors) > 0 {
 			comp := component{
 				name:     "consensus-node",
 				monitors: result.Monitors,
@@ -117,9 +116,8 @@ func NewFromConfig(paths models.WeaverPaths, cfg DaemonConfig) (*Daemon, error) 
 			Namespace:            bn.Orbit,
 		})
 		if err != nil {
-			return nil, err
-		}
-		if len(result.Monitors) > 0 {
+			logComponentBuildSkipped("block-node", bn.Kubeconfig, err)
+		} else if len(result.Monitors) > 0 {
 			comp := component{
 				name:     "block-node",
 				monitors: result.Monitors,
@@ -154,6 +152,23 @@ func NewFromConfig(paths models.WeaverPaths, cfg DaemonConfig) (*Daemon, error) 
 		Logger: slog.Default(),
 	}, daemonkit.ServerConfig{})
 	return d, nil
+}
+
+// logComponentBuildSkipped reports that an enabled daemon component could not be
+// built (typically its scoped kubeconfig is missing or unreadable) and is being
+// skipped so the daemon still starts with its remaining components — one
+// component's construction failure must not take down the whole daemon. A missing
+// kubeconfig is an install/provisioning gap, not a transient fault, so the
+// operator must provision it and restart the daemon.
+func logComponentBuildSkipped(name, kubeconfig string, err error) {
+	logx.As().Error().Err(err).
+		Str("reason", "DaemonComponentSkipped").
+		Str("component", name).
+		Str("kubeconfig", kubeconfig).
+		Msgf("skipping daemon component %q — it could not be built; the daemon starts without it. "+
+			"Verify its kubeconfig exists (%s), then reinstall and restart the daemon: "+
+			"sudo solo-provisioner daemon service stop && sudo solo-provisioner daemon service install && sudo solo-provisioner daemon service start",
+			name, kubeconfig)
 }
 
 // componentSupervisor starts one supervised goroutine per monitor in every

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -288,6 +288,43 @@ func TestNewFromConfig_BlockNodeOnly(t *testing.T) {
 	assert.Len(t, d.components[0].monitors, 1)
 }
 
+func TestNewFromConfig_MissingKubeconfigSkipsComponentNotDaemon(t *testing.T) {
+	dir := t.TempDir()
+	// A block-node component whose scoped kubeconfig does not exist must not crash
+	// the whole daemon: the component is skipped and NewFromConfig still succeeds so
+	// any other components keep running.
+	cfg := DaemonConfig{Components: DaemonComponents{
+		BlockNode: &BlockNodeComponentConfig{
+			Enabled:    true,
+			Kubeconfig: filepath.Join(dir, "does-not-exist.kubeconfig"),
+			Orbit:      "hedera-block-node",
+			Monitors:   BlockNodeMonitors{TrafficShaper: true},
+		},
+	}}
+	d, err := NewFromConfig(models.WeaverPaths{DaemonSockPath: filepath.Join(dir, "d.sock")}, cfg)
+	require.NoError(t, err, "a missing component kubeconfig must not fail daemon construction")
+	assert.Empty(t, d.components, "the block-node component must be skipped when its kubeconfig is missing")
+}
+
+func TestNewFromConfig_ConsensusNodeMissingKubeconfigSkipsComponentNotDaemon(t *testing.T) {
+	dir := t.TempDir()
+	// A consensus-node component whose scoped kubeconfig does not exist must not
+	// crash the whole daemon: the component is skipped and NewFromConfig still
+	// succeeds so any other components keep running.
+	cfg := DaemonConfig{Components: DaemonComponents{
+		ConsensusNode: &ConsensusNodeComponentConfig{
+			Enabled:    true,
+			Kubeconfig: filepath.Join(dir, "does-not-exist.kubeconfig"),
+			NodeID:     "0",
+			Orbit:      "hedera-network",
+			Monitors:   ConsensusNodeMonitors{Upgrade: true},
+		},
+	}}
+	d, err := NewFromConfig(models.WeaverPaths{DaemonSockPath: filepath.Join(dir, "d.sock")}, cfg)
+	require.NoError(t, err, "a missing component kubeconfig must not fail daemon construction")
+	assert.Empty(t, d.components, "the consensus-node component must be skipped when its kubeconfig is missing")
+}
+
 func TestNewFromConfig_BlockNodeEnabledNoMonitorsProducesNoComponent(t *testing.T) {
 	cfg := DaemonConfig{Components: DaemonComponents{
 		BlockNode: &BlockNodeComponentConfig{Enabled: true}, // TrafficShaper off → zero monitors


### PR DESCRIPTION
## Description

`solo-provisioner-daemon` failed to start **entirely** when a single enabled
component's kubeconfig was missing or unreadable: `NewFromConfig` propagated the
error from `blocknode.NewComponent` (and `consensus.NewComponent`), aborting the
whole daemon and taking every other component down with it. Enabling the
block-node component before its `daemon-bn.kubeconfig` exists made the daemon exit
on startup:

```
solo-provisioner-daemon: Error: common.external_error: load kubeconfig /opt/solo/weaver/config/daemon-bn.kubeconfig, cause: stat ...: no such file or directory
  at internal/daemon/blocknode.NewVethResolver() veth_resolver.go:75
  at internal/daemon.NewFromConfig() daemon.go:114
systemd[1]: solo-provisioner-daemon.service: Failed with result 'exit-code'.
```

Now a component whose `NewComponent` fails is logged with an actionable
resolution and **skipped**, so the daemon starts with whatever built
successfully. A missing kubeconfig is an install/provisioning gap, not a transient
fault, so the operator provisions it and restarts the daemon (this PR does not try
to hot-recover). The startup-error resolution hint, which hardcoded
`daemon-cn.kubeconfig` even for a block-node failure, now names both component
kubeconfigs.

### Files changed

| File | Change |
|---|---|
| `internal/daemon/daemon.go` | `NewFromConfig` logs + skips a component whose `NewComponent` errors (both consensus-node and block-node) instead of returning the error; new `logComponentBuildSkipped` helper. |
| `cmd/daemon/main.go` | Generalize the startup-error resolution to list both `daemon-cn.kubeconfig` and `daemon-bn.kubeconfig` rather than always CN. |
| `internal/daemon/daemon_test.go` | New test: a block-node component with a missing kubeconfig is skipped and `NewFromConfig` still succeeds. |

### Test plan

```bash
go test -race -tags='!integration' ./internal/daemon/...
```

All daemon unit tests pass on the host; the daemon + CLI binaries cross-compile
for `linux/arm64`.

### Related Issues

* Closes #901
