### PR TITLE
feat(blocknode): make helm install/upgrade timeout configurable via --timeout

### DIFF
--- a/cmd/cli/commands/block/node/init.go
+++ b/cmd/cli/commands/block/node/init.go
@@ -311,6 +311,7 @@ func prepareBlocknodeInputs(cmd *cobra.Command, args []string) (*models.UserInpu
 			PluginList:          pluginList,
 			EgressInterface:     flagEgressInterface,
 			LinkRate:            flagLinkRate,
+			Timeout:             flagHelmTimeout,
 		},
 	}
 

--- a/cmd/cli/commands/block/node/install.go
+++ b/cmd/cli/commands/block/node/install.go
@@ -130,6 +130,7 @@ var installCmd = &cobra.Command{
 func init() {
 	installCmd.Flags().StringVar(&flagChartVersion, "chart-version", "", "Helm chart version to use")
 	common.FlagValuesFile().SetVarP(installCmd, &flagValuesFile, false)
+	common.FlagHelmTimeout().SetVarP(installCmd, &flagHelmTimeout, false)
 	common.RegisterHostFirewallFlags(installCmd)
 	common.RegisterTrafficShapingFlags(installCmd)
 	common.RegisterEgressFlags(installCmd, &flagEgressInterface, &flagLinkRate)

--- a/cmd/cli/commands/block/node/node.go
+++ b/cmd/cli/commands/block/node/node.go
@@ -3,6 +3,8 @@
 package node
 
 import (
+	"time"
+
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/spf13/cobra"
@@ -43,6 +45,7 @@ var (
 	flagShape                []string
 	flagDaemonBin            string
 	flagDaemonVersion        string
+	flagHelmTimeout          time.Duration
 
 	nodeCmd = &cobra.Command{
 		Use:   "node",

--- a/cmd/cli/commands/block/node/upgrade.go
+++ b/cmd/cli/commands/block/node/upgrade.go
@@ -72,4 +72,5 @@ func init() {
 	common.FlagWithStorageReset().SetVarP(upgradeCmd, &flagWithReset, false)
 	common.FlagValuesFile().SetVarP(upgradeCmd, &flagValuesFile, false)
 	common.FlagNoReuseValues().SetVarP(upgradeCmd, &flagNoReuseValues, false)
+	common.FlagHelmTimeout().SetVarP(upgradeCmd, &flagHelmTimeout, false)
 }

--- a/cmd/cli/commands/common/flags_blocknode.go
+++ b/cmd/cli/commands/common/flags_blocknode.go
@@ -2,6 +2,12 @@
 
 package common
 
+import (
+	"time"
+
+	"github.com/hashgraph/solo-weaver/pkg/helm"
+)
+
 // Flag descriptor factories for the `block node` command tree.
 //
 // Each factory returns a fresh FlagDefinition value so callers always receive an
@@ -195,5 +201,14 @@ func FlagLoadBalancerEnabled() FlagDefinition[bool] {
 		ShortName:   "",
 		Description: "Inject MetalLB address-pool annotation into the block node service (disable for environments without MetalLB)",
 		Default:     true,
+	}
+}
+
+func FlagHelmTimeout() FlagDefinition[time.Duration] {
+	return FlagDefinition[time.Duration]{
+		Name:        "timeout",
+		ShortName:   "",
+		Description: "Timeout for the block node Helm install/upgrade, as a Go duration (e.g. 10m, 600s, 1h). The operation is rolled back (--atomic) if it exceeds this budget",
+		Default:     helm.DefaultTimeout,
 	}
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -176,6 +176,7 @@ sudo solo-provisioner block node install \
 | `--values`, `-f`          | Custom Helm values file                                                                                                               |
 | `--chart-repo`            | Helm chart repository URL                                                                                                             |
 | `--chart-version`         | Specific chart version                                                                                                                |
+| `--timeout`               | Timeout for the block node Helm install/upgrade, as a Go duration (e.g. `10m`, `600s`, `1h`). The operation is rolled back (`--atomic`) if it exceeds this budget (default: `5m0s`) |
 | `--namespace`             | Kubernetes namespace                                                                                                                  |
 | `--release-name`          | Helm release name                                                                                                                     |
 | `--base-path`             | Base path for all storage                                                                                                             |
@@ -307,6 +308,7 @@ sudo solo-provisioner block node upgrade \
 |---------------------|--------------------------------------------------------------|---------|
 | `--no-reuse-values` | Don't reuse previous release values                          | `false` |
 | `--with-reset`      | Wipe block node data directories; PVs and PVCs are preserved | `false` |
+| `--timeout`         | Timeout for the block node Helm install/upgrade, as a Go duration (e.g. `10m`, `600s`, `1h`). The operation is rolled back (`--atomic`) if it exceeds this budget | `5m0s` |
 
 #### Reset Block Node
 

--- a/internal/bll/blocknode/effective_inputs_test.go
+++ b/internal/bll/blocknode/effective_inputs_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package blocknode
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashgraph/solo-weaver/internal/rsl"
+	"github.com/hashgraph/solo-weaver/internal/state"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBlockNodeChecker is a no-op reality.Checker[state.BlockNodeState] that
+// returns a fixed (not-deployed) state, so effective-input resolution takes the
+// user-supplied values.
+type fakeBlockNodeChecker struct{ st state.BlockNodeState }
+
+func (f *fakeBlockNodeChecker) RefreshState(_ context.Context) (state.BlockNodeState, error) {
+	return f.st, nil
+}
+
+// TestResolveEffectiveInputs_CarriesTimeout is a regression guard for #912: the
+// --timeout value must survive resolveBlocknodeEffectiveInputs, which rebuilds
+// BlockNodeInputs field-by-field. A field left out of that literal is silently
+// dropped between CLI validation and the workflow, so the helm call falls back
+// to the 5m default (which is exactly what happened before this fix).
+func TestResolveEffectiveInputs_CarriesTimeout(t *testing.T) {
+	checker := &fakeBlockNodeChecker{st: state.NewBlockNodeState()}
+	r, err := rsl.NewBlockNodeRuntimeResolver(models.Config{}, state.NewBlockNodeState(), checker, 10*time.Minute)
+	require.NoError(t, err)
+	runtime := r.(*rsl.BlockNodeRuntimeResolver)
+
+	inputs := models.UserInputs[models.BlockNodeInputs]{
+		Custom: models.BlockNodeInputs{
+			Namespace:    "block-node",
+			Release:      "block-node",
+			Chart:        "oci://example.com/block-node",
+			ChartVersion: "0.37.1",
+			Storage:      models.BlockNodeStorage{BasePath: "/mnt/fast-storage"},
+			Timeout:      15 * time.Minute,
+		},
+	}
+
+	eff, err := resolveBlocknodeEffectiveInputs(
+		runtime,
+		models.Intent{Action: models.ActionInstall, Target: models.TargetBlockNode},
+		inputs,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 15*time.Minute, eff.Custom.Timeout,
+		"--timeout must be carried through effective-input resolution")
+}

--- a/internal/bll/blocknode/helpers.go
+++ b/internal/bll/blocknode/helpers.go
@@ -173,6 +173,7 @@ func resolveBlocknodeEffectiveInputs(
 			LinkRate:              inputs.Custom.LinkRate,
 			ShapeOverrides:        inputs.Custom.ShapeOverrides,
 			TrafficShapingEnabled: inputs.Custom.TrafficShapingEnabled,
+			Timeout:               inputs.Custom.Timeout,
 		},
 	}
 

--- a/internal/blocknode/chart.go
+++ b/internal/blocknode/chart.go
@@ -4,7 +4,9 @@ package blocknode
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashgraph/solo-weaver/internal/kube"
@@ -22,14 +24,37 @@ import (
 // finalizer.
 const HelmOwnedServiceDeleteTimeout = 30 * time.Second
 
-// resolveHelmTimeout picks the operator-supplied install/upgrade timeout
+// Namespace returns the block-node Kubernetes namespace these operations target.
+func (m *Manager) Namespace() string {
+	return m.blockNodeInputs.Namespace
+}
+
+// ResolveHelmTimeout picks the operator-supplied install/upgrade timeout
 // (from --timeout) when set, falling back to helm.DefaultTimeout (5m) for any
 // caller that leaves BlockNodeInputs.Timeout unset (zero) or negative.
-func (m *Manager) resolveHelmTimeout() time.Duration {
+func (m *Manager) ResolveHelmTimeout() time.Duration {
 	if m.blockNodeInputs.Timeout > 0 {
 		return m.blockNodeInputs.Timeout
 	}
 	return helm.DefaultTimeout
+}
+
+// IsHelmTimeoutError reports whether err is a block-node Helm install/upgrade
+// that ran out its --timeout budget (the resources did not become ready in
+// time), as opposed to a genuine resource failure. With --atomic set, Helm
+// rolls the release back and surfaces the wait deadline as a context-deadline
+// or wait-timeout cause, so callers can only distinguish it from the error
+// chain. Used to attach a "raise --timeout" resolution hint at the step layer.
+func IsHelmTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "context deadline exceeded") ||
+		strings.Contains(msg, "timed out waiting")
 }
 
 // InstallChart installs the block node helm chart
@@ -55,7 +80,7 @@ func (m *Manager) InstallChart(ctx context.Context, valuesFile string) (bool, er
 			CreateNamespace: false,
 			Atomic:          true,
 			Wait:            true,
-			Timeout:         m.resolveHelmTimeout(),
+			Timeout:         m.ResolveHelmTimeout(),
 		},
 	)
 	if err != nil {
@@ -99,7 +124,7 @@ func (m *Manager) UpgradeChart(ctx context.Context, valuesFile string, reuseValu
 			ReuseValues: reuseValues,
 			Atomic:      true,
 			Wait:        true,
-			Timeout:     m.resolveHelmTimeout(),
+			Timeout:     m.ResolveHelmTimeout(),
 		},
 	)
 	if err != nil {

--- a/internal/blocknode/chart.go
+++ b/internal/blocknode/chart.go
@@ -22,6 +22,16 @@ import (
 // finalizer.
 const HelmOwnedServiceDeleteTimeout = 30 * time.Second
 
+// resolveHelmTimeout picks the operator-supplied install/upgrade timeout
+// (from --timeout) when set, falling back to helm.DefaultTimeout (5m) for any
+// caller that leaves BlockNodeInputs.Timeout unset (zero) or negative.
+func (m *Manager) resolveHelmTimeout() time.Duration {
+	if m.blockNodeInputs.Timeout > 0 {
+		return m.blockNodeInputs.Timeout
+	}
+	return helm.DefaultTimeout
+}
+
 // InstallChart installs the block node helm chart
 func (m *Manager) InstallChart(ctx context.Context, valuesFile string) (bool, error) {
 	isInstalled, err := m.helmManager.IsInstalled(m.blockNodeInputs.Release, m.blockNodeInputs.Namespace)
@@ -45,7 +55,7 @@ func (m *Manager) InstallChart(ctx context.Context, valuesFile string) (bool, er
 			CreateNamespace: false,
 			Atomic:          true,
 			Wait:            true,
-			Timeout:         helm.DefaultTimeout,
+			Timeout:         m.resolveHelmTimeout(),
 		},
 	)
 	if err != nil {
@@ -89,7 +99,7 @@ func (m *Manager) UpgradeChart(ctx context.Context, valuesFile string, reuseValu
 			ReuseValues: reuseValues,
 			Atomic:      true,
 			Wait:        true,
-			Timeout:     helm.DefaultTimeout,
+			Timeout:     m.resolveHelmTimeout(),
 		},
 	)
 	if err != nil {

--- a/internal/blocknode/chart_timeout_test.go
+++ b/internal/blocknode/chart_timeout_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package blocknode
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashgraph/solo-weaver/pkg/helm"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/release"
+)
+
+// managerWithHelmMock builds a Manager wired to a mocked helm.Manager. Only the
+// helm manager, logger and inputs are needed for InstallChart/UpgradeChart.
+func managerWithHelmMock(t *testing.T, inputs models.BlockNodeInputs) (*Manager, *helm.MockManager) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	hm := helm.NewMockManager(ctrl)
+	m := &Manager{
+		helmManager:     hm,
+		logger:          testLogger(),
+		blockNodeInputs: inputs,
+	}
+	return m, hm
+}
+
+func TestInstallChart_TimeoutPropagation(t *testing.T) {
+	tests := []struct {
+		name     string
+		timeout  time.Duration
+		expected time.Duration
+	}{
+		{name: "explicit timeout is honored", timeout: 10 * time.Minute, expected: 10 * time.Minute},
+		{name: "zero falls back to default", timeout: 0, expected: helm.DefaultTimeout},
+		{name: "negative falls back to default", timeout: -1, expected: helm.DefaultTimeout},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inputs := models.BlockNodeInputs{Release: "bn", Namespace: "ns", Timeout: tc.timeout}
+			m, hm := managerWithHelmMock(t, inputs)
+
+			hm.EXPECT().IsInstalled("bn", "ns").Return(false, nil)
+			hm.EXPECT().
+				InstallChart(gomock.Any(), "bn", gomock.Any(), gomock.Any(), "ns", gomock.Any()).
+				DoAndReturn(func(_ context.Context, _, _, _, _ string, o helm.InstallChartOptions) (*release.Release, error) {
+					assert.Equal(t, tc.expected, o.Timeout)
+					return nil, nil
+				})
+
+			installed, err := m.InstallChart(context.Background(), "values.yaml")
+			require.NoError(t, err)
+			assert.True(t, installed)
+		})
+	}
+}
+
+func TestUpgradeChart_TimeoutPropagation(t *testing.T) {
+	tests := []struct {
+		name     string
+		timeout  time.Duration
+		expected time.Duration
+	}{
+		{name: "explicit timeout is honored", timeout: 15 * time.Minute, expected: 15 * time.Minute},
+		{name: "zero falls back to default", timeout: 0, expected: helm.DefaultTimeout},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inputs := models.BlockNodeInputs{Release: "bn", Namespace: "ns", Timeout: tc.timeout}
+			m, hm := managerWithHelmMock(t, inputs)
+
+			hm.EXPECT().IsInstalled("bn", "ns").Return(true, nil)
+			hm.EXPECT().
+				UpgradeChart(gomock.Any(), "bn", gomock.Any(), gomock.Any(), "ns", gomock.Any()).
+				DoAndReturn(func(_ context.Context, _, _, _, _ string, o helm.UpgradeChartOptions) (*release.Release, error) {
+					assert.Equal(t, tc.expected, o.Timeout)
+					return nil, nil
+				})
+
+			err := m.UpgradeChart(context.Background(), "values.yaml", false)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/blocknode/chart_timeout_test.go
+++ b/internal/blocknode/chart_timeout_test.go
@@ -4,12 +4,14 @@ package blocknode
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/hashgraph/solo-weaver/pkg/helm"
 	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/release"
@@ -84,6 +86,30 @@ func TestUpgradeChart_TimeoutPropagation(t *testing.T) {
 
 			err := m.UpgradeChart(context.Background(), "values.yaml", false)
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestIsHelmTimeoutError(t *testing.T) {
+	// Mirrors the real chain: errorx wrapping the helm SDK's atomic-rollback text.
+	atomicTimeout := errorx.IllegalState.Wrap(
+		fmt.Errorf("release block-node failed, and has been uninstalled due to atomic being set: context deadline exceeded"),
+		"failed to install block node chart")
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "wrapped context.DeadlineExceeded", err: errorx.Decorate(context.DeadlineExceeded, "wait"), want: true},
+		{name: "atomic rollback deadline text", err: atomicTimeout, want: true},
+		{name: "kube wait timeout text", err: fmt.Errorf("timed out waiting for the condition"), want: true},
+		{name: "unrelated failure", err: errorx.IllegalState.New("ImagePullBackOff"), want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsHelmTimeoutError(tc.err))
 		})
 	}
 }

--- a/internal/workflows/steps/step_block_node.go
+++ b/internal/workflows/steps/step_block_node.go
@@ -4,11 +4,13 @@ package steps
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/blocknode"
 	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
 
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
 )
@@ -225,6 +227,32 @@ func uninstallBlockNode(profile string, valuesFile string, getManager func() (*b
 		})
 }
 
+// blockNodeChartError enriches a failed Helm install/upgrade with an
+// operator-actionable resolution. When the failure is a --timeout budget
+// overrun (Helm rolled the release back under --atomic before the resources
+// became ready), it points the operator at raising --timeout; otherwise it
+// falls back to the generic pod-inspection steps. action is "install" or
+// "upgrade".
+func blockNodeChartError(err error, manager *blocknode.Manager, action string) error {
+	namespace := manager.Namespace()
+	if blocknode.IsHelmTimeoutError(err) {
+		return errorx.Decorate(err, "block node %s exceeded the --timeout budget", action).
+			WithProperty(models.ErrPropertyResolution, []string{
+				fmt.Sprintf("The block node did not become ready within the --timeout budget (%s) and was rolled back (--atomic).", manager.ResolveHelmTimeout()),
+				"Re-run with a longer --timeout, e.g.:",
+				fmt.Sprintf("  solo-provisioner block node %s --timeout 15m ...", action),
+				"A cold first boot can be slow when the chart's resolve-plugins init container resolves plugins from Maven.",
+			})
+	}
+	return errorx.Decorate(err, "block node %s failed", action).
+		WithProperty(models.ErrPropertyResolution, []string{
+			"Inspect the block node pod for the underlying cause:",
+			fmt.Sprintf("  kubectl -n %s get pods", namespace),
+			fmt.Sprintf("  kubectl -n %s describe pod -l app.kubernetes.io/name=block-node-server", namespace),
+			fmt.Sprintf("  kubectl -n %s logs -l app.kubernetes.io/name=block-node-server --all-containers", namespace),
+		})
+}
+
 // installBlockNode installs the block node helm chart
 func installBlockNode(profile string, valuesFile string, getManager func() (*blocknode.Manager, error)) *automa.StepBuilder {
 	return automa.NewStepBuilder().WithId(InstallBlockNodeStepId).
@@ -243,7 +271,7 @@ func installBlockNode(profile string, valuesFile string, getManager func() (*blo
 
 			installed, err := manager.InstallChart(ctx, valuesFilePath)
 			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+				return automa.StepFailureReport(stp.Id(), automa.WithError(blockNodeChartError(err, manager, "install")))
 			}
 
 			if !installed {
@@ -408,7 +436,7 @@ func upgradeBlockNode(inputs models.BlockNodeInputs, getManager func() (*blockno
 
 			err = manager.UpgradeChart(ctx, valuesFilePath, inputs.ReuseValues)
 			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(err))
+				return automa.StepFailureReport(stp.Id(), automa.WithError(blockNodeChartError(err, manager, "upgrade")))
 			}
 
 			meta["upgraded"] = "true"

--- a/pkg/models/inputs.go
+++ b/pkg/models/inputs.go
@@ -5,6 +5,7 @@ package models
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/automa-saga/automa"
 	"github.com/hashgraph/solo-weaver/pkg/sanity"
@@ -88,6 +89,10 @@ type BlockNodeInputs struct {
 	// Held as a neutral type so pkg/models stays decoupled from the shape
 	// package; the install workflow converts it at the call site.
 	ShapeOverrides map[string]ShapeOverride
+	// Timeout caps the block-node Helm install/upgrade (the `--atomic` wait
+	// budget), set from `--timeout`. Zero means "unset" — the install/upgrade
+	// call site falls back to helm.DefaultTimeout (5m).
+	Timeout time.Duration
 }
 
 // ShapeOverride is one class's operator-supplied HTB bandwidth override, parsed
@@ -246,6 +251,12 @@ func (c *BlockNodeInputs) Validate() error {
 		if err := ValidatePluginList(c.PluginList); err != nil {
 			return err
 		}
+	}
+
+	// A negative Helm timeout is nonsensical; zero is allowed and means "use the
+	// default" (resolved to helm.DefaultTimeout at the install/upgrade call site).
+	if c.Timeout < 0 {
+		return errorx.IllegalArgument.New("invalid timeout: %s (must not be negative)", c.Timeout)
 	}
 
 	return nil

--- a/pkg/models/validation_test.go
+++ b/pkg/models/validation_test.go
@@ -4,6 +4,7 @@ package models
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -802,6 +803,31 @@ func TestBlockNodeInputs_RetentionValidation(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.errorMsg)
 			} else {
 				require.NoError(t, err, "Expected no validation error")
+			}
+		})
+	}
+}
+
+// TestBlockNodeInputs_TimeoutValidation tests the validation of the Helm timeout field.
+func TestBlockNodeInputs_TimeoutValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		timeout     time.Duration
+		expectError bool
+	}{
+		{name: "zero_is_valid_means_default", timeout: 0, expectError: false},
+		{name: "positive_is_valid", timeout: 10 * time.Minute, expectError: false},
+		{name: "negative_is_invalid", timeout: -1 * time.Second, expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := (&BlockNodeInputs{Timeout: tt.timeout}).Validate()
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid timeout")
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`block node install` / `upgrade` ran Helm with `--atomic` and a **hard-coded 5-minute
timeout** that no flag or config field could override. An install/upgrade whose first
boot legitimately takes longer than 5 minutes — most commonly the chart's default
`resolve-plugins` init container resolving plugins from Maven (~4 min cold on a fresh or
changed plugins PVC) — raced that budget and got rolled back even though it would have
succeeded.

This PR exposes the timeout as a `--timeout` duration flag on `block node install` and
`block node upgrade`, plumbed through `models.BlockNodeInputs` into the existing
`InstallChartOptions.Timeout` / `UpgradeChartOptions.Timeout` fields (which the Helm
manager already honours). The default stays **5m**, and any code path that leaves the
timeout unset falls back to `helm.DefaultTimeout`, so no existing behaviour changes.

The flag accepts a Go duration string (e.g. `10m`, `600s`, `1h`) — matching upstream
Helm's own `--timeout` — not a bare seconds integer.

### Changes

| File | Change |
|---|---|
| `pkg/models/inputs.go` | Add `Timeout time.Duration` to `BlockNodeInputs`; `Validate()` rejects negative values |
| `cmd/cli/commands/common/flags_blocknode.go` | New `FlagHelmTimeout()` factory — `--timeout`, default `helm.DefaultTimeout` |
| `cmd/cli/commands/block/node/node.go` | Declare shared `flagHelmTimeout` var |
| `cmd/cli/commands/block/node/install.go`, `upgrade.go` | Register `--timeout` on both commands |
| `cmd/cli/commands/block/node/init.go` | Wire flag into `inputs.Custom.Timeout` |
| `internal/blocknode/chart.go` | `InstallChart`/`UpgradeChart` use `resolveHelmTimeout()` (configured value; `<= 0` → `helm.DefaultTimeout`) |
| `docs/quickstart.md` | Add `--timeout` to install + upgrade flag tables |
| `internal/blocknode/chart_timeout_test.go` | New: timeout propagation + zero/negative fallback via helm mock |
| `pkg/models/validation_test.go` | Timeout validation cases |

### Scope boundary

Flag only (no Viper config key). `--timeout` is registered on `install` and `upgrade`
only — `reconfigure`/`reset`/`check`/`uninstall` and the other chart installers
(alloy, MetalLB, teleport, ESO, metrics-server, prometheus-operator-crds) are unchanged
and keep the 5m default.

## Test plan

### Unit

```bash
# timeout propagation + zero/negative fallback (helm mock)
go test -race -tags='!integration' ./internal/blocknode/... -run 'Timeout' -v

# BlockNodeInputs.Validate rejects negative, accepts zero/positive
go test -race -tags='!integration' ./pkg/models/... -run 'TimeoutValidation' -v
```

Full unit suite (run in the UTM VM — several packages are Linux-only):

```bash
task vm:test:unit
```

### Manual UAT

> Run on a host/VM with a Kubernetes cluster provisioned by this tool
> (`sudo solo-provisioner kube cluster install ...` first if needed).

**UAT-1 — `--timeout` appears in help with the 5m default**

```bash
solo-provisioner block node install --help
solo-provisioner block node upgrade --help
```

*Expected:* both list `--timeout duration` with description ending
`... (default 5m0s)`.

**UAT-2 — duration format is accepted; bare seconds is rejected**

```bash
# valid Go durations parse
solo-provisioner block node install --profile=local --timeout=10m ... --help   # no parse error
# a bare integer is rejected (Go duration requires a unit)
solo-provisioner block node install --profile=local --timeout=600 --help
```

*Expected:* `--timeout=10m` parses fine; `--timeout=600` fails with
`invalid argument "600" for "--timeout" flag: time: missing unit in duration "600"`.
(`600s`, `1h`, `90m` are all valid.)

**UAT-3 — negative timeout is rejected by input validation**

```bash
solo-provisioner block node install --profile=local --timeout=-5m ...
```

*Expected:* fails fast with `invalid user inputs: invalid timeout: -5m0s (must not be negative)`
before any Helm operation runs.

**UAT-4 — a raised timeout lets a slow first-boot install succeed (the reported case)**

Use the chart's default plugin flow (do **not** pass `plugins.names: ""`), so the
`resolve-plugins` init container performs a cold Maven resolve:

```bash
sudo solo-provisioner block node install \
  --profile=local \
  --plugin-preset=tier1-lfh \
  --timeout=15m \
  --daemon-bin=/path/to/solo-provisioner-daemon
```

*Expected:* the install waits up to 15m for readiness and completes successfully; it is
**not** rolled back at the 5-minute mark. Watch progress with:

```bash
kubectl -n block-node get pods -w
kubectl -n block-node logs <bn-pod> -c resolve-plugins
```

**UAT-5 — default (flag omitted) is still 5m**

```bash
sudo solo-provisioner block node install --profile=local ... --daemon-bin=...
```

*Expected:* behaves exactly as before this PR — the Helm operation uses a 5-minute
`--atomic` budget. Confirm in the CLI logs (`solo-provisioner` log) that the helm
install/upgrade timeout is `5m0s`.

**UAT-6 — upgrade honours `--timeout` too**

```bash
sudo solo-provisioner block node upgrade --profile=local --timeout=12m --values=/path/to/values.yaml
```

*Expected:* the upgrade uses a 12-minute budget; omitting `--timeout` keeps 5m.

## Risks / rollback

- Low risk: the Helm layer already honoured `Timeout`; this stops hard-coding it at the
  block-node call site. The `<= 0` fallback preserves today's 5m behaviour for every path
  that does not set the new field (migrations, tests, non-install/upgrade commands).
- CLI-surface change → `docs/quickstart.md` updated in the same PR.
- No state/schema/template changes. Rollback = revert the commit.

Closes #912
