### PR TITLE
feat(daemon): wire the statusz poll scheduler to exec reconcile-shaper on an interval

### DIFF
--- a/internal/daemon/blocknode/component.go
+++ b/internal/daemon/blocknode/component.go
@@ -3,6 +3,8 @@
 package blocknode
 
 import (
+	"time"
+
 	"github.com/automa-saga/daemonkit"
 	"github.com/joomcode/errorx"
 	"k8s.io/client-go/kubernetes"
@@ -20,6 +22,16 @@ type ComponentConfig struct {
 	// Namespace is the Kubernetes namespace (orbit) where BN pods run.
 	// Required when TrafficShaperEnabled is true.
 	Namespace string
+
+	// StatuszBaseURL is the block node's statusz base URL the traffic-shaper
+	// poll loop reconciles from (components.block_node.statusz.base_url). Empty
+	// keeps the poll loop idle.
+	StatuszBaseURL string
+
+	// StatuszPollInterval is the poll loop's cadence
+	// (components.block_node.statusz.poll_interval, already defaulted via
+	// StatuszConfig.EffectivePollInterval by the caller).
+	StatuszPollInterval time.Duration
 }
 
 // ComponentResult contains the monitors built by NewComponent and a reference
@@ -53,7 +65,7 @@ func NewComponent(cfg ComponentConfig) (ComponentResult, error) {
 		if err != nil {
 			return ComponentResult{}, err
 		}
-		tsm = NewTrafficShaperMonitor(resolver, client, cfg.Namespace)
+		tsm = NewTrafficShaperMonitor(resolver, client, cfg.Namespace, cfg.StatuszBaseURL, cfg.StatuszPollInterval)
 		monitors = append(monitors, tsm)
 	}
 

--- a/internal/daemon/blocknode/handler_test.go
+++ b/internal/daemon/blocknode/handler_test.go
@@ -19,7 +19,7 @@ import (
 // returns 200 with the supervisor-reported monitor state when the monitor is
 // enabled.
 func TestBlockNodeHandler_TrafficShaperStatus_Enabled(t *testing.T) {
-	mon := NewTrafficShaperMonitor(nil, nil, "")
+	mon := NewTrafficShaperMonitor(nil, nil, "", "", 0)
 	stateFn := func() daemonkit.MonitorState { return daemonkit.MonitorState{State: "running"} }
 	h := NewBlockNodeHandler(mon, stateFn)
 

--- a/internal/daemon/blocknode/pod_watcher_test.go
+++ b/internal/daemon/blocknode/pod_watcher_test.go
@@ -58,6 +58,10 @@ func (f *fakeDelegator) TCDetach(_ context.Context, veth string) error {
 	f.detached = append(f.detached, veth)
 	return nil
 }
+func (f *fakeDelegator) ReconcileShaper(context.Context, string) error { return nil }
+func (f *fakeDelegator) ReconcileShaperCheck(context.Context, string) (string, error) {
+	return "", nil
+}
 
 func newTestMonitor(r vethResolver, d *fakeDelegator) *TrafficShaperMonitor {
 	return &TrafficShaperMonitor{

--- a/internal/daemon/blocknode/traffic_shaper_monitor.go
+++ b/internal/daemon/blocknode/traffic_shaper_monitor.go
@@ -37,9 +37,9 @@ const responsibilityBackoffFactor = 2.0
 //   - the pod-lifecycle watcher (resolves host-side veths and installs/rebinds
 //     ingress HTB qdiscs — implemented in #748/#749), and
 //   - the statusz poll loop, which reconciles the nft policy membership from
-//     statusz. Its reconcile logic now lives in the `block node reconcile-shaper`
-//     CLI worker; the daemon-side scheduler that execs that worker is not yet
-//     wired, so this responsibility is currently an idle stub.
+//     statusz. Its reconcile logic lives in the `block node reconcile-shaper`
+//     CLI worker; this loop is the daemon-side scheduler that execs that worker
+//     once per poll tick (see runStatuszPoll).
 //
 // Each responsibility is independently retried with exponential back-off so a
 // fault in one cannot stop the other or crash the daemon.
@@ -61,6 +61,15 @@ type TrafficShaperMonitor struct {
 	// to.
 	namespace string
 
+	// statuszURL is the base URL of the block node's statusz endpoints the poll
+	// loop reconciles from (components.block_node.statusz.base_url). Empty means
+	// no source is configured and the poll loop idles.
+	statuszURL string
+	// pollInterval is the steady-state cadence of the statusz poll loop
+	// (components.block_node.statusz.poll_interval). A non-positive value falls
+	// back to defaultStatuszPollInterval.
+	pollInterval time.Duration
+
 	// mu guards attached and inflight.
 	mu sync.Mutex
 	// attached maps pod UID → installed veth, used to dedupe redundant attaches
@@ -74,16 +83,20 @@ type TrafficShaperMonitor struct {
 
 // NewTrafficShaperMonitor constructs a TrafficShaperMonitor. resolver and client
 // are built from the BN-scoped kubeconfig by NewComponent; namespace is the BN
-// orbit. The delegator defaults to the sudo-backed privileged-exec seam so the
-// watcher can install veth qdiscs without the unprivileged daemon holding root.
-func NewTrafficShaperMonitor(resolver *VethResolver, client kubernetes.Interface, namespace string) *TrafficShaperMonitor {
+// orbit. statuszURL and pollInterval configure the poll loop (an empty URL keeps
+// it idle). The delegator defaults to the sudo-backed privileged-exec seam so
+// both responsibilities delegate their privileged work without the unprivileged
+// daemon holding root.
+func NewTrafficShaperMonitor(resolver *VethResolver, client kubernetes.Interface, namespace, statuszURL string, pollInterval time.Duration) *TrafficShaperMonitor {
 	return &TrafficShaperMonitor{
-		resolver:  resolver,
-		delegator: privexec.New(),
-		client:    client,
-		namespace: namespace,
-		attached:  make(map[types.UID]string),
-		inflight:  make(map[types.UID]bool),
+		resolver:     resolver,
+		delegator:    privexec.New(),
+		client:       client,
+		namespace:    namespace,
+		statuszURL:   statuszURL,
+		pollInterval: pollInterval,
+		attached:     make(map[types.UID]string),
+		inflight:     make(map[types.UID]bool),
 	}
 }
 
@@ -154,17 +167,117 @@ func (m *TrafficShaperMonitor) superviseResponsibility(ctx context.Context, name
 	}
 }
 
-// runStatuszPoll is the statusz poll-loop responsibility. The reconciliation
-// logic now lives in the `solo-provisioner block node reconcile-shaper` worker;
-// the daemon-side scheduler that execs it is not yet wired. Until then this is a
-// pure idle stub that blocks until ctx is cancelled and touches no set.
+// defaultStatuszPollInterval mirrors daemon.DefaultStatuszPollInterval as a
+// local fallback (the daemon package can't be imported here without a cycle) so
+// a monitor constructed with a non-positive interval — only reachable in tests;
+// daemon.go always passes StatuszConfig.EffectivePollInterval() — still ticks at
+// a sane cadence rather than panicking in time.NewTicker.
+const defaultStatuszPollInterval = 5 * time.Second
+
+// statuszForceResyncInterval bounds how long the poll loop trusts the
+// desired-membership digest before forcing a full apply even when the digest is
+// unchanged. The digest is computed over the desired membership (from statusz),
+// not the live nft sets, so a pure digest gate would never notice an
+// out-of-band edit to the daemon-owned sets; a periodic forced apply re-diffs
+// live nft and self-heals that drift. A var (not const) so tests can shrink it.
+var statuszForceResyncInterval = time.Minute
+
+// runStatuszPoll is the statusz poll-loop responsibility: the daemon-side
+// scheduler that execs the `solo-provisioner block node reconcile-shaper` worker
+// once per poll tick to keep the daemon-owned nft policy sets reconciled from
+// statusz.
+//
+// When no statusz base_url is configured it stays inert — it logs once and
+// blocks on ctx, touching no set — so installs that never configured statusz
+// keep a quiet loop rather than erroring.
+//
+// Each tick first runs the unprivileged `--check` digest probe; the privileged
+// apply (a root sudo exec) fires only when the desired membership changed or the
+// force-resync interval has elapsed since the last apply. A worker-exec failure
+// is returned to superviseResponsibility, which retries with the 5s→5min
+// back-off; a ctx cancellation returns nil (clean shutdown).
 func (m *TrafficShaperMonitor) runStatuszPoll(ctx context.Context) error {
+	if m.statuszURL == "" {
+		logx.As().Info().
+			Str("reason", "TrafficShaperStatuszUnconfigured").
+			Str("monitor", m.Name()).
+			Msg("no statusz base_url configured — traffic-shaper poll loop idle")
+		<-ctx.Done()
+		return nil
+	}
+
+	interval := m.pollInterval
+	if interval <= 0 {
+		interval = defaultStatuszPollInterval
+	}
+
 	logx.As().Info().
-		Str("reason", "TrafficShaperStatuszPollStub").
+		Str("reason", "TrafficShaperStatuszPollStarting").
 		Str("monitor", m.Name()).
-		Msg("statusz poll loop not yet wired — reconcile-shaper scheduler pending")
-	<-ctx.Done()
-	return nil
+		Str("statusz_url", m.statuszURL).
+		Dur("poll_interval", interval).
+		Msg("statusz poll loop starting")
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// lastDigest/lastApply are local to this invocation: a fault restarts
+	// runStatuszPoll (via superviseResponsibility), which resets them and forces
+	// a fresh apply — correct, since post-fault we can't trust the prior state.
+	var lastDigest string
+	var lastApply time.Time
+
+	reconcile := func() error {
+		digest, err := m.delegator.ReconcileShaperCheck(ctx, m.statuszURL)
+		if err != nil {
+			return err
+		}
+		// Skip the root apply only when the desired membership is unchanged AND
+		// the force-resync window has not elapsed. lastApply.IsZero() forces the
+		// first reconcile of the loop to apply.
+		if digest == lastDigest && !lastApply.IsZero() && time.Since(lastApply) < statuszForceResyncInterval {
+			return nil
+		}
+		if err := m.delegator.ReconcileShaper(ctx, m.statuszURL); err != nil {
+			return err
+		}
+		lastDigest = digest
+		lastApply = time.Now()
+		return nil
+	}
+
+	// runReconcile absorbs a cancellation-caused fault: when ctx is cancelled
+	// mid-exec, the worker exec (exec.CommandContext) is killed and returns a
+	// context.Canceled error that reconcile propagates. That is a clean shutdown,
+	// not a subsystem fault, so it must surface as nil — both to honor this
+	// function's contract and so a future direct caller never mistakes a
+	// shutdown for a fault.
+	runReconcile := func() error {
+		if err := reconcile(); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+		return nil
+	}
+
+	// Reconcile once on entry so a fresh daemon converges immediately instead of
+	// waiting a full interval for the first tick.
+	if err := runReconcile(); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := runReconcile(); err != nil {
+				return err
+			}
+		}
+	}
 }
 
 // minDuration returns the smaller of a and b.

--- a/internal/daemon/blocknode/traffic_shaper_monitor_test.go
+++ b/internal/daemon/blocknode/traffic_shaper_monitor_test.go
@@ -7,6 +7,7 @@ package blocknode
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,10 +15,235 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// pollFakeDelegator is a thread-safe Delegator fake for the statusz poll-loop
+// tests. It scripts the digest returned by successive ReconcileShaperCheck calls
+// (holding the last value once exhausted) and records how many times each
+// reconcile path ran, so tests can assert the check-gate/apply behavior while
+// runStatuszPoll runs in its own goroutine.
+type pollFakeDelegator struct {
+	mu       sync.Mutex
+	digests  []string // scripted check digests, in call order
+	checkErr error
+	applyErr error
+	lastURL  string
+
+	// blockUntilCancel makes ReconcileShaperCheck block until ctx is cancelled
+	// and then return ctx.Err() — simulating a worker exec killed by a shutdown
+	// mid-flight, which must surface as a clean (nil) exit from runStatuszPoll.
+	blockUntilCancel bool
+
+	checkCalls atomic.Int32
+	applyCalls atomic.Int32
+}
+
+func (f *pollFakeDelegator) Run(context.Context, ...string) ([]byte, error)           { return nil, nil }
+func (f *pollFakeDelegator) NetworkPolicySet(context.Context, string, []string) error { return nil }
+func (f *pollFakeDelegator) TCAttach(context.Context, string) error                   { return nil }
+func (f *pollFakeDelegator) TCDetach(context.Context, string) error                   { return nil }
+
+func (f *pollFakeDelegator) ReconcileShaperCheck(ctx context.Context, url string) (string, error) {
+	n := f.checkCalls.Add(1)
+	if f.blockUntilCancel {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastURL = url
+	if f.checkErr != nil {
+		return "", f.checkErr
+	}
+	if len(f.digests) == 0 {
+		return "", nil
+	}
+	idx := int(n - 1)
+	if idx >= len(f.digests) {
+		idx = len(f.digests) - 1 // hold the last scripted digest
+	}
+	return f.digests[idx], nil
+}
+
+func (f *pollFakeDelegator) ReconcileShaper(_ context.Context, url string) error {
+	f.applyCalls.Add(1)
+	f.mu.Lock()
+	f.lastURL = url
+	f.mu.Unlock()
+	return f.applyErr
+}
+
+// newPollMonitor builds a monitor wired to a poll fake, bypassing the
+// privexec-backed constructor.
+func newPollMonitor(d *pollFakeDelegator, statuszURL string, interval time.Duration) *TrafficShaperMonitor {
+	return &TrafficShaperMonitor{
+		delegator:    d,
+		statuszURL:   statuszURL,
+		pollInterval: interval,
+	}
+}
+
+// waitForCount blocks until get() >= want or the deadline elapses.
+func waitForCount(t *testing.T, get func() int32, want int32) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		if get() >= want {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for count >= %d (last: %d)", want, get())
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// TestRunStatuszPoll_InertWhenUnset verifies that with no statusz base_url the
+// poll loop touches no delegator path and returns nil on ctx cancel.
+func TestRunStatuszPoll_InertWhenUnset(t *testing.T) {
+	d := &pollFakeDelegator{}
+	m := newPollMonitor(d, "", time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- m.runStatuszPoll(ctx) }()
+	cancel()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("runStatuszPoll did not return after ctx cancellation")
+	}
+	require.Zero(t, d.checkCalls.Load(), "no check exec when unconfigured")
+	require.Zero(t, d.applyCalls.Load(), "no apply exec when unconfigured")
+}
+
+// TestRunStatuszPoll_AppliesOnEntryThenGatesUnchanged verifies the loop applies
+// once on entry and then skips the root apply while the digest is unchanged
+// (with the force-resync window held open).
+func TestRunStatuszPoll_AppliesOnEntryThenGatesUnchanged(t *testing.T) {
+	restore := statuszForceResyncInterval
+	statuszForceResyncInterval = time.Hour
+	t.Cleanup(func() { statuszForceResyncInterval = restore })
+
+	d := &pollFakeDelegator{digests: []string{"D1"}} // holds "D1" for every check
+	m := newPollMonitor(d, "http://127.0.0.1:8080", time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- m.runStatuszPoll(ctx) }()
+
+	waitForCount(t, d.checkCalls.Load, 3)
+	cancel()
+	<-done
+
+	require.Equal(t, int32(1), d.applyCalls.Load(),
+		"unchanged digest must apply only once (on entry), then gate")
+	d.mu.Lock()
+	require.Equal(t, "http://127.0.0.1:8080", d.lastURL)
+	d.mu.Unlock()
+}
+
+// TestRunStatuszPoll_AppliesWhenDigestChanges verifies a changed digest triggers
+// a second apply.
+func TestRunStatuszPoll_AppliesWhenDigestChanges(t *testing.T) {
+	restore := statuszForceResyncInterval
+	statuszForceResyncInterval = time.Hour
+	t.Cleanup(func() { statuszForceResyncInterval = restore })
+
+	d := &pollFakeDelegator{digests: []string{"D1", "D2"}} // D1 then D2 (held)
+	m := newPollMonitor(d, "http://127.0.0.1:8080", time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- m.runStatuszPoll(ctx) }()
+
+	waitForCount(t, d.applyCalls.Load, 2)
+	cancel()
+	<-done
+
+	require.GreaterOrEqual(t, d.applyCalls.Load(), int32(2),
+		"entry apply for D1 plus one for the D2 change")
+}
+
+// TestRunStatuszPoll_ForceResyncAppliesDespiteUnchangedDigest verifies the
+// periodic forced apply: with a zero resync window, an unchanged digest still
+// applies every tick (self-healing out-of-band nft drift).
+func TestRunStatuszPoll_ForceResyncAppliesDespiteUnchangedDigest(t *testing.T) {
+	restore := statuszForceResyncInterval
+	statuszForceResyncInterval = 0 // every tick is past due
+	t.Cleanup(func() { statuszForceResyncInterval = restore })
+
+	d := &pollFakeDelegator{digests: []string{"D1"}} // never changes
+	m := newPollMonitor(d, "http://127.0.0.1:8080", time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- m.runStatuszPoll(ctx) }()
+
+	waitForCount(t, d.applyCalls.Load, 3)
+	cancel()
+	<-done
+
+	require.GreaterOrEqual(t, d.applyCalls.Load(), int32(3),
+		"forced resync must re-apply each tick even when the digest is unchanged")
+}
+
+// TestRunStatuszPoll_CheckFaultReturnsError verifies a failing check probe is
+// surfaced to the supervisor (returned, not swallowed) so the back-off applies.
+func TestRunStatuszPoll_CheckFaultReturnsError(t *testing.T) {
+	sentinel := errors.New("statusz unreachable")
+	d := &pollFakeDelegator{checkErr: sentinel}
+	m := newPollMonitor(d, "http://127.0.0.1:8080", time.Second)
+
+	err := m.runStatuszPoll(context.Background())
+	require.ErrorIs(t, err, sentinel)
+	require.Zero(t, d.applyCalls.Load(), "apply must not run when the check fails")
+}
+
+// TestRunStatuszPoll_ApplyFaultReturnsError verifies a failing apply is returned
+// to the supervisor.
+func TestRunStatuszPoll_ApplyFaultReturnsError(t *testing.T) {
+	sentinel := errors.New("nft: operation not permitted")
+	d := &pollFakeDelegator{digests: []string{"D1"}, applyErr: sentinel}
+	m := newPollMonitor(d, "http://127.0.0.1:8080", time.Second)
+
+	err := m.runStatuszPoll(context.Background())
+	require.ErrorIs(t, err, sentinel)
+}
+
+// TestRunStatuszPoll_CancelMidExecReturnsNil verifies that a cancellation while a
+// worker exec is in flight surfaces as a clean (nil) exit, not a fault — the loop
+// must honor its "ctx cancellation returns nil" contract even when the error
+// originates from the killed exec rather than the select.
+func TestRunStatuszPoll_CancelMidExecReturnsNil(t *testing.T) {
+	d := &pollFakeDelegator{blockUntilCancel: true}
+	m := newPollMonitor(d, "http://127.0.0.1:8080", time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- m.runStatuszPoll(ctx) }()
+
+	// Wait until the entry reconcile is blocked inside the check exec, then cancel.
+	waitForCount(t, d.checkCalls.Load, 1)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "cancel mid-exec must be a clean shutdown, not a fault")
+	case <-time.After(time.Second):
+		t.Fatal("runStatuszPoll did not return after ctx cancellation")
+	}
+	require.Zero(t, d.applyCalls.Load(), "apply must not run when the check was cancelled")
+}
+
 // TestTrafficShaperMonitor_RunReturnsOnContextCancel verifies Run starts both
 // responsibilities and returns nil promptly once ctx is cancelled.
 func TestTrafficShaperMonitor_RunReturnsOnContextCancel(t *testing.T) {
-	m := NewTrafficShaperMonitor(nil, nil, "")
+	m := NewTrafficShaperMonitor(nil, nil, "", "", 0)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan error, 1)
@@ -46,7 +272,7 @@ func TestSuperviseResponsibility_RetriesFaultsWithoutPropagating(t *testing.T) {
 		responsibilityBackoffMax = origMax
 	})
 
-	m := NewTrafficShaperMonitor(nil, nil, "")
+	m := NewTrafficShaperMonitor(nil, nil, "", "", 0)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var calls atomic.Int32
@@ -77,7 +303,7 @@ func TestSuperviseResponsibility_RetriesFaultsWithoutPropagating(t *testing.T) {
 // path: a responsibility that returns without error (and without ctx being
 // cancelled) is re-entered immediately, and the loop exits once ctx is done.
 func TestSuperviseResponsibility_ResetsBackoffAndExitsOnCancel(t *testing.T) {
-	m := NewTrafficShaperMonitor(nil, nil, "")
+	m := NewTrafficShaperMonitor(nil, nil, "", "", 0)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var calls atomic.Int32

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -110,10 +110,21 @@ func NewFromConfig(paths models.WeaverPaths, cfg DaemonConfig) (*Daemon, error) 
 
 	bn := cfg.Components.BlockNode
 	if bn != nil && bn.Enabled {
+		// statusz is optional (see BlockNodeComponentConfig.Statusz): when it is
+		// nil or its base_url is empty, the poll loop idles. EffectivePollInterval
+		// already applies the 5s default.
+		var statuszBaseURL string
+		var statuszPollInterval time.Duration
+		if bn.Statusz != nil {
+			statuszBaseURL = bn.Statusz.BaseURL
+			statuszPollInterval = bn.Statusz.EffectivePollInterval()
+		}
 		result, err := blocknode.NewComponent(blocknode.ComponentConfig{
 			TrafficShaperEnabled: bn.Monitors.TrafficShaper,
 			KubeconfigPath:       bn.Kubeconfig,
 			Namespace:            bn.Orbit,
+			StatuszBaseURL:       statuszBaseURL,
+			StatuszPollInterval:  statuszPollInterval,
 		})
 		if err != nil {
 			logComponentBuildSkipped("block-node", bn.Kubeconfig, err)

--- a/internal/daemon/privexec/delegate.go
+++ b/internal/daemon/privexec/delegate.go
@@ -8,8 +8,12 @@
 // docs/dev/daemon/daemon-architecture.md and the BN traffic-shaper design's
 // daemon-vs-CLI separation. This package is the ONLY place in the daemon's
 // import closure that reaches for os/exec, and it execs nothing but sudo +
-// solo-provisioner: never kubectl/helm/systemctl/nft/tc directly. The sudoers
-// grant (internal/templates/files/weaver/sudoers) is the single escalation path
+// solo-provisioner: never kubectl/helm/systemctl/nft/tc directly. Almost every
+// delegation runs solo-provisioner under sudo; the sole exception is the
+// traffic-shaper poll loop's unprivileged `reconcile-shaper --check` digest
+// probe, which execs solo-provisioner directly (no sudo) because the check path
+// touches no privileged state. The sudoers grant
+// (internal/templates/files/weaver/sudoers) remains the single escalation path
 // and is restricted to the solo-provisioner binary.
 //
 // The delegation is synchronous (run, wait, capture output) — distinct from the
@@ -18,6 +22,7 @@ package privexec
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
@@ -75,6 +80,20 @@ type Delegator interface {
 	// best-effort teardown of the $VETH HTB hierarchy on pod delete or before a
 	// clean re-attach.
 	TCDetach(ctx context.Context, veth string) error
+
+	// ReconcileShaper delegates `block node reconcile-shaper --statusz-url <url>`
+	// under sudo — the traffic-shaper poll loop's privileged apply path. The
+	// worker fetches statusz, diffs the live nft policy sets, and rewrites only
+	// the policies whose membership changed.
+	ReconcileShaper(ctx context.Context, statuszURL string) error
+
+	// ReconcileShaperCheck delegates the unprivileged
+	// `block node reconcile-shaper --statusz-url <url> --check --output json`
+	// probe (no sudo, no nft) and returns the desired-membership digest. The
+	// poll loop calls it every tick and only invokes the privileged
+	// ReconcileShaper when the digest changed, so a steady-state roster costs no
+	// root escalation.
+	ReconcileShaperCheck(ctx context.Context, statuszURL string) (digest string, err error)
 }
 
 // execDelegator is the production Delegator. Its resolution and exec seams are
@@ -166,6 +185,77 @@ func (d *execDelegator) TCDetach(ctx context.Context, veth string) error {
 	return d.tcAttach(ctx, veth, true)
 }
 
+func (d *execDelegator) ReconcileShaper(ctx context.Context, statuszURL string) error {
+	if strings.TrimSpace(statuszURL) == "" {
+		return &daemonkit.ProbeError{
+			Reason:     "StatuszURLEmpty",
+			Message:    "block node reconcile-shaper requires a non-empty statusz URL",
+			Resolution: "this is a daemon bug; report it with the daemon logs",
+		}
+	}
+	_, err := d.Run(ctx, "block", "node", "reconcile-shaper", "--statusz-url", statuszURL)
+	return err
+}
+
+// ReconcileShaperCheck execs the reconcile-shaper worker's unprivileged --check
+// path directly (not under sudo): it fetches statusz and prints the
+// desired-membership digest as JSON without reading or writing any nft state, so
+// no escalation is needed. It parses `desired-digest` from that JSON and returns
+// it. The daemon-facing name of the CLI is resolved the same way Run resolves
+// it, so the sibling-preference and granted-path fallbacks apply identically.
+func (d *execDelegator) ReconcileShaperCheck(ctx context.Context, statuszURL string) (string, error) {
+	if strings.TrimSpace(statuszURL) == "" {
+		return "", &daemonkit.ProbeError{
+			Reason:     "StatuszURLEmpty",
+			Message:    "block node reconcile-shaper --check requires a non-empty statusz URL",
+			Resolution: "this is a daemon bug; report it with the daemon logs",
+		}
+	}
+
+	cliBin, err := d.resolveCLI()
+	if err != nil {
+		return "", err
+	}
+
+	// No sudo: --check reads only statusz over HTTP and touches no nft state, so
+	// it runs as the unprivileged daemon user. --output json makes the digest
+	// machine-parseable.
+	args := []string{"block", "node", "reconcile-shaper", "--statusz-url", statuszURL, "--check", "--output", "json"}
+	out, err := d.output(ctx, cliBin, args...)
+	if err != nil {
+		return "", &daemonkit.ProbeError{
+			Reason:     "ReconcileShaperCheckFailed",
+			Message:    unprivilegedExecMessage(cliBin, args, err),
+			Resolution: "reproduce manually as the daemon user: " + cliBin + " " + strings.Join(args, " "),
+			Err:        err,
+		}
+	}
+
+	var res struct {
+		Digest string `json:"desired-digest"`
+	}
+	if err := json.Unmarshal(out, &res); err != nil {
+		return "", &daemonkit.ProbeError{
+			Reason:     "ReconcileShaperCheckParseFailed",
+			Message:    "could not parse reconcile-shaper --check --output json digest",
+			Resolution: "this is a daemon/CLI contract bug; report it with the daemon logs",
+			Err:        err,
+		}
+	}
+	// A missing or empty desired-digest means the CLI's --check contract drifted
+	// (the field vanished or renamed). Fail fast: an empty digest would otherwise
+	// be treated as a real membership value by the poll loop's digest gate and
+	// silently suppress the privileged apply until the next forced resync.
+	if res.Digest == "" {
+		return "", &daemonkit.ProbeError{
+			Reason:     "ReconcileShaperCheckEmptyDigest",
+			Message:    "reconcile-shaper --check returned an empty desired-digest",
+			Resolution: "this is a daemon/CLI contract bug; report it with the daemon logs",
+		}
+	}
+	return res.Digest, nil
+}
+
 // tcAttach delegates the `block node tc-attach --veth <veth> [--detach]` exec.
 // The veth-name format is validated by the CLI/shape layer the exec reaches;
 // here we only guard against an empty name so a daemon bug surfaces as a clear
@@ -218,7 +308,20 @@ func (d *execDelegator) resolveCLI() (string, error) {
 // privilegedExecMessage builds the human-readable failure message, preferring
 // the CLI's stderr (available on a non-zero exit) over the raw exec error.
 func privilegedExecMessage(cliBin string, args []string, err error) string {
-	base := "sudo " + cliBin + " " + strings.Join(args, " ") + " failed"
+	return execMessage("sudo "+cliBin, args, err)
+}
+
+// unprivilegedExecMessage is privilegedExecMessage's no-sudo counterpart for the
+// reconcile-shaper --check probe.
+func unprivilegedExecMessage(cliBin string, args []string, err error) string {
+	return execMessage(cliBin, args, err)
+}
+
+// execMessage builds the human-readable failure message for a prefix (the sudo+
+// CLI or the bare CLI) and argv, preferring the CLI's stderr (available on a
+// non-zero exit) over the raw exec error.
+func execMessage(prefix string, args []string, err error) string {
+	base := prefix + " " + strings.Join(args, " ") + " failed"
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		if stderr := strings.TrimSpace(string(exitErr.Stderr)); stderr != "" {

--- a/internal/daemon/privexec/delegate_test.go
+++ b/internal/daemon/privexec/delegate_test.go
@@ -142,6 +142,116 @@ func TestTCAttach_EmptyVethIsGuarded(t *testing.T) {
 	require.Empty(t, call.name, "exec must not run when the veth name is empty")
 }
 
+func TestReconcileShaper_BuildsSudoArgv(t *testing.T) {
+	d, call := fakeDelegator(
+		[]string{"/usr/bin/sudo", "/opt/solo/weaver/bin/solo-provisioner"},
+		"/opt/solo/weaver/bin/solo-provisioner-daemon",
+		nil, nil,
+	)
+
+	require.NoError(t, d.ReconcileShaper(context.Background(), "http://127.0.0.1:8080"))
+	require.Equal(t, "/usr/bin/sudo", call.name)
+	require.Equal(t, []string{
+		"-n",
+		"/opt/solo/weaver/bin/solo-provisioner",
+		"block", "node", "reconcile-shaper", "--statusz-url", "http://127.0.0.1:8080",
+	}, call.args)
+}
+
+func TestReconcileShaper_EmptyURLIsGuarded(t *testing.T) {
+	d, call := fakeDelegator([]string{"/usr/bin/sudo", "/usr/local/bin/solo-provisioner"}, "", nil, nil)
+
+	err := d.ReconcileShaper(context.Background(), "  ")
+	require.Error(t, err)
+	var pe *daemonkit.ProbeError
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, "StatuszURLEmpty", pe.Reason)
+	require.Empty(t, call.name, "exec must not run when the statusz URL is empty")
+}
+
+func TestReconcileShaperCheck_BuildsUnprivilegedArgvAndParsesDigest(t *testing.T) {
+	// Deliberately omit sudo from the existing paths: the --check probe must
+	// resolve and exec the CLI directly, never sudo.
+	d, call := fakeDelegator(
+		[]string{"/opt/solo/weaver/bin/solo-provisioner"},
+		"/opt/solo/weaver/bin/solo-provisioner-daemon",
+		[]byte(`{"desired-digest":"abc123","desired":{}}`), nil,
+	)
+
+	digest, err := d.ReconcileShaperCheck(context.Background(), "http://127.0.0.1:8080")
+	require.NoError(t, err)
+	require.Equal(t, "abc123", digest)
+
+	require.Equal(t, "/opt/solo/weaver/bin/solo-provisioner", call.name,
+		"the check probe execs the CLI directly, not sudo")
+	require.Equal(t, []string{
+		"block", "node", "reconcile-shaper",
+		"--statusz-url", "http://127.0.0.1:8080",
+		"--check", "--output", "json",
+	}, call.args)
+	require.NotContains(t, call.args, "-n", "no sudo non-interactive flag on the unprivileged path")
+}
+
+func TestReconcileShaperCheck_EmptyURLIsGuarded(t *testing.T) {
+	d, call := fakeDelegator([]string{"/usr/local/bin/solo-provisioner"}, "", nil, nil)
+
+	_, err := d.ReconcileShaperCheck(context.Background(), "")
+	require.Error(t, err)
+	var pe *daemonkit.ProbeError
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, "StatuszURLEmpty", pe.Reason)
+	require.Empty(t, call.name, "exec must not run when the statusz URL is empty")
+}
+
+func TestReconcileShaperCheck_BadJSONReportsParseError(t *testing.T) {
+	d, _ := fakeDelegator(
+		[]string{"/opt/solo/weaver/bin/solo-provisioner"},
+		"/opt/solo/weaver/bin/solo-provisioner-daemon",
+		[]byte("not json at all"), nil,
+	)
+
+	_, err := d.ReconcileShaperCheck(context.Background(), "http://127.0.0.1:8080")
+	require.Error(t, err)
+	var pe *daemonkit.ProbeError
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, "ReconcileShaperCheckParseFailed", pe.Reason)
+}
+
+func TestReconcileShaperCheck_EmptyDigestReportsContractError(t *testing.T) {
+	// Well-formed JSON but no (or empty) desired-digest — the --check contract
+	// drifted. Must fail fast rather than return "".
+	d, _ := fakeDelegator(
+		[]string{"/opt/solo/weaver/bin/solo-provisioner"},
+		"/opt/solo/weaver/bin/solo-provisioner-daemon",
+		[]byte(`{"desired":{}}`), nil,
+	)
+
+	_, err := d.ReconcileShaperCheck(context.Background(), "http://127.0.0.1:8080")
+	require.Error(t, err)
+	var pe *daemonkit.ProbeError
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, "ReconcileShaperCheckEmptyDigest", pe.Reason)
+}
+
+func TestReconcileShaperCheck_ExecFailureReportsProbeError(t *testing.T) {
+	exitErr := runFailingCommand(t)
+	exitErr.Stderr = []byte("statusz unreachable\n")
+
+	d, _ := fakeDelegator(
+		[]string{"/opt/solo/weaver/bin/solo-provisioner"},
+		"/opt/solo/weaver/bin/solo-provisioner-daemon",
+		nil, exitErr,
+	)
+
+	_, err := d.ReconcileShaperCheck(context.Background(), "http://127.0.0.1:8080")
+	require.Error(t, err)
+	var pe *daemonkit.ProbeError
+	require.ErrorAs(t, err, &pe)
+	require.Equal(t, "ReconcileShaperCheckFailed", pe.Reason)
+	require.Contains(t, pe.Message, "statusz unreachable")
+	require.ErrorIs(t, err, exitErr, "underlying exec error must remain unwrappable")
+}
+
 func TestResolveCLI_PrefersDaemonSibling(t *testing.T) {
 	// Both the sibling and a granted path exist; the sibling wins.
 	d, _ := fakeDelegator(


### PR DESCRIPTION
## Description

The block-node traffic-shaper monitor's statusz poll loop
(`TrafficShaperMonitor.runStatuszPoll`, `internal/daemon/blocknode/traffic_shaper_monitor.go`)
was an idle stub that logged `statusz poll loop not yet wired` and blocked on
`ctx.Done()` without touching any nft set. A running daemon therefore never
reconciled the daemon-owned `inet weaver` sets (`bn-publisher`, `bn-partner-out`,
`bn-restricted`, `bn-backfill`) on its own — reconciliation only happened when an
operator ran `block node reconcile-shaper` by hand.

This PR replaces the stub with the daemon-side scheduler. When a statusz
`base_url` is configured, the loop reconciles once on entry and then on each
`poll_interval` tick (default 5s), so a change in the statusz source is reflected
in the nft sets within ~one poll interval with no manual worker run. When
`base_url` is unset the loop stays inert (logs once, blocks on ctx) so installs
that never configured statusz keep a quiet loop rather than erroring.

### Design: check-gate before the privileged apply

Reconciliation is driven by exec'ing the existing `reconcile-shaper` worker
through the daemon's privileged-exec seam, **not** in-process: importing
`internal/blocknode/shaper` into the daemon would pull `internal/network/policy`'s
`os/exec` usage into the daemon binary, breaking the invariant that `privexec` is
the daemon's only `os/exec` seam.

Each tick first runs the **unprivileged** `reconcile-shaper --check --output json`
digest probe (no sudo, no nft), and only execs the **privileged** (sudo) apply
when the desired-membership digest changed since the last apply. Steady-state
ticks therefore cost zero root escalation — no continuous `sudo`/audit-log noise.

Because the digest is computed over the *desired* membership (from statusz), a
pure digest gate would never notice an out-of-band edit to the daemon-owned nft
sets. To close that drift window, the loop also forces a full apply when it has
been longer than `statuszForceResyncInterval` (1m) since the last apply; the
apply path re-diffs live nft, so the periodic forced apply self-heals drift.

Worker-exec failures propagate to `superviseResponsibility`, preserving the
existing 5s→5min back-off; ctx cancellation returns nil (clean shutdown). The
per-invocation digest/last-apply state resets on a supervised restart, forcing a
fresh apply post-fault.

### Files changed

| File | Change |
|---|---|
| `internal/daemon/blocknode/traffic_shaper_monitor.go` | Replace the `runStatuszPoll` stub with the ticker-driven scheduler (inert-when-unset branch, check-gate + forced-resync apply, back-off preserved); add `statuszURL`/`pollInterval` fields, `statuszForceResyncInterval` var, and the two new constructor params |
| `internal/daemon/privexec/delegate.go` | Add `ReconcileShaper` (sudo apply) and `ReconcileShaperCheck` (unprivileged `--check --output json`, parses `desired-digest`) to the `Delegator`; extend the package doc to document the single unprivileged exception |
| `internal/daemon/blocknode/component.go` | `ComponentConfig.StatuszBaseURL`/`StatuszPollInterval`; forward onto the monitor |
| `internal/daemon/daemon.go` | Thread `bn.Statusz.BaseURL` + `EffectivePollInterval()` into `ComponentConfig` (nil-safe) |
| `internal/daemon/privexec/delegate_test.go` | Argv/parse/guard tests for both new methods (asserts the check path never execs sudo) |
| `internal/daemon/blocknode/traffic_shaper_monitor_test.go` | Poll-loop tests: inert-when-unset, entry-apply-then-gate, apply-on-change, forced-resync, check-fault, apply-fault |
| `internal/daemon/blocknode/pod_watcher_test.go` | `fakeDelegator` gains the two new methods |
| `internal/daemon/blocknode/handler_test.go` | Constructor-call update for the new signature |

## Test plan

```bash
# Native (macOS-safe) — the touched daemon packages have no Linux-only deps
go test -race ./internal/daemon/blocknode/... ./internal/daemon/privexec/...

# Full daemon suite
go test ./internal/daemon/...

# Cross-compile check (Linux-target type-correctness without a VM)
GOOS=linux GOARCH=amd64 go vet ./internal/daemon/...

# Lint (0 issues expected)
task lint
```

## Manual UAT

This exercises the daemon *driving* the reconcile that #909's UAT step 12 drove by
hand. It needs a prior `--traffic-shaping-enabled` install (so the daemon-owned
`inet weaver` sets exist and the daemon is active) and the same mock statusz
server. The daemon reads statusz only from `daemon.yaml` — there is no
`--statusz-url` override flag — so each scenario edits the config and restarts the
service. Watch the poll loop through the daemon log; the reconcile decisions are
logged there.

Paths used below: config `/opt/solo/weaver/config/daemon.yaml`, service
`solo-provisioner-daemon.service`, log `solo-provisioner-daemon.log` (in the
provisioner logs dir); `$DAEMON_LOG` below points at that file.

1. **Baseline: seed the mock statusz roster** (same mock + accessory-VM IPs as
   #909 step 12; the mock re-reads its roster file on every request):
   ```bash
   cd /mnt/solo-weaver
   cat > /tmp/roster.json <<EOF
   {
     "inbound": [
       { "remote": {"address": "${CN_VM_IP}/32", "port": "*"}, "category": "publisher" },
       { "remote": {"address": "${PARTNER_VM_IP}/32", "port": "*"}, "category": "partner" }
     ],
     "outbound": [
       { "remote": {"address": "${PEER_VM_IP}", "port": "43473"}, "category": "peer_bn" }
     ]
   }
   EOF
   nohup go run ./internal/daemon/blocknode/statuszmock/cmd \
     --addr 127.0.0.1:8080 --roster /tmp/roster.json > /tmp/statuszmock.log 2>&1 &
   ```

2. **Configure statusz in `daemon.yaml` and restart** — the daemon starts
   reconciling on its own:
   ```yaml
   # under components.block_node:
   statusz:
     base_url: http://127.0.0.1:8080
     poll_interval: 5s
   ```
   ```bash
   sudo systemctl restart solo-provisioner-daemon
   sudo journalctl -u solo-provisioner-daemon -f | grep -i statusz
   # expect: "statusz poll loop starting" with statusz_url + poll_interval=5s
   #         (NOT the old "statusz poll loop not yet wired" stub line)
   ```
   Within ~one poll interval, with **no manual worker run**, the sets converge:
   ```bash
   sudo nft list set inet weaver bn-publisher    # elements = { $CN_VM_IP }
   sudo nft list set inet weaver bn-partner-out  # elements = { $PARTNER_VM_IP }
   sudo nft list set inet weaver bn-backfill     # elements = { $PEER_VM_IP . 43473 }
   ```
   > **Caveat on `bn-backfill` / `peer_bn`.** The `statuszmock` server echoes
   > whatever `category` the roster carries, so seeding `peer_bn` makes this step
   > pass against the mock. A **real** BN statusz never emits `peer_bn` — it
   > reports only `partner`/`publisher`/`public`/`restricted`, and the backfill
   > peers are derived from the *outbound* `partner` endpoints. So this step
   > validates the daemon→worker→nft wiring, not the real category contract; the
   > reconciler's category mapping is corrected separately in #920. The other
   > three sets (`bn-publisher`/`bn-partner-out`/`bn-restricted`) use real
   > categories and are unaffected.

3. **A statusz change is picked up within one poll interval.** Drop the partner
   entry from `/tmp/roster.json` (no mock restart needed) and watch:
   ```bash
   sudo nft list set inet weaver bn-partner-out  # clears within ~5s
   ```
   This is the daemon-driven equivalent of #909 step 12's "category present,
   membership empty → set cleared" check, and keeps the `bn-partner-out`
   regression covered.

4. **Empty roster reconciles cleanly** (no `policy ... not found` errors). Replace
   the roster with empty inbound/outbound arrays:
   ```bash
   echo '{"inbound":[],"outbound":[]}' > /tmp/roster.json
   # all four daemon-owned sets clear; the daemon log shows the apply, no errors
   sudo nft list set inet weaver bn-publisher    # no elements clause
   grep -i 'not found' "$DAEMON_LOG"             # expect: no matches
   ```

5. **Steady state costs no root escalation** (the check-gate). With the roster
   unchanged across several poll intervals, confirm the daemon runs the
   unprivileged check but not the sudo apply each tick:
   ```bash
   # over ~30s of ticks, sudo is NOT invoked for reconcile-shaper on every tick
   sudo journalctl -u solo-provisioner-daemon --since '30 seconds ago' \
     | grep -c 'reconcile-shaper'
   # apply (sudo) fires only on change or the 1-min forced resync, not every 5s tick
   ```

6. **Drift self-heal (forced resync).** Manually corrupt a daemon-owned set, then
   confirm the periodic forced apply (within 1m) restores it even though statusz
   — and therefore the digest — did not change:
   ```bash
   sudo nft add element inet weaver bn-publisher { 203.0.113.99/32 }
   # within <= 1 min the forced resync re-diffs live nft and removes the stray element
   sudo nft list set inet weaver bn-publisher    # 203.0.113.99 gone; back to { $CN_VM_IP }
   ```

7. **Unset base_url stays inert** — no exec, no error spam. Remove the `statusz:`
   block from `daemon.yaml` (or blank `base_url`) and restart:
   ```bash
   sudo systemctl restart solo-provisioner-daemon
   sudo journalctl -u solo-provisioner-daemon --since '10 seconds ago' | grep -i statusz
   # expect: "no statusz base_url configured — traffic-shaper poll loop idle" (once)
   #         no reconcile-shaper execs, no repeated errors
   ```

## Risks / rollback

- **Poll cadence execs a subprocess every `poll_interval`.** The unprivileged
  `--check` runs every tick (default 5s); the root apply runs only on a digest
  change or the 1-min forced resync, so steady-state root escalation is bounded to
  roughly once per minute rather than once per tick.
- **Forced-resync drift window.** An out-of-band edit to a daemon-owned nft set
  persists for up to `statuszForceResyncInterval` (1m) before the forced apply
  heals it. Shrinking that constant trades a tighter window for more frequent root
  applies.
- **No migration boundary / no template change.** This is daemon-runtime behavior
  only; it touches no embedded template or startup migration, so it cannot leak
  into already-provisioned clusters via the upgrade path.
- **Rollback.** Revert the commit; the stub returns and the daemon simply stops
  self-reconciling (the current released behavior). No on-disk schema changed —
  `statusz.base_url`/`poll_interval` already existed and are still honored by the
  manual worker.

### Related Issues

* Closes #914
* Closes #755 (Story 3.10 — the daemon-side scheduler this PR implements; #914 was a concrete restatement of the same work)

