### PR TITLE
fix(blocknode): gate MetalLB service injection on loadBalancer.enabled

### DIFF
--- a/internal/blocknode/manager_test.go
+++ b/internal/blocknode/manager_test.go
@@ -1128,6 +1128,164 @@ func TestInjectServiceAnnotations_PreservesExistingType(t *testing.T) {
 	assert.Equal(t, "ClusterIP", service["type"], "operator-set service.type must not be clobbered")
 }
 
+// TestInjectServiceAnnotations_ChartOwnedLoadBalancerDefers is issue #900, case 3 (the
+// "split topology"): service.type: ClusterIP + the chart's own loadBalancer.enabled: true.
+// The chart owns the "-external" LoadBalancer Service and its annotations, so weaver must
+// defer entirely — no warning, no MetalLB annotation injected onto the ClusterIP service —
+// and return the values byte-identical.
+func TestInjectServiceAnnotations_ChartOwnedLoadBalancerDefers(t *testing.T) {
+	manager := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{
+			LoadBalancerEnabled: true,
+		},
+		logger: testLogger(),
+	}
+
+	input := []byte(`service:
+  type: ClusterIP
+  port: 40840
+loadBalancer:
+  enabled: true
+  annotations:
+    metallb.io/address-pool: "public-address-pool"
+`)
+
+	result, err := manager.injectServiceAnnotations(input)
+	require.NoError(t, err)
+
+	// Deferred to the chart → byte-identical, no service.* mutation.
+	assert.Equal(t, input, result)
+
+	// The MetalLB annotation stays under loadBalancer.annotations (chart-owned); weaver must
+	// not have injected one onto service.annotations.
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+	service := vals["service"].(map[string]interface{})
+	_, hasServiceAnnotations := service["annotations"]
+	assert.False(t, hasServiceAnnotations, "weaver must not inject service.annotations when the chart owns the LoadBalancer")
+	assert.Equal(t, "ClusterIP", service["type"], "operator service.type must be left untouched")
+}
+
+// TestInjectServiceAnnotations_ChartOwnedLoadBalancerNoOperatorAnnotation covers case 3 when
+// the operator enables loadBalancer but has not (yet) set loadBalancer.annotations. Weaver
+// still defers — it must not "helpfully" inject onto service.annotations, since that tag would
+// be inert on the ClusterIP service and the real tag belongs under loadBalancer.annotations.
+func TestInjectServiceAnnotations_ChartOwnedLoadBalancerNoOperatorAnnotation(t *testing.T) {
+	manager := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{
+			LoadBalancerEnabled: true,
+		},
+		logger: testLogger(),
+	}
+
+	input := []byte(`service:
+  type: ClusterIP
+loadBalancer:
+  enabled: true
+`)
+
+	result, err := manager.injectServiceAnnotations(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, input, result)
+	assert.NotContains(t, string(result), "metallb.io/address-pool")
+}
+
+// TestInjectServiceAnnotations_ChartOwnedLoadBalancerQuotedBoolDefers covers issue #900 case 3
+// when the operator quotes the flag (loadBalancer.enabled: "true"). Helm treats that quoted
+// string as enabled, so weaver must too — a bool-only gate would misread it as disabled and
+// re-introduce the misleading warning + inert service.annotations injection. Weaver defers and
+// returns the values byte-identical, exactly as for the unquoted bool.
+func TestInjectServiceAnnotations_ChartOwnedLoadBalancerQuotedBoolDefers(t *testing.T) {
+	manager := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{
+			LoadBalancerEnabled: true,
+		},
+		logger: testLogger(),
+	}
+
+	input := []byte(`service:
+  type: ClusterIP
+  port: 40840
+loadBalancer:
+  enabled: "true"
+  annotations:
+    metallb.io/address-pool: "public-address-pool"
+`)
+
+	result, err := manager.injectServiceAnnotations(input)
+	require.NoError(t, err)
+
+	// Deferred to the chart → byte-identical, no service.* mutation.
+	assert.Equal(t, input, result)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+	service := vals["service"].(map[string]interface{})
+	_, hasServiceAnnotations := service["annotations"]
+	assert.False(t, hasServiceAnnotations, "quoted loadBalancer.enabled must still defer to the chart")
+	assert.Equal(t, "ClusterIP", service["type"], "operator service.type must be left untouched")
+}
+
+// TestInjectServiceAnnotations_QuotedFalseNotChartOwned pins the other end of the string parse:
+// loadBalancer.enabled: "false" reads operator intent (off), not Helm's "any non-empty string is
+// truthy" quirk. That is not the chart-owned split topology, so weaver keeps its default behavior
+// and still injects the MetalLB annotation onto the main service.
+func TestInjectServiceAnnotations_QuotedFalseNotChartOwned(t *testing.T) {
+	manager := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{
+			LoadBalancerEnabled: true,
+		},
+		logger: testLogger(),
+	}
+
+	input := []byte(`service:
+  type: LoadBalancer
+loadBalancer:
+  enabled: "false"
+`)
+
+	result, err := manager.injectServiceAnnotations(input)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+	service := vals["service"].(map[string]interface{})
+	annotations := service["annotations"].(map[string]interface{})
+	assert.Equal(t, "public-address-pool", annotations["metallb.io/address-pool"],
+		`loadBalancer.enabled: "false" reads as off; weaver must still inject the MetalLB annotation`)
+}
+
+// TestInjectServiceAnnotations_LoadBalancerDisabledStillInjects is the non-regression guard
+// for cases 1/2/4 (issue #900): loadBalancer.enabled: false is NOT the chart-owned split
+// topology, so weaver keeps its default behavior and injects the MetalLB annotation onto the
+// main service. This pins that the new gate keys off loadBalancer.enabled being true, not
+// merely present.
+func TestInjectServiceAnnotations_LoadBalancerDisabledStillInjects(t *testing.T) {
+	manager := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{
+			LoadBalancerEnabled: true,
+		},
+		logger: testLogger(),
+	}
+
+	input := []byte(`service:
+  type: LoadBalancer
+loadBalancer:
+  enabled: false
+`)
+
+	result, err := manager.injectServiceAnnotations(input)
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+	service := vals["service"].(map[string]interface{})
+	annotations := service["annotations"].(map[string]interface{})
+	assert.Equal(t, "public-address-pool", annotations["metallb.io/address-pool"],
+		"loadBalancer.enabled=false is not chart-owned; weaver must still inject the MetalLB annotation")
+}
+
 // TestMergeValues_OperatorWinsOnScalar verifies the deep-merge contract: operator scalars
 // override base scalars at the same path.
 func TestMergeValues_OperatorWinsOnScalar(t *testing.T) {

--- a/internal/blocknode/values.go
+++ b/internal/blocknode/values.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	oslib "os"
 	"path"
+	"strconv"
 
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/templates"
@@ -407,6 +408,15 @@ func (m *Manager) injectPluginsConfig(valuesContent []byte) ([]byte, error) {
 // left untouched. An explicit non-LoadBalancer service.type triggers a warning so the
 // mismatch is visible in logs without weaver clobbering an explicit operator choice.
 // When LoadBalancerEnabled is false the values are returned unchanged.
+//
+// Exception (issue #900): when the operator enables the chart's own loadBalancer block
+// (loadBalancer.enabled: true — the "split topology": a ClusterIP main Service plus a
+// separate "-external" LoadBalancer Service), the chart renders that external Service and
+// applies its annotations from .Values.loadBalancer.annotations. In that case weaver defers
+// entirely to the chart: it does not warn about a ClusterIP service.type and does not inject
+// a MetalLB annotation onto the main service (which would be inert there, since MetalLB
+// ignores non-LoadBalancer services). The reachability probe already locates the chart's
+// "-external" Service, so no service.* injection is needed.
 func (m *Manager) injectServiceAnnotations(valuesContent []byte) ([]byte, error) {
 	if !m.blockNodeInputs.LoadBalancerEnabled {
 		return valuesContent, nil
@@ -415,6 +425,15 @@ func (m *Manager) injectServiceAnnotations(valuesContent []byte) ([]byte, error)
 	var vals map[string]interface{}
 	if err := yaml.Unmarshal(valuesContent, &vals); err != nil {
 		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse values YAML for service annotation injection")
+	}
+
+	// Issue #900: if the operator drives the external endpoint through the chart's own
+	// loadBalancer block, the chart owns the "-external" Service and its annotations. Weaver
+	// must not warn about a ClusterIP main service.type or inject an inert MetalLB annotation
+	// onto it — defer entirely to the chart.
+	if chartOwnsLoadBalancer(vals) {
+		logx.As().Debug().Msg("values enable the chart's loadBalancer block; deferring the external Service and its MetalLB annotation to the chart (skipping service.* injection)")
+		return valuesContent, nil
 	}
 
 	service, ok := vals["service"].(map[string]interface{})
@@ -474,4 +493,32 @@ func (m *Manager) injectServiceAnnotations(valuesContent []byte) ([]byte, error)
 	}
 
 	return result, nil
+}
+
+// chartOwnsLoadBalancer reports whether the merged values enable the block-node chart's own
+// loadBalancer block (loadBalancer.enabled: true). When enabled, the chart renders a dedicated
+// "-external" LoadBalancer Service and applies its annotations from .Values.loadBalancer.annotations,
+// so weaver must not inject its own service.type/annotations for the LoadBalancer. See issue #900.
+//
+// The value is read for truthiness rather than a strict bool type: an operator may quote it
+// (loadBalancer.enabled: "true"), which Helm still treats as enabled, so a bool-only check would
+// misread that as disabled and re-introduce the misleading warning + inert injection this gate
+// suppresses. A native bool is honored directly; a string is parsed with strconv.ParseBool
+// (accepting "true"/"1"/"t" and "false"/"0"/"f", case-insensitive). Any other shape — absent
+// block, missing key, unparseable value — is treated as not-enabled, preserving the default
+// single-LB path and the accurate ClusterIP-with-no-LB warning.
+func chartOwnsLoadBalancer(vals map[string]interface{}) bool {
+	lb, ok := vals["loadBalancer"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	switch enabled := lb["enabled"].(type) {
+	case bool:
+		return enabled
+	case string:
+		parsed, err := strconv.ParseBool(enabled)
+		return err == nil && parsed
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
## Description

`injectServiceAnnotations` (`internal/blocknode/values.go`) keyed its warning and MetalLB annotation injection off `service.type != LoadBalancer`, which is too broad. In the **split topology** — `service.type: ClusterIP` plus the chart's own `loadBalancer.enabled: true` block — it logged a misleading `verify-block-node-reachable will fail` warning and injected a `metallb.io/address-pool` annotation onto the ClusterIP main service, where MetalLB ignores it (inert). The chart already owns the separate `-external` LoadBalancer Service and tags it from `.Values.loadBalancer.annotations`, and the reachability probe (`findLoadBalancerEndpoint`) already finds that `-external` Service — so both the warning and the injection were wrong for this supported topology. This confused operators during the LFH mainnet config review.

This change gates the behavior on **`loadBalancer.enabled`** instead of `service.type` alone: when the operator declares a chart-owned LoadBalancer, weaver defers entirely (no warning, no `service.*` injection). All other paths are unchanged.

### Behavior matrix

| # | Values (`--load-balancer-enabled=true`) | Before | After |
|---|---|---|---|
| 1 | no `service.type`, no `loadBalancer` block | set `service.type: LoadBalancer` + tag main svc | **unchanged** |
| 2 | `service.type: LoadBalancer`, no `loadBalancer` block | tag main svc, no warning | **unchanged** |
| 3 | `service.type: ClusterIP` **+ `loadBalancer.enabled: true`** | misleading warning + inert tag on ClusterIP svc | **fixed:** defer to chart — no warning, no injection |
| 4 | `service.type: ClusterIP`, no `loadBalancer` block | warning + inert tag; no LB exists anywhere | **unchanged** (warning is correct here) |

### Files changed

| File | Change |
|---|---|
| `internal/blocknode/values.go` | Add `chartOwnsLoadBalancer` helper; short-circuit `injectServiceAnnotations` to defer to the chart when `loadBalancer.enabled: true` |
| `internal/blocknode/manager_test.go` | Add tests for case 3 (defer, with/without operator annotation) and the `loadBalancer.enabled: false` non-regression guard |

### Review guide

- **Discriminator:** `chartOwnsLoadBalancer` returns true only for `loadBalancer.enabled == true` (bool). `enabled: false` or an absent block → false, so cases 1/2/4 keep the existing `service.type`/annotation logic untouched.
- **Deferral is side-effect-free:** case 3 returns `valuesContent` byte-identical (no parse-rewrite), so the operator's `loadBalancer.annotations` reach the chart verbatim.
- **No probe change:** `findLoadBalancerEndpoint` (`internal/blocknode/reachability.go`) already scans for any `type: LoadBalancer` Service, so the `-external` Service is still verified after install.

**Tests**
```bash
go test -tags='!integration' ./internal/blocknode/... -run TestInjectServiceAnnotations -v
task lint
```

**Risks / rollback:** Low, additive gate. Operators on the split topology stop seeing the false-alarm warning and the redundant ClusterIP annotation; the externally-reachable LoadBalancer is unaffected (chart-owned). The default single-service LB path and the accurate ClusterIP-with-no-LB warning are preserved (covered by existing + new tests). Rollback is a straight revert of `values.go`.

### Manual UAT (end-to-end from a fresh environment)

This verifies the fix through the real `block node install` workflow, from a host with no cluster. `block node install` runs the whole pipeline — **Preflight → System Setup → Kubernetes Setup (kubeadm, Cilium, MetalLB) → Deploy (Helm) → Verify (reachability)** — so the first case brings the cluster up from scratch (~15–30 min on a VM); later cases reuse it and only re-deploy the block node.

#### One-time setup (fresh host / UTM VM)

1. Install the branch binary as the provisioner. The `block node install` command must run via the **installed** `solo-provisioner` on PATH — invoking the raw `bin/…` binary is rejected with *"solo-provisioner installation or re-installation required"*:

```bash
sudo /path/to/bin/solo-provisioner-linux-arm64 install   # match the VM arch
solo-provisioner --version                               # confirm the branch commit
```

2. Create the shared weaver config `~/solo-config.yml`:

```yaml
profile: local
blockNode:
  namespace: "block-node"
  release: "block-node"
  chart: "oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server"
  version: "0.37.1"
  storage:
    basePath: /opt/hiero/block-node
```

#### Running a case

```bash
sudo solo-provisioner block node install \
  --config ~/solo-config.yml -f ~/values-c{N}.yml \
  --profile local --skip-hardware-checks --log-level debug --non-interactive
```

- `--log-level debug` surfaces the issue #900 deferral line; `--non-interactive` skips the TUI prompts (e.g. *Storage Path Mode*). Run interactively without it and pick *Single base path* when prompted.
- `plugins.names` is intentionally omitted from the case values so the chart's default plugin set is used — pinning a minimal list (e.g. `server-status,health`) can keep the app pod from reaching readiness on a small VM. Plugins are orthogonal to #900.
- On an under-resourced VM the overall install may still roll back when the app pod misses Helm's 5-minute atomic wait — **unrelated to this fix**. The values computation, the log lines, the Service creation, and the MetalLB IP assignment all happen *before* that wait and remain observable in the log/events/services even after a rollback.

#### Inspection helper (run after each case)

```bash
LOG=/opt/solo/weaver/logs/solo-provisioner.log
# (1) misleading warning  (2) inert injection  (3) the #900 defer line
grep -iE "non-LoadBalancer|Injecting MetalLB address-pool|deferring the external Service" "$LOG"
# kubectl is installed by weaver during Kubernetes Setup
kubectl -n block-node get svc
kubectl -n block-node get events | grep -i IPAllocated
```

Reset between cases (keeps the cluster, re-deploys only the block node):

```bash
sudo solo-provisioner block node uninstall --config ~/solo-config.yml --profile local --non-interactive
```

#### Case 1 — default single-LB path (non-regression)

`~/values-c1.yml`:

```yaml
service:
  port: 40840
```
**Expected:** log shows `Injecting service.type: LoadBalancer` and `Injecting MetalLB address-pool annotation`; the main `block-node-block-node-server` Service is `type: LoadBalancer` and gets a MetalLB IP; no warning.

#### Case 2 — explicit LoadBalancer, no chart block (non-regression)

`~/values-c2.yml`:

```yaml
service:
  type: LoadBalancer
  port: 40840
```
**Expected:** no warning; main Service is `type: LoadBalancer`, tagged with `metallb.io/address-pool`, gets an IP.

#### Case 3 — split topology (the fix)

`~/values-c3.yml`:

```yaml
service:
  type: ClusterIP
  port: 40840
loadBalancer:
  enabled: true
  port: "40840"
  annotations:
    metallb.io/address-pool: "public-address-pool"
```
**Expected:**
- log does **not** contain `verify-block-node-reachable will fail` and does **not** contain `Injecting MetalLB address-pool`;
- the Debug line `deferring the external Service ... (skipping service.* injection)` is present;
- a `block-node-block-node-server-external` Service of `type: LoadBalancer` is created and gets an IP:

```
Normal  IPAllocated  service/block-node-block-node-server-external  Assigned IP ["192.168.8.247"]
```

- the main `block-node-block-node-server` Service stays `ClusterIP` with **no** `metallb.io/address-pool` annotation:

```bash
kubectl -n block-node get svc block-node-block-node-server -o jsonpath='{.metadata.annotations}'
# -> no metallb.io/address-pool key
```

Also worth confirming the quoted-bool hardening: repeat with `loadBalancer.enabled: "true"` (quoted) and expect the identical deferral (no warning, no injection).

#### Case 4 — ClusterIP with no LoadBalancer anywhere (warning must remain)

`~/values-c4.yml`:

```yaml
service:
  type: ClusterIP
  port: 40840
```
**Expected:** log **does** contain `verify-block-node-reachable will fail` (accurate — no LoadBalancer Service exists anywhere) and no `-external` Service is created. Confirms the fix did not over-suppress.

#### Case 5 — upgrade path (0.37.1 → 0.38.1), split topology

With Case 3 installed (chart 0.37.1), upgrade the chart version — this exercises the historically fragile "MetalLB annotation on upgrade" path. `--chart-version` sets the target (no TUI/config edit); keep `-f ~/values-c3.yml` so the split-topology values are re-asserted:

```bash
sudo solo-provisioner block node upgrade \
  --config ~/solo-config.yml -f ~/values-c3.yml \
  --chart-version 0.38.1 \
  --profile local --skip-hardware-checks --log-level debug --non-interactive
```

**Expected** — the defer holds across the upgrade:
- Helm advances to `revision 2` / chart `block-node-server-0.38.1` (`sudo helm -n block-node list`);
- no new `verify-block-node-reachable will fail` warning and no `Injecting MetalLB address-pool`; the `deferring the external Service …` line runs again;
- the main `block-node-block-node-server` (ClusterIP) still has **no** `metallb.io/address-pool` annotation (only helm's own);
- the `block-node-block-node-server-external` (LoadBalancer) keeps its MetalLB IP — a second `IPAllocated` event re-asserts the same address (e.g. `192.168.8.247`), tag still sourced from the chart's `loadBalancer.annotations`.

| Case | Warning? | MetalLB tag on main svc? | `-external` LB svc + IP? |
|---|---|---|---|
| 1 | no | yes | n/a (single svc is the LB) |
| 2 | no | yes | n/a (single svc is the LB) |
| 3 | **no** | **no** | **yes** |
| 4 | **yes** | yes (inert) | no |
| 3 upgraded to 0.38.1 | **no** | **no** | **yes** (same IP retained) |

### Related Issues

* Closes #900



