### PR TITLE
feat(blocknode): orchestrate network policy plane + daemon setup at install

### DIFF
--- a/cmd/cli/commands/block/node/daemon_offer.go
+++ b/cmd/cli/commands/block/node/daemon_offer.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package node
+
+import (
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/internal/daemon"
+	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
+	"github.com/hashgraph/solo-weaver/internal/workflows"
+	workflowsteps "github.com/hashgraph/solo-weaver/internal/workflows/steps"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	pkgos "github.com/hashgraph/solo-weaver/pkg/os"
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+// daemonServiceName is the systemd unit for the solo-provisioner daemon; matched
+// against systemd's active state to decide whether the daemon is already running.
+const daemonServiceName = "solo-provisioner-daemon"
+
+// ensureBlockNodeDaemon closes the gap between installing a block node and
+// getting its traffic-shaper daemon running. Daemon activation is not a
+// separate decision from the operator: it is part of the traffic-shaping
+// bundle. install.go calls this only when TrafficShapingEnabled is true — a
+// block node with the policy plane and tc shaping in place, but no daemon,
+// would otherwise have no ingress prioritization (the veth HTB is never
+// installed) and nothing reconciling the daemon-owned nft sets from statusz.
+//
+// When the daemon is already active there is nothing to do; otherwise it is
+// installed and provisioned (RBAC + daemon-bn.kubeconfig + systemd unit)
+// scoped to this block node's namespace, unconditionally — no prompt, no flag.
+// source controls where the daemon binary itself comes from (see
+// resolveDaemonBinarySource).
+func ensureBlockNodeDaemon(cmd *cobra.Command, namespace string, source workflowsteps.DaemonBinarySource) error {
+	ctx := cmd.Context()
+
+	// A running daemon needs no further action (the check is a no-op on hosts
+	// where the daemon is already up). A systemd/DBus error is non-fatal — treat
+	// the daemon as not running — but log it so an operator can tell a genuine
+	// "not installed" from a failed state query.
+	running, err := pkgos.IsServiceRunning(ctx, daemonServiceName)
+	if err != nil {
+		logx.As().Warn().Err(err).Msg(
+			"could not determine solo-provisioner-daemon service state; treating it as not running")
+	}
+	if running {
+		return nil
+	}
+
+	return provisionBlockNodeDaemon(cmd, namespace, source)
+}
+
+// resolveDaemonBinarySource determines where ensureBlockNodeDaemon should get
+// the daemon binary from: --daemon-bin (bypasses the catalog entirely) or
+// --daemon-version (selects which catalog version to auto-download; defaults
+// to this CLI's own version — meaningful once CLI and daemon are co-released
+// under one version scheme).
+//
+// --profile=local is a special case: local/dev builds report an unstamped
+// version (e.g. "dev") that has no corresponding catalog entry, so
+// auto-download can never succeed there. When traffic shaping is enabled and
+// --daemon-bin wasn't supplied, this becomes a required value — prompted for
+// interactively, or a fail-fast error non-interactively.
+func resolveDaemonBinarySource(cmd *cobra.Command, args []string, profile string, cv *prompt.ChosenValues) (workflowsteps.DaemonBinarySource, error) {
+	source := workflowsteps.DaemonBinarySource{BinPath: flagDaemonBin, Version: flagDaemonVersion}
+
+	if profile != models.ProfileLocal || source.BinPath != "" {
+		return source, nil
+	}
+
+	var rootFlags common.RootFlags
+	_ = common.ExtractRootFlags(cmd, args, &rootFlags)
+	if !prompt.ShouldPrompt(rootFlags.Force) {
+		return source, errorx.IllegalArgument.New(
+			"--daemon-bin is required for --profile=local: local/dev builds have no downloadable "+
+				"solo-provisioner-daemon release to auto-download").
+			WithProperty(models.ErrPropertyResolution, []string{
+				"Build the daemon locally: task build:daemon GOOS=linux GOARCH=<arch>",
+				"Then pass its path: --daemon-bin=<path-to-binary>",
+			})
+	}
+
+	localCV := cv
+	if localCV == nil {
+		localCV = prompt.NewChosenValues()
+	}
+	if err := prompt.RunInputPrompts(cmd, []prompt.InputPrompt{
+		daemonBinInputPrompt(source.BinPath, &source.BinPath),
+	}, localCV); err != nil {
+		return source, err
+	}
+	if source.BinPath == "" {
+		return source, errorx.IllegalArgument.New("--daemon-bin is required for --profile=local").
+			WithProperty(models.ErrPropertyResolution, []string{
+				"Build the daemon locally: task build:daemon GOOS=linux GOARCH=<arch>",
+				"Then pass its path: --daemon-bin=<path-to-binary>",
+			})
+	}
+	return source, nil
+}
+
+// daemonBinInputPrompt returns the interactive prompt for --daemon-bin, shown
+// only when --profile=local requires a local daemon binary path (see
+// resolveDaemonBinarySource).
+func daemonBinInputPrompt(eff string, target *string) prompt.InputPrompt {
+	return prompt.InputPrompt{
+		FlagName:       "daemon-bin",
+		Title:          "Daemon Binary Path (required for --profile=local)",
+		Description:    "Path to a locally-built solo-provisioner-daemon binary. Local/dev builds have no downloadable release to auto-download.",
+		Placeholder:    "bin/solo-provisioner-daemon-linux-amd64",
+		EffectiveValue: eff,
+		Target:         target,
+		Validate: func(s string) error {
+			if s == "" {
+				return errorx.IllegalArgument.New("daemon binary path cannot be empty for --profile=local")
+			}
+			_, err := sanity.SanitizePath(s)
+			return err
+		},
+	}
+}
+
+// provisionBlockNodeDaemon runs the daemon install + provisioning workflow for
+// the block-node component. daemon.yaml has already been written by the install
+// workflow's Traffic-shaper Monitor phase, so it is loaded here as the source of
+// truth; the block-node component's orbit is defaulted to this install's
+// namespace if not already set (never re-prompted).
+func provisionBlockNodeDaemon(cmd *cobra.Command, namespace string, source workflowsteps.DaemonBinarySource) error {
+	paths := models.Paths()
+
+	cfg, err := daemon.LoadDaemonConfig(paths.DaemonConfigPath)
+	if err != nil {
+		// A missing daemon.yaml is expected on some paths — fall back to a fresh
+		// config and provision for this namespace. A malformed (or otherwise
+		// unreadable) daemon.yaml is fatal: swallowing it would provision the
+		// daemon while the operator's broken config silently goes unnoticed.
+		if !daemon.IsConfigNotFound(err) {
+			return err
+		}
+		cfg = daemon.DaemonConfig{}
+	}
+	// This path is an explicit request to install/provision the block-node
+	// daemon, so force the block-node component and its traffic-shaper monitor
+	// on regardless of any pre-existing disabled state — otherwise
+	// NewDaemonServiceInstallWorkflow would skip BN RBAC/kubeconfig and the
+	// monitor would never run.
+	if cfg.Components.BlockNode == nil {
+		cfg.Components.BlockNode = &daemon.BlockNodeComponentConfig{}
+	}
+	cfg.Components.BlockNode.Enabled = true
+	cfg.Components.BlockNode.Monitors.TrafficShaper = true
+	if cfg.Components.BlockNode.Kubeconfig == "" {
+		cfg.Components.BlockNode.Kubeconfig = paths.DaemonBNKubeconfigPath
+	}
+	if cfg.Components.BlockNode.Orbit == "" {
+		cfg.Components.BlockNode.Orbit = namespace
+	}
+
+	wf, err := workflows.NewDaemonServiceInstallWorkflow(cfg, source)
+	if err != nil {
+		return err
+	}
+	if err := common.RunWorkflowBuilder(cmd.Context(), wf); err != nil {
+		return err
+	}
+	logx.As().Info().Msg("solo-provisioner-daemon service installed, enabled, and started")
+	return nil
+}

--- a/cmd/cli/commands/block/node/install.go
+++ b/cmd/cli/commands/block/node/install.go
@@ -8,6 +8,7 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	workflowsteps "github.com/hashgraph/solo-weaver/internal/workflows/steps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/spf13/cobra"
 )
@@ -28,21 +29,47 @@ var installCmd = &cobra.Command{
 			return err
 		}
 
-		inputs, cv, err := prepareBlocknodeInputs(cmd, args)
+		shapeOverrides, err := common.ParseShapeOverrides(flagShape)
 		if err != nil {
 			return err
 		}
 
-		// Prompt for egress NIC and bandwidth independently of the host firewall —
-		// tc-egress traffic shaping applies regardless of whether the host
-		// firewall is enabled.
-		if err := common.ResolveEgressConfig(cmd, args, cv, &flagEgressInterface, &flagLinkRate); err != nil {
+		inputs, cv, err := prepareBlocknodeInputs(cmd, args)
+		if err != nil {
 			return err
+		}
+		// prepareBlocknodeInputs is shared with other block-node commands; patch
+		// in the install-only network field here.
+		inputs.Custom.ShapeOverrides = shapeOverrides
+
+		// The traffic-shaping gate is independent of the host firewall — it
+		// covers the BN workload network-policy plane and tc HTB shaping, not
+		// the host's own SSH/mgmt firewall.
+		trafficShapingEnabled, err := common.ResolveTrafficShapingConfig(cmd, args, cv)
+		if err != nil {
+			return err
+		}
+		inputs.Custom.TrafficShapingEnabled = trafficShapingEnabled
+
+		// Prompt for egress NIC and bandwidth, and resolve where the daemon
+		// binary comes from, only when traffic shaping is enabled — declining
+		// the gate above means there is nothing left to configure here.
+		var daemonSource workflowsteps.DaemonBinarySource
+		if trafficShapingEnabled {
+			if err := common.ResolveEgressConfig(cmd, args, cv, &flagEgressInterface, &flagLinkRate); err != nil {
+				return err
+			}
+			daemonSource, err = resolveDaemonBinarySource(cmd, args, inputs.Custom.Profile, cv)
+			if err != nil {
+				return err
+			}
 		}
 		// prepareBlocknodeInputs ran before the prompts; patch in the final values.
 		inputs.Custom.EgressInterface = flagEgressInterface
 		inputs.Custom.LinkRate = flagLinkRate
 
+		// Host firewall is independently gated from traffic shaping above — it
+		// applies regardless of whether the BN policy plane/tc shaping is enabled.
 		if err := common.ResolveHostFirewallConfig(cmd, args, cv); err != nil {
 			return err
 		}
@@ -82,6 +109,20 @@ var installCmd = &cobra.Command{
 
 		logx.As().Info().Msg("Successfully installed Hedera Block Node")
 
+		// Daemon activation is part of the traffic-shaping bundle, not a separate
+		// decision: a block node without its daemon has no ingress prioritization
+		// and nothing reconciling the daemon-owned nft sets from statusz, so
+		// enabling traffic shaping installs and provisions the daemon
+		// automatically (no separate prompt/flag). Skipped entirely when traffic
+		// shaping is disabled — there would be nothing for the daemon to do.
+		if trafficShapingEnabled {
+			if err := ensureBlockNodeDaemon(cmd, inputs.Custom.Namespace, daemonSource); err != nil {
+				return err
+			}
+		} else {
+			logx.As().Info().Msg("traffic shaping disabled (--traffic-shaping-enabled=false); skipping traffic-shaper daemon activation")
+		}
+
 		return nil
 	},
 }
@@ -90,5 +131,11 @@ func init() {
 	installCmd.Flags().StringVar(&flagChartVersion, "chart-version", "", "Helm chart version to use")
 	common.FlagValuesFile().SetVarP(installCmd, &flagValuesFile, false)
 	common.RegisterHostFirewallFlags(installCmd)
+	common.RegisterTrafficShapingFlags(installCmd)
 	common.RegisterEgressFlags(installCmd, &flagEgressInterface, &flagLinkRate)
+	installCmd.Flags().StringArrayVar(&flagShape, common.FlagNameShape, nil,
+		"Per-class HTB bandwidth override, repeatable: --shape <class>=rate=<r>,ceil=<c>,prio=<p> "+
+			"(e.g. --shape publisher=rate=800mbit,ceil=1gbit,prio=0). Classes not overridden use the profile defaults.")
+	common.FlagDaemonBin().SetVarP(installCmd, &flagDaemonBin, false)
+	common.FlagDaemonVersion().SetVarP(installCmd, &flagDaemonVersion, false)
 }

--- a/cmd/cli/commands/block/node/node.go
+++ b/cmd/cli/commands/block/node/node.go
@@ -40,6 +40,9 @@ var (
 	flagLoadBalancerEnabled  bool
 	flagEgressInterface      string
 	flagLinkRate             string
+	flagShape                []string
+	flagDaemonBin            string
+	flagDaemonVersion        string
 
 	nodeCmd = &cobra.Command{
 		Use:   "node",

--- a/cmd/cli/commands/common/flags_common.go
+++ b/cmd/cli/commands/common/flags_common.go
@@ -5,6 +5,7 @@ package common
 import (
 	"fmt"
 
+	"github.com/automa-saga/version"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 )
 
@@ -311,5 +312,20 @@ func FlagDaemonChecksum() FlagDefinition[string] {
 		ShortName:   "",
 		Description: "SHA-256 hex digest of the binary supplied via --daemon-bin (e.g. the value from a .sha256 release asset)",
 		Default:     "",
+	}
+}
+
+// FlagDaemonVersion is the solo-provisioner-daemon version to auto-download
+// from the infrastructure catalog. Ignored when --daemon-bin is set (the local
+// binary is installed as-is; no version resolution needed). Defaults to this
+// CLI's own running version — meaningful once the CLI and daemon are
+// co-released under one version scheme; for unstamped local/dev builds this
+// resolves to "dev", which has no catalog entry, hence --daemon-bin instead.
+func FlagDaemonVersion() FlagDefinition[string] {
+	return FlagDefinition[string]{
+		Name:        "daemon-version",
+		ShortName:   "",
+		Description: "Version of solo-provisioner-daemon to auto-download (defaults to this CLI's own version); ignored when --daemon-bin is set",
+		Default:     version.Get().Version,
 	}
 }

--- a/cmd/cli/commands/common/host_firewall.go
+++ b/cmd/cli/commands/common/host_firewall.go
@@ -21,6 +21,7 @@ import (
 const (
 	FlagNameFirewallEnabled = "firewall-enabled"
 	FlagNameMgmtCIDRs       = "mgmt-cidrs"
+	FlagNameBlockedCIDRs    = "blocked-cidrs"
 	FlagNameSSHPort         = "ssh-port"
 	FlagNamePodCIDR         = "pod-cidr"
 	FlagNameInClusterPorts  = "in-cluster-ports"
@@ -57,6 +58,14 @@ func ValidateHostFirewallFlags(cmd *cobra.Command) error {
 			}
 		}
 	}
+	if cmd.Flags().Changed(FlagNameBlockedCIDRs) {
+		cidrs, _ := cmd.Flags().GetStringSlice(FlagNameBlockedCIDRs)
+		for _, cidr := range normalizeCIDRs(cidrs) {
+			if err := sanity.ValidateIPv4CIDR(cidr); err != nil {
+				return errorx.IllegalArgument.Wrap(err, "invalid --%s %q", FlagNameBlockedCIDRs, cidr)
+			}
+		}
+	}
 	if cmd.Flags().Changed(FlagNamePodCIDR) {
 		podCIDR, _ := cmd.Flags().GetString(FlagNamePodCIDR)
 		if err := sanity.ValidateIPv4CIDR(strings.TrimSpace(podCIDR)); err != nil {
@@ -70,11 +79,16 @@ func ValidateHostFirewallFlags(cmd *cobra.Command) error {
 // The values are read back by name in ResolveHostFirewallConfig (no bound vars),
 // so the same registration works for any command that provisions a host.
 func RegisterHostFirewallFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool(FlagNameFirewallEnabled, true,
+	cmd.Flags().Bool(FlagNameFirewallEnabled, false,
 		"Apply the node-level host firewall (inet host table: SSH/mgmt allowlist, ICMP policy, in-cluster ports). "+
-			"Disable for hosts managed by an external firewall.")
+			"Opt-in (default: false) so existing non-interactive callers are unaffected; enable explicitly for "+
+			"hosts you want this tool to manage the firewall on.")
 	cmd.Flags().StringSlice(FlagNameMgmtCIDRs, nil,
 		"SSH/management allowlist CIDRs for the node host firewall (comma-separated or repeated). Empty skips the host firewall.")
+	cmd.Flags().StringSlice(FlagNameBlockedCIDRs, nil,
+		"Operator-curated block list CIDRs for the node host firewall, dropped before any other rule including "+
+			"established connections (comma-separated or repeated). Distinct from the BN workload plane's "+
+			"bn-restricted set, which the traffic-shaper daemon manages automatically.")
 	cmd.Flags().Int(FlagNameSSHPort, firewall.DefaultSSHPort,
 		"SSH/management TCP port allowed from --mgmt-cidrs by the node host firewall")
 	cmd.Flags().String(FlagNamePodCIDR, models.DefaultClusterPodCIDR,
@@ -107,7 +121,11 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.Cho
 	}
 
 	cfg := config.Get().Host
-	firewallEnabled := effectiveBool(cmd, FlagNameFirewallEnabled, !cfg.Disabled)
+	// Seeded false (opt-in), not derived from cfg.Disabled: this is a one-shot
+	// default for "nothing specified anywhere," not a round-tripped decision —
+	// config.yaml's zero value is indistinguishable from "not mentioned," so it
+	// can never safely override this default toward "enabled."
+	firewallEnabled := effectiveBool(cmd, FlagNameFirewallEnabled, false)
 
 	// Prompt for the enable/disable choice only when it wasn't already decided
 	// on the CLI. Declining here skips the allowlist/port prompts below entirely
@@ -116,13 +134,30 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.Cho
 		enabled, err := prompt.RunConfirm(
 			"Enable host firewall?",
 			"Apply the node-level inet host firewall (SSH/mgmt allowlist, ICMP policy, in-cluster ports). "+
-				"Choose No to skip entirely, e.g. for hosts managed by an external firewall.",
+				"Opt-in, default No — choose Yes to have this tool manage the host firewall.",
 			firewallEnabled,
 		)
 		if err != nil {
 			return err
 		}
 		firewallEnabled = enabled
+	}
+
+	// Non-interactive callers that supply host-firewall config flags without also
+	// passing --firewall-enabled=true would otherwise have those flags silently
+	// ignored: with the opt-in default there's no confirm prompt to catch the
+	// mismatch, and the early return below drops out without applying anything.
+	if !firewallEnabled && !prompt.ShouldPrompt(force) {
+		for _, name := range []string{FlagNameMgmtCIDRs, FlagNameBlockedCIDRs, FlagNameSSHPort, FlagNamePodCIDR, FlagNameInClusterPorts} {
+			if cmd.Flags().Changed(name) {
+				return errorx.IllegalArgument.New(
+					"--%s was supplied but the host firewall is not enabled (--firewall-enabled defaults to false)", name).
+					WithProperty(models.ErrPropertyResolution, []string{
+						"Pass --firewall-enabled=true to actually apply the host firewall settings",
+						"Or drop --" + name + " if you did not intend to configure the host firewall",
+					})
+			}
+		}
 	}
 
 	// An explicit opt-out skips resolving/prompting for the allowlist/port
@@ -141,6 +176,7 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.Cho
 	// prompt layer skips any flag already set on the CLI, leaving these seeds
 	// intact, so the same strings are parsed whether or not a prompt ran.
 	mgmtStr := effectiveCSV(cmd, FlagNameMgmtCIDRs, cfg.ManagementCIDRs)
+	blockedStr := effectiveCSV(cmd, FlagNameBlockedCIDRs, cfg.BlockedCIDRs)
 	sshStr := effectiveInt(cmd, FlagNameSSHPort, cfg.SSHPort, firewall.DefaultSSHPort)
 	portsStr := effectiveIntCSV(cmd, FlagNameInClusterPorts, cfg.InClusterPorts, firewall.DefaultInClusterPorts)
 	podStr := effectiveStr(cmd, FlagNamePodCIDR, cfg.PodCIDR, models.DefaultClusterPodCIDR)
@@ -152,6 +188,7 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.Cho
 		}
 		if err := prompt.RunInputPrompts(cmd, []prompt.InputPrompt{
 			prompt.MgmtCIDRsInputPrompt(mgmtStr, &mgmtStr),
+			prompt.BlockedCIDRsInputPrompt(blockedStr, &blockedStr),
 			prompt.SSHPortInputPrompt(sshStr, &sshStr),
 			prompt.PodCIDRInputPrompt(podStr, &podStr),
 			prompt.InClusterPortsInputPrompt(portsStr, &portsStr),
@@ -174,6 +211,7 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.Cho
 
 	hostCfg := models.HostConfig{
 		ManagementCIDRs: normalizeCIDRs(strings.Split(mgmtStr, ",")),
+		BlockedCIDRs:    normalizeCIDRs(strings.Split(blockedStr, ",")),
 		SSHPort:         sshPort,
 		PodCIDR:         strings.TrimSpace(podStr),
 		InClusterPorts:  ports,

--- a/cmd/cli/commands/common/shape_override.go
+++ b/cmd/cli/commands/common/shape_override.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// FlagNameShape is the CLI flag name for the per-class HTB bandwidth
+// overrides applied by `block node install`.
+const FlagNameShape = "shape"
+
+// ParseShapeOverrides parses repeated --shape values of the form
+// `<class>=rate=<r>,ceil=<c>,prio=<p>` into per-class overrides keyed by class
+// name. Each --shape occurrence carries one class; any subset of rate/ceil/prio
+// may be given (omitted fields keep the profile default). Every override is
+// validated against the known classes and tc-rate/prio rules, so a bad value is
+// rejected before any install work runs. The returned map is nil when raw is
+// empty.
+func ParseShapeOverrides(raw []string) (map[string]models.ShapeOverride, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]models.ShapeOverride, len(raw))
+	for _, entry := range raw {
+		class, spec, ok := strings.Cut(strings.TrimSpace(entry), "=")
+		class = strings.TrimSpace(class)
+		if !ok || class == "" || strings.TrimSpace(spec) == "" {
+			return nil, errorx.IllegalArgument.New(
+				"invalid --%s %q: expected <class>=rate=<r>,ceil=<c>,prio=<p>", FlagNameShape, entry)
+		}
+		if _, dup := out[class]; dup {
+			return nil, errorx.IllegalArgument.New("duplicate --%s override for class %q", FlagNameShape, class)
+		}
+
+		var o models.ShapeOverride
+		for _, kv := range strings.Split(spec, ",") {
+			key, val, ok := strings.Cut(strings.TrimSpace(kv), "=")
+			key, val = strings.TrimSpace(key), strings.TrimSpace(val)
+			if !ok || val == "" {
+				return nil, errorx.IllegalArgument.New(
+					"invalid --%s field %q for class %q: expected key=value", FlagNameShape, kv, class)
+			}
+			switch key {
+			case "rate":
+				o.Rate = val
+			case "ceil":
+				o.Ceil = val
+			case "prio":
+				n, err := strconv.Atoi(val)
+				if err != nil {
+					return nil, errorx.IllegalArgument.New(
+						"invalid --%s prio %q for class %q: must be an integer in [0,7]", FlagNameShape, val, class)
+				}
+				o.Prio = &n
+			default:
+				return nil, errorx.IllegalArgument.New(
+					"unknown --%s field %q for class %q: expected rate, ceil, or prio", FlagNameShape, key, class)
+			}
+		}
+
+		if err := shape.ValidateClassOverride(class, shape.ClassOverride{Rate: o.Rate, Ceil: o.Ceil, Prio: o.Prio}); err != nil {
+			return nil, errorx.Decorate(err, "invalid --%s override for class %q", FlagNameShape, class)
+		}
+		out[class] = o
+	}
+	return out, nil
+}

--- a/cmd/cli/commands/common/shape_override_test.go
+++ b/cmd/cli/commands/common/shape_override_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import "testing"
+
+func TestParseShapeOverrides(t *testing.T) {
+	t.Run("nil for empty", func(t *testing.T) {
+		got, err := ParseShapeOverrides(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("expected nil map, got %v", got)
+		}
+	})
+
+	t.Run("parses full and partial specs", func(t *testing.T) {
+		got, err := ParseShapeOverrides([]string{
+			"publisher=rate=800mbit,ceil=1gbit,prio=0",
+			"partner=ceil=700mbit",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		pub := got["publisher"]
+		if pub.Rate != "800mbit" || pub.Ceil != "1gbit" || pub.Prio == nil || *pub.Prio != 0 {
+			t.Errorf("publisher parsed wrong: %+v", pub)
+		}
+		part := got["partner"]
+		if part.Rate != "" || part.Ceil != "700mbit" || part.Prio != nil {
+			t.Errorf("partner parsed wrong: %+v", part)
+		}
+	})
+
+	t.Run("rejects bad input", func(t *testing.T) {
+		bad := [][]string{
+			{"publisher"},                                    // no spec
+			{"publisher="},                                   // empty spec
+			{"=rate=1gbit"},                                  // no class
+			{"publisher=rate="},                              // empty value
+			{"publisher=bogus=1gbit"},                        // unknown field
+			{"publisher=prio=notanumber"},                    // bad prio
+			{"nope=rate=1gbit"},                              // unknown class
+			{"publisher=rate=1gbit,ceil=100mbit"},            // ceil < rate
+			{"publisher=rate=1gbit", "publisher=ceil=1gbit"}, // duplicate class
+		}
+		for _, in := range bad {
+			if _, err := ParseShapeOverrides(in); err == nil {
+				t.Errorf("expected error for %v, got nil", in)
+			}
+		}
+	})
+}

--- a/cmd/cli/commands/common/traffic_shaping.go
+++ b/cmd/cli/commands/common/traffic_shaping.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+// FlagNameTrafficShapingEnabled is the CLI flag name for the top-level gate
+// over the BN workload network-policy plane (`inet weaver` classification) and
+// tc HTB traffic shaping. It is only registered on `block node install` today:
+// `reconfigure`/`upgrade` only re-persist an already-created plane and have no
+// equivalent toggle — tearing an existing plane down is a separate concern.
+const FlagNameTrafficShapingEnabled = "traffic-shaping-enabled"
+
+// RegisterTrafficShapingFlags registers the top-level traffic-shaping gate flag
+// on cmd. The value is read back by name in ResolveTrafficShapingConfig.
+func RegisterTrafficShapingFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool(FlagNameTrafficShapingEnabled, false,
+		"Create the BN workload network-policy plane (inet weaver classification) and tc HTB traffic "+
+			"shaping, and install the traffic-shaper daemon. Opt-in (default: false) so existing "+
+			"non-interactive callers are unaffected; enable explicitly to get all three.")
+}
+
+// ResolveTrafficShapingConfig determines whether the traffic-shaping/network-
+// policy bundle should be created for this install, prompting for the choice
+// when the session is interactive and the flag was not supplied on the CLI.
+// Accepting is the caller's signal to run the egress NIC/link-rate prompts
+// (ResolveEgressConfig), the NetworkPolicyCreate/NftWeaverPersist/
+// TcEgressPersist/TcIngressRecord steps, and to install and provision the
+// traffic-shaper daemon automatically at the end of install — daemon
+// activation is not a separate question, it follows directly from this one.
+// Declining skips all of it: there is nothing for any of them to configure
+// once the policy plane itself is off.
+//
+// It requires RegisterTrafficShapingFlags to have been called on cmd.
+func ResolveTrafficShapingConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues) (bool, error) {
+	force, err := FlagForce().Value(cmd, args)
+	if err != nil {
+		return false, errorx.IllegalArgument.Wrap(err, "failed to get %s flag", FlagForce().Name)
+	}
+
+	// Seeded false (opt-in) so existing non-interactive/scripted installs that
+	// don't pass this flag keep today's behavior rather than silently picking
+	// up the policy plane, tc shaping, and daemon install.
+	enabled := effectiveBool(cmd, FlagNameTrafficShapingEnabled, false)
+
+	// Prompt for the enable/disable choice only when it wasn't already decided
+	// on the CLI. Declining here skips the egress prompts below entirely —
+	// there's nothing left to ask once the plane itself is turned off.
+	if prompt.ShouldPrompt(force) && !cmd.Flags().Changed(FlagNameTrafficShapingEnabled) {
+		confirmed, err := prompt.RunConfirm(
+			"Enable traffic shaping?",
+			"Create the BN workload network-policy plane (inet weaver classification) and tc HTB "+
+				"traffic shaping, and install the traffic-shaper daemon. Opt-in, default No — choose Yes "+
+				"to get all three.",
+			enabled,
+		)
+		if err != nil {
+			return false, err
+		}
+		enabled = confirmed
+	}
+
+	// Non-interactive callers that supply traffic-shaping-only flags (egress
+	// NIC/link-rate, --shape overrides, daemon binary source) without also
+	// passing --traffic-shaping-enabled=true would otherwise have those flags
+	// silently ignored: with the opt-in default there's no confirm prompt to
+	// catch the mismatch, and the caller just skips configuring any of it.
+	if !enabled && !prompt.ShouldPrompt(force) {
+		for _, name := range []string{
+			FlagNameEgressInterface, FlagNameLinkRate, FlagNameShape,
+			FlagDaemonBin().Name, FlagDaemonVersion().Name,
+		} {
+			if cmd.Flags().Changed(name) {
+				return false, errorx.IllegalArgument.New(
+					"--%s was supplied but traffic shaping is not enabled (--traffic-shaping-enabled defaults to false)", name).
+					WithProperty(models.ErrPropertyResolution, []string{
+						"Pass --traffic-shaping-enabled=true to actually apply these settings",
+						"Or drop --" + name + " if you did not intend to configure traffic shaping",
+					})
+			}
+		}
+	}
+
+	return enabled, nil
+}

--- a/cmd/cli/commands/network/firewall/add.go
+++ b/cmd/cli/commands/network/firewall/add.go
@@ -9,22 +9,25 @@ import (
 
 var addCmd = &cobra.Command{
 	Use:   "add",
-	Short: "Add a single --mgmt-cidr or --in-cluster-port",
+	Short: "Add a single --mgmt-cidr, --blocked-cidr, or --in-cluster-port",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		mgr := newManager()
 		switch {
 		case cmd.Flags().Changed("mgmt-cidr"):
 			return mgr.AddMgmtCIDR(cmd.Context(), flagMgmtCIDR)
+		case cmd.Flags().Changed("blocked-cidr"):
+			return mgr.AddBlockedCIDR(cmd.Context(), flagBlockedCIDR)
 		case cmd.Flags().Changed("in-cluster-port"):
 			return mgr.AddPort(cmd.Context(), flagInClusterPort)
 		default:
-			return errorx.IllegalArgument.New("one of --mgmt-cidr or --in-cluster-port is required")
+			return errorx.IllegalArgument.New("one of --mgmt-cidr, --blocked-cidr, or --in-cluster-port is required")
 		}
 	},
 }
 
 func init() {
 	addCmd.Flags().StringVar(&flagMgmtCIDR, "mgmt-cidr", "", "A single management CIDR to add")
+	addCmd.Flags().StringVar(&flagBlockedCIDR, "blocked-cidr", "", "A single operator block-list CIDR to add")
 	addCmd.Flags().IntVar(&flagInClusterPort, "in-cluster-port", 0, "A single in-cluster host-service port to add")
-	addCmd.MarkFlagsMutuallyExclusive("mgmt-cidr", "in-cluster-port")
+	addCmd.MarkFlagsMutuallyExclusive("mgmt-cidr", "blocked-cidr", "in-cluster-port")
 }

--- a/cmd/cli/commands/network/firewall/create.go
+++ b/cmd/cli/commands/network/firewall/create.go
@@ -39,6 +39,9 @@ var createCmd = &cobra.Command{
 		if cmd.Flags().Changed("mgmt-cidrs") {
 			t.MgmtCIDRs = flagMgmtCIDRs
 		}
+		if cmd.Flags().Changed("blocked-cidrs") {
+			t.BlockedCIDRs = flagBlockedCIDRs
+		}
 		if cmd.Flags().Changed("in-cluster-ports") {
 			t.InClusterPorts = flagInClusterPorts
 		}
@@ -87,6 +90,7 @@ var createCmd = &cobra.Command{
 
 func init() {
 	createCmd.Flags().StringSliceVar(&flagMgmtCIDRs, "mgmt-cidrs", nil, "Management/SSH allowlist CIDRs (comma-separated or repeated)")
+	createCmd.Flags().StringSliceVar(&flagBlockedCIDRs, "blocked-cidrs", nil, "Operator-curated block list CIDRs, dropped before any other rule (comma-separated or repeated)")
 	createCmd.Flags().IntSliceVar(&flagInClusterPorts, "in-cluster-ports", fw.DefaultInClusterPorts, "Host-service ports reachable from the pod CIDR")
 	createCmd.Flags().IntVar(&flagSSHPort, "ssh-port", fw.DefaultSSHPort, "SSH/management TCP port accepted from the allowlist")
 	createCmd.Flags().StringVar(&flagPodCIDR, "pod-cidr", "", "Pod CIDR allowed to reach the in-cluster host-service ports (default: auto-detected from the local node's .spec.podCIDR; the rule is omitted if no cluster is reachable)")

--- a/cmd/cli/commands/network/firewall/firewall.go
+++ b/cmd/cli/commands/network/firewall/firewall.go
@@ -23,6 +23,8 @@ import (
 var (
 	flagMgmtCIDRs      []string
 	flagMgmtCIDR       string
+	flagBlockedCIDRs   []string
+	flagBlockedCIDR    string
 	flagInClusterPorts []int
 	flagInClusterPort  int
 	flagSSHPort        int

--- a/cmd/cli/commands/network/firewall/firewall_test.go
+++ b/cmd/cli/commands/network/firewall/firewall_test.go
@@ -42,7 +42,7 @@ func TestFirewallCmd_Structure(t *testing.T) {
 }
 
 func TestCreateCmd_Flags(t *testing.T) {
-	for _, name := range []string{"mgmt-cidrs", "in-cluster-ports", "ssh-port", "pod-cidr"} {
+	for _, name := range []string{"mgmt-cidrs", "blocked-cidrs", "in-cluster-ports", "ssh-port", "pod-cidr"} {
 		require.NotNil(t, createCmd.Flags().Lookup(name), "create is missing --%s", name)
 	}
 	// Defaults must match the firewall package defaults.
@@ -100,6 +100,7 @@ func TestAddRemoveCmd_Flags(t *testing.T) {
 			cmd = removeCmd
 		}
 		require.NotNil(t, cmd.Flags().Lookup("mgmt-cidr"), "%s missing --mgmt-cidr", c)
+		require.NotNil(t, cmd.Flags().Lookup("blocked-cidr"), "%s missing --blocked-cidr", c)
 		require.NotNil(t, cmd.Flags().Lookup("in-cluster-port"), "%s missing --in-cluster-port", c)
 	}
 }

--- a/cmd/cli/commands/network/firewall/remove.go
+++ b/cmd/cli/commands/network/firewall/remove.go
@@ -9,22 +9,25 @@ import (
 
 var removeCmd = &cobra.Command{
 	Use:   "remove",
-	Short: "Remove a single --mgmt-cidr or --in-cluster-port",
+	Short: "Remove a single --mgmt-cidr, --blocked-cidr, or --in-cluster-port",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		mgr := newManager()
 		switch {
 		case cmd.Flags().Changed("mgmt-cidr"):
 			return mgr.RemoveMgmtCIDR(cmd.Context(), flagMgmtCIDR)
+		case cmd.Flags().Changed("blocked-cidr"):
+			return mgr.RemoveBlockedCIDR(cmd.Context(), flagBlockedCIDR)
 		case cmd.Flags().Changed("in-cluster-port"):
 			return mgr.RemovePort(cmd.Context(), flagInClusterPort)
 		default:
-			return errorx.IllegalArgument.New("one of --mgmt-cidr or --in-cluster-port is required")
+			return errorx.IllegalArgument.New("one of --mgmt-cidr, --blocked-cidr, or --in-cluster-port is required")
 		}
 	},
 }
 
 func init() {
 	removeCmd.Flags().StringVar(&flagMgmtCIDR, "mgmt-cidr", "", "A single management CIDR to remove")
+	removeCmd.Flags().StringVar(&flagBlockedCIDR, "blocked-cidr", "", "A single operator block-list CIDR to remove")
 	removeCmd.Flags().IntVar(&flagInClusterPort, "in-cluster-port", 0, "A single in-cluster host-service port to remove")
-	removeCmd.MarkFlagsMutuallyExclusive("mgmt-cidr", "in-cluster-port")
+	removeCmd.MarkFlagsMutuallyExclusive("mgmt-cidr", "blocked-cidr", "in-cluster-port")
 }

--- a/cmd/cli/commands/network/firewall/set.go
+++ b/cmd/cli/commands/network/firewall/set.go
@@ -9,9 +9,9 @@ import (
 
 var setCmd = &cobra.Command{
 	Use:   "set",
-	Short: "Atomically replace the full --mgmt-cidrs and/or --in-cluster-ports list",
+	Short: "Atomically replace the full --mgmt-cidrs, --blocked-cidrs, and/or --in-cluster-ports list",
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		var mgmt []string
+		var mgmt, blocked []string
 		var ports []int
 
 		// A nil slice leaves that dimension unchanged; a changed flag (even with
@@ -22,6 +22,12 @@ var setCmd = &cobra.Command{
 				mgmt = []string{}
 			}
 		}
+		if cmd.Flags().Changed("blocked-cidrs") {
+			blocked = flagBlockedCIDRs
+			if blocked == nil {
+				blocked = []string{}
+			}
+		}
 		if cmd.Flags().Changed("in-cluster-ports") {
 			ports = flagInClusterPorts
 			if ports == nil {
@@ -29,15 +35,16 @@ var setCmd = &cobra.Command{
 			}
 		}
 
-		if mgmt == nil && ports == nil {
-			return errorx.IllegalArgument.New("at least one of --mgmt-cidrs or --in-cluster-ports is required")
+		if mgmt == nil && blocked == nil && ports == nil {
+			return errorx.IllegalArgument.New("at least one of --mgmt-cidrs, --blocked-cidrs, or --in-cluster-ports is required")
 		}
 
-		return newManager().Set(cmd.Context(), mgmt, ports)
+		return newManager().Set(cmd.Context(), mgmt, blocked, ports)
 	},
 }
 
 func init() {
 	setCmd.Flags().StringSliceVar(&flagMgmtCIDRs, "mgmt-cidrs", nil, "Full management allowlist (comma-separated; replaces the existing list)")
+	setCmd.Flags().StringSliceVar(&flagBlockedCIDRs, "blocked-cidrs", nil, "Full operator block list (comma-separated; replaces the existing list)")
 	setCmd.Flags().IntSliceVar(&flagInClusterPorts, "in-cluster-ports", nil, "Full in-cluster host-service port list (comma-separated; replaces the existing list)")
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -196,24 +196,49 @@ sudo solo-provisioner block node install \
 | `--historic-retention`    | Historic block retention threshold (`0` = unlimited)                                                                                  |
 | `--recent-retention`      | Recent block retention threshold (default: `96000`)                                                                                   |
 | `--load-balancer-enabled` | Inject MetalLB address-pool annotation into the block node service; set to `false` for environments without MetalLB (default: `true`) |
-| `--firewall-enabled`      | Apply the node-level host firewall (`inet host` table: SSH/mgmt allowlist, ICMP policy, in-cluster ports). Set to `false` for hosts managed by an external firewall (default: `true`) |
+| `--firewall-enabled`      | Apply the node-level host firewall (`inet host` table: SSH/mgmt allowlist, ICMP policy, in-cluster ports). Opt-in (default: `false`); set to `true` to have this tool manage the host firewall |
 | `--mgmt-cidrs`            | Host firewall SSH/management allowlist CIDRs. Empty skips the host firewall.                                                          |
+| `--blocked-cidrs`         | Host firewall operator-curated block list CIDRs, dropped before any other rule including established connections. Distinct from the BN workload plane's `bn-restricted` set, which the traffic-shaper daemon manages automatically. |
 | `--ssh-port`              | Host firewall SSH/management TCP port (default `22`)                                                                                  |
 | `--pod-cidr`              | Host firewall pod CIDR for the in-cluster host-service ports rule (defaults to the cluster pod subnet)                                |
 | `--in-cluster-ports`      | Host firewall in-cluster host-service ports (defaults to `6443,4244,7472,10250`)                                                     |
+| `--traffic-shaping-enabled` | Create the BN workload network-policy plane (`inet weaver` classification) and tc HTB traffic shaping, and install the traffic-shaper daemon. Opt-in (default: `false`); set to `true` to get all three |
 | `--egress-interface`      | Physical NIC for the `$EGRESS` HTB traffic-shaper hierarchy (e.g. `eth0`). Auto-detected from the default route when omitted; use this flag to override on multi-NIC hosts. Renders `/usr/local/sbin/solo-provisioner-tc-egress.sh` and installs `solo-provisioner-tc-egress.service` so the HTB hierarchy survives reboot. |
-| `--link-rate`             | NIC line rate in tc-style format (e.g. `1gbit`, `100mbit`), or `auto` to detect and store the link speed at install time (written as explicit proportional class rates). Auto-detected from sysfs at each boot when omitted. Interactively, the prompt accepts a rate, `auto`, or blank. |
+| `--link-rate`             | NIC line rate in tc-style format (e.g. `1gbit`, `100mbit`), or `auto` to detect and store the link speed at install time (written as explicit proportional class rates). Auto-detected from sysfs at each boot when omitted. Interactively, the prompt accepts a rate, `auto`, or blank. The link is full-duplex, so this rate parameterizes both the `$EGRESS` and `$VETH` HTB trunks. |
+| `--shape`                 | Per-class HTB bandwidth override, repeatable: `--shape <class>=rate=<r>,ceil=<c>,prio=<p>` (e.g. `--shape publisher=rate=800mbit,ceil=1gbit,prio=0`). Any subset of `rate`/`ceil`/`prio` may be given; classes not overridden use the profile defaults. Valid classes: `publisher`, `backfill-response`, `reserve-ingress`, `partner`, `public`, `reserve-egress`. |
+| `--daemon-version`        | Version of `solo-provisioner-daemon` to auto-download when traffic shaping installs the daemon (defaults to this CLI's own version). Ignored when `--daemon-bin` is set. |
+| `--daemon-bin`            | Local path to a pre-built `solo-provisioner-daemon` binary, installed as-is instead of downloaded. **Required for `--profile=local`** — local/dev builds have no downloadable release to auto-download from. |
 
-> **Host firewall**: `block node install` always lays down the node-level `inet
+> **Host firewall**: `block node install` can lay down the node-level `inet
 > host` firewall (SSH/management allowlist, ICMP policy, in-cluster host-service
 > ports) — regardless of whether it's bootstrapping a bare-metal host or deploying
-> onto an already-existing cluster. This is a deliberate design choice: the
+> onto an already-existing cluster. This is opt-in (`--firewall-enabled`, default
+> `false`) so existing non-interactive callers are unaffected; when enabled, the
 > firewall is owned by the block-node workflow, not by the generic `kube cluster
 > install` (which provisions clusters for other purposes too and should not
-> unconditionally apply node-specific rules). The `--mgmt-cidrs` / `--ssh-port` /
-> `--pod-cidr` / `--in-cluster-ports` flags (and interactive prompts) configure
-> it. An empty management allowlist skips the firewall to avoid locking the host
-> out of SSH; `--firewall-enabled=false` opts out of it entirely.
+> unconditionally apply node-specific rules). The `--mgmt-cidrs` / `--blocked-cidrs`
+> / `--ssh-port` / `--pod-cidr` / `--in-cluster-ports` flags (and interactive
+> prompts) configure it once enabled. An empty management allowlist skips the
+> firewall to avoid locking the host out of SSH. `--blocked-cidrs` only takes
+> effect when `--firewall-enabled` is also true — both live on the same `inet
+> host` table, rendered by the same step — but the *set itself* is a plain deny
+> list, dropped before every other rule (including established connections),
+> and is purely operator-managed for its whole lifecycle, unlike the
+> daemon-owned `bn-restricted` set on the BN workload plane.
+
+> **Traffic shaping gate**: daemon activation is not a separate decision from
+> traffic shaping — `block node install` automatically installs and provisions
+> the traffic-shaper daemon whenever traffic shaping is enabled, with no
+> separate prompt or flag. `--traffic-shaping-enabled` is opt-in (default
+> `false`) so existing non-interactive callers are unaffected; enabling it
+> creates the BN workload network-policy plane (`inet weaver` classification),
+> tc HTB shaping, and installs the daemon, all together — declining (or the
+> default) skips the egress NIC/link-rate prompts too, since there would be
+> nothing left for any of it to reconcile. This decision is durable: it's
+> recorded in the runtime state and honored by later `reconfigure`/`upgrade`
+> runs too, not just the install where it was made. This whole gate is
+> independent of `--firewall-enabled`, which only gates the host's own SSH/mgmt
+> firewall.
 
 > **Traffic-shaper defaults**: `block node install` records both the `$EGRESS`
 > (physical NIC) and the `$VETH` (per-pod ingress) HTB shapes using the design's
@@ -222,7 +247,37 @@ sudo solo-provisioner block node install \
 > is persisted for reboot replay (`solo-provisioner-tc-egress.service`); the
 > ingress shape is recorded as config only (the `$VETH` is ephemeral and replayed
 > per-pod). Ingress bandwidth defaults to the egress `--link-rate`. Tune any class
-> afterward with `network shape set --class <name> --rate/--ceil/--prio`.
+> afterward with `network shape set --class <name> --rate/--ceil/--prio`, or at
+> install time with `--shape <class>=rate=...,ceil=...,prio=...`.
+
+> **Network policies**: when traffic shaping is enabled (see the traffic shaping
+> gate above), `block node install` lays down the `inet weaver`
+> classification plane by creating the fixed set of BN policies (`bn-publisher`,
+> `bn-subscriber-in`, `bn-partner-out`, `bn-public-out`, `bn-status-in/out`,
+> `bn-mgmt-in/out`, `bn-restricted`, `bn-backfill`) idempotently, then persists the
+> rendered `network-weaver.nft` for reboot replay. The one operator-curated set,
+> `bn-mgmt-in/out`, is seeded here from the host management allowlist
+> (`--mgmt-cidrs`). Every other set's membership — including `bn-restricted` —
+> is reconciled at runtime by the traffic-shaper daemon from the block node's
+> statusz; `bn-restricted` in particular reflects a "restricted" category the
+> block node itself reports, so it always starts empty and has no install-time
+> flag. A permanent, purely operator-managed block list lives instead on the
+> host firewall (`--blocked-cidrs`, a different table).
+> Re-running the install never clobbers operator-applied set membership or per-class
+> shape values; `--force` re-renders the static rules from these definitions.
+
+> **Traffic-shaper daemon**: a block node without its traffic-shaper daemon has no
+> ingress prioritization (the `$VETH` HTB is never installed) and nothing
+> reconciling the daemon-owned nft sets from statusz. At the end of a successful
+> install, `block node install` installs and provisions the daemon for this
+> block node's namespace automatically whenever traffic shaping is enabled (see
+> the traffic-shaping gate above) — no separate prompt or flag. If the daemon is
+> already active, this is a no-op. By default the daemon binary is auto-downloaded
+> from the infrastructure catalog at `--daemon-version` (defaulting to this CLI's
+> own version); pass `--daemon-bin` to install a local binary instead. For
+> `--profile=local`, `--daemon-bin` is required — local/dev builds have no
+> downloadable release, so interactive sessions prompt for the path and
+> non-interactive ones fail fast with a resolution hint.
 
 #### Upgrade Block Node
 

--- a/internal/bll/blocknode/helpers.go
+++ b/internal/bll/blocknode/helpers.go
@@ -52,6 +52,26 @@ func patchBlockNodeState() func(st *state.State, effectiveInputs models.UserInpu
 	}
 }
 
+// patchBlockNodeStateAfterInstall extends patchBlockNodeState with the one
+// field that only `block node install` ever decides: TrafficShapingDisabled.
+// It must NOT live in the shared patchBlockNodeState — that callback is also
+// used by reconfigure/upgrade/reset/uninstall's HandleIntent, none of which
+// resolve or carry TrafficShapingEnabled, so their effectiveInputs.Custom
+// value is always the unset zero value and would silently flip a
+// true-at-install decision back to "disabled" on every later run. Recording it
+// only here, and only from InstallHandler, is what lets reconfigure/upgrade
+// read back the original decision (via currentState.BlockNodeState) without
+// ever having the chance to overwrite it themselves.
+func patchBlockNodeStateAfterInstall() func(st *state.State, effectiveInputs models.UserInputs[models.BlockNodeInputs]) error {
+	base := patchBlockNodeState()
+	return func(st *state.State, effectiveInputs models.UserInputs[models.BlockNodeInputs]) error {
+		st.BlockNodeState.TrafficShapingDisabled = !effectiveInputs.Custom.TrafficShapingEnabled
+		logx.As().Debug().Bool("trafficShapingDisabled", st.BlockNodeState.TrafficShapingDisabled).
+			Msg("Persisted block node traffic-shaping decision into runtime state")
+		return base(st, effectiveInputs)
+	}
+}
+
 // resolveBlocknodeEffectiveInputs resolves common fields for blocknode commands.
 func resolveBlocknodeEffectiveInputs(
 	runtime *rsl.BlockNodeRuntimeResolver,
@@ -140,17 +160,19 @@ func resolveBlocknodeEffectiveInputs(
 			HistoricRetention: effHistoricRetention.Get().Val(),
 			RecentRetention:   effRecentRetention.Get().Val(),
 			// Passed through from user input (no resolution)
-			ValuesFile:          inputs.Custom.ValuesFile,
-			ReuseValues:         inputs.Custom.ReuseValues,
-			SkipHardwareChecks:  inputs.Custom.SkipHardwareChecks,
-			ResetStorage:        inputs.Custom.ResetStorage,
-			PurgeStorage:        inputs.Custom.PurgeStorage,
-			NoRestart:           inputs.Custom.NoRestart,
-			LoadBalancerEnabled: inputs.Custom.LoadBalancerEnabled,
-			PluginPreset:        inputs.Custom.PluginPreset,
-			PluginList:          inputs.Custom.PluginList,
-			EgressInterface:     inputs.Custom.EgressInterface,
-			LinkRate:            inputs.Custom.LinkRate,
+			ValuesFile:            inputs.Custom.ValuesFile,
+			ReuseValues:           inputs.Custom.ReuseValues,
+			SkipHardwareChecks:    inputs.Custom.SkipHardwareChecks,
+			ResetStorage:          inputs.Custom.ResetStorage,
+			PurgeStorage:          inputs.Custom.PurgeStorage,
+			NoRestart:             inputs.Custom.NoRestart,
+			LoadBalancerEnabled:   inputs.Custom.LoadBalancerEnabled,
+			PluginPreset:          inputs.Custom.PluginPreset,
+			PluginList:            inputs.Custom.PluginList,
+			EgressInterface:       inputs.Custom.EgressInterface,
+			LinkRate:              inputs.Custom.LinkRate,
+			ShapeOverrides:        inputs.Custom.ShapeOverrides,
+			TrafficShapingEnabled: inputs.Custom.TrafficShapingEnabled,
 		},
 	}
 

--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/hashgraph/solo-weaver/internal/bll"
 	bnpkg "github.com/hashgraph/solo-weaver/internal/blocknode"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
 	"github.com/hashgraph/solo-weaver/internal/rsl"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/internal/workflows"
@@ -61,53 +62,71 @@ func (h *InstallHandler) BuildWorkflow(
 
 	ins := inputs.Custom
 
+	// Enable the traffic-shaper monitor in daemon.yaml only when the policy
+	// plane it reconciles against was actually created — with traffic shaping
+	// disabled there is no inet weaver classification for the daemon to watch.
+	var daemonConfigStep []automa.Builder
+	if ins.TrafficShapingEnabled {
+		daemonConfigStep = []automa.Builder{workflows.BlockNodeDaemonConfigWorkflow(ins.Namespace)}
+	}
+
 	var wb *automa.WorkflowBuilder
 	if currentState.ClusterState.Created {
-		wb = automa.NewWorkflowBuilder().WithId("block-node-install").
-			Steps(
-				// Backwards-compat guard: older released binaries did not create
-				// weaver:2500 during self-install, so the account may be absent on
-				// machines upgraded from an old binary. The global pre-run check only
-				// verifies the binary exists, not the user account. This step is
-				// idempotent and safe to repeat on up-to-date installations.
-				steps.EnsureWeaverOwnerStep(),
-				// Static network plane (host firewall + weaver policy persistence +
-				// $EGRESS/$VETH tc shape config), grouped as the "Network Setup" phase.
-				// The host firewall is owned by the block-node workflow (not the generic
-				// kube cluster install); nftables is already installed/enabled by prior
-				// cluster provisioning, so it's safe to apply here.
-				workflows.NetworkSetupWorkflow(ins.EgressInterface, ins.LinkRate),
-				steps.SetupBlockNode(ins),
-				// Enable the traffic-shaper monitor in daemon.yaml so it starts
-				// reconciling statusz-driven nft membership once the daemon runs.
-				workflows.BlockNodeDaemonConfigWorkflow(ins.Namespace),
-			)
+		stepList := []automa.Builder{
+			// Backwards-compat guard: older released binaries did not create
+			// weaver:2500 during self-install, so the account may be absent on
+			// machines upgraded from an old binary. The global pre-run check only
+			// verifies the binary exists, not the user account. This step is
+			// idempotent and safe to repeat on up-to-date installations.
+			steps.EnsureWeaverOwnerStep(),
+			// Static network plane (host firewall + weaver policy persistence +
+			// $EGRESS/$VETH tc shape config), grouped as the "Network Setup" phase.
+			// The host firewall is owned by the block-node workflow (not the generic
+			// kube cluster install); nftables is already installed/enabled by prior
+			// cluster provisioning, so it's safe to apply here.
+			workflows.NetworkSetupWorkflow(ins.EgressInterface, ins.LinkRate, toClassOverrides(ins.ShapeOverrides), inputs.Common.Force, ins.TrafficShapingEnabled),
+			steps.SetupBlockNode(ins),
+		}
+		stepList = append(stepList, daemonConfigStep...)
+		wb = automa.NewWorkflowBuilder().WithId("block-node-install").Steps(stepList...)
 	} else {
-		wb = automa.NewWorkflowBuilder().WithId("block-node-install").
-			Steps(
-				// Same backwards-compat guard as above: ensure weaver:2500 exists
-				// before the preflight check validates it. Older binaries did not
-				// create this account during self-install.
-				steps.EnsureWeaverOwnerStep(),
-				// Block node install owns its workload-sized preflight (block provider,
-				// profile, plugin preset) plus system setup, then stands up Kubernetes.
-				// InstallClusterWorkflow is intentionally not reused here: it validates
-				// only the substrate floor, which is weaker than the block-node floor.
-				workflows.NodeSetupWorkflow(models.NodeTypeBlock, ins.Profile, ins.PluginPreset, ins.SkipHardwareChecks),
-				workflows.KubernetesSetupWorkflow(h.mr),
-				// Static network plane (host firewall + weaver policy persistence +
-				// $EGRESS/$VETH tc shape config), grouped as the "Network Setup" phase.
-				// nftables was just installed/enabled by NodeSetupWorkflow's
-				// systemSetupWorkflow, so applying the host firewall here (rather than
-				// in that generic, node-type-agnostic workflow) is safe.
-				workflows.NetworkSetupWorkflow(ins.EgressInterface, ins.LinkRate),
-				steps.SetupBlockNode(ins),
-				// Enable the traffic-shaper monitor in daemon.yaml so it starts
-				// reconciling statusz-driven nft membership once the daemon runs.
-				workflows.BlockNodeDaemonConfigWorkflow(ins.Namespace),
-			)
+		stepList := []automa.Builder{
+			// Same backwards-compat guard as above: ensure weaver:2500 exists
+			// before the preflight check validates it. Older binaries did not
+			// create this account during self-install.
+			steps.EnsureWeaverOwnerStep(),
+			// Block node install owns its workload-sized preflight (block provider,
+			// profile, plugin preset) plus system setup, then stands up Kubernetes.
+			// InstallClusterWorkflow is intentionally not reused here: it validates
+			// only the substrate floor, which is weaker than the block-node floor.
+			workflows.NodeSetupWorkflow(models.NodeTypeBlock, ins.Profile, ins.PluginPreset, ins.SkipHardwareChecks),
+			workflows.KubernetesSetupWorkflow(h.mr),
+			// Static network plane (host firewall + weaver policy persistence +
+			// $EGRESS/$VETH tc shape config), grouped as the "Network Setup" phase.
+			// nftables was just installed/enabled by NodeSetupWorkflow's
+			// systemSetupWorkflow, so applying the host firewall here (rather than
+			// in that generic, node-type-agnostic workflow) is safe.
+			workflows.NetworkSetupWorkflow(ins.EgressInterface, ins.LinkRate, toClassOverrides(ins.ShapeOverrides), inputs.Common.Force, ins.TrafficShapingEnabled),
+			steps.SetupBlockNode(ins),
+		}
+		stepList = append(stepList, daemonConfigStep...)
+		wb = automa.NewWorkflowBuilder().WithId("block-node-install").Steps(stepList...)
 	}
 	return wb, nil
+}
+
+// toClassOverrides converts the neutral models.ShapeOverride map carried on the
+// inputs into the shape package's ClassOverride map the network setup workflow
+// consumes. It exists so pkg/models stays decoupled from internal/network/shape.
+func toClassOverrides(in map[string]models.ShapeOverride) map[string]shape.ClassOverride {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]shape.ClassOverride, len(in))
+	for name, o := range in {
+		out[name] = shape.ClassOverride{Rate: o.Rate, Ceil: o.Ceil, Prio: o.Prio}
+	}
+	return out
 }
 
 // HandleIntent delegates to the shared BaseHandler which orchestrates all block-node intents.
@@ -116,7 +135,7 @@ func (h *InstallHandler) HandleIntent(
 	intent models.Intent,
 	inputs models.UserInputs[models.BlockNodeInputs],
 ) (*automa.Report, error) {
-	return h.BaseHandler.HandleIntent(ctx, intent, inputs, h, patchBlockNodeState())
+	return h.BaseHandler.HandleIntent(ctx, intent, inputs, h, patchBlockNodeStateAfterInstall())
 }
 
 func NewInstallHandler(

--- a/internal/bll/blocknode/reconfigure_handler.go
+++ b/internal/bll/blocknode/reconfigure_handler.go
@@ -55,6 +55,19 @@ func (h *ReconfigureHandler) BuildWorkflow(
 
 	ins := inputs.Custom
 
+	// networkSteps is the shared network-plane prefix for every branch below.
+	// TcEgressPersist is omitted when the install-time TrafficShapingEnabled
+	// decision (persisted onto BlockNodeState — see patchBlockNodeStateAfterInstall)
+	// was "no": reconfigure never resolves --traffic-shaping-enabled itself, so
+	// without this check it would silently re-provision tc shaping for a block
+	// node that was deliberately installed without it. NetworkFirewallCreate and
+	// NftWeaverPersist are always safe to include unconditionally — they
+	// self-gate (host-firewall disabled / empty policy registry respectively).
+	networkSteps := []automa.Builder{steps.NetworkFirewallCreate(), steps.NftWeaverPersist()}
+	if !currentState.BlockNodeState.TrafficShapingDisabled {
+		networkSteps = append(networkSteps, steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate, nil))
+	}
+
 	var wb *automa.WorkflowBuilder
 	switch {
 	case ins.PurgeStorage:
@@ -68,17 +81,12 @@ func (h *ReconfigureHandler) BuildWorkflow(
 
 		// After purging old dirs, recreate PVs/PVCs and create new directories at
 		// the new paths, then upgrade the chart.
-		wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-purge-storage").
-			Steps(
-				steps.NetworkFirewallCreate(),
-				// Keep network-weaver.nft in sync with the policy registry (no-op
-				// if the registry is empty), matching the install ordering.
-				steps.NftWeaverPersist(),
-				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
-				steps.PurgeBlockNodeStorage(oldIns),
-				steps.RecreateBlockNodeStorage(ins),
-				steps.UpgradeBlockNode(ins),
-			)
+		stepList := append(networkSteps,
+			steps.PurgeBlockNodeStorage(oldIns),
+			steps.RecreateBlockNodeStorage(ins),
+			steps.UpgradeBlockNode(ins),
+		)
+		wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-purge-storage").Steps(stepList...)
 	case ins.ResetStorage:
 		// --with-reset wipes data only; PVs/PVCs are preserved. Storage paths must
 		// not have changed because local-PV hostPath is immutable.
@@ -95,16 +103,11 @@ func (h *ReconfigureHandler) BuildWorkflow(
 
 		oldIns := ins
 		oldIns.Storage = currentState.BlockNodeState.Storage
-		wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-with-reset").
-			Steps(
-				steps.NetworkFirewallCreate(),
-				// Keep network-weaver.nft in sync with the policy registry (no-op
-				// if the registry is empty), matching the install ordering.
-				steps.NftWeaverPersist(),
-				steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
-				steps.PurgeBlockNodeStorage(oldIns),
-				steps.UpgradeBlockNode(ins),
-			)
+		stepList := append(networkSteps,
+			steps.PurgeBlockNodeStorage(oldIns),
+			steps.UpgradeBlockNode(ins),
+		)
+		wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-with-reset").Steps(stepList...)
 	default:
 		// For non-reset reconfigures, storage path changes require --purge-storage because
 		// existing PVs/PVCs cannot be mutated in-place; block with a clear error.
@@ -121,28 +124,13 @@ func (h *ReconfigureHandler) BuildWorkflow(
 
 		if ins.NoRestart {
 			// Opt-out: apply new values via helm but skip the rollout-restart.
-			wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-no-restart").
-				Steps(
-					steps.NetworkFirewallCreate(),
-					// Keep network-weaver.nft in sync with the policy registry (no-op
-					// if the registry is empty), matching the install ordering.
-					steps.NftWeaverPersist(),
-					steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
-					steps.UpgradeBlockNode(ins),
-				)
+			stepList := append(networkSteps, steps.UpgradeBlockNode(ins))
+			wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure-no-restart").Steps(stepList...)
 		} else {
 			// Default: apply new values then trigger a rolling restart so ConfigMap-only
 			// changes are picked up by the running pod.
-			wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure").
-				Steps(
-					steps.NetworkFirewallCreate(),
-					// Keep network-weaver.nft in sync with the policy registry (no-op
-					// if the registry is empty), matching the install ordering.
-					steps.NftWeaverPersist(),
-					steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate),
-					steps.UpgradeBlockNode(ins),
-					steps.RolloutRestartBlockNode(ins),
-				)
+			stepList := append(networkSteps, steps.UpgradeBlockNode(ins), steps.RolloutRestartBlockNode(ins))
+			wb = automa.NewWorkflowBuilder().WithId("block-node-reconfigure").Steps(stepList...)
 		}
 	}
 	return wb, nil

--- a/internal/blocknode/shaper/policy_map.go
+++ b/internal/blocknode/shaper/policy_map.go
@@ -47,7 +47,7 @@ type categoryBinding struct {
 // by the monitor.
 var categoryBindings = map[Category]categoryBinding{
 	CategoryPublisher:  {policyName: "bn-publisher"},
-	CategoryPartner:    {policyName: "bn-partner"},
+	CategoryPartner:    {policyName: "bn-partner-out"},
 	CategoryRestricted: {policyName: "bn-restricted"},
 	CategoryPeerBN:     {policyName: "bn-backfill", compound: true},
 }

--- a/internal/blocknode/shaper/policy_map_test.go
+++ b/internal/blocknode/shaper/policy_map_test.go
@@ -51,7 +51,7 @@ func TestComputePolicyDeltas_MapsCategoriesToPolicies(t *testing.T) {
 	// Ordered by policy name; no-op deltas omitted (all four have changes here).
 	require.Equal(t, []PolicyDelta{
 		{Policy: "bn-backfill", SetDelta: setDelta([]string{"10.30.5.7 . 43473"}, nil)},
-		{Policy: "bn-partner", SetDelta: setDelta([]string{"10.2.0.1"}, nil)},
+		{Policy: "bn-partner-out", SetDelta: setDelta([]string{"10.2.0.1"}, nil)},
 		{Policy: "bn-publisher", SetDelta: setDelta([]string{"10.1.0.2"}, nil)},
 		{Policy: "bn-restricted", SetDelta: setDelta([]string{"10.3.0.0/24"}, nil)},
 	}, deltas)
@@ -78,7 +78,7 @@ func TestComputePolicyDeltas_AbsentCategoryLeavesSetUntouched(t *testing.T) {
 	deltas, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{CategoryPartner: {"10.2.0.1/32"}})
 	require.NoError(t, err)
 	require.Equal(t, []PolicyDelta{
-		{Policy: "bn-partner", SetDelta: setDelta([]string{"10.2.0.1"}, nil)},
+		{Policy: "bn-partner-out", SetDelta: setDelta([]string{"10.2.0.1"}, nil)},
 	}, deltas)
 	require.NotContains(t, l.reads, "bn-publisher", "absent category's set must not be read")
 }
@@ -169,4 +169,27 @@ func TestCanonicalDesiredMembership_MalformedCompoundErrors(t *testing.T) {
 // (adds, deletes) pair.
 func setDelta(adds, deletes []string) policy.SetDelta {
 	return policy.SetDelta{Adds: adds, Deletes: deletes}
+}
+
+// TestCategoryBindings_PolicyNamesAreCanonical guards against categoryBindings
+// drifting from the canonical BN policy set created by NetworkPolicyCreate
+// (internal/workflows/steps/step_network_policy.go). A binding to a policy
+// name that doesn't exist there makes ApplyMembership fail every time that
+// category has any endpoint reported (Manager.ApplyMembership never calls
+// create: "a name absent from the registry ... is an error") — this bit once,
+// with CategoryPartner bound to "bn-partner" instead of "bn-partner-out".
+// There is no shared export between the two packages, so this list must be
+// kept in sync by hand; this test is what catches the next drift.
+func TestCategoryBindings_PolicyNamesAreCanonical(t *testing.T) {
+	canonicalBNPolicyNames := map[string]bool{
+		"bn-publisher": true, "bn-subscriber-in": true, "bn-partner-out": true,
+		"bn-public-out": true, "bn-status-in": true, "bn-status-out": true,
+		"bn-mgmt-in": true, "bn-mgmt-out": true, "bn-restricted": true, "bn-backfill": true,
+	}
+	for cat, b := range categoryBindings {
+		if !canonicalBNPolicyNames[b.policyName] {
+			t.Errorf("categoryBindings[%q].policyName = %q is not one of the canonical "+
+				"BN policy names created by NetworkPolicyCreate", cat, b.policyName)
+		}
+	}
 }

--- a/internal/blocknode/shaper/reconciler_test.go
+++ b/internal/blocknode/shaper/reconciler_test.go
@@ -224,9 +224,9 @@ func TestReconciler_Apply_AppliesOnlyChangedPolicies(t *testing.T) {
 		outbound: NetworkData{},
 	}
 	lister := newFakeLister()
-	// bn-partner already matches desired; bn-publisher differs; bn-restricted and
-	// bn-backfill are seeded empty and live-empty → no change.
-	lister.elements["bn-partner"] = []string{"10.2.0.1"}
+	// bn-partner-out already matches desired; bn-publisher differs; bn-restricted
+	// and bn-backfill are seeded empty and live-empty → no change.
+	lister.elements["bn-partner-out"] = []string{"10.2.0.1"}
 	lister.elements["bn-publisher"] = []string{"10.9.9.9"}
 
 	applier := &fakeApplier{applied: true}
@@ -241,7 +241,7 @@ func TestReconciler_Apply_AppliesOnlyChangedPolicies(t *testing.T) {
 
 	assert.Equal(t, []string{"bn-publisher"}, res.Applied)
 	// The other three owned policies are reported unchanged.
-	assert.Equal(t, []string{"bn-backfill", "bn-partner", "bn-restricted"}, res.Unchanged)
+	assert.Equal(t, []string{"bn-backfill", "bn-partner-out", "bn-restricted"}, res.Unchanged)
 	assert.NotEmpty(t, res.Digest)
 }
 
@@ -274,7 +274,7 @@ func TestReconciler_Apply_LockHeldReportsNothingApplied(t *testing.T) {
 	// The changed policy must not silently vanish from the result: it is
 	// reported skipped (still out of sync), not folded into unchanged.
 	assert.Equal(t, []string{"bn-publisher"}, res.Skipped)
-	assert.Equal(t, []string{"bn-backfill", "bn-partner", "bn-restricted"}, res.Unchanged)
+	assert.Equal(t, []string{"bn-backfill", "bn-partner-out", "bn-restricted"}, res.Unchanged)
 }
 
 func TestReconciler_Apply_PropagatesApplyError(t *testing.T) {

--- a/internal/network/firewall/firewall_test.go
+++ b/internal/network/firewall/firewall_test.go
@@ -28,6 +28,7 @@ func (f *fakeRunner) Exists(_ context.Context) (bool, error) { return f.exists, 
 func sampleTable() *Table {
 	return &Table{
 		MgmtCIDRs:      []string{"10.0.0.0/8", "192.168.0.0/16"},
+		BlockedCIDRs:   []string{"203.0.113.0/24"},
 		InClusterPorts: []int{4244, 6443, 7472, 10250},
 		SSHPort:        22,
 		PodCIDR:        "10.4.0.0/24",
@@ -65,6 +66,10 @@ func TestRender_SecurityInvariants(t *testing.T) {
 	require.Contains(t, doc, "ip saddr @mgmt_addrs tcp dport 22 accept")
 	require.Contains(t, doc, "elements = { 10.0.0.0/8, 192.168.0.0/16 }")
 	require.Contains(t, doc, "elements = { 4244, 6443, 7472, 10250 }")
+	// The operator block list is a distinct set from the mgmt allowlist and
+	// must be dropped before anything else, including established/related.
+	require.Contains(t, doc, "set blocked_addrs { type ipv4_addr; flags interval; elements = { 203.0.113.0/24 }; }")
+	require.Contains(t, doc, "ip saddr @blocked_addrs drop")
 	// ICMP is a static, safe ruleset: full ICMP from mgmt, and from everyone
 	// else the path-health subset (PMTUD + traceroute) plus rate-limited echo.
 	require.Contains(t, doc, "ip saddr @mgmt_addrs icmp type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem } accept")
@@ -86,6 +91,12 @@ func TestRender_SecurityInvariants(t *testing.T) {
 	estIdx := strings.LastIndex(doc, "ct state established,related accept")
 	require.Greater(t, dropIdx, limitIdx, "echo drop must follow the echo rate limit")
 	require.Greater(t, estIdx, dropIdx, "established,related accept must come after the ICMP echo rules")
+
+	// The block list must be evaluated before established/related so an
+	// operator-added CIDR also kills already-open connections, not just new ones.
+	blockedIdx := strings.Index(doc, "ip saddr @blocked_addrs drop")
+	require.Greater(t, blockedIdx, 0)
+	require.Less(t, blockedIdx, estIdx, "blocked-CIDR drop must precede established,related accept")
 }
 
 func TestRender_NoMgmtNoPod(t *testing.T) {
@@ -96,6 +107,7 @@ func TestRender_NoMgmtNoPod(t *testing.T) {
 	// Empty mgmt set renders without an elements clause; no pod CIDR means no
 	// in-cluster rule line.
 	require.Contains(t, doc, "set mgmt_addrs { type ipv4_addr; flags interval; }")
+	require.Contains(t, doc, "set blocked_addrs { type ipv4_addr; flags interval; }")
 	require.NotContains(t, doc, "tcp dport @in_cluster_ports accept")
 }
 
@@ -181,10 +193,21 @@ func TestManager_AddRemoveSet(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, string(data), "10.5.0.0/16")
 
-	require.NoError(t, m.Set(ctx, []string{"172.16.0.0/12"}, []int{9100}))
+	require.NoError(t, m.AddBlockedCIDR(ctx, "203.0.113.0/24"))
+	data, err = os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "203.0.113.0/24")
+
+	require.NoError(t, m.RemoveBlockedCIDR(ctx, "203.0.113.0/24"))
+	data, err = os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "203.0.113.0/24")
+
+	require.NoError(t, m.Set(ctx, []string{"172.16.0.0/12"}, []string{"198.51.100.0/24"}, []int{9100}))
 	data, err = os.ReadFile(nftPath)
 	require.NoError(t, err)
 	require.Contains(t, string(data), "172.16.0.0/12")
+	require.Contains(t, string(data), "198.51.100.0/24")
 	require.Contains(t, string(data), "9100")
 	// Set replaced the port list entirely.
 	require.NotContains(t, string(data), "6443")
@@ -201,6 +224,8 @@ func TestManager_AddRejectsBadInput(t *testing.T) {
 	require.Error(t, m.AddMgmtCIDR(ctx, "not-a-cidr"))
 	require.Error(t, m.AddPort(ctx, 70000))
 	require.Error(t, m.AddMgmtCIDR(ctx, "2001:db8::/32")) // IPv6 not supported by ipv4_addr sets
+	require.Error(t, m.AddBlockedCIDR(ctx, "not-a-cidr"))
+	require.Error(t, m.AddBlockedCIDR(ctx, "2001:db8::/32")) // IPv6 not supported by ipv4_addr sets
 }
 
 func TestTable_Validate_RejectsIPv6(t *testing.T) {
@@ -211,6 +236,10 @@ func TestTable_Validate_RejectsIPv6(t *testing.T) {
 	pod := sampleTable()
 	pod.PodCIDR = "2001:db8::/32"
 	require.ErrorContains(t, pod.Validate(), "IPv6 CIDRs are not yet supported")
+
+	blocked := sampleTable()
+	blocked.BlockedCIDRs = []string{"2001:db8::/32"}
+	require.ErrorContains(t, blocked.Validate(), "IPv6 CIDRs are not yet supported")
 }
 
 func TestManager_MutateBeforeCreateFails(t *testing.T) {

--- a/internal/network/firewall/manager.go
+++ b/internal/network/firewall/manager.go
@@ -96,6 +96,16 @@ func (m *Manager) RemoveMgmtCIDR(ctx context.Context, cidr string) error {
 	return m.mutate(ctx, func(t *Table) error { t.RemoveMgmtCIDR(cidr); return nil })
 }
 
+// AddBlockedCIDR adds one CIDR to the operator block list and re-renders.
+func (m *Manager) AddBlockedCIDR(ctx context.Context, cidr string) error {
+	return m.mutate(ctx, func(t *Table) error { return t.AddBlockedCIDR(cidr) })
+}
+
+// RemoveBlockedCIDR removes one CIDR from the operator block list and re-renders.
+func (m *Manager) RemoveBlockedCIDR(ctx context.Context, cidr string) error {
+	return m.mutate(ctx, func(t *Table) error { t.RemoveBlockedCIDR(cidr); return nil })
+}
+
 // AddPort adds one in-cluster host-service port and re-renders.
 func (m *Manager) AddPort(ctx context.Context, port int) error {
 	return m.mutate(ctx, func(t *Table) error { return t.AddPort(port) })
@@ -106,13 +116,18 @@ func (m *Manager) RemovePort(ctx context.Context, port int) error {
 	return m.mutate(ctx, func(t *Table) error { t.RemovePort(port); return nil })
 }
 
-// Set atomically replaces the management CIDR list and/or the in-cluster port
-// list. A nil slice leaves that dimension unchanged; an empty (non-nil) slice
-// clears it.
-func (m *Manager) Set(ctx context.Context, mgmtCIDRs []string, ports []int) error {
+// Set atomically replaces the management CIDR list, the operator block list,
+// and/or the in-cluster port list. A nil slice leaves that dimension unchanged;
+// an empty (non-nil) slice clears it.
+func (m *Manager) Set(ctx context.Context, mgmtCIDRs, blockedCIDRs []string, ports []int) error {
 	return m.mutate(ctx, func(t *Table) error {
 		if mgmtCIDRs != nil {
 			if err := t.SetMgmtCIDRs(mgmtCIDRs); err != nil {
+				return err
+			}
+		}
+		if blockedCIDRs != nil {
+			if err := t.SetBlockedCIDRs(blockedCIDRs); err != nil {
 				return err
 			}
 		}

--- a/internal/network/firewall/parse.go
+++ b/internal/network/firewall/parse.go
@@ -25,6 +25,9 @@ func Parse(content string) (*Table, error) {
 	if cidrs, ok := parseElements(content, reMgmtSet); ok {
 		t.MgmtCIDRs = splitElements(cidrs)
 	}
+	if cidrs, ok := parseElements(content, reBlockedSet); ok {
+		t.BlockedCIDRs = splitElements(cidrs)
+	}
 	if ports, ok := parseElements(content, rePortSet); ok {
 		for _, p := range splitElements(ports) {
 			n, err := strconv.Atoi(p)
@@ -50,10 +53,11 @@ func Parse(content string) (*Table, error) {
 }
 
 var (
-	reMgmtSet = regexp.MustCompile(`set mgmt_addrs \{[^}]*elements = \{ ([^}]*) \}`)
-	rePortSet = regexp.MustCompile(`set in_cluster_ports \{[^}]*elements = \{ ([^}]*) \}`)
-	reSSHPort = regexp.MustCompile(`ip saddr @mgmt_addrs tcp dport (\d+) accept`)
-	rePodCIDR = regexp.MustCompile(`ip saddr (\S+) tcp dport @in_cluster_ports accept`)
+	reMgmtSet    = regexp.MustCompile(`set mgmt_addrs \{[^}]*elements = \{ ([^}]*) \}`)
+	reBlockedSet = regexp.MustCompile(`set blocked_addrs \{[^}]*elements = \{ ([^}]*) \}`)
+	rePortSet    = regexp.MustCompile(`set in_cluster_ports \{[^}]*elements = \{ ([^}]*) \}`)
+	reSSHPort    = regexp.MustCompile(`ip saddr @mgmt_addrs tcp dport (\d+) accept`)
+	rePodCIDR    = regexp.MustCompile(`ip saddr (\S+) tcp dport @in_cluster_ports accept`)
 )
 
 func parseElements(content string, re *regexp.Regexp) (string, bool) {

--- a/internal/network/firewall/render.go
+++ b/internal/network/firewall/render.go
@@ -16,10 +16,11 @@ import (
 // Strings are pre-joined here because templates.Render parses without a FuncMap,
 // so the template itself cannot call join.
 type renderData struct {
-	MgmtElements string
-	PortElements string
-	SSHPort      int
-	PodCIDR      string
+	MgmtElements    string
+	BlockedElements string
+	PortElements    string
+	SSHPort         int
+	PodCIDR         string
 }
 
 // Render produces the full `inet host` nft document for this table. The same
@@ -36,10 +37,11 @@ func (t *Table) Render() (string, error) {
 	}
 
 	data := renderData{
-		MgmtElements: strings.Join(t.MgmtCIDRs, ", "),
-		PortElements: strings.Join(ports, ", "),
-		SSHPort:      t.SSHPort,
-		PodCIDR:      t.PodCIDR,
+		MgmtElements:    strings.Join(t.MgmtCIDRs, ", "),
+		BlockedElements: strings.Join(t.BlockedCIDRs, ", "),
+		PortElements:    strings.Join(ports, ", "),
+		SSHPort:         t.SSHPort,
+		PodCIDR:         t.PodCIDR,
 	}
 
 	rendered, err := templates.Render(hostNftTemplate, data)

--- a/internal/network/firewall/table.go
+++ b/internal/network/firewall/table.go
@@ -28,6 +28,14 @@ var DefaultInClusterPorts = []int{6443, 4244, 7472, 10250}
 type Table struct {
 	// MgmtCIDRs is the management/SSH allowlist (set @mgmt_addrs).
 	MgmtCIDRs []string
+	// BlockedCIDRs is the operator-curated deny list (set @blocked_addrs). It is
+	// purely operator-managed for its whole lifecycle — nothing in this package
+	// or the daemon ever writes to it automatically. This is deliberately
+	// distinct from the BN workload plane's `bn-restricted` set (`inet weaver`),
+	// which the traffic-shaper daemon reconciles from the block node's statusz
+	// "restricted" category; an operator block list needs a home the daemon
+	// never overwrites.
+	BlockedCIDRs []string
 	// InClusterPorts are host-service ports reachable from PodCIDR (set
 	// @in_cluster_ports). Per design there is deliberately no --service-ports:
 	// BN ports live only in `network policy --ports`.
@@ -59,6 +67,12 @@ func (t *Table) Validate() error {
 	for _, c := range t.MgmtCIDRs {
 		if err := sanity.ValidateIPv4CIDR(c); err != nil {
 			return errorx.IllegalArgument.Wrap(err, "invalid --mgmt-cidr %q", c)
+		}
+	}
+
+	for _, c := range t.BlockedCIDRs {
+		if err := sanity.ValidateIPv4CIDR(c); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --blocked-cidr %q", c)
 		}
 	}
 
@@ -116,6 +130,44 @@ func (t *Table) SetMgmtCIDRs(cidrs []string) error {
 	dedup := dedupeStrings(cidrs)
 	sort.Strings(dedup)
 	t.MgmtCIDRs = dedup
+	return nil
+}
+
+// AddBlockedCIDR adds a single CIDR to the operator block list (idempotent).
+func (t *Table) AddBlockedCIDR(cidr string) error {
+	if err := sanity.ValidateIPv4CIDR(cidr); err != nil {
+		return errorx.IllegalArgument.Wrap(err, "invalid --blocked-cidr %q", cidr)
+	}
+	if sanity.Contains(cidr, t.BlockedCIDRs) {
+		return nil
+	}
+	t.BlockedCIDRs = append(t.BlockedCIDRs, cidr)
+	sort.Strings(t.BlockedCIDRs)
+	return nil
+}
+
+// RemoveBlockedCIDR removes a single CIDR from the operator block list
+// (idempotent; removing an absent CIDR is a no-op).
+func (t *Table) RemoveBlockedCIDR(cidr string) {
+	out := t.BlockedCIDRs[:0]
+	for _, c := range t.BlockedCIDRs {
+		if c != cidr {
+			out = append(out, c)
+		}
+	}
+	t.BlockedCIDRs = out
+}
+
+// SetBlockedCIDRs atomically replaces the full operator block list.
+func (t *Table) SetBlockedCIDRs(cidrs []string) error {
+	for _, c := range cidrs {
+		if err := sanity.ValidateIPv4CIDR(c); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --blocked-cidr %q", c)
+		}
+	}
+	dedup := dedupeStrings(cidrs)
+	sort.Strings(dedup)
+	t.BlockedCIDRs = dedup
 	return nil
 }
 

--- a/internal/network/firewall/testdata/network-host.golden.nft
+++ b/internal/network/firewall/testdata/network-host.golden.nft
@@ -3,6 +3,7 @@ delete table inet host
 add table inet host
 table inet host {
 	set mgmt_addrs { type ipv4_addr; flags interval; elements = { 10.0.0.0/8, 192.168.0.0/16 }; }
+	set blocked_addrs { type ipv4_addr; flags interval; elements = { 203.0.113.0/24 }; }
 	set in_cluster_ports { type inet_service; elements = { 4244, 6443, 7472, 10250 }; }
 
 	chain input {
@@ -10,6 +11,13 @@ table inet host {
 
 		# Drop invalid; admit loopback.
 		ct state invalid drop
+
+		# Operator-curated block list (`network firewall --blocked-cidrs`). Runs
+		# before every other rule, including established/related, so an entry
+		# added here drops already-open connections too. Purely operator-managed:
+		# nothing else ever writes to this set.
+		ip saddr @blocked_addrs drop
+
 		iif "lo" accept
 
 		# ICMP is evaluated BEFORE the established/related fast-path. netfilter

--- a/internal/network/policy/registry.go
+++ b/internal/network/policy/registry.go
@@ -29,6 +29,22 @@ func writeEntry(dir string, p *Policy) error {
 	return atomicWriteFile(registryPath(dir, p.Name), string(data)+"\n", 0o644)
 }
 
+// Exists reports whether a policy with the given name is present in the
+// registry at RegistryDir. A missing file is not an error (returns false). It
+// lets install orchestration tell a genuinely new policy from one that already
+// existed before a create — e.g. so rollback deletes only what it created and
+// never an operator-owned policy replaced via --force.
+func Exists(name string) (bool, error) {
+	_, err := os.Stat(registryPath(RegistryDir, name))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, errorx.ExternalError.Wrap(err, "failed to stat policy registry %s", registryPath(RegistryDir, name))
+}
+
 // readEntry loads a single policy from its registry file.
 func readEntry(dir, name string) (*Policy, error) {
 	data, err := os.ReadFile(registryPath(dir, name))

--- a/internal/network/policy/render.go
+++ b/internal/network/policy/render.go
@@ -26,8 +26,9 @@ import (
 //  2. asymmetric reply-stamp restore
 //  3. stamp classification — specific (has an IP-set match)
 //  4. stamp classification — fallthrough (--from-entity world)
-//  5. ct state established,related accept   (structural)
-//  6. drop                                   (structural)
+//  5. unclassified pod egress                (structural; only when podCIDR is set)
+//  6. ct state established,related accept   (structural)
+//  7. drop                                   (structural)
 func Render(policies []*Policy, podCIDR string) (string, error) {
 	if podCIDR == "" && needsPodCIDR(policies) {
 		return "", errorx.IllegalArgument.New("pod CIDR is required to render a --stamp policy in the inet weaver chain")
@@ -113,7 +114,7 @@ func renderSetDecls(policies []*Policy) ([]string, error) {
 }
 
 // renderChain builds the forward chain body lines (indented two tabs), grouped
-// into the six tiers above.
+// into the seven tiers above.
 func renderChain(policies []*Policy, podCIDR string) ([]string, error) {
 	lines := []string{
 		"\t\ttype filter hook forward priority 0; policy drop;",
@@ -196,6 +197,22 @@ func renderChain(policies []*Policy, podCIDR string) ([]string, error) {
 	if len(fallthr) > 0 {
 		lines = append(lines, "", "\t\t# Classification — fallthrough (any source/dest).")
 		lines = append(lines, fallthr...)
+	}
+
+	// Tier 5: unclassified pod egress. Only rendered when a pod CIDR is known
+	// (the canonical BN install set always supplies one; a deny-only chain
+	// built without one just skips this tier rather than erroring, since
+	// nothing above requires it either). Deliberately no meta priority: this
+	// is a default-allow escape hatch for outbound traffic this registry
+	// doesn't otherwise classify (e.g. the chart's Maven-based plugin
+	// resolution), so it falls to the HTB default class instead of one of
+	// the classified priority bands. ip daddr != podCIDR keeps this scoped to
+	// egress leaving the node, not a blanket pass for intra-CIDR pod-to-pod
+	// traffic the classification tiers above don't already cover.
+	if podCIDR != "" {
+		lines = append(lines, "",
+			"\t\t# Unclassified pod egress (no meta priority; HTB default class).",
+			fmt.Sprintf("\t\tip saddr %s ip daddr != %s accept", podCIDR, podCIDR))
 	}
 
 	lines = append(lines, "",

--- a/internal/network/policy/testdata/network-weaver.golden.nft
+++ b/internal/network/policy/testdata/network-weaver.golden.nft
@@ -33,6 +33,9 @@ table inet weaver {
 		ip saddr 10.4.0.0/24 tcp sport @bn-public-out_ports meta priority set 0x10050 accept
 		ip daddr 10.4.0.0/24 tcp dport @bn-subscriber-in_ports meta priority set 0x10030 accept
 
+		# Unclassified pod egress (no meta priority; HTB default class).
+		ip saddr 10.4.0.0/24 ip daddr != 10.4.0.0/24 accept
+
 		ct state established,related accept
 		drop
 	}

--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -284,6 +284,22 @@ func (m *Manager) SetClass(ctx context.Context, name string, rate, ceil *string,
 	})
 }
 
+// HasEgressConfig reports whether the egress device already has a recorded
+// shape config (device + classes) in the registry — i.e. whether a prior
+// ProvisionDefaultEgress (via `block node install`/`network shape create`)
+// has already run. Used by the install-time TcEgressPersist step to decide
+// between provisioning fresh defaults (nothing recorded yet: matches
+// TcIngressRecord's unconditional behavior) and re-applying from what's
+// already there (an existing install: never clobber operator-adjusted
+// `network shape set` values just because --link-rate was omitted).
+func (m *Manager) HasEgressConfig() (bool, error) {
+	dev, err := readDevice(DirEgress)
+	if err != nil {
+		return false, err
+	}
+	return dev != nil, nil
+}
+
 // ShowClass returns a human-readable summary of the named class config.
 func (m *Manager) ShowClass(name string) (string, error) {
 	cls, err := readClass(name)
@@ -608,10 +624,14 @@ func defaultEgressConfig(trunkRate string) (*DeviceConfig, []*ClassConfig, error
 // create time (see resolveAutoRateString). Existing configs are always
 // replaced. Called by block node install so the shape registry is the single
 // source of truth from first install.
-func (m *Manager) ProvisionDefaultEgress(ctx context.Context, nicName, trunkRate string) error {
+func (m *Manager) ProvisionDefaultEgress(ctx context.Context, nicName, trunkRate string, overrides map[string]ClassOverride) error {
 	trunkRate = m.resolveAutoRateString(trunkRate)
 	dev, classes, err := defaultEgressConfig(trunkRate)
 	if err != nil {
+		return err
+	}
+	applyClassOverrides(classes, overrides)
+	if err := validateProvisionedClasses(classes, dev.Rate); err != nil {
 		return err
 	}
 	return m.withLock(func() error {
@@ -635,10 +655,11 @@ func (m *Manager) RenderAndApplyEgress(ctx context.Context, nic string) error {
 }
 
 // ProvisionDefaultEgressShape configures the egress shape registry with the
-// three default HTB classes at proportions derived from trunkRate, then renders
-// and applies the boot script. Convenience wrapper over NewManager().ProvisionDefaultEgress.
-func ProvisionDefaultEgressShape(ctx context.Context, nicName, trunkRate string) error {
-	return NewManager().ProvisionDefaultEgress(ctx, nicName, trunkRate)
+// three default HTB classes at proportions derived from trunkRate (with any
+// per-class --shape overrides merged in), then renders and applies the boot
+// script. Convenience wrapper over NewManager().ProvisionDefaultEgress.
+func ProvisionDefaultEgressShape(ctx context.Context, nicName, trunkRate string, overrides map[string]ClassOverride) error {
+	return NewManager().ProvisionDefaultEgress(ctx, nicName, trunkRate, overrides)
 }
 
 // defaultIngressConfig returns the ingress device root and three default ingress
@@ -677,10 +698,14 @@ func defaultIngressConfig(trunkRate string) (*DeviceConfig, []*ClassConfig, erro
 // the stored class configs. Called by block node install so ApplyIngressVeth
 // finds concrete ingress config on the first pod create (the per-pod replay has
 // no sysfs fallback, so the recorded rates must always be concrete).
-func (m *Manager) ProvisionDefaultIngress(_ context.Context, trunkRate string) error {
+func (m *Manager) ProvisionDefaultIngress(_ context.Context, trunkRate string, overrides map[string]ClassOverride) error {
 	trunkRate = m.resolveAutoRateString(trunkRate)
 	dev, classes, err := defaultIngressConfig(trunkRate)
 	if err != nil {
+		return err
+	}
+	applyClassOverrides(classes, overrides)
+	if err := validateProvisionedClasses(classes, dev.Rate); err != nil {
 		return err
 	}
 	return m.withLock(func() error {
@@ -701,12 +726,12 @@ func (m *Manager) ProvisionDefaultIngress(_ context.Context, trunkRate string) e
 // over ProvisionDefaultIngress. When nicName is non-empty it pins the resolution
 // of a "auto" trunkRate to the operator-chosen NIC (parity with the egress path
 // on multi-NIC hosts); ingress bandwidth defaults to egress.
-func ProvisionDefaultIngressShape(ctx context.Context, nicName, trunkRate string) error {
+func ProvisionDefaultIngressShape(ctx context.Context, nicName, trunkRate string, overrides map[string]ClassOverride) error {
 	cfg := Config{}
 	if nicName != "" {
 		cfg.NICDetect = func() (string, error) { return nicName, nil }
 	}
-	return NewManagerWithConfig(cfg).ProvisionDefaultIngress(ctx, trunkRate)
+	return NewManagerWithConfig(cfg).ProvisionDefaultIngress(ctx, trunkRate, overrides)
 }
 
 // RenderAndApplyDefaultEgress renders the tc-egress script for nic from the

--- a/internal/network/shape/override.go
+++ b/internal/network/shape/override.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import "github.com/joomcode/errorx"
+
+// ClassOverride carries operator-supplied overrides for one HTB class's
+// bandwidth fields, parsed from
+// `block node install --shape <class>=rate=...,ceil=...,prio=...`. A zero-value
+// field (empty Rate/Ceil, nil Prio) means "keep the profile default", so an
+// operator can override just one field (e.g. only --shape publisher=ceil=1gbit)
+// without restating the others.
+type ClassOverride struct {
+	Rate string
+	Ceil string
+	Prio *int
+}
+
+// ValidateClassOverride checks that name is a known class and that each set
+// field is individually valid (rate/ceil parseable, ceil >= rate when both are
+// set, prio in [0,7]). It deliberately does NOT check the sum-of-rates
+// constraint — that is enforced against the full merged class set when the shape
+// is provisioned (see validateProvisionedClasses), because the sum depends on
+// the profile defaults the override merges into.
+func ValidateClassOverride(name string, o ClassOverride) error {
+	if _, err := lookupClassInfo(name); err != nil {
+		return err
+	}
+	if o.Rate != "" {
+		if err := validateRate(o.Rate); err != nil {
+			return errorx.Decorate(err, "invalid --shape rate for class %q", name)
+		}
+	}
+	if o.Ceil != "" {
+		if err := validateRate(o.Ceil); err != nil {
+			return errorx.Decorate(err, "invalid --shape ceil for class %q", name)
+		}
+	}
+	if o.Rate != "" && o.Ceil != "" {
+		if err := validateCeilGeRate(o.Ceil, o.Rate); err != nil {
+			return err
+		}
+	}
+	if o.Prio != nil {
+		if err := validatePrio(*o.Prio); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ClassDirection returns the tc device direction ("ingress" or "egress") a
+// class belongs to, so callers can route a --shape override to the device it
+// applies to. Unknown class names return an error naming the known classes.
+func ClassDirection(name string) (string, error) {
+	info, err := lookupClassInfo(name)
+	if err != nil {
+		return "", err
+	}
+	return info.Dir, nil
+}
+
+// applyClassOverrides merges overrides into the matching classes by name,
+// leaving unmatched classes and unset override fields at their profile
+// defaults. Overrides naming a class not in classes (e.g. an egress class when
+// provisioning the ingress device) are ignored here — each provision call sees
+// the full override map and applies only the entries for its own direction.
+func applyClassOverrides(classes []*ClassConfig, overrides map[string]ClassOverride) {
+	for _, c := range classes {
+		o, ok := overrides[c.Name]
+		if !ok {
+			continue
+		}
+		if o.Rate != "" {
+			c.Rate = o.Rate
+		}
+		if o.Ceil != "" {
+			c.Ceil = o.Ceil
+		}
+		if o.Prio != nil {
+			c.Prio = *o.Prio
+		}
+	}
+}
+
+// validateProvisionedClasses re-checks the merged class set (profile defaults
+// with any --shape overrides applied) before it is written: each class's
+// rate/ceil/prio must be valid, and the sum of class rates must not exceed the
+// device root rate. The profile defaults always pass; this exists to catch an
+// override that individually validates but pushes the total over the trunk
+// budget.
+func validateProvisionedClasses(classes []*ClassConfig, deviceRate string) error {
+	for _, c := range classes {
+		if err := validateRate(c.Rate); err != nil {
+			return errorx.Decorate(err, "invalid rate for class %q", c.Name)
+		}
+		if c.Ceil != "" {
+			if err := validateCeilGeRate(c.Ceil, c.Rate); err != nil {
+				return errorx.Decorate(err, "class %q", c.Name)
+			}
+		}
+		if err := validatePrio(c.Prio); err != nil {
+			return errorx.Decorate(err, "class %q", c.Name)
+		}
+	}
+	deviceBps, err := parseBandwidthBps(deviceRate)
+	if err != nil {
+		return nil // device rate unparseable (legacy expression): skip the sum check
+	}
+	var sum int64
+	for _, c := range classes {
+		bps, err := parseBandwidthBps(c.Rate)
+		if err != nil {
+			continue
+		}
+		sum += bps
+	}
+	if sum > deviceBps {
+		return errorx.IllegalArgument.New(
+			"total class rates (%d bit) exceed the device root rate %s (%d bit) after --shape overrides; lower a --shape rate or raise --link-rate",
+			sum, deviceRate, deviceBps)
+	}
+	return nil
+}

--- a/internal/network/shape/override_test.go
+++ b/internal/network/shape/override_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import "testing"
+
+func intPtr(n int) *int { return &n }
+
+func TestValidateClassOverride(t *testing.T) {
+	tests := []struct {
+		name    string
+		class   string
+		o       ClassOverride
+		wantErr bool
+	}{
+		{name: "valid rate/ceil/prio", class: "publisher", o: ClassOverride{Rate: "800mbit", Ceil: "1gbit", Prio: intPtr(0)}},
+		{name: "valid partial (ceil only)", class: "partner", o: ClassOverride{Ceil: "700mbit"}},
+		{name: "unknown class", class: "nope", o: ClassOverride{Rate: "100mbit"}, wantErr: true},
+		{name: "bad rate", class: "publisher", o: ClassOverride{Rate: "fast"}, wantErr: true},
+		{name: "bad ceil", class: "publisher", o: ClassOverride{Ceil: "quick"}, wantErr: true},
+		{name: "ceil below rate", class: "publisher", o: ClassOverride{Rate: "1gbit", Ceil: "100mbit"}, wantErr: true},
+		{name: "prio too high", class: "publisher", o: ClassOverride{Prio: intPtr(8)}, wantErr: true},
+		{name: "prio negative", class: "publisher", o: ClassOverride{Prio: intPtr(-1)}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateClassOverride(tt.class, tt.o)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestApplyClassOverrides(t *testing.T) {
+	classes := []*ClassConfig{
+		{Name: "partner", Rate: "400mbit", Ceil: "700mbit", Prio: 0},
+		{Name: "public", Rate: "300mbit", Ceil: "700mbit", Prio: 5},
+	}
+	overrides := map[string]ClassOverride{
+		"partner": {Ceil: "1gbit", Prio: intPtr(3)}, // rate untouched
+		"unknown": {Rate: "10mbit"},                 // no matching class → ignored
+	}
+	applyClassOverrides(classes, overrides)
+
+	if classes[0].Rate != "400mbit" {
+		t.Errorf("partner rate mutated: got %q, want unchanged 400mbit", classes[0].Rate)
+	}
+	if classes[0].Ceil != "1gbit" {
+		t.Errorf("partner ceil not overridden: got %q, want 1gbit", classes[0].Ceil)
+	}
+	if classes[0].Prio != 3 {
+		t.Errorf("partner prio not overridden: got %d, want 3", classes[0].Prio)
+	}
+	if classes[1].Ceil != "700mbit" || classes[1].Prio != 5 {
+		t.Errorf("public class unexpectedly mutated: %+v", classes[1])
+	}
+}
+
+func TestValidateProvisionedClasses(t *testing.T) {
+	t.Run("default egress classes pass", func(t *testing.T) {
+		_, classes, err := defaultEgressConfig("1gbit")
+		if err != nil {
+			t.Fatalf("defaultEgressConfig: %v", err)
+		}
+		if err := validateProvisionedClasses(classes, "1gbit"); err != nil {
+			t.Fatalf("default classes should validate: %v", err)
+		}
+	})
+
+	t.Run("override pushing sum over trunk fails", func(t *testing.T) {
+		_, classes, err := defaultEgressConfig("1gbit")
+		if err != nil {
+			t.Fatalf("defaultEgressConfig: %v", err)
+		}
+		// Raise partner to the full trunk; with public + reserve-egress still
+		// present the sum now exceeds 1gbit.
+		applyClassOverrides(classes, map[string]ClassOverride{"partner": {Rate: "1gbit"}})
+		if err := validateProvisionedClasses(classes, "1gbit"); err == nil {
+			t.Fatalf("expected sum-exceeds-trunk error, got nil")
+		}
+	})
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -151,7 +151,15 @@ type BlockNodeState struct {
 	RecentRetention   string                  `yaml:"recentRetention,omitempty" json:"recentRetention,omitempty"`
 	PluginPreset      string                  `yaml:"pluginPreset,omitempty" json:"pluginPreset,omitempty"`
 	PluginList        string                  `yaml:"pluginList,omitempty" json:"pluginList,omitempty"`
-	LastSync          htime.Time              `yaml:"lastSync,omitempty" json:"lastSync,omitempty"` // last time state was reconciled
+	// TrafficShapingDisabled records an install-time opt-out
+	// (--traffic-shaping-enabled=false) that cannot be recovered from the Helm
+	// release or the live cluster. Negative polarity so the zero value means
+	// "enabled", matching HostConfig.Disabled's convention. Only `block node
+	// install` ever writes this (see patchBlockNodeStateAfterInstall); reconfigure
+	// and upgrade read it to durably skip re-provisioning tc shaping for a block
+	// node that was deliberately installed without it.
+	TrafficShapingDisabled bool       `yaml:"trafficShapingDisabled,omitempty" json:"trafficShapingDisabled,omitempty"`
+	LastSync               htime.Time `yaml:"lastSync,omitempty" json:"lastSync,omitempty"` // last time state was reconciled
 }
 
 // ClusterNodeState represents a single Kubernetes node summary.

--- a/internal/templates/files/network/network-host.nft.tmpl
+++ b/internal/templates/files/network/network-host.nft.tmpl
@@ -3,6 +3,7 @@ delete table inet host
 add table inet host
 table inet host {
 	set mgmt_addrs { type ipv4_addr; flags interval;{{if .MgmtElements}} elements = { {{.MgmtElements}} };{{end}} }
+	set blocked_addrs { type ipv4_addr; flags interval;{{if .BlockedElements}} elements = { {{.BlockedElements}} };{{end}} }
 	set in_cluster_ports { type inet_service;{{if .PortElements}} elements = { {{.PortElements}} };{{end}} }
 
 	chain input {
@@ -10,6 +11,13 @@ table inet host {
 
 		# Drop invalid; admit loopback.
 		ct state invalid drop
+
+		# Operator-curated block list (`network firewall --blocked-cidrs`). Runs
+		# before every other rule, including established/related, so an entry
+		# added here drops already-open connections too. Purely operator-managed:
+		# nothing else ever writes to this set.
+		ip saddr @blocked_addrs drop
+
 		iif "lo" accept
 
 		# ICMP is evaluated BEFORE the established/related fast-path. netfilter

--- a/internal/ui/prompt/cluster.go
+++ b/internal/ui/prompt/cluster.go
@@ -31,6 +31,26 @@ func validateMgmtCIDRs(s string) error {
 	return nil
 }
 
+// validateBlockedCIDRs validates a comma-separated operator block list. An
+// empty value is allowed — it means no CIDRs are blocked. Each non-empty entry
+// must be a valid CIDR.
+func validateBlockedCIDRs(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	for _, c := range strings.Split(s, ",") {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		if err := sanity.ValidateIPv4CIDR(c); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid blocked CIDR %q", c)
+		}
+	}
+	return nil
+}
+
 // validatePodCIDR validates the pod CIDR. Empty is allowed (the in-cluster
 // host-service ports rule is then omitted); a non-empty value must be a CIDR.
 func validatePodCIDR(s string) error {
@@ -89,6 +109,24 @@ func MgmtCIDRsInputPrompt(eff string, target *string) InputPrompt {
 		EffectiveValue: eff,
 		Target:         target,
 		Validate:       validateMgmtCIDRs,
+	}
+}
+
+// BlockedCIDRsInputPrompt returns the interactive prompt for the host
+// firewall's operator-curated block list. eff is the effective value (from
+// flag/config) shown as the pre-filled suggestion; target receives the
+// comma-separated result. This is distinct from the BN workload plane's
+// `bn-restricted` set, which the traffic-shaper daemon manages automatically —
+// this list is purely operator-managed.
+func BlockedCIDRsInputPrompt(eff string, target *string) InputPrompt {
+	return InputPrompt{
+		FlagName:       "blocked-cidrs",
+		Title:          "Blocked CIDRs (host firewall)",
+		Description:    "CIDRs to drop before any other rule, including already-open connections (comma-separated). Leave empty to block nothing.",
+		Placeholder:    "203.0.113.0/24",
+		EffectiveValue: eff,
+		Target:         target,
+		Validate:       validateBlockedCIDRs,
 	}
 }
 

--- a/internal/workflows/network_setup.go
+++ b/internal/workflows/network_setup.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	"github.com/automa-saga/automa"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
 	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
@@ -19,16 +20,30 @@ import (
 //
 // Ordering note preserved from the caller: this must run after the Kubernetes
 // setup, since nftables is installed/enabled by the system-setup phase before the
-// host firewall is applied here.
-func NetworkSetupWorkflow(egressInterface, linkRate string) *automa.WorkflowBuilder {
+// host firewall is applied here. NetworkPolicyCreate runs before NftWeaverPersist
+// so the policy registry is populated when the weaver table is rendered and
+// persisted; an empty registry would persist a policy-drop chain.
+//
+// trafficShapingEnabled gates the BN workload policy plane and tc shaping
+// (NetworkPolicyCreate, NftWeaverPersist, TcEgressPersist, TcIngressRecord) as
+// one bundle, independent of the host firewall (NetworkFirewallCreate, always
+// included — it is gated separately by hostCfg.Disabled inside its own step).
+// When false, none of the four steps are added: there is no inet weaver table
+// to persist and no tc config to shape traffic with.
+func NetworkSetupWorkflow(egressInterface, linkRate string, shapeOverrides map[string]shape.ClassOverride, force bool, trafficShapingEnabled bool) *automa.WorkflowBuilder {
+	stepList := []automa.Builder{steps.NetworkFirewallCreate()}
+	if trafficShapingEnabled {
+		stepList = append(stepList,
+			steps.NetworkPolicyCreate(force),
+			steps.NftWeaverPersist(),
+			steps.TcEgressPersist(egressInterface, linkRate, shapeOverrides),
+			steps.TcIngressRecord(egressInterface, linkRate, shapeOverrides),
+		)
+	}
+
 	return automa.NewWorkflowBuilder().
 		WithId("block-node-network-setup").
-		Steps(
-			steps.NetworkFirewallCreate(),
-			steps.NftWeaverPersist(),
-			steps.TcEgressPersist(egressInterface, linkRate),
-			steps.TcIngressRecord(egressInterface, linkRate),
-		).
+		Steps(stepList...).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
 			notify.As().PhaseStart(ctx, stp, "Network Setup")
 			return ctx, nil

--- a/internal/workflows/steps/step_daemon.go
+++ b/internal/workflows/steps/step_daemon.go
@@ -50,6 +50,10 @@ type DaemonBinarySource struct {
 	// Checksum is an optional sha256 hex digest to verify BinPath.
 	// Ignored when BinPath is empty (the catalog checksum is used instead).
 	Checksum string
+	// Version selects which catalog version to auto-download. Ignored when
+	// BinPath is set (no version resolution needed for a locally-supplied
+	// binary). Empty means the catalog's own default version.
+	Version string
 }
 
 // InstallDaemonBinaryStep obtains, verifies, and installs the solo-provisioner-daemon
@@ -84,7 +88,11 @@ func InstallDaemonBinaryStep(src DaemonBinarySource, paths models.WeaverPaths) *
 
 			if src.BinPath == "" {
 				// ── Auto-download path: delegate entirely to daemonInstaller ────────
-				installer, err := software.NewDaemonInstaller()
+				var opts []software.InstallerOption
+				if src.Version != "" {
+					opts = append(opts, software.WithVersion(src.Version))
+				}
+				installer, err := software.NewDaemonInstaller(opts...)
 				if err != nil {
 					return automa.StepFailureReport(stp.Id(),
 						automa.WithError(errorx.InternalError.Wrap(err, "failed to initialise daemon installer").

--- a/internal/workflows/steps/step_network_firewall.go
+++ b/internal/workflows/steps/step_network_firewall.go
@@ -81,6 +81,7 @@ func NetworkFirewallCreate() *automa.StepBuilder {
 			// otherwise indicate a config the resolver never touched.
 			t := firewall.NewTable()
 			t.MgmtCIDRs = hostCfg.ManagementCIDRs
+			t.BlockedCIDRs = hostCfg.BlockedCIDRs
 			if hostCfg.SSHPort != 0 {
 				t.SSHPort = hostCfg.SSHPort
 			}

--- a/internal/workflows/steps/step_network_policy.go
+++ b/internal/workflows/steps/step_network_policy.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/kube"
+	"github.com/hashgraph/solo-weaver/internal/network/policy"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/config"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// NetworkPolicyCreateStepId is the step ID for NetworkPolicyCreate.
+const NetworkPolicyCreateStepId = "network-policy-create"
+
+// policyCreatedNamesKey is the step-local state key under which the names of the
+// policies this step actually created are recorded, so rollback removes only
+// those (never a policy that pre-existed the install).
+const policyCreatedNamesKey = "networkPolicyCreatedNames"
+
+// newPolicyManager is the seam over the production policy manager so unit tests
+// can substitute a manager wired to a fake nft runner and temp paths (the
+// production manager restarts a systemd service, which is Linux-only).
+var newPolicyManager = func() *policy.Manager { return policy.NewManager() }
+
+// detectPolicyPodCIDR resolves the local node's pod CIDR from the cluster. It is
+// indirected through a var so unit tests can stub cluster access.
+var detectPolicyPodCIDR = func(ctx context.Context) (string, error) {
+	c, err := kube.NewClient()
+	if err != nil {
+		return "", err
+	}
+	return c.DetectNodePodCIDR(ctx)
+}
+
+// canonicalPolicy describes one entry in the fixed BN static-plane policy set
+// laid down at install. Its fields mirror the `network policy create` flags: the
+// install is a thin orchestrator that runs the equivalent of one create per
+// category. The vocabulary (names, classes, ports) is fixed by the BN's
+// contract, not operator-configurable — only the curated sets' initial
+// membership is supplied by the operator.
+type canonicalPolicy struct {
+	name       string
+	stamp      string // --stamp class ("" for a deny policy)
+	replyStamp string // --reply-stamp class (asymmetric conntrack reply)
+	deny       bool   // --deny (drop both directions)
+	fromWorld  bool   // --from-entity world (no IP-set clause)
+	ports      []string
+	// curated marks an operator-curated set (bn-mgmt-*) that receives its
+	// initial membership from operator input at create time rather than from
+	// the daemon's statusz poll loop. bn-restricted is NOT curated: it reflects
+	// a "restricted" category the block node itself reports via statusz, fully
+	// reconciled by the daemon every poll tick — an operator-supplied seed
+	// would just be overwritten on the first tick. A permanent, purely
+	// operator-managed block list lives instead on the host firewall
+	// (`network firewall --blocked-cidrs`, a different table entirely).
+	curated bool
+}
+
+// canonicalBNPolicies is the fixed set of policies `block node install` creates,
+// in creation order. The daemon binds the classification sets to statusz
+// categories at runtime; these definitions are statusz-agnostic. --stamp
+// references the class names in the stable mark map; each class fixes its own
+// direction, so there is no direction flag.
+var canonicalBNPolicies = []canonicalPolicy{
+	{name: "bn-publisher", ports: []string{"40840"}, stamp: "publisher"},
+	{name: "bn-subscriber-in", ports: []string{"40980", "40981"}, stamp: "reserve-ingress", fromWorld: true},
+	{name: "bn-partner-out", ports: []string{"40980", "40981"}, stamp: "partner"},
+	{name: "bn-public-out", ports: []string{"40980", "40981"}, stamp: "public", fromWorld: true},
+	{name: "bn-status-in", ports: []string{"40982"}, stamp: "reserve-ingress", fromWorld: true},
+	{name: "bn-status-out", ports: []string{"40982"}, stamp: "public", fromWorld: true},
+	{name: "bn-mgmt-in", ports: []string{"40983"}, stamp: "reserve-ingress", curated: true},
+	{name: "bn-mgmt-out", ports: []string{"40983"}, stamp: "reserve-egress", curated: true},
+	{name: "bn-restricted", deny: true},
+	{name: "bn-backfill", stamp: "reserve-egress", replyStamp: "backfill-response"},
+}
+
+// toPolicy builds the policy.Policy for a canonical entry. Action/Direction are
+// resolved from the stamp/deny fields; Validate (called inside Manager.Create)
+// derives Direction from the class and rejects any invalid combination.
+func (c canonicalPolicy) toPolicy() *policy.Policy {
+	p := &policy.Policy{
+		Name:            c.name,
+		Stamp:           c.stamp,
+		ReplyStamp:      c.replyStamp,
+		Ports:           c.ports,
+		FromEntityWorld: c.fromWorld,
+	}
+	if c.deny {
+		p.Action = policy.ActionDeny
+	} else {
+		p.Action = policy.ActionStamp
+	}
+	return p
+}
+
+// NetworkPolicyCreate lays down the BN workload classification plane (the `inet
+// weaver` table) by running the create-if-missing equivalent of `network policy
+// create` for each canonical BN category. It must run before NftWeaverPersist so
+// the policy registry is populated when that step re-renders and persists
+// network-weaver.nft (an empty registry would render a policy-drop chain).
+//
+// Every create is idempotent: a re-run leaves existing policies and their
+// operator-mutated set membership untouched. When force is set, each policy's
+// static rules are re-rendered from these definitions (membership is preserved
+// by the manager). The one operator-curated set, bn-mgmt-in/out, receives its
+// initial membership here from the host management allowlist (--mgmt-cidrs).
+// bn-restricted starts empty and is left entirely to the daemon's statusz poll
+// loop — see canonicalPolicy.curated.
+func NetworkPolicyCreate(force bool) *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(NetworkPolicyCreateStepId).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Creating network policies (inet weaver)")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to create network policies")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Network policies created")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			mgmtCIDRs := config.Get().Host.ManagementCIDRs
+
+			// The pod CIDR scopes every --stamp classification rule to the local
+			// node's pods. It is auto-detected from the node's .spec.podCIDR at
+			// install time (matching `network policy create`), not taken from the
+			// host firewall's --pod-cidr — that flag carries the broader
+			// cluster-wide subnet used for the in-cluster host-service rule, which
+			// would over-match here. A deny-only plane would not need it, but every
+			// BN plane has --stamp policies.
+			podCIDR, err := detectPolicyPodCIDR(ctx)
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to auto-detect the pod CIDR for network policy classification").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Verify the cluster is reachable: kubectl get nodes",
+							"Check the local node has a pod CIDR: kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}'",
+							"Ensure kubeconfig is present for the provisioner (block node install runs against a live cluster)",
+						})))
+			}
+			logx.As().Info().Str("pod_cidr", podCIDR).Msg("auto-detected pod CIDR for network policies")
+
+			mgr := newPolicyManager()
+			var created []string
+			for _, c := range canonicalBNPolicies {
+				// Record for rollback only policies that did not already exist:
+				// Manager.Create also returns changed=true when it replaces a
+				// pre-existing policy (--force) or self-heals a missing live table
+				// under an existing registry entry, and rollback must never delete
+				// an operator-owned policy this step did not create.
+				preExisting, err := policy.Exists(c.name)
+				if err != nil {
+					stp.State().Local().Set(policyCreatedNamesKey, created)
+					return automa.FailureReport(stp, automa.WithError(
+						errorx.Decorate(err, "failed to check whether network policy %q already exists", c.name).
+							WithProperty(models.ErrPropertyResolution, []string{
+								"Inspect the policy registry: ls " + policy.RegistryDir,
+							})))
+				}
+
+				cidrs := initialCIDRs(c, mgmtCIDRs)
+				changed, err := mgr.Create(ctx, c.toPolicy(), cidrs, podCIDR, force)
+				if err != nil {
+					stp.State().Local().Set(policyCreatedNamesKey, created)
+					return automa.FailureReport(stp, automa.WithError(
+						errorx.Decorate(err, "failed to create network policy %q", c.name).
+							WithProperty(models.ErrPropertyResolution, []string{
+								"Inspect the policy registry: ls " + policy.RegistryDir,
+								"Check the rendered chain for syntax errors: nft -c -f " + policy.WeaverNftPath,
+								"Re-run the install; policy creation is idempotent (create-if-missing)",
+							})))
+				}
+				if changed && !preExisting {
+					created = append(created, c.name)
+				}
+			}
+			stp.State().Local().Set(policyCreatedNamesKey, created)
+			logx.As().Info().Int("created", len(created)).Int("total", len(canonicalBNPolicies)).
+				Msg("network policies reconciled")
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			// Remove only the policies this step created; a pre-existing policy
+			// (create-if-missing found it already present, or a --force replace
+			// of one the operator owns) is left intact. Deleting in reverse
+			// creation order keeps the last delete — which tears the whole table
+			// down — for the case where this step created every policy.
+			created := automa.StringSliceFromState(stp.State().Local(), policyCreatedNamesKey)
+			if len(created) == 0 {
+				return automa.SkippedReport(stp,
+					automa.WithDetail("no network policies were created by this step, skipping rollback"))
+			}
+			mgr := newPolicyManager()
+			for i := len(created) - 1; i >= 0; i-- {
+				if err := mgr.Delete(ctx, created[i]); err != nil {
+					return automa.FailureReport(stp, automa.WithError(
+						errorx.Decorate(err, "failed to roll back network policy %q", created[i]).
+							WithProperty(models.ErrPropertyResolution, []string{
+								"Inspect the live weaver table: nft list table inet weaver",
+								"Complete teardown of the workload plane: block node uninstall",
+								"Check the policy registry for leftover entries: ls " + policy.RegistryDir,
+							})))
+				}
+			}
+			return automa.SuccessReport(stp)
+		})
+}
+
+// initialCIDRs returns the initial set membership supplied at create time for a
+// canonical policy: the host management allowlist for the bn-mgmt-* sets, and
+// nil for every daemon-reconciled set (whose membership arrives from the
+// statusz poll loop instead), including bn-restricted.
+func initialCIDRs(c canonicalPolicy, mgmtCIDRs []string) []string {
+	if !c.curated {
+		return nil
+	}
+	return mgmtCIDRs
+}

--- a/internal/workflows/steps/step_network_policy_test.go
+++ b/internal/workflows/steps/step_network_policy_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/internal/network/policy"
+)
+
+// TestCanonicalBNPolicies_Names pins the fixed BN static-plane policy set so a
+// change to the design list is a deliberate, reviewed edit.
+func TestCanonicalBNPolicies_Names(t *testing.T) {
+	want := []string{
+		"bn-publisher", "bn-subscriber-in", "bn-partner-out", "bn-public-out",
+		"bn-status-in", "bn-status-out", "bn-mgmt-in", "bn-mgmt-out",
+		"bn-restricted", "bn-backfill",
+	}
+	if len(canonicalBNPolicies) != len(want) {
+		t.Fatalf("policy count: got %d, want %d", len(canonicalBNPolicies), len(want))
+	}
+	for i, c := range canonicalBNPolicies {
+		if c.name != want[i] {
+			t.Errorf("policy[%d]: got %q, want %q", i, c.name, want[i])
+		}
+	}
+}
+
+// TestCanonicalBNPolicies_Valid verifies every canonical policy validates (the
+// class names resolve, flag combinations are legal) and that no two "specific"
+// stamp policies share the same (direction, ports) group — the overlap the
+// policy manager would reject at create time.
+func TestCanonicalBNPolicies_Valid(t *testing.T) {
+	mgmt := []string{"10.0.0.0/8"}
+
+	seen := map[string]string{} // (direction|ports) → policy name, for specific stamps
+	for _, c := range canonicalBNPolicies {
+		p := c.toPolicy()
+		cidrs := initialCIDRs(c, mgmt)
+		if err := p.Validate(cidrs); err != nil {
+			t.Fatalf("policy %q failed validation: %v", c.name, err)
+		}
+
+		// A "specific" stamp policy renders an IP-set clause (not deny, not
+		// --from-entity world). Two such policies sharing a (direction, ports)
+		// group would have ambiguous classification.
+		if p.Action != policy.ActionStamp || p.FromEntityWorld {
+			continue
+		}
+		ports := append([]string(nil), p.Ports...)
+		sort.Strings(ports)
+		key := string(p.Direction) + "|" + strings.Join(ports, ",")
+		if other, dup := seen[key]; dup {
+			t.Errorf("policies %q and %q overlap on group %q", c.name, other, key)
+		}
+		seen[key] = c.name
+	}
+}
+
+// TestInitialCIDRs checks curated-set membership routing: mgmt sets get the
+// management allowlist, everything else (including bn-restricted) starts empty
+// (populated by the daemon poll loop).
+func TestInitialCIDRs(t *testing.T) {
+	mgmt := []string{"10.0.0.0/8"}
+	byName := map[string]canonicalPolicy{}
+	for _, c := range canonicalBNPolicies {
+		byName[c.name] = c
+	}
+
+	if got := initialCIDRs(byName["bn-mgmt-in"], mgmt); len(got) != 1 || got[0] != "10.0.0.0/8" {
+		t.Errorf("bn-mgmt-in cidrs: got %v, want mgmt list", got)
+	}
+	if got := initialCIDRs(byName["bn-restricted"], mgmt); got != nil {
+		t.Errorf("bn-restricted cidrs: got %v, want nil (daemon-reconciled, not operator-curated)", got)
+	}
+	if got := initialCIDRs(byName["bn-publisher"], mgmt); got != nil {
+		t.Errorf("bn-publisher cidrs: got %v, want nil (daemon-reconciled)", got)
+	}
+}

--- a/internal/workflows/steps/step_network_tc_egress.go
+++ b/internal/workflows/steps/step_network_tc_egress.go
@@ -17,17 +17,24 @@ import (
 const TcEgressPersistStepId = "tc-egress-persist"
 
 // TcEgressPersist provisions the egress tc HTB hierarchy for reboot persistence.
-// When trunkRate is non-empty it writes the egress device root and three default
-// classes (partner/public/reserve-egress) at proportional rates into the shape
-// registry and renders the boot script from those explicit values. When
-// trunkRate is empty it re-renders the script from whatever shape config
-// already exists, falling back to sysfs auto-detect.
+// It writes the egress device root and three default classes
+// (partner/public/reserve-egress) into the shape registry — either at the
+// operator-supplied trunkRate/overrides, or, when neither was supplied and no
+// egress registry entry exists yet (a fresh install), at auto-detected
+// defaults. This mirrors TcIngressRecord's unconditional provisioning so
+// `network shape show` always reports all six classes after install, not just
+// the three from TcIngressRecord.
+//
+// When trunkRate/overrides are empty and an egress registry entry already
+// exists (a reconfigure/upgrade re-run that didn't pass --link-rate/--shape),
+// it re-renders the boot script from that existing config instead, so it
+// never clobbers operator-applied `network shape set` adjustments.
 //
 // When nicName is empty the NIC is auto-detected from the default route via
 // DetectEgressInterface. Pass --egress-interface to override on multi-NIC
 // hosts or when the default route does not identify the correct physical
 // interface.
-func TcEgressPersist(nicName string, trunkRate string) *automa.StepBuilder {
+func TcEgressPersist(nicName string, trunkRate string, overrides map[string]shape.ClassOverride) *automa.StepBuilder {
 	return automa.NewStepBuilder().WithId(TcEgressPersistStepId).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
 			notify.As().StepStart(ctx, stp, "Persisting tc-egress HTB hierarchy for reboot")
@@ -62,8 +69,26 @@ func TcEgressPersist(nicName string, trunkRate string) *automa.StepBuilder {
 				"Find the NIC used by the default route: ip route get 8.8.8.8 | grep dev",
 			}
 
-			if trunkRate != "" {
-				if err := shape.ProvisionDefaultEgressShape(ctx, nic, trunkRate); err != nil {
+			hasExisting, err := shape.NewManager().HasEgressConfig()
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to check existing egress shape config").
+						WithProperty(models.ErrPropertyResolution, tcEgressResolution)))
+			}
+
+			// Provision explicit class config when the operator gave a trunk rate,
+			// gave per-class --shape overrides (which need concrete classes to
+			// merge into), or there is no egress registry entry yet (a fresh
+			// install — matches TcIngressRecord's unconditional provisioning, so
+			// the registry always ends up populated with all six classes).
+			// Resolve an empty rate to "auto" so the proportional defaults are
+			// computed against the detected link speed at install time.
+			if trunkRate != "" || len(overrides) > 0 || !hasExisting {
+				rate := trunkRate
+				if rate == "" {
+					rate = "auto"
+				}
+				if err := shape.ProvisionDefaultEgressShape(ctx, nic, rate, overrides); err != nil {
 					return automa.FailureReport(stp, automa.WithError(
 						errorx.Decorate(err, "failed to provision default egress shape").
 							WithProperty(models.ErrPropertyResolution, tcEgressResolution)))
@@ -71,8 +96,9 @@ func TcEgressPersist(nicName string, trunkRate string) *automa.StepBuilder {
 				return automa.SuccessReport(stp)
 			}
 
-			// No trunk rate supplied: re-render from existing shape registry (if
-			// populated) or sysfs auto-detect, then apply.
+			// No trunk rate or overrides supplied, and a registry entry already
+			// exists (reconfigure/upgrade without --link-rate/--shape): re-render
+			// from that existing shape config, then apply.
 			if err := shape.RenderAndApplyDefaultEgress(ctx, nic); err != nil {
 				return automa.FailureReport(stp, automa.WithError(
 					errorx.Decorate(err, "failed to apply tc-egress script").

--- a/internal/workflows/steps/step_network_tc_ingress.go
+++ b/internal/workflows/steps/step_network_tc_ingress.go
@@ -28,7 +28,7 @@ const TcIngressRecordStepId = "tc-ingress-record"
 // speed at install time — so the recorded class rates are always concrete, since
 // the per-pod replay has no sysfs fallback. nicName pins auto-resolution to the
 // operator-chosen NIC on multi-NIC hosts.
-func TcIngressRecord(nicName string, linkRate string) *automa.StepBuilder {
+func TcIngressRecord(nicName string, linkRate string, overrides map[string]shape.ClassOverride) *automa.StepBuilder {
 	return automa.NewStepBuilder().WithId(TcIngressRecordStepId).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
 			notify.As().StepStart(ctx, stp, "Recording tc-ingress ($VETH) HTB shape for per-pod replay")
@@ -45,7 +45,7 @@ func TcIngressRecord(nicName string, linkRate string) *automa.StepBuilder {
 			if rate == "" {
 				rate = "auto"
 			}
-			if err := shape.ProvisionDefaultIngressShape(ctx, nicName, rate); err != nil {
+			if err := shape.ProvisionDefaultIngressShape(ctx, nicName, rate, overrides); err != nil {
 				return automa.FailureReport(stp, automa.WithError(
 					errorx.Decorate(err, "failed to record default ingress shape").
 						WithProperty(models.ErrPropertyResolution, []string{

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -72,10 +72,16 @@ const DefaultClusterPodCIDR = "10.4.0.0/14"
 // connections, so the firewall step skips applying it when empty.
 type HostConfig struct {
 	ManagementCIDRs []string `yaml:"managementCidrs" json:"managementCidrs"` // SSH/management allowlist CIDRs
-	SSHPort         int      `yaml:"sshPort" json:"sshPort"`                 // SSH/management TCP port accepted from the allowlist (0 = default 22)
-	PodCIDR         string   `yaml:"podCidr" json:"podCidr"`                 // Pod source range allowed to reach the in-cluster host-service ports (empty = rule omitted)
-	InClusterPorts  []int    `yaml:"inClusterPorts" json:"inClusterPorts"`   // Host-service ports reachable from the pod CIDR
-	Disabled        bool     `yaml:"disabled" json:"disabled"`               // Operator explicitly opted out via --firewall-enabled=false (negative polarity so the zero value means "enabled")
+	// BlockedCIDRs is the operator-curated deny list, dropped before every
+	// other rule (set @blocked_addrs in the `inet host` table). It is distinct
+	// from the BN workload plane's `bn-restricted` set (`inet weaver`), which
+	// the traffic-shaper daemon reconciles automatically from block-node
+	// statusz; this list is purely operator-managed and nothing else writes it.
+	BlockedCIDRs   []string `yaml:"blockedCidrs" json:"blockedCidrs"`
+	SSHPort        int      `yaml:"sshPort" json:"sshPort"`               // SSH/management TCP port accepted from the allowlist (0 = default 22)
+	PodCIDR        string   `yaml:"podCidr" json:"podCidr"`               // Pod source range allowed to reach the in-cluster host-service ports (empty = rule omitted)
+	InClusterPorts []int    `yaml:"inClusterPorts" json:"inClusterPorts"` // Host-service ports reachable from the pod CIDR
+	Disabled       bool     `yaml:"disabled" json:"disabled"`             // Operator explicitly opted out via --firewall-enabled=false (negative polarity so the zero value means "enabled")
 }
 
 // Validate rejects host-firewall config that would be unsafe to render into the
@@ -85,6 +91,11 @@ func (c *HostConfig) Validate() error {
 	for _, cidr := range c.ManagementCIDRs {
 		if err := sanity.ValidateIPv4CIDR(cidr); err != nil {
 			return errorx.IllegalArgument.Wrap(err, "invalid host managementCidr: %s", cidr)
+		}
+	}
+	for _, cidr := range c.BlockedCIDRs {
+		if err := sanity.ValidateIPv4CIDR(cidr); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid host blockedCidr: %s", cidr)
 		}
 	}
 	if c.SSHPort != 0 {

--- a/pkg/models/inputs.go
+++ b/pkg/models/inputs.go
@@ -74,8 +74,31 @@ type BlockNodeInputs struct {
 	RecentRetention     string // FILES_RECENT_BLOCK_RETENTION_THRESHOLD (~96000 default)
 	PluginPreset        string // preset ID (e.g. "tier1-lfh"), "custom", or "none" (no override); empty/"none" = use --values or chart default
 	PluginList          string // resolved comma-separated plugin list injected into plugins.names
-	EgressInterface     string // physical NIC for the $EGRESS HTB hierarchy; auto-detected from the default route when empty
-	LinkRate            string // tc-style NIC line rate override (e.g. "1gbit"); empty = auto-detect from sysfs at boot
+	// TrafficShapingEnabled gates the BN workload network-policy plane (inet
+	// weaver classification) and tc HTB traffic shaping (from
+	// --traffic-shaping-enabled). When false, the network-setup workflow skips
+	// creating the policy plane and tc config entirely, and the caller skips
+	// offering the traffic-shaper daemon — there is nothing left for it to
+	// reconcile without the policy plane's classification.
+	TrafficShapingEnabled bool
+	EgressInterface       string // physical NIC for the $EGRESS HTB hierarchy; auto-detected from the default route when empty
+	LinkRate              string // tc-style NIC line rate override (e.g. "1gbit"); empty = auto-detect from sysfs at boot
+	// ShapeOverrides carries per-class HTB bandwidth overrides from --shape,
+	// keyed by class name. Empty = use the profile defaults for every class.
+	// Held as a neutral type so pkg/models stays decoupled from the shape
+	// package; the install workflow converts it at the call site.
+	ShapeOverrides map[string]ShapeOverride
+}
+
+// ShapeOverride is one class's operator-supplied HTB bandwidth override, parsed
+// from `block node install --shape <class>=rate=...,ceil=...,prio=...`. A
+// zero-value field (empty Rate/Ceil, nil Prio) keeps that class's profile
+// default. It mirrors internal/network/shape.ClassOverride without creating a
+// dependency from pkg/models onto that package.
+type ShapeOverride struct {
+	Rate string
+	Ceil string
+	Prio *int
 }
 
 type ClusterInputs struct {


### PR DESCRIPTION
## Description

`block node install` is now a complete, opt-in static-plane orchestrator that also
closes the daemon-activation gap. This PR grew across several rounds as review and
manual UAT surfaced real gaps in the original design; this description reflects the
final state, not the chronological history.

### What `block node install` does now

- **Host firewall** (`--firewall-enabled`, default `false`, opt-in): applies the
  node-level `inet host` firewall (SSH/mgmt allowlist, ICMP policy, in-cluster
  ports). `--mgmt-cidrs` configures the allowlist; the new `--blocked-cidrs` adds a
  permanent, purely operator-managed deny list (set `@blocked_addrs`, dropped before
  every other rule including established connections) — distinct from the BN
  workload plane's `bn-restricted` set, which is daemon-owned (see below).
- **Traffic shaping** (`--traffic-shaping-enabled`, default `false`, opt-in): one
  gate that creates the BN workload network-policy plane (`inet weaver`
  classification, the fixed set of BN policies), tc HTB shaping for `$EGRESS`/`$VETH`,
  and installs the traffic-shaper daemon — all three together, no separate daemon
  prompt or flag. Declining skips the egress NIC/link-rate prompts too. This decision
  is durable: it's recorded in `state.yaml` (`BlockNodeState.TrafficShapingDisabled`)
  and honored by later `reconfigure`/`upgrade` runs, not just the install where it
  was made.
- **Daemon binary source** (`--daemon-version`, `--daemon-bin`): the daemon binary is
  auto-downloaded from the infrastructure catalog at `--daemon-version` (defaults to
  this CLI's own version) unless `--daemon-bin` points at a local binary instead.
  `--daemon-bin` is required for `--profile=local` (prompted interactively, or a
  fail-fast error non-interactively) since local/dev builds have no downloadable
  release.
- Adds per-class `--shape <class>=rate=...,ceil=...,prio=...` overrides.

### Why the defaults are opt-in (`false`), not opt-out

An earlier version of this PR defaulted both gates to `true`. Two things forced the
change: (1) it would have been a breaking change for every existing non-interactive/
scripted caller of `block node install` that doesn't pass these flags — they'd
silently start getting a host firewall, network policy plane, tc shaping, and a
daemon install they never asked for; (2) the daemon auto-install path is currently
broken regardless (see below), so defaulting it on would make a plain `block node
install` fail by default. Opt-in avoids both problems until these features have more
mileage.

### Known follow-up (not in this PR): daemon catalog entry

`pkg/software/infrastructure-catalog.yaml` has no entry for
`solo-provisioner-daemon`, so `--daemon-version` auto-download currently fails with
`software 'solo-provisioner-daemon' not found in configuration`. This is a
pre-existing gap (not introduced here) — tracked separately; `--daemon-bin` is the
workaround until it's added.

### Known limitation (not in this PR): reconfigure/upgrade can't change either gate

Both gates are effectively install-time-only decisions. `reconfigure` happens to
be able to *enable* the host firewall later (its prompt/flags re-resolve fresh on
every run and `NetworkFirewallCreate` is create-if-missing), but there's no
equivalent for traffic shaping, and neither command can *disable* anything —
there's no teardown logic outside a full `block node uninstall`. For an
already-installed block node, the only way to turn either feature on or off today
is a full `block node install --force` reinstall. Filed as #911.

### Bug fixed along the way: effective-inputs passthrough

`resolveBlocknodeEffectiveInputs` (`internal/bll/blocknode/helpers.go`) — whose
output is what actually reaches `BuildWorkflow` — was missing `ShapeOverrides` and
`TrafficShapingEnabled` from its "passed through from user input" section, silently
dropping `--shape` and the traffic-shaping gate's resolved value on every install.
Fixed.

### CI fix: unclassified pod egress (Maven plugin resolution)

UAT `block node upgrade --chart-version 0.29.0` was crash-looping the chart's
`resolve-plugins` init container. Root cause: the `inet weaver` forward chain only
allowed BN's own ports, with no rule for the chart's Maven-based plugin-prefix
resolution (repo1.maven.org, hyperledger.jfrog.io, artifacts.consensys.net,
central.sonatype.com on 443) — never surfaced at the initial 0.26.2 install since
that chart feature is gated to >=0.28.1. Fixed with a new unclassified-pod-egress
tier: a blanket `ip saddr <podCIDR> ip daddr != <podCIDR> accept` with no `meta
priority`, so unclassified outbound traffic falls to the HTB default class (shaped,
not prioritized) instead of being dropped. This is a deliberate default-allow escape
hatch — see Risks.

## Files changed

| File | Change |
|---|---|
| `internal/network/shape/override.go` (new) | `ClassOverride`, validation, apply, sum-check |
| `internal/network/shape/manager.go` | `ProvisionDefault{Egress,Ingress}` accept overrides |
| `internal/workflows/steps/step_network_policy.go` (new) | `NetworkPolicyCreate` step, canonical BN policy set (`bn-mgmt-in/out` curated from `--mgmt-cidrs`; `bn-restricted` always empty, daemon-owned) |
| `internal/workflows/steps/step_network_tc_{egress,ingress}.go` | Accept + forward `--shape` overrides |
| `internal/network/policy/render.go` | New tier: unclassified pod egress (Maven-egress fix) |
| `internal/network/firewall/{table,render,parse,manager}.go` | `BlockedCIDRs` field, `@blocked_addrs` set, `Add/Remove/SetBlockedCIDR(s)` |
| `internal/templates/files/network/network-host.nft.tmpl` | `@blocked_addrs` set + early drop rule (before established/related) |
| `internal/workflows/steps/step_network_firewall.go` | Applies `hostCfg.BlockedCIDRs` |
| `internal/workflows/network_setup.go` | `trafficShapingEnabled` param gates `NetworkPolicyCreate`/`NftWeaverPersist`/`TcEgressPersist`/`TcIngressRecord` as one bundle |
| `internal/state/state.go` | `BlockNodeState.TrafficShapingDisabled` (persisted, negative polarity) |
| `internal/bll/blocknode/install_handler.go` | Threads `trafficShapingEnabled`; `patchBlockNodeStateAfterInstall()`; daemon-config workflow conditional |
| `internal/bll/blocknode/reconfigure_handler.go` | Reads `currentState.BlockNodeState.TrafficShapingDisabled`; omits `TcEgressPersist` across all 4 branches when disabled |
| `internal/bll/blocknode/helpers.go` | Fixed `ShapeOverrides`/`TrafficShapingEnabled` passthrough; new `patchBlockNodeStateAfterInstall()` (install-only) |
| `internal/workflows/steps/step_daemon.go` | `DaemonBinarySource.Version` field, wired to `software.WithVersion()` |
| `pkg/models/inputs.go` | `ShapeOverride` type; `ShapeOverrides`/`TrafficShapingEnabled` fields |
| `pkg/models/config.go` | `HostConfig.BlockedCIDRs` field + validation |
| `cmd/cli/commands/common/host_firewall.go` | `--blocked-cidrs` flag; `--firewall-enabled` default flipped to `false` |
| `cmd/cli/commands/common/traffic_shaping.go` (new) | `--traffic-shaping-enabled` flag (default `false`) + gate resolution/prompt |
| `cmd/cli/commands/common/flags_common.go` | `FlagDaemonVersion()` (new) |
| `cmd/cli/commands/block/node/install.go` | `--shape`, `--traffic-shaping-enabled`, `--daemon-version`, `--daemon-bin`; gates egress prompts/daemon-source resolution/daemon activation on the traffic-shaping gate |
| `cmd/cli/commands/block/node/daemon_offer.go` | `ensureBlockNodeDaemon` (renamed from `offerDaemonInstall`, no prompt — installs unconditionally when called); `resolveDaemonBinarySource` (local-profile `--daemon-bin` requirement) |
| `cmd/cli/commands/network/firewall/*.go` | `--blocked-cidrs`/`--blocked-cidr` across `create`/`add`/`remove`/`set` |
| `internal/ui/prompt/cluster.go` | `BlockedCIDRsInputPrompt` |
| `docs/quickstart.md` | All new flags + notes; removed flags dropped |

## Test plan

```bash
# Native (macOS-safe) — pure logic
go test ./internal/network/shape/... ./internal/network/policy/... ./internal/network/firewall/... ./internal/ui/prompt/... ./pkg/models/...

# Full unit suite (Linux-only packages: steps, common, bll) — run in UTM VM
task vm:test:unit

# Cross-compile check (validates Linux-target type-correctness without a VM)
GOOS=linux GOARCH=amd64 go vet ./...

# Lint (0 issues expected)
task lint
```

## Manual UAT

Steps 1–11 are single-host checks with the actual commands. Steps 12–13 use the
accessory-VM IPs: step 12 drives the daemon-owned nft sets from a mock statusz
roster keyed on those IPs (via the `reconcile-shaper` worker), and step 13 is the
deeper multi-VM traffic validation — two accessory VMs generating concurrent
traffic while a `tc_rates` helper streams live per-class Mbit/s on the BN-host,
proving priority preemption holds under contention (not just that the tc classes
exist).

1. **Default install, non-interactive** — nothing network-related gets created:
   ```bash
   sudo solo-provisioner block node install --profile=local --non-interactive
   sudo nft list tables | grep -E 'inet (host|weaver)'   # expect: no output
   systemctl is-active solo-provisioner-daemon            # expect: inactive
   ```
2. **Traffic shaping opt-in**:
   ```bash
   sudo solo-provisioner block node install --profile=local \
     --traffic-shaping-enabled --daemon-bin <path> --non-interactive
   sudo nft list table inet weaver | head -20   # 10 canonical policies
   sudo solo-provisioner network shape show     # 6 classes, rate/ceil/prio
   systemctl is-active solo-provisioner-daemon  # active, no separate prompt/flag needed
   ```
3. **Host firewall opt-in**:
   ```bash
   sudo solo-provisioner block node install --profile=local \
     --firewall-enabled --mgmt-cidrs 10.0.0.0/8 --non-interactive
   sudo nft list table inet host   # default-drop, @mgmt_addrs = {10.0.0.0/8}
   ```
4. **Host firewall block list** — quarantine proven with a live connection:
   ```bash
   sudo solo-provisioner network firewall create --blocked-cidrs 198.51.100.0/24
   # from 198.51.100.x: nc -zv <bn-host-ip> 22 → refused/timeout within ~1s
   sudo nft list table inet host | grep blocked_addrs   # elements present
   sudo solo-provisioner network firewall add/remove --blocked-cidr ...   # round-trips
   ```
5. **Shape override** — `publisher` is an ingress class (classid `1:10`), so it
   lives on `$VETH` (the BN pod's host-side veth peer), not the physical
   `$EGRESS` NIC. Resolve `$VETH` the same way the daemon does: match the pod's
   `eth0` iflink against the host's `/sys/class/net/*/ifindex`. The block node
   installs into the `block-node` namespace by default (`--namespace` to
   override):
   ```bash
   BN_POD=$(kubectl get pod -n block-node -l app.kubernetes.io/name=block-node-server -o jsonpath='{.items[0].metadata.name}')
   IFLINK=$(kubectl exec -n block-node "$BN_POD" -- cat /sys/class/net/eth0/iflink)
   VETH=$(for f in /sys/class/net/*/ifindex; do [ "$(cat "$f")" = "$IFLINK" ] && basename "$(dirname "$f")"; done)

   sudo solo-provisioner block node install --profile=local --traffic-shaping-enabled \
     --daemon-bin <path> --shape publisher=rate=800mbit,ceil=1gbit,prio=0 --non-interactive
   sudo solo-provisioner network shape show   # publisher: rate=800mbit ceil=1gbit prio=0
   CLASSID=$(sudo solo-provisioner network shape show | awk -F'[()]' '/publisher/{print $2}')  # e.g. 1:10
   sudo tc class show dev "$VETH" classid "$CLASSID"  # htb rate 800mbit ceil 1gbit
   ```
6. **Durability across reconfigure** — declined stays declined. `$EGRESS` is the
   physical NIC auto-detected from the default route (same detection
   `TcEgressPersist` uses internally):
   ```bash
   EGRESS=$(ip route get 8.8.8.8 | grep -oP 'dev \K\S+')

   sudo solo-provisioner block node install --profile=local --non-interactive   # declined (default)
   sudo solo-provisioner block node reconfigure --recent-retention 50000
   sudo tc qdisc show dev "$EGRESS"   # expect: still no htb qdisc (was silently re-enabled pre-fix)
   ```
7. **Upgrade past 0.28.1**:
   ```bash
   sudo solo-provisioner block node upgrade --profile=local --chart-version 0.29.0
   kubectl logs -n block-node -l app.kubernetes.io/name=block-node-server -c resolve-plugins --tail=20
   # expect: succeeds, no crash loop
   BN_POD=$(kubectl get pod -n block-node -l app.kubernetes.io/name=block-node-server -o jsonpath='{.items[0].metadata.name}')
   kubectl exec -n block-node "$BN_POD" -- curl -sSI --max-time 5 https://repo1.maven.org/maven2/ | head -1
   # expect: HTTP response — proves the unclassified-pod-egress tier
   ```
8. **`--profile=local` without `--daemon-bin`**:
   ```bash
   sudo solo-provisioner block node install --profile=local --traffic-shaping-enabled --non-interactive
   # expect: "--daemon-bin is required for --profile=local ..."
   ```
9. **Host-firewall flags without the gate, non-interactive**:
   ```bash
   sudo solo-provisioner block node install --profile=local --non-interactive --mgmt-cidrs 10.0.0.0/8
   # expect: "--mgmt-cidrs was supplied but the host firewall is not enabled ..."
   ```
10. **Traffic-shaping flags without the gate, non-interactive**:
    ```bash
    sudo solo-provisioner block node install --profile=local --non-interactive \
      --shape publisher=rate=800mbit,ceil=1gbit,prio=0
    # expect: "--shape was supplied but traffic shaping is not enabled ..."
    ```
11. **`--shape` error message names the class**:
    ```bash
    sudo solo-provisioner block node install --profile=local --traffic-shaping-enabled \
      --daemon-bin <path> --shape publisher=rate=bogus --non-interactive
    # expect: error mentions "publisher" and "--shape rate" (not a bare parse error)
    ```
12. **Daemon-owned nft sets reconcile from statusz (mock roster)** — proves the
    daemon-owned `inet weaver` sets (`bn-publisher`, `bn-partner-out`,
    `bn-restricted`, and the compound `bn-backfill`) follow the block node's
    reported endpoints. The daemon's in-process poll loop is still an idle stub
    (`statusz poll loop not yet wired — reconcile-shaper scheduler pending`), so a
    daemon restart alone reconciles nothing; membership is driven by running the
    `reconcile-shaper` worker by hand against a mock statusz server (the same
    worker the scheduler will eventually exec). Requires a prior
    `--traffic-shaping-enabled` install (step 2) so the sets already exist. The
    mock re-reads its roster file on every request, so edits take effect on the
    next run with no restart. Seed the roster from the accessory-VM IPs
    (`$CN_VM_IP` publisher, `$PARTNER_VM_IP` partner, `$PEER_VM_IP` backfill peer);
    `$PUBLIC_VM_IP` deliberately has no daemon-owned set — `bn-public-out` is a
    `--from-entity world` port match, not statusz-reconciled.
    ```bash
    cd /mnt/solo-weaver
    cat > /tmp/roster.json <<EOF
    {
      "inbound": [
        { "remote": {"address": "${CN_VM_IP}/32", "port": "*"}, "category": "publisher" },
        { "remote": {"address": "${PARTNER_VM_IP}/32", "port": "*"}, "category": "partner" }
      ],
      "outbound": [
        { "remote": {"address": "${PEER_VM_IP}", "port": "43473"}, "category": "peer_bn" }
      ]
    }
    EOF
    nohup go run ./internal/daemon/blocknode/statuszmock/cmd \
      --addr 127.0.0.1:8080 --roster /tmp/roster.json > /tmp/statuszmock.log 2>&1 &
    ```
    `peer_bn` is a compound (address·port) set, so the backfill peer needs a
    concrete non-wildcard port (the port the BN's backfill client dials on the
    peer; wildcard/empty ports are skipped). Then reconcile:
    ```bash
    # dry-run first (unprivileged) — fetches statusz, prints the desired-membership
    # digest, touches no nft state:
    solo-provisioner block node reconcile-shaper --statusz-url http://127.0.0.1:8080 --check
    # apply (root) — diffs live nft and rewrites only the changed policy sets:
    sudo solo-provisioner block node reconcile-shaper --statusz-url http://127.0.0.1:8080
    # expect: applied: bn-backfill, bn-partner-out, bn-publisher

    sudo nft list set inet weaver bn-publisher    # elements = { $CN_VM_IP }
    sudo nft list set inet weaver bn-partner-out  # elements = { $PARTNER_VM_IP } — the bn-partner-out fix
    sudo nft list set inet weaver bn-backfill     # elements = { $PEER_VM_IP . 43473 } — compound addr . port
    sudo nft list set inet weaver bn-public-out   # no elements clause (port match, not statusz-driven)
    ```
    Drop the partner entry from `/tmp/roster.json`, re-run the apply, and confirm
    `bn-partner-out` clears on the next reconcile — validates the "category
    present, membership empty → set cleared" contract.
13. **Priority preemption across VMs (`tc_rates`)** — proves shaping actually
    enforces priority under contention. **Two parts,** because the real Block Node
    chart is not an iperf3 server and its LoadBalancer Service exposes only
    `40840`; the facility ports `40980`–`40983` live only in the host nft policy
    plane this PR adds, not on the Service. So `iperf3 -c $BN_LB_IP` hangs against
    the real chart — 40840's TCP handshake succeeds but the listener is the BN
    gRPC server, not `iperf3 -s`, and 40980/40981 aren't served at all.

    **(a) Classification-only, against the real chart (runnable now)** — proves the
    SYN from a roster-classified source gets `meta priority` marked; a bare TCP
    connect suffices (the app may RST the unknown protocol right after —
    classification happens on the SYN, before any L7 payload):
    ```bash
    # 🐧 BN-host: trace the publisher rule, then connect from the CN VM
    sudo nft add rule inet weaver forward ip saddr $CN_VM_IP tcp dport 40840 meta nftrace set 1
    sudo nft monitor trace & TRACE_PID=$!
    # 🟦 CN VM:  nc -zv $BN_LB_IP 40840
    kill $TRACE_PID   # trace shows the rule firing → meta priority 0x10010 on the SYN
    ```

    **(b) Sustained throughput/preemption (optional — needs the iperf3 stand-in)** —
    validates the shaping *mechanism* (already proven upstream), so skip it if (a)
    is enough. `iperf3` needs a real `iperf3 -s` behind each port, which the real
    chart does not run: swap it for the POC's Alpine+iperf3 stand-in
    Deployment+Service (exposes all facility ports, runs `iperf3 -s` on each) —
    `block node uninstall` leaves the `inet weaver`/tc plane in place — then run the
    live per-class stream below.
    Requires two accessory VMs (e.g. PARTNER + PUBLIC, cloned from the same
    golden image as the BN-host) reachable from it. On the BN-host, resolve the
    MetalLB-assigned LB IP once and pass it to both accessory VMs as
    `$BN_LB_IP` (exact Service name depends on the Helm release name used):
    ```bash
    kubectl get svc -n block-node -o json | jq -r '.items[] | select(.spec.type=="LoadBalancer") | select(.metadata.name | test("block-node")) | .status.loadBalancer.ingress[0].ip'
    ```
    ```bash
    # 🐧 BN-host VM — stream live per-class Mbit/s (Ctrl-C to stop)
    tc_rates() {
        local dev=$1 classes=$2 interval=${3:-2}
        (while true; do sudo tc -s class show dev "$dev"; echo "TICK $(date +%s.%N)"; sleep "$interval"; done) \
        | mawk -v CLASSES="$classes" '
    BEGIN { n=split(CLASSES,cls,","); for(i=1;i<=n;i++) want[cls[i]]=1 }
    /^class htb / { c=(want[$3])?$3:"" }
    /Sent/&&c { cur[c]=$2; c="" }
    /^TICK / { now=$2+0; if(warmed){dt=now-last_t; for(i=1;i<=n;i++){k=cls[i]; d=cur[k]-prev[k];
      printf "  %-5s rate=%6.2f Mbit/s\n", k, (d*8)/(dt*1000000)}} else warmed=1
      for(i=1;i<=n;i++) prev[cls[i]]=cur[cls[i]]; last_t=now }'
    }
    EGRESS=$(ip route get 8.8.8.8 | grep -oP 'dev \K\S+')   # see step 6 if already resolved
    PARTNER_CLASS=$(sudo solo-provisioner network shape show | awk -F'[()]' '/partner/{print $2}')
    PUBLIC_CLASS=$(sudo solo-provisioner network shape show | awk -F'[()]' '/public/{print $2}')
    tc_rates "$EGRESS" "$PARTNER_CLASS,$PUBLIC_CLASS" 2
    ```
    ```bash
    # 🟩 PARTNER VM (higher priority, e.g. prio=0) — start first
    iperf3 -c $BN_LB_IP -p 40980 -t 60 -R
    ```
    ```bash
    # 🟨 PUBLIC VM (lower priority, e.g. prio=5) — start ~5s later, overlapping
    iperf3 -c $BN_LB_IP -p 40981 -t 45 -R
    ```
    Expected: partner holds its configured `rate` floor throughout the overlap;
    public yields bandwidth while partner is active and recovers toward its
    `ceil` within ~5s once partner's transfer ends.

## Risks / rollback

- **Default-allow escape hatch.** The unclassified-pod-egress tier broadens BN pod
  outbound reachability beyond BN's own ports (unclassified traffic is shaped, not
  blocked). Deliberate trade-off to unblock the chart's plugin resolution; flagged
  here per the design discussion that led to it.
- **Daemon auto-download is currently non-functional** (missing catalog entry, not
  introduced by this PR) — `--daemon-bin` is the workaround until a follow-up adds
  the catalog entry.
- **The daemon's statusz poll loop is a stub in this PR.** The reconcile engine,
  the `reconcile-shaper` worker, and the `statusz.base_url`/`poll_interval` config
  all land here, but `TrafficShaperMonitor.runStatuszPoll` is deliberately an idle
  no-op — the scheduler that execs the worker on each poll tick is not yet wired.
  A running daemon therefore does not reconcile the daemon-owned `inet weaver` sets
  (`bn-publisher`, `bn-partner-out`, `bn-restricted`, `bn-backfill`) on its own;
  reconciliation is driven by running the worker by hand until the scheduler lands.
  Filed as #914.
- **Defaults changed from an earlier revision of this same PR** (not from `main`):
  `--firewall-enabled` and `--traffic-shaping-enabled` now default to `false`. Since
  neither flag exists on `main` yet, this is not a breaking change relative to
  released behavior.
- **`--restricted-cidrs` was added then removed within this PR** (never released) —
  `bn-restricted` is confirmed daemon-owned (reconciled from BN's statusz every poll
  tick), so an install-time seed would have been silently overwritten; no user-facing
  regression since the flag never shipped.
- **No migration boundary.** All of this is install-time orchestration; it does not
  touch embedded templates or startup migrations, so none of it can leak into
  already-provisioned clusters via the upgrade path.
- **Rollback.** Revert the commit(s); no on-disk schema changed other than the new
  `state.yaml` field (`trafficShapingDisabled`), which is additive and ignored by
  older binaries.

## Related Issues

* Closes #762
* Closes #904
* Closes #798
* Closes #915 
* Follow-up filed: #911 (reconfigure/upgrade can't enable or disable either gate on an existing install)
* Follow-up filed: #914 (wire the daemon-side statusz poll scheduler that execs `reconcile-shaper` on an interval)
