### PR TITLE
feat(daemon): provision block-node RBAC + kubeconfig on daemon service install

### DIFF
--- a/internal/workflows/daemon.go
+++ b/internal/workflows/daemon.go
@@ -33,13 +33,30 @@ func buildComponentSpecs(cfg daemon.DaemonConfig, paths models.WeaverPaths) []st
 		})
 	}
 
-	// block_node: added in S7 (#667). When enabled, append:
-	//   specs = append(specs, steps.DaemonComponentSpec{
-	//       ShortName:      "bn",
-	//       Namespace:      bn.Orbit,
-	//       KubeconfigPath: paths.DaemonBNKubeconfigPath,
-	//       PolicyRules:    <bn RBAC rules>,
-	//   })
+	// block_node: only the traffic-shaper monitor touches the K8s API, so RBAC is
+	// provisioned only when that monitor is enabled. The daemon's pod-lifecycle
+	// watcher lists/watches BN pods (pods: get/list/watch) and the veth resolver
+	// execs into a pod to read eth0's iflink (pods/exec: create). The statusz poll
+	// loop talks HTTP + `sudo network policy set`, so it needs no API access.
+	if bn := cfg.Components.BlockNode; bn != nil && bn.Enabled && bn.Monitors.TrafficShaper {
+		specs = append(specs, steps.DaemonComponentSpec{
+			ShortName:      "bn",
+			Namespace:      bn.Orbit,
+			KubeconfigPath: paths.DaemonBNKubeconfigPath,
+			PolicyRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods/exec"},
+					Verbs:     []string{"create"},
+				},
+			},
+		})
+	}
 
 	return specs
 }

--- a/internal/workflows/daemon_test.go
+++ b/internal/workflows/daemon_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package workflows
+
+import (
+	"testing"
+
+	daemon "github.com/hashgraph/solo-weaver/internal/daemon"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testPaths() models.WeaverPaths {
+	return models.WeaverPaths{
+		DaemonCNKubeconfigPath: "/opt/solo/weaver/config/daemon-cn.kubeconfig",
+		DaemonBNKubeconfigPath: "/opt/solo/weaver/config/daemon-bn.kubeconfig",
+	}
+}
+
+func TestBuildComponentSpecs_BlockNodeTrafficShaper(t *testing.T) {
+	cfg := daemon.DaemonConfig{Components: daemon.DaemonComponents{
+		BlockNode: &daemon.BlockNodeComponentConfig{
+			Enabled:  true,
+			Orbit:    "hedera-block-node",
+			Monitors: daemon.BlockNodeMonitors{TrafficShaper: true},
+		},
+	}}
+
+	specs := buildComponentSpecs(cfg, testPaths())
+	require.Len(t, specs, 1)
+
+	bn := specs[0]
+	assert.Equal(t, "bn", bn.ShortName)
+	assert.Equal(t, "hedera-block-node", bn.Namespace)
+	assert.Equal(t, "/opt/solo/weaver/config/daemon-bn.kubeconfig", bn.KubeconfigPath)
+
+	// Exactly the two least-privilege rules: pods get/list/watch + pods/exec create.
+	require.Len(t, bn.PolicyRules, 2)
+	assert.Equal(t, []string{"pods"}, bn.PolicyRules[0].Resources)
+	assert.ElementsMatch(t, []string{"get", "list", "watch"}, bn.PolicyRules[0].Verbs)
+	assert.Equal(t, []string{"pods/exec"}, bn.PolicyRules[1].Resources)
+	assert.ElementsMatch(t, []string{"create"}, bn.PolicyRules[1].Verbs)
+}
+
+func TestBuildComponentSpecs_BlockNodeWithoutTrafficShaperNoSpec(t *testing.T) {
+	cfg := daemon.DaemonConfig{Components: daemon.DaemonComponents{
+		BlockNode: &daemon.BlockNodeComponentConfig{
+			Enabled:  true,
+			Orbit:    "hedera-block-node",
+			Monitors: daemon.BlockNodeMonitors{TrafficShaper: false},
+		},
+	}}
+	assert.Empty(t, buildComponentSpecs(cfg, testPaths()),
+		"block-node with the traffic-shaper monitor off needs no K8s RBAC")
+}
+
+func TestBuildComponentSpecs_NoBlockNodeNoSpec(t *testing.T) {
+	assert.Empty(t, buildComponentSpecs(daemon.DaemonConfig{}, testPaths()))
+}
+
+func TestBuildComponentSpecs_ConsensusAndBlockNode(t *testing.T) {
+	cfg := daemon.DaemonConfig{Components: daemon.DaemonComponents{
+		ConsensusNode: &daemon.ConsensusNodeComponentConfig{
+			Enabled:  true,
+			Orbit:    "hedera-network",
+			Monitors: daemon.ConsensusNodeMonitors{Upgrade: true},
+		},
+		BlockNode: &daemon.BlockNodeComponentConfig{
+			Enabled:  true,
+			Orbit:    "hedera-block-node",
+			Monitors: daemon.BlockNodeMonitors{TrafficShaper: true},
+		},
+	}}
+
+	specs := buildComponentSpecs(cfg, testPaths())
+	require.Len(t, specs, 2)
+	shorts := []string{specs[0].ShortName, specs[1].ShortName}
+	assert.ElementsMatch(t, []string{"cn", "bn"}, shorts)
+}


### PR DESCRIPTION
## Description

`solo-provisioner daemon service install --components block-node` provisioned no
Kubernetes access for the block-node component, so the traffic-shaper monitor
could never start. `buildComponentSpecs` only built a spec for consensus-node
(the block-node branch was a commented-out TODO), so the returned slice was empty
for a block-node-only install, the workflow's `if len(componentSpecs) > 0` guard
skipped `CheckClusterStep` → `CreateDaemonRBACStep` → `WriteDaemonKubeconfigStep`,
and `daemon-bn.kubeconfig` was never written — while `WriteBlockNodeDaemonConfigStep`
still pointed `daemon.yaml` at it. The daemon then failed to build the block-node
component (surfaced by the #748 UAT; a hard crash before #902).

This wires the block-node branch of `buildComponentSpecs`: when the traffic-shaper
monitor is enabled it appends a component spec, so the generic provisioning steps
create the ServiceAccount, ClusterRole/ClusterRoleBinding, and token Secret, and
write the scoped `daemon-bn.kubeconfig`. Least-privilege rules are exactly what the
daemon uses: `pods: get/list/watch` (the pod-lifecycle watcher) and `pods/exec:
create` (the veth resolver's `iflink` read). RBAC is provisioned only when
`traffic_shaper` is on — the statusz poll loop talks HTTP + `sudo network policy
set` and needs no API access. Uninstall cleanup is automatic: the same specs
(`loadComponentSpecs` → `buildComponentSpecs`) drive `RemoveDaemonKubeconfigStep` +
`DeleteDaemonRBACStep`.

RBAC scope is a cluster-wide `ClusterRole`, reusing the consensus-node pattern for
a minimal diff. A namespaced `Role` (tighter — pod read/exec only in the orbit)
would be strictly least-privilege but needs a `Namespaced` switch on
`DaemonComponentSpec` and the RBAC steps; deferred as a possible follow-up.

This unblocks the #748 (#899) traffic-shaper UAT end-to-end.

### Files changed

| File | Change |
|---|---|
| `internal/workflows/daemon.go` | Implement the block-node branch of `buildComponentSpecs` (SA + ClusterRole RBAC + kubeconfig), gated on `bn.Enabled && bn.Monitors.TrafficShaper`. |
| `internal/workflows/daemon_test.go` | New. Unit-tests the pure `buildComponentSpecs`: BN spec shape/rules, gated off when traffic_shaper is off, absent when no BN, and CN+BN together. |

### Test plan

`internal/workflows` is Linux-only (transitive `mount` import), so the unit test
runs in the UTM VM (`task vm:test:unit`); it was compile-verified for `linux/arm64`
here (`go test -c`). The RBAC *creation* uses a non-injected client, so it stays
integration/UAT-covered:

- Integration/UAT (VM + cluster): `daemon service install --components block-node --bn-orbit <ns>` creates the SA + ClusterRole/CRB + token Secret and writes `daemon-bn.kubeconfig`; the daemon starts and the traffic-shaper monitor runs. Verify least-privilege:

```bash
kubectl auth can-i --as=system:serviceaccount:<ns>:solo-provisioner-daemon-bn get pods
kubectl auth can-i --as=system:serviceaccount:<ns>:solo-provisioner-daemon-bn create pods/exec
```

- Then run the #748 (#899) Manual UAT — it should now get past daemon startup and auto-attach the veth.
- Uninstall (`daemon service uninstall`) removes the BN RBAC + kubeconfig.

### Related Issues

* Closes #903
