### PR TITLE
fix(shaper): derive bn-backfill from outbound partner endpoints

### DIFF
--- a/docs/dev/daemon/traffic-shaper-statusz.md
+++ b/docs/dev/daemon/traffic-shaper-statusz.md
@@ -66,7 +66,7 @@ Both endpoints are REST/JSON, resolved relative to the configured base URL:
 
 - `remote.address` is the source (inbound) or destination (outbound) host or
   CIDR. It is the value written into the nft set.
-- `remote.port` is only meaningful for the outbound `peer_bn` category, where
+- `remote.port` is only meaningful for the outbound `partner` category, where
   the backfill set is keyed on `address . port`. Inbound categories ignore the
   port (it is the BN's listener port, not part of the source allowlist).
 - Fields the shaper does not consume (`scheme`, `protocol`, `certificate`) are
@@ -83,14 +83,21 @@ a shared config file.
 | statusz endpoint | category | policy / nft set | key shape |
 |---|---|---|---|
 | inbound-clients | `publisher` | `bn-publisher` | ipv4 host/CIDR |
-| inbound-clients | `partner` | `bn-partner` | ipv4 host/CIDR |
+| inbound-clients | `partner` | `bn-partner-out` | ipv4 host/CIDR |
 | inbound-clients | `restricted` | `bn-restricted` | ipv4 host/CIDR |
-| outbound-clients | `peer_bn` | `bn-backfill` | compound `ip . port` |
+| outbound-clients | `partner` | `bn-backfill` | compound `ip . port` |
 
-Categories not in this table (for example `public`, or the operator-curated
-management set) are **never touched** by the monitor. A `public` source is
-expressed as the absence of a source-match on its rule, not as a set element, so
-it is intentionally dropped during bucketing.
+The mapping is keyed on **(direction, category)**, not category alone: the same
+`partner` string maps to `bn-partner-out` inbound and to the compound
+`bn-backfill` outbound. A peer block node this BN backfills from is reported as
+an outbound `partner` connection — there is no distinct `peer_bn` category.
+
+The `public` category is **recognized but deliberately unmapped**: a `public`
+source is expressed as the absence of a source-match on its rule (the
+`bn-public-out` port-match set), not as a statusz-reconciled set element, so it
+is intentionally dropped during bucketing rather than treated as an unknown
+category. The operator-curated management sets are likewise never touched by the
+monitor.
 
 Each owned category is reconciled on every successful poll: an address that
 drops out of statusz is removed from its set, not left stale. A poll that
@@ -160,7 +167,7 @@ Roster file shape:
     { "remote": {"address": "10.20.1.0/24", "port": "*"}, "category": "partner" }
   ],
   "outbound": [
-    { "remote": {"address": "10.30.5.7", "port": "43473"}, "category": "peer_bn" }
+    { "remote": {"address": "10.30.5.7", "port": "43473"}, "category": "partner" }
   ]
 }
 ```

--- a/docs/dev/traffic-shaper-demo.md
+++ b/docs/dev/traffic-shaper-demo.md
@@ -42,24 +42,28 @@ exactly, and each `--stamp` references one of the fixed class names (`publisher`
 creates the `inet weaver` table:
 
 ```bash
-sudo solo-provisioner network policy create --name bn-publisher  --stamp publisher --ports 40840
-sudo solo-provisioner network policy create --name bn-partner    --stamp partner   --ports 40980,40981
-sudo solo-provisioner network policy create --name bn-restricted --deny
+sudo solo-provisioner network policy create --name bn-publisher   --stamp publisher --ports 40840
+sudo solo-provisioner network policy create --name bn-partner-out --stamp partner   --ports 40980,40981
+sudo solo-provisioner network policy create --name bn-restricted  --deny
 sudo solo-provisioner network policy create --name bn-backfill    --stamp reserve-egress --reply-stamp backfill-response
 ```
 
-| category (statusz) | policy / nft set | create flags |
+| statusz (direction, category) | policy / nft set | create flags |
 |---|---|---|
-| publisher | bn-publisher | `--stamp publisher --ports 40840` |
-| partner | bn-partner | `--stamp partner --ports 40980,40981` |
-| restricted | bn-restricted | `--deny` |
-| peer_bn | bn-backfill | `--stamp reserve-egress --reply-stamp backfill-response` (compound ip:port) |
+| inbound publisher | bn-publisher | `--stamp publisher --ports 40840` |
+| inbound partner | bn-partner-out | `--stamp partner --ports 40980,40981` |
+| inbound restricted | bn-restricted | `--deny` |
+| outbound partner | bn-backfill | `--stamp reserve-egress --reply-stamp backfill-response` (compound ip:port) |
+
+The backfill peers appear as **outbound** `partner` endpoints — there is no
+`peer_bn` category. Inbound `partner` and outbound `partner` map to different
+sets.
 
 Confirm the table and its sets exist and are empty (no roster applied yet):
 
 ```bash
 sudo nft list table inet weaver
-# expect sets: bn-publisher, bn-partner, bn-restricted, bn-backfill (empty)
+# expect sets: bn-publisher, bn-partner-out, bn-restricted, bn-backfill (empty)
 ```
 
 ## Step 2 - start the mock statusz server
@@ -74,7 +78,7 @@ cat > roster.json <<'JSON'
     { "remote": {"address": "10.20.1.0/24", "port": "*"}, "category": "partner" }
   ],
   "outbound": [
-    { "remote": {"address": "10.30.5.7", "port": "43473"}, "category": "peer_bn" }
+    { "remote": {"address": "10.30.5.7", "port": "43473"}, "category": "partner" }
   ]
 }
 JSON
@@ -158,9 +162,9 @@ watch -n1 'sudo nft list table inet weaver | sed -n "/set bn-/,/}/p"'
 
 Within one poll interval the sets fill from the roster:
 
-- `bn-publisher` -> `10.10.1.0/24`
-- `bn-partner`   -> `10.20.1.0/24`
-- `bn-backfill`  -> `10.30.5.7 . 43473`
+- `bn-publisher`   -> `10.10.1.0/24`
+- `bn-partner-out` -> `10.20.1.0/24`
+- `bn-backfill`    -> `10.30.5.7 . 43473`
 
 Now edit `roster.json` (no restart needed - the mock re-reads it, the daemon
 re-polls it):
@@ -178,7 +182,7 @@ cat > roster.json <<'JSON'
 JSON
 ```
 
-Within ~5s: `bn-publisher` gains `10.11.0.0/16`, `bn-partner` empties, and
+Within ~5s: `bn-publisher` gains `10.11.0.0/16`, `bn-partner-out` empties, and
 `bn-backfill` empties. Stop the mock server (or block its port) and confirm the
 sets are **left as-is** - an outage keeps the last-good state, it does not drop
 rules.
@@ -223,17 +227,19 @@ otherwise-idle class be borrowed against. Consequences to look for:
 
 ### Category VMs and roster
 
-| VM | Roster category | Exercises |
+| VM | Roster placement | Exercises |
 |---|---|---|
-| `solo-weaver-cn` | `publisher` | ingress publisher class 1:10 |
-| `solo-weaver-partner` | `partner` | egress partner class 1:40 |
-| `solo-weaver-public` | (unmapped `public`) | egress public class 1:50 |
-| `solo-weaver-peer` | `peer_bn` | backfill: egress 1:60 req / ingress 1:20 resp |
+| `solo-weaver-cn` | inbound `publisher` | ingress publisher class 1:10 |
+| `solo-weaver-partner` | inbound `partner` | egress partner class 1:40 |
+| `solo-weaver-public` | (recognized-but-unmapped `public`) | egress public class 1:50 |
+| `solo-weaver-peer` | outbound `partner` | backfill: egress 1:60 req / ingress 1:20 resp |
 
-Put each VM's address in `roster.json` under its category (publisher/partner/
-peer_bn); the public VM stays **unmapped** (a `public` source is any-source, not
-a set member, so it falls through to the public class). Reload is automatic — the
-mock re-reads the file, the daemon re-polls it.
+Put each VM's address in `roster.json` under the right direction and category:
+the publisher and partner clients under `inbound`, the backfill peer under
+`outbound` with category `partner`. The public VM stays **unmapped** (a `public`
+source is any-source, not a set member, so it falls through to the public
+class). Reload is automatic — the mock re-reads the file, the daemon re-polls
+it.
 
 ### iperf3 setup
 

--- a/internal/blocknode/shaper/policy_map.go
+++ b/internal/blocknode/shaper/policy_map.go
@@ -12,27 +12,53 @@ import (
 
 // Category is a statusz traffic category as reported by the block node's statusz
 // endpoints (inbound-clients / outbound-clients). The vocabulary is fixed by the
-// BN's contract, not operator-configurable.
+// BN's contract, not operator-configurable: partner, publisher, public,
+// restricted.
 type Category string
 
 const (
-	// CategoryPublisher is the inbound publisher category.
+	// CategoryPublisher is the publisher category.
 	CategoryPublisher Category = "publisher"
-	// CategoryPartner is the inbound partner category.
+	// CategoryPartner is the partner category. It appears on both statusz
+	// endpoints and binds to a different policy set per direction: inbound
+	// partner clients feed bn-partner-out, while outbound partner connections are
+	// the peer block nodes this BN backfills from and feed the compound
+	// bn-backfill set.
 	CategoryPartner Category = "partner"
-	// CategoryRestricted is the inbound restricted category.
+	// CategoryRestricted is the restricted category.
 	CategoryRestricted Category = "restricted"
-	// CategoryPeerBN is the outbound peer-block-node category. Its endpoints are
-	// compound ip:port pairs — the backfill set is keyed on destination address
-	// AND port.
-	CategoryPeerBN Category = "peer_bn"
+	// CategoryPublic is the public category. It is recognized but deliberately
+	// left unmapped: public access is enforced by the bn-public-out port-match
+	// set, not reconciled from statusz membership, so a public endpoint is
+	// neither an "unknown category" surprise nor a monitor-owned set.
+	CategoryPublic Category = "public"
 )
 
-// categoryBinding is the fixed mapping from a statusz category to the nft policy
-// set it drives and how that set is keyed.
+// Direction is the statusz endpoint an endpoint set is read from: inbound
+// (clients connecting to this BN) or outbound (connections this BN opens). The
+// same category string can bind to a different policy set per direction, so a
+// binding is keyed on (direction, category), not category alone.
+type Direction int
+
+const (
+	// Inbound is the statusz/inbound-clients endpoint.
+	Inbound Direction = iota
+	// Outbound is the statusz/outbound-clients endpoint.
+	Outbound
+)
+
+// bindingKey identifies an owned policy set by the (direction, category) it is
+// fed from. Category alone is not a unique key: partner appears under both
+// directions bound to different sets.
+type bindingKey struct {
+	dir Direction
+	cat Category
+}
+
+// categoryBinding is the fixed mapping from a (direction, category) to the nft
+// policy set it drives and how that set is keyed.
 type categoryBinding struct {
-	// policyName is the nft set (network policy) the category's endpoints
-	// populate.
+	// policyName is the nft set (network policy) the endpoints populate.
 	policyName string
 	// compound is true when the set is a compound `ipv4_addr . inet_service`
 	// key set fed ip:port endpoints (bn-backfill); false for plain ipv4_addr
@@ -40,31 +66,33 @@ type categoryBinding struct {
 	compound bool
 }
 
-// categoryBindings is the internal, non-configurable statusz-category → policy
-// mapping. Both the BN's category vocabulary and the provisioner's policy names
-// are fixed in code, so this is a static table rather than config. Categories
-// not listed here — including the operator-curated mgmt sets — are never touched
-// by the monitor.
-var categoryBindings = map[Category]categoryBinding{
-	CategoryPublisher:  {policyName: "bn-publisher"},
-	CategoryPartner:    {policyName: "bn-partner-out"},
-	CategoryRestricted: {policyName: "bn-restricted"},
-	CategoryPeerBN:     {policyName: "bn-backfill", compound: true},
+// categoryBindings is the internal, non-configurable (direction, category) →
+// policy mapping. Both the BN's category vocabulary and the provisioner's policy
+// names are fixed in code, so this is a static table rather than config. Keys
+// not listed here — the public category, or the operator-curated mgmt sets — are
+// never touched by the monitor.
+//
+// bn-backfill is fed by OUTBOUND partner endpoints (the peer block nodes this BN
+// backfills from), keyed on the compound destination address AND port. Inbound
+// partner clients are a distinct set (bn-partner-out).
+var categoryBindings = map[bindingKey]categoryBinding{
+	{Inbound, CategoryPublisher}:  {policyName: "bn-publisher"},
+	{Inbound, CategoryPartner}:    {policyName: "bn-partner-out"},
+	{Inbound, CategoryRestricted}: {policyName: "bn-restricted"},
+	{Outbound, CategoryPartner}:   {policyName: "bn-backfill", compound: true},
 }
 
-// CategoryEndpoints is one poll's desired membership view, keyed by statusz
-// category. For each category PRESENT in the map, the slice is its active
-// endpoints: plain IPv4 hosts/CIDRs for inbound categories, "ip:port" pairs for
-// the outbound peer_bn category. The present-vs-absent distinction is load
-// bearing and preserved end to end:
+// categoryEndpoints is one poll's desired membership view, keyed by the
+// (direction, category) each endpoint set was read from. For each key PRESENT in
+// the map, the slice is its active endpoints: plain IPv4 hosts/CIDRs for the
+// plain sets, "ip:port" pairs for the compound bn-backfill set. The
+// present-vs-absent distinction is load bearing and preserved end to end:
 //
-//   - a category present with an empty (or nil) slice clears that policy's set;
-//   - a category absent from the map leaves that policy's set untouched.
+//   - a key present with an empty (or nil) slice clears that policy's set;
+//   - a key absent from the map leaves that policy's set untouched.
 //
-// This is the minimal shape the diff needs; the statusz client (#751) decodes the
-// wire NetworkData response into it, and the apply path (#754) consumes the
-// resulting deltas.
-type CategoryEndpoints map[Category][]string
+// This is the minimal shape the diff needs.
+type categoryEndpoints map[bindingKey][]string
 
 // PolicyDelta is the computed membership change for one policy set: the policy
 // (nft set) name and the canonicalized add/delete lists.
@@ -75,33 +103,30 @@ type PolicyDelta struct {
 
 // elementLister reads one nft set's live membership. Satisfied by policy.Runner
 // (via ListElements) and by test fakes; kept deliberately narrow so the diff can
-// never mutate sets — applying deltas is #754's responsibility, not this stage's.
+// never mutate sets — applying deltas is the apply path's responsibility, not
+// this stage's.
 type elementLister interface {
 	ListElements(ctx context.Context, set string) ([]string, error)
 }
 
-// computePolicyDeltas maps each category present in ce to its policy, builds the
+// computePolicyDeltas maps each key present in ce to its policy, builds the
 // desired membership, reads the policy's live nft set membership back from the
-// kernel, and diffs the two. Categories absent from ce produce no delta (the set
-// is left untouched); a present-but-empty category produces a delta that clears
-// the set. Unmapped categories are ignored. No-op deltas are omitted and the
-// result is ordered by policy name for deterministic output.
-func computePolicyDeltas(ctx context.Context, lister elementLister, ce CategoryEndpoints) ([]PolicyDelta, error) {
-	cats := make([]Category, 0, len(ce))
-	for c := range ce {
-		cats = append(cats, c)
-	}
-	sort.Slice(cats, func(i, j int) bool { return cats[i] < cats[j] })
+// kernel, and diffs the two. Keys absent from ce produce no delta (the set is
+// left untouched); a present-but-empty key produces a delta that clears the set.
+// Unmapped keys are ignored. No-op deltas are omitted and the result is ordered
+// by policy name for deterministic output.
+func computePolicyDeltas(ctx context.Context, lister elementLister, ce categoryEndpoints) ([]PolicyDelta, error) {
+	keys := sortedKeys(ce)
 
 	var deltas []PolicyDelta
-	for _, c := range cats {
-		b, ok := categoryBindings[c]
+	for _, k := range keys {
+		b, ok := categoryBindings[k]
 		if !ok {
-			// Unmapped category (e.g. an mgmt set, or one the BN adds later):
-			// not monitor-owned, so leave it untouched.
+			// Unmapped key (e.g. an mgmt set, or one the BN adds later): not
+			// monitor-owned, so leave it untouched.
 			continue
 		}
-		desired, err := desiredElements(b, ce[c])
+		desired, err := desiredElements(b, ce[k])
 		if err != nil {
 			return nil, err
 		}
@@ -119,19 +144,19 @@ func computePolicyDeltas(ctx context.Context, lister elementLister, ce CategoryE
 	return deltas, nil
 }
 
-// canonicalDesiredMembership maps each owned category present in ce to its nft
-// policy name and the canonical, nft-rendered form of its desired membership:
-// compound "<ip> . <port>" tokens for peer_bn, /32-collapsed and numerically
-// ordered elements otherwise (via policy.CanonicalizeElements). This is exactly
-// the rendering computePolicyDeltas diffs against live nft state, so digesting
-// this form — rather than the raw statusz endpoints desiredMembership carries —
-// means the digest only changes when the actual applied membership would
-// change, regardless of how statusz happens to spell an equivalent host/CIDR
-// across polls.
-func canonicalDesiredMembership(ce CategoryEndpoints) (map[string][]string, error) {
+// canonicalDesiredMembership maps each owned key present in ce to its nft policy
+// name and the canonical, nft-rendered form of its desired membership: compound
+// "<ip> . <port>" tokens for the compound bn-backfill set, /32-collapsed and
+// numerically ordered elements otherwise (via policy.CanonicalizeElements). This
+// is exactly the rendering computePolicyDeltas diffs against live nft state, so
+// digesting this form — rather than the raw statusz endpoints desiredMembership
+// carries — means the digest only changes when the actual applied membership
+// would change, regardless of how statusz happens to spell an equivalent
+// host/CIDR across polls.
+func canonicalDesiredMembership(ce categoryEndpoints) (map[string][]string, error) {
 	m := make(map[string][]string, len(ce))
-	for cat, endpoints := range ce {
-		b, ok := categoryBindings[cat]
+	for k, endpoints := range ce {
+		b, ok := categoryBindings[k]
 		if !ok {
 			continue
 		}
@@ -144,9 +169,9 @@ func canonicalDesiredMembership(ce CategoryEndpoints) (map[string][]string, erro
 	return m, nil
 }
 
-// desiredElements converts a category's raw statusz endpoints into nft set
-// element tokens for its policy: compound "<ip> . <port>" keys for the peer_bn
-// category, plain elements otherwise. Canonicalization (ordering, /32 collapse)
+// desiredElements converts a binding's raw statusz endpoints into nft set
+// element tokens for its policy: compound "<ip> . <port>" keys for a compound
+// set, plain elements otherwise. Canonicalization (ordering, /32 collapse)
 // happens later in policy.DiffElements, so this only handles the compound-key
 // conversion.
 func desiredElements(b categoryBinding, endpoints []string) ([]string, error) {
@@ -162,4 +187,20 @@ func desiredElements(b categoryBinding, endpoints []string) ([]string, error) {
 		out = append(out, tok)
 	}
 	return out, nil
+}
+
+// sortedKeys returns ce's keys ordered by (direction, category) for
+// deterministic iteration.
+func sortedKeys(ce categoryEndpoints) []bindingKey {
+	keys := make([]bindingKey, 0, len(ce))
+	for k := range ce {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].dir != keys[j].dir {
+			return keys[i].dir < keys[j].dir
+		}
+		return keys[i].cat < keys[j].cat
+	})
+	return keys
 }

--- a/internal/blocknode/shaper/policy_map_test.go
+++ b/internal/blocknode/shaper/policy_map_test.go
@@ -38,11 +38,11 @@ func TestComputePolicyDeltas_MapsCategoriesToPolicies(t *testing.T) {
 	l := newFakeLister()
 	l.elements["bn-publisher"] = []string{"10.1.0.1/32"}
 
-	ce := CategoryEndpoints{
-		CategoryPublisher:  {"10.1.0.1/32", "10.1.0.2/32"}, // one add
-		CategoryPartner:    {"10.2.0.1/32"},                // all add (empty live)
-		CategoryRestricted: {"10.3.0.0/24"},                // all add
-		CategoryPeerBN:     {"10.30.5.7:43473"},            // compound add
+	ce := categoryEndpoints{
+		{Inbound, CategoryPublisher}:  {"10.1.0.1/32", "10.1.0.2/32"}, // one add
+		{Inbound, CategoryPartner}:    {"10.2.0.1/32"},                // all add (empty live)
+		{Inbound, CategoryRestricted}: {"10.3.0.0/24"},                // all add
+		{Outbound, CategoryPartner}:   {"10.30.5.7:43473"},            // compound add
 	}
 
 	deltas, err := computePolicyDeltas(context.Background(), l, ce)
@@ -57,12 +57,31 @@ func TestComputePolicyDeltas_MapsCategoriesToPolicies(t *testing.T) {
 	}, deltas)
 }
 
+// TestComputePolicyDeltas_PartnerSplitsByDirection proves the same partner
+// category maps to two different sets depending on direction: inbound partner
+// feeds bn-partner-out, outbound partner feeds the compound bn-backfill.
+func TestComputePolicyDeltas_PartnerSplitsByDirection(t *testing.T) {
+	l := newFakeLister()
+
+	ce := categoryEndpoints{
+		{Inbound, CategoryPartner}:  {"10.2.0.1/32"},
+		{Outbound, CategoryPartner}: {"10.30.5.7:43473"},
+	}
+
+	deltas, err := computePolicyDeltas(context.Background(), l, ce)
+	require.NoError(t, err)
+	require.Equal(t, []PolicyDelta{
+		{Policy: "bn-backfill", SetDelta: setDelta([]string{"10.30.5.7 . 43473"}, nil)},
+		{Policy: "bn-partner-out", SetDelta: setDelta([]string{"10.2.0.1"}, nil)},
+	}, deltas)
+}
+
 func TestComputePolicyDeltas_EmptyCategoryClearsSet(t *testing.T) {
 	l := newFakeLister()
 	l.elements["bn-publisher"] = []string{"10.1.0.1/32", "10.1.0.2/32"}
 
 	// Present with an empty slice → clear the whole set.
-	deltas, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{CategoryPublisher: {}})
+	deltas, err := computePolicyDeltas(context.Background(), l, categoryEndpoints{{Inbound, CategoryPublisher}: {}})
 	require.NoError(t, err)
 	require.Equal(t, []PolicyDelta{
 		{Policy: "bn-publisher", SetDelta: setDelta(nil, []string{"10.1.0.1", "10.1.0.2"})},
@@ -75,7 +94,7 @@ func TestComputePolicyDeltas_AbsentCategoryLeavesSetUntouched(t *testing.T) {
 
 	// bn-publisher's category is absent entirely → no delta, and its live set is
 	// never even read.
-	deltas, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{CategoryPartner: {"10.2.0.1/32"}})
+	deltas, err := computePolicyDeltas(context.Background(), l, categoryEndpoints{{Inbound, CategoryPartner}: {"10.2.0.1/32"}})
 	require.NoError(t, err)
 	require.Equal(t, []PolicyDelta{
 		{Policy: "bn-partner-out", SetDelta: setDelta([]string{"10.2.0.1"}, nil)},
@@ -89,17 +108,31 @@ func TestComputePolicyDeltas_NoOpDeltaOmitted(t *testing.T) {
 	l.elements["bn-publisher"] = []string{"10.1.0.1", "10.1.0.2"}
 
 	deltas, err := computePolicyDeltas(context.Background(), l,
-		CategoryEndpoints{CategoryPublisher: {"10.1.0.2/32", "10.1.0.1/32"}})
+		categoryEndpoints{{Inbound, CategoryPublisher}: {"10.1.0.2/32", "10.1.0.1/32"}})
 	require.NoError(t, err)
 	require.Empty(t, deltas)
 }
 
 func TestComputePolicyDeltas_UnmappedCategoryIgnored(t *testing.T) {
 	l := newFakeLister()
-	deltas, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{Category("mgmt"): {"10.9.0.1/32"}})
+	deltas, err := computePolicyDeltas(context.Background(), l, categoryEndpoints{{Inbound, Category("mgmt")}: {"10.9.0.1/32"}})
 	require.NoError(t, err)
 	require.Empty(t, deltas)
 	require.Empty(t, l.reads, "unmapped category must not trigger any live-set read")
+}
+
+// TestComputePolicyDeltas_PublicRecognizedButUnmapped confirms the public
+// category produces no delta and no live-set read: it is deliberately not a
+// monitor-owned set (bn-public-out stays port-match-driven), not an "unknown
+// category" surprise.
+func TestComputePolicyDeltas_PublicRecognizedButUnmapped(t *testing.T) {
+	l := newFakeLister()
+	for _, dir := range []Direction{Inbound, Outbound} {
+		deltas, err := computePolicyDeltas(context.Background(), l, categoryEndpoints{{dir, CategoryPublic}: {"0.0.0.0/0"}})
+		require.NoError(t, err)
+		require.Empty(t, deltas)
+	}
+	require.Empty(t, l.reads, "public category must not trigger any live-set read")
 }
 
 func TestComputePolicyDeltas_CompoundEndpointConversion(t *testing.T) {
@@ -107,7 +140,7 @@ func TestComputePolicyDeltas_CompoundEndpointConversion(t *testing.T) {
 	l.elements["bn-backfill"] = []string{"10.30.5.7 . 43473"}
 
 	deltas, err := computePolicyDeltas(context.Background(), l,
-		CategoryEndpoints{CategoryPeerBN: {"10.30.5.8:43473"}})
+		categoryEndpoints{{Outbound, CategoryPartner}: {"10.30.5.8:43473"}})
 	require.NoError(t, err)
 	require.Equal(t, []PolicyDelta{
 		{Policy: "bn-backfill", SetDelta: setDelta([]string{"10.30.5.8 . 43473"}, []string{"10.30.5.7 . 43473"})},
@@ -122,7 +155,7 @@ func TestComputePolicyDeltas_MalformedCompoundEndpointErrors(t *testing.T) {
 		"::1:80",          // IPv6 host
 	} {
 		l := newFakeLister()
-		_, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{CategoryPeerBN: {bad}})
+		_, err := computePolicyDeltas(context.Background(), l, categoryEndpoints{{Outbound, CategoryPartner}: {bad}})
 		require.Error(t, err, "expected %q to be rejected", bad)
 		require.ErrorContains(t, err, "bn-backfill")
 	}
@@ -131,14 +164,14 @@ func TestComputePolicyDeltas_MalformedCompoundEndpointErrors(t *testing.T) {
 func TestComputePolicyDeltas_LiveReadErrorPropagates(t *testing.T) {
 	l := newFakeLister()
 	l.err["bn-publisher"] = errors.New("nft boom")
-	_, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{CategoryPublisher: {"10.1.0.1/32"}})
+	_, err := computePolicyDeltas(context.Background(), l, categoryEndpoints{{Inbound, CategoryPublisher}: {"10.1.0.1/32"}})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "bn-publisher")
 }
 
 func TestComputePolicyDeltas_ComputesDeltas(t *testing.T) {
 	l := newFakeLister()
-	deltas, err := computePolicyDeltas(context.Background(), l, CategoryEndpoints{CategoryPublisher: {"10.1.0.1/32"}})
+	deltas, err := computePolicyDeltas(context.Background(), l, categoryEndpoints{{Inbound, CategoryPublisher}: {"10.1.0.1/32"}})
 	require.NoError(t, err)
 	require.Equal(t, []PolicyDelta{
 		{Policy: "bn-publisher", SetDelta: setDelta([]string{"10.1.0.1"}, nil)},
@@ -146,10 +179,10 @@ func TestComputePolicyDeltas_ComputesDeltas(t *testing.T) {
 }
 
 func TestCanonicalDesiredMembership_MatchesDeltaRendering(t *testing.T) {
-	ce := CategoryEndpoints{
-		CategoryPublisher: {"10.1.0.2/32", "10.1.0.1/32"}, // /32 collapse + numeric order
-		CategoryPeerBN:    {"10.30.5.7:43473"},            // compound conversion
-		Category("mgmt"):  {"10.9.0.1"},                   // unmapped → dropped
+	ce := categoryEndpoints{
+		{Inbound, CategoryPublisher}: {"10.1.0.2/32", "10.1.0.1/32"}, // /32 collapse + numeric order
+		{Outbound, CategoryPartner}:  {"10.30.5.7:43473"},            // compound conversion
+		{Inbound, Category("mgmt")}:  {"10.9.0.1"},                   // unmapped → dropped
 	}
 
 	m, err := canonicalDesiredMembership(ce)
@@ -161,7 +194,7 @@ func TestCanonicalDesiredMembership_MatchesDeltaRendering(t *testing.T) {
 }
 
 func TestCanonicalDesiredMembership_MalformedCompoundErrors(t *testing.T) {
-	_, err := canonicalDesiredMembership(CategoryEndpoints{CategoryPeerBN: {"not-an-ip-port"}})
+	_, err := canonicalDesiredMembership(categoryEndpoints{{Outbound, CategoryPartner}: {"not-an-ip-port"}})
 	require.Error(t, err)
 }
 
@@ -186,10 +219,10 @@ func TestCategoryBindings_PolicyNamesAreCanonical(t *testing.T) {
 		"bn-public-out": true, "bn-status-in": true, "bn-status-out": true,
 		"bn-mgmt-in": true, "bn-mgmt-out": true, "bn-restricted": true, "bn-backfill": true,
 	}
-	for cat, b := range categoryBindings {
+	for key, b := range categoryBindings {
 		if !canonicalBNPolicyNames[b.policyName] {
-			t.Errorf("categoryBindings[%q].policyName = %q is not one of the canonical "+
-				"BN policy names created by NetworkPolicyCreate", cat, b.policyName)
+			t.Errorf("categoryBindings[%+v].policyName = %q is not one of the canonical "+
+				"BN policy names created by NetworkPolicyCreate", key, b.policyName)
 		}
 	}
 }

--- a/internal/blocknode/shaper/reconciler.go
+++ b/internal/blocknode/shaper/reconciler.go
@@ -143,7 +143,7 @@ func (r *Reconciler) Apply(ctx context.Context) (Result, error) {
 
 // fetchEndpoints reads both statusz endpoints and buckets them into the desired
 // per-category membership view.
-func (r *Reconciler) fetchEndpoints(ctx context.Context) (CategoryEndpoints, error) {
+func (r *Reconciler) fetchEndpoints(ctx context.Context) (categoryEndpoints, error) {
 	inbound, err := r.fetcher.InboundClients(ctx)
 	if err != nil {
 		return nil, err
@@ -155,55 +155,61 @@ func (r *Reconciler) fetchEndpoints(ctx context.Context) (CategoryEndpoints, err
 	return bucketizeEndpoints(inbound, outbound), nil
 }
 
-// bucketizeEndpoints folds one statusz snapshot into the desired per-category
-// membership. Inbound categories (publisher/partner/restricted) contribute their
-// remote host/CIDR; the outbound peer_bn category contributes compound
+// bucketizeEndpoints folds one statusz snapshot into the desired membership,
+// keyed by (direction, category). Inbound endpoints are matched against the
+// inbound bindings (publisher/partner/restricted) and contribute their remote
+// host/CIDR; outbound endpoints are matched against the outbound bindings. The
+// compound bn-backfill set (outbound partner) contributes compound
 // "remote.Address:remote.Port" pairs, skipping any endpoint whose port is empty
 // or "*" (a wildcard port cannot key a compound set).
 //
-// Every owned category is seeded present with an empty slice, so a category the
+// Every owned binding is seeded present with an empty slice, so a category the
 // BN no longer reports collapses to an empty membership that clears its set
 // rather than leaving stale members behind — each owned set is fully reconciled
-// every tick. Categories outside categoryBindings (e.g. the public category, or
-// operator-curated mgmt sets) are ignored.
-func bucketizeEndpoints(inbound, outbound NetworkData) CategoryEndpoints {
-	ce := make(CategoryEndpoints, len(categoryBindings))
-	for c := range categoryBindings {
-		ce[c] = []string{}
+// every tick. Endpoints whose (direction, category) is not an owned binding
+// (e.g. the public category, or operator-curated mgmt sets) are ignored.
+func bucketizeEndpoints(inbound, outbound NetworkData) categoryEndpoints {
+	ce := make(categoryEndpoints, len(categoryBindings))
+	for k := range categoryBindings {
+		ce[k] = []string{}
 	}
 
-	for _, conn := range inbound.ActiveEndpoints {
-		cat := Category(conn.Category)
-		b, ok := categoryBindings[cat]
-		if !ok || b.compound {
+	bucketize(ce, Inbound, inbound)
+	bucketize(ce, Outbound, outbound)
+
+	return ce
+}
+
+// bucketize appends one direction's endpoints into ce under their owned
+// bindings, rendering compound "ip:port" tokens for compound sets and plain
+// host/CIDR otherwise. Endpoints with no owned binding for (dir, category) are
+// dropped; a compound endpoint with an empty or wildcard port is skipped.
+func bucketize(ce categoryEndpoints, dir Direction, data NetworkData) {
+	for _, conn := range data.ActiveEndpoints {
+		k := bindingKey{dir: dir, cat: Category(conn.Category)}
+		b, ok := categoryBindings[k]
+		if !ok {
 			continue
 		}
-		ce[cat] = append(ce[cat], conn.Remote.Address)
-	}
-
-	for _, conn := range outbound.ActiveEndpoints {
-		cat := Category(conn.Category)
-		b, ok := categoryBindings[cat]
-		if !ok || !b.compound {
+		if !b.compound {
+			ce[k] = append(ce[k], conn.Remote.Address)
 			continue
 		}
 		if conn.Remote.Port == "" || conn.Remote.Port == "*" {
 			continue
 		}
-		ce[cat] = append(ce[cat], conn.Remote.Address+":"+conn.Remote.Port)
+		ce[k] = append(ce[k], conn.Remote.Address+":"+conn.Remote.Port)
 	}
-
-	return ce
 }
 
-// desiredMembership maps each owned category present in ce to its nft policy
-// name, carrying the raw statusz endpoints through unchanged (the policy Manager
-// and the diff engine canonicalize them on the way to the kernel). Categories
-// with no policy binding are dropped.
-func desiredMembership(ce CategoryEndpoints) map[string][]string {
+// desiredMembership maps each owned key present in ce to its nft policy name,
+// carrying the raw statusz endpoints through unchanged (the policy Manager and
+// the diff engine canonicalize them on the way to the kernel). Keys with no
+// policy binding are dropped.
+func desiredMembership(ce categoryEndpoints) map[string][]string {
 	m := make(map[string][]string, len(ce))
-	for cat, endpoints := range ce {
-		b, ok := categoryBindings[cat]
+	for k, endpoints := range ce {
+		b, ok := categoryBindings[k]
 		if !ok {
 			continue
 		}

--- a/internal/blocknode/shaper/reconciler_test.go
+++ b/internal/blocknode/shaper/reconciler_test.go
@@ -104,56 +104,57 @@ func TestBucketizeEndpoints_CategorizesAndSeedsAllOwned(t *testing.T) {
 	inbound := NetworkData{ActiveEndpoints: []NetworkConnection{
 		conn("publisher", "10.10.1.0/24", "*"),
 		conn("partner", "10.20.1.0/24", "*"),
-		conn("public", "0.0.0.0/0", "*"), // unmapped → skipped
+		conn("public", "0.0.0.0/0", "*"), // recognized but unmapped → skipped
 	}}
 	outbound := NetworkData{ActiveEndpoints: []NetworkConnection{
-		conn("peer_bn", "10.30.5.7", "43473"),
+		conn("partner", "10.30.5.7", "43473"), // outbound partner → bn-backfill
 	}}
 
 	ce := bucketizeEndpoints(inbound, outbound)
 
-	// All four owned categories present.
+	// All four owned bindings present.
 	require.Len(t, ce, 4)
-	require.Contains(t, ce, CategoryPublisher)
-	require.Contains(t, ce, CategoryPartner)
-	require.Contains(t, ce, CategoryRestricted)
-	require.Contains(t, ce, CategoryPeerBN)
+	require.Contains(t, ce, bindingKey{Inbound, CategoryPublisher})
+	require.Contains(t, ce, bindingKey{Inbound, CategoryPartner})
+	require.Contains(t, ce, bindingKey{Inbound, CategoryRestricted})
+	require.Contains(t, ce, bindingKey{Outbound, CategoryPartner})
 
-	assert.Equal(t, []string{"10.10.1.0/24"}, ce[CategoryPublisher])
-	assert.Equal(t, []string{"10.20.1.0/24"}, ce[CategoryPartner])
+	assert.Equal(t, []string{"10.10.1.0/24"}, ce[bindingKey{Inbound, CategoryPublisher}])
+	assert.Equal(t, []string{"10.20.1.0/24"}, ce[bindingKey{Inbound, CategoryPartner}])
 	// restricted reported nothing → present but empty (clears its set).
-	assert.Empty(t, ce[CategoryRestricted])
-	// peer_bn folds to a compound ip:port raw endpoint.
-	assert.Equal(t, []string{"10.30.5.7:43473"}, ce[CategoryPeerBN])
+	assert.Empty(t, ce[bindingKey{Inbound, CategoryRestricted}])
+	// outbound partner folds to a compound ip:port raw endpoint.
+	assert.Equal(t, []string{"10.30.5.7:43473"}, ce[bindingKey{Outbound, CategoryPartner}])
 
-	// The unmapped public category never appears.
-	require.NotContains(t, ce, Category("public"))
+	// The unmapped public category never appears, on either direction.
+	require.NotContains(t, ce, bindingKey{Inbound, CategoryPublic})
+	require.NotContains(t, ce, bindingKey{Outbound, CategoryPublic})
 }
 
-func TestBucketizeEndpoints_SkipsWildcardAndEmptyPeerPort(t *testing.T) {
+func TestBucketizeEndpoints_SkipsWildcardAndEmptyBackfillPort(t *testing.T) {
 	outbound := NetworkData{ActiveEndpoints: []NetworkConnection{
-		conn("peer_bn", "10.30.5.7", "43473"), // kept
-		conn("peer_bn", "10.30.5.8", "*"),     // wildcard port → skipped
-		conn("peer_bn", "10.30.5.9", ""),      // empty port → skipped
+		conn("partner", "10.30.5.7", "43473"), // kept
+		conn("partner", "10.30.5.8", "*"),     // wildcard port → skipped
+		conn("partner", "10.30.5.9", ""),      // empty port → skipped
 	}}
 
 	ce := bucketizeEndpoints(NetworkData{}, outbound)
-	assert.Equal(t, []string{"10.30.5.7:43473"}, ce[CategoryPeerBN])
+	assert.Equal(t, []string{"10.30.5.7:43473"}, ce[bindingKey{Outbound, CategoryPartner}])
 }
 
 func TestBucketizeEndpoints_EmptySnapshotSeedsAllOwnedEmpty(t *testing.T) {
 	ce := bucketizeEndpoints(NetworkData{}, NetworkData{})
 	require.Len(t, ce, 4)
-	for c := range categoryBindings {
-		assert.Empty(t, ce[c], "category %s should be present but empty", c)
+	for k := range categoryBindings {
+		assert.Empty(t, ce[k], "binding %+v should be present but empty", k)
 	}
 }
 
 func TestDesiredMembership_MapsOwnedCategoriesToPolicies(t *testing.T) {
-	ce := CategoryEndpoints{
-		CategoryPublisher: {"10.1.0.1"},
-		CategoryPeerBN:    {"10.30.5.7:43473"},
-		Category("mgmt"):  {"10.9.0.1"}, // unmapped → dropped
+	ce := categoryEndpoints{
+		{Inbound, CategoryPublisher}: {"10.1.0.1"},
+		{Outbound, CategoryPartner}:  {"10.30.5.7:43473"},
+		{Inbound, Category("mgmt")}:  {"10.9.0.1"}, // unmapped → dropped
 	}
 	m := desiredMembership(ce)
 	require.Equal(t, map[string][]string{
@@ -168,7 +169,7 @@ func TestReconciler_Check_DigestsDesired(t *testing.T) {
 			conn("publisher", "10.10.1.0/24", "*"),
 		}},
 		outbound: NetworkData{ActiveEndpoints: []NetworkConnection{
-			conn("peer_bn", "10.30.5.7", "43473"),
+			conn("partner", "10.30.5.7", "43473"),
 		}},
 	}
 	r := &Reconciler{fetcher: f}

--- a/internal/blocknode/shaper/statusz_client_mock_test.go
+++ b/internal/blocknode/shaper/statusz_client_mock_test.go
@@ -27,7 +27,7 @@ func TestStatuszClient_DecodesMockServer(t *testing.T) {
 			{Remote: statuszmock.Endpoint{Address: "10.20.1.0/24", Port: "*"}, Category: "partner", TLSRequired: true},
 		},
 		Outbound: []statuszmock.Connection{
-			{Remote: statuszmock.Endpoint{Address: "10.30.5.7", Port: "43473"}, Category: "peer_bn"},
+			{Remote: statuszmock.Endpoint{Address: "10.30.5.7", Port: "43473"}, Category: "partner"},
 		},
 	}
 	srv := httptest.NewServer(statuszmock.Handler(statuszmock.StaticRoster(roster)))
@@ -46,7 +46,7 @@ func TestStatuszClient_DecodesMockServer(t *testing.T) {
 	outbound, err := client.OutboundClients(context.Background())
 	require.NoError(t, err)
 	require.Len(t, outbound.ActiveEndpoints, 1)
-	assert.Equal(t, "peer_bn", outbound.ActiveEndpoints[0].Category)
+	assert.Equal(t, "partner", outbound.ActiveEndpoints[0].Category)
 	assert.Equal(t, "10.30.5.7", outbound.ActiveEndpoints[0].Remote.Address)
 	assert.Equal(t, "43473", outbound.ActiveEndpoints[0].Remote.Port)
 }

--- a/internal/blocknode/shaper/statusz_client_test.go
+++ b/internal/blocknode/shaper/statusz_client_test.go
@@ -29,7 +29,7 @@ const sampleInboundClientsJSON = `{
 
 const sampleOutboundClientsJSON = `{
   "active_endpoints": [
-    { "local": {"address": "0.0.0.0", "port": "*"}, "remote": {"address": "10.30.5.7", "port": "43473"}, "category": "peer_bn", "tls_required": true }
+    { "local": {"address": "0.0.0.0", "port": "*"}, "remote": {"address": "10.30.5.7", "port": "43473"}, "category": "partner", "tls_required": true }
   ]
 }`
 
@@ -90,7 +90,7 @@ func TestStatuszClient_OutboundClients_DecodesSample(t *testing.T) {
 	require.Len(t, data.ActiveEndpoints, 1)
 
 	peer := data.ActiveEndpoints[0]
-	require.Equal(t, "peer_bn", peer.Category)
+	require.Equal(t, "partner", peer.Category)
 	require.Equal(t, "10.30.5.7", peer.Remote.Address)
 	require.Equal(t, "43473", peer.Remote.Port)
 	require.True(t, peer.TLSRequired)

--- a/internal/daemon/blocknode/statuszmock/cmd/main.go
+++ b/internal/daemon/blocknode/statuszmock/cmd/main.go
@@ -14,7 +14,7 @@
 //
 //	{
 //	  "inbound":  [ { "remote": {"address":"10.10.1.0/24","port":"*"}, "category":"publisher" } ],
-//	  "outbound": [ { "remote": {"address":"10.30.5.7","port":"43473"}, "category":"peer_bn" } ]
+//	  "outbound": [ { "remote": {"address":"10.30.5.7","port":"43473"}, "category":"partner" } ]
 //	}
 package main
 

--- a/internal/daemon/blocknode/statuszmock/server.go
+++ b/internal/daemon/blocknode/statuszmock/server.go
@@ -10,8 +10,9 @@
 // The wire contract mirrors block-node/api/network-data.proto (a `NetworkData`
 // with `active_endpoints`). It is defined independently here so the mock stays
 // decoupled from the daemon's decode types and can serve the contract on its
-// own. The contract is PROVISIONAL — confirming it with the BN team is a
-// blocking dependency.
+// own. The category vocabulary is the real BN contract: partner, publisher,
+// public, restricted. Peer block nodes this BN backfills from appear as OUTBOUND
+// partner endpoints, not a distinct category.
 package statuszmock
 
 import (

--- a/internal/daemon/blocknode/statuszmock/server_test.go
+++ b/internal/daemon/blocknode/statuszmock/server_test.go
@@ -38,7 +38,7 @@ func TestHandler_StaticRoster(t *testing.T) {
 			{Remote: statuszmock.Endpoint{Address: "10.10.1.0/24", Port: "*"}, Category: "publisher"},
 		},
 		Outbound: []statuszmock.Connection{
-			{Remote: statuszmock.Endpoint{Address: "10.30.5.7", Port: "43473"}, Category: "peer_bn"},
+			{Remote: statuszmock.Endpoint{Address: "10.30.5.7", Port: "43473"}, Category: "partner"},
 		},
 	}
 	srv := httptest.NewServer(statuszmock.Handler(statuszmock.StaticRoster(roster)))
@@ -50,7 +50,7 @@ func TestHandler_StaticRoster(t *testing.T) {
 
 	out := decode(t, srv, "/statusz/outbound-clients")
 	require.Len(t, out, 1)
-	assert.Equal(t, "peer_bn", out[0]["category"])
+	assert.Equal(t, "partner", out[0]["category"])
 }
 
 func TestHandler_EmptyRosterReturnsEmptyArray(t *testing.T) {


### PR DESCRIPTION
## Description

The traffic-shaper reconciler mapped statusz traffic categories to nft policy
sets against a **provisional** contract, and one assumption was wrong: it keyed
the compound `bn-backfill` set on a literal `peer_bn` category. A real block node
never emits `peer_bn` — its only categories are `partner`, `publisher`, `public`,
and `restricted`, and the peer block nodes it backfills from are reported as
**outbound `partner`** connections. So against a real BN the outbound bucketize
loop matched nothing and `bn-backfill` **silently never populated**. The gap was
masked because `statuszmock` echoes whatever category the roster carries, so
`peer_bn` rosters validated the wiring against themselves, not the real contract.

The fix makes the binding table **direction-aware**. The same `partner` string
now maps to a different set depending on direction — inbound `partner` →
`bn-partner-out`, outbound `partner` → the compound `bn-backfill` — so the table
is keyed on `(direction, category)` rather than category alone. `peer_bn` is
removed entirely, and `public` is added as a recognized-but-unmapped category
(`bn-public-out` stays a port-match set, not statusz-reconciled), so a `public`
endpoint is deliberately dropped rather than treated as an unknown category.

The category vocabulary is confirmed with the BN team, so the `PROVISIONAL`
caveat is dropped from `policy_map.go` and `statuszmock`.

### Files changed

| File | Change |
|---|---|
| `internal/blocknode/shaper/policy_map.go` | `Direction` type + composite `(direction, category)` binding key; drop `peer_bn`, add `public`; `bn-backfill` ← outbound `partner`; drop PROVISIONAL caveat |
| `internal/blocknode/shaper/reconciler.go` | `bucketizeEndpoints` matches inbound/outbound endpoints against direction-specific bindings (new `bucketize` helper) |
| `internal/blocknode/shaper/policy_map_test.go` | Composite-key fixtures; new direction-split and public-unmapped cases |
| `internal/blocknode/shaper/reconciler_test.go` | Composite-key fixtures; outbound `partner` replaces `peer_bn` |
| `internal/blocknode/shaper/statusz_client_test.go`, `statusz_client_mock_test.go` | Wire samples use outbound `partner` |
| `internal/daemon/blocknode/statuszmock/server.go`, `server_test.go`, `cmd/main.go` | Serve/document the real vocabulary; drop PROVISIONAL caveat |
| `docs/dev/daemon/traffic-shaper-statusz.md`, `docs/dev/traffic-shaper-demo.md` | Mapping tables reflect the direction-aware binding; fix stale `bn-partner` → `bn-partner-out` |

### Scope boundary

Minimal mapping change: only the `partner` split is confirmed and encoded.
`publisher`/`restricted` stay inbound (as before); if the BN's real split for
those differs, the composite-key structure already supports a follow-up without
further refactor.

### Review guide

**Checklist**
- `policy_map.go` — `categoryBindings` has exactly the four `(direction, category)`
  keys; only `{Outbound, partner}` is `compound: true`. No `peer_bn` anywhere.
- `reconciler.go` `bucketize` — inbound endpoints look up `{Inbound, cat}`,
  outbound look up `{Outbound, cat}`; wildcard/empty ports still skipped for the
  compound set.
- `policy_map_test.go:TestComputePolicyDeltas_PartnerSplitsByDirection` — proves
  inbound and outbound `partner` produce `bn-partner-out` and `bn-backfill`
  separately.
- `policy_map_test.go:TestComputePolicyDeltas_PublicRecognizedButUnmapped` —
  `public` yields no delta and no live-set read.
- `TestCategoryBindings_PolicyNamesAreCanonical` still guards the policy-name set.

**Test commands**
```bash
go test -tags='!integration' ./internal/blocknode/shaper/... ./internal/daemon/blocknode/statuszmock/...
task lint
```

**Manual UAT** — serve a real-vocabulary roster and confirm `bn-backfill`
populates from outbound `partner`:
```bash
cat > roster.json <<'JSON'
{
  "inbound":  [ { "remote": {"address": "10.20.1.0/24", "port": "*"}, "category": "partner" } ],
  "outbound": [ { "remote": {"address": "10.30.5.7", "port": "43473"}, "category": "partner" } ]
}
JSON
go run ./internal/daemon/blocknode/statuszmock/cmd --addr 127.0.0.1:8080 --roster roster.json &
solo-provisioner block node reconcile-shaper --statusz-url http://127.0.0.1:8080 --check --output json
# expect desired["bn-backfill"] == ["10.30.5.7 . 43473"] and desired["bn-partner-out"] == ["10.20.1.0/24"]
```

**Risks / rollback** — re-keying `CategoryEndpoints` touches every reader in the
package; a missed call site is a compile error, not a silent bug. Rollback:
revert this PR (the inert `peer_bn` binding returns).

### Related Issues

* Closes #920
