### PR TITLE
fix(blocknode): stop forcing service.type LoadBalancer on split-topology installs

### DIFF
--- a/docs/block-node-service-exposure.md
+++ b/docs/block-node-service-exposure.md
@@ -1,0 +1,160 @@
+# Block-node service exposure: `--load-balancer-enabled`, `service.type`, and the split topology
+
+How the block node's Kubernetes Services are exposed is decided by **three independent
+inputs** that combine at install/upgrade time. This page explains how they interact and shows
+the three configurations operators actually use, with the resulting `kubectl get svc` output.
+
+## The three inputs
+
+| Input | Where it's set | What it controls |
+|---|---|---|
+| `--load-balancer-enabled` | CLI flag (default `true`) | Whether weaver injects the MetalLB `metallb.io/address-pool` annotation onto the **main** service. Set `false` in clusters without MetalLB. |
+| `service.type` | operator `-f` values file | The main `<release>-block-node-server` service type. If you don't set it, weaver picks the default (below). |
+| `loadBalancer.enabled` | operator `-f` values file (a **chart** value) | Turns on the chart's **split topology**: the chart renders a dedicated `<release>-block-node-server-external` LoadBalancer service and keeps the main service on the chart's `ClusterIP` default. |
+
+Weaver renders a base values template and merges your `-f` on top, then at deploy time
+resolves the main service type in `injectServiceAnnotations`. The base template intentionally
+does **not** hardcode `service.type` (that hardcode was the bug in
+[#926](https://github.com/hashgraph/solo-weaver/issues/926)); weaver owns the decision in one
+place so it can defer to the chart's `ClusterIP` on the split path.
+
+## Decision table (main service, when you don't set `service.type` yourself)
+
+| `--load-balancer-enabled` | `loadBalancer.enabled` (chart split) | Main service `type` | MetalLB pool annotation on main service |
+|---|---|---|---|
+| `true` (default) | unset / `false` | `LoadBalancer` | injected (`public-address-pool`) |
+| `true` | `true` (split) | `ClusterIP` (chart default) | none — the chart's `-external` LB carries the annotation |
+| `false` | unset / `false` | `LoadBalancer` | none |
+| `false` | `true` (split) | `ClusterIP` (chart default) | none |
+
+An **explicit** `service.type` in your `-f` is always honored and never clobbered.
+
+> **Gotcha — ClusterIP main service + `--load-balancer-enabled=true` fails the install.** On the
+> non-split path, `--load-balancer-enabled=true` (the default) runs `verify-block-node-reachable`,
+> which dials the main LoadBalancer's external IP. If you force `service.type: ClusterIP` there,
+> weaver honors it and logs a warning, but the probe then finds no LoadBalancer Service and fails:
+> ```
+> common.illegal_state: no LoadBalancer Service found in namespace <ns>; cannot probe reachability
+> ```
+> To run a ClusterIP main service, also pass `--load-balancer-enabled=false` (which skips the
+> probe) — see Showcase 3. On the **split** path this doesn't arise: the chart's `-external`
+> LoadBalancer Service is what the probe dials, so the main service can stay `ClusterIP`.
+
+## Showcase 1 — Default single-service (MetalLB present)
+
+The common case: one `LoadBalancer` service, MetalLB assigns it an external IP from
+`public-address-pool`.
+
+```bash
+solo-provisioner block node install ...        # --load-balancer-enabled defaults to true
+```
+
+No `service` or `loadBalancer` block needed in `-f`. Result:
+
+```
+NAME                           TYPE           EXTERNAL-IP    PORT(S)
+block-node-block-node-server   LoadBalancer   192.168.99.0   40840,16007,40983
+```
+
+> The single `LoadBalancer` publishes all main-service ports (`40840` gRPC, `16007` metrics,
+> `40983` plugin). If you only want the gRPC port externally reachable, use the split topology
+> (Showcase 2).
+
+## Showcase 2 — Split topology (chart-owned external LoadBalancer)
+
+You want **only** the public gRPC port (`40840`) exposed externally, and the metrics/plugin
+ports kept in-cluster. Enable the chart's own external LoadBalancer and leave the main service
+on `ClusterIP`:
+
+```yaml
+# operator -f values
+service:
+  port: 40840
+loadBalancer:
+  enabled: true
+  port: "40840"
+  annotations:
+    metallb.io/address-pool: "public-address-pool"
+```
+
+```bash
+solo-provisioner block node install -f split-values.yaml ...   # --load-balancer-enabled stays true
+```
+
+Result — the main service is `ClusterIP` (no external IP; metrics/plugin ports stay internal),
+and only the `-external` service is a `LoadBalancer`, exposing just `40840`:
+
+```
+NAME                                    TYPE           EXTERNAL-IP    PORT(S)
+block-node-block-node-server            ClusterIP      <none>         40840,16007,40983
+block-node-block-node-server-external   LoadBalancer   152.236.24.7   40840
+```
+
+You do **not** need to set `service.type: ClusterIP` yourself — weaver defers to the chart's
+default. (Setting it explicitly also works and is honored.)
+
+## Showcase 3 — No MetalLB
+
+Cluster has no MetalLB (or any LoadBalancer controller). Disable the annotation injection:
+
+```bash
+solo-provisioner block node install --load-balancer-enabled=false ...
+```
+
+The main service stays `LoadBalancer` (weaver's default main-service shape) but carries **no**
+pool annotation. Without a LoadBalancer controller the external IP never materializes and stays
+`<pending>` — the service is still reachable in-cluster via its ClusterIP and via the
+auto-allocated NodePort:
+
+```
+NAME                           TYPE           EXTERNAL-IP   PORT(S)
+block-node-block-node-server   LoadBalancer   <pending>     40840:31234/TCP,...
+```
+
+If you want no external exposure at all in a no-MetalLB cluster, set `service.type: ClusterIP`
+explicitly in your `-f` — weaver honors it and injects nothing.
+
+## Upgrade behavior — existing broken installs are not auto-healed by a default upgrade
+
+The [#926](https://github.com/hashgraph/solo-weaver/issues/926) fix corrects **fresh installs**.
+It does **not** automatically fix an already-installed split-topology block node on a routine
+upgrade, because of how `block node upgrade` reuses values:
+
+- A block node installed with an **older** provisioner baked `service.type: LoadBalancer` into the
+  release's stored user values (the old base template rendered it into the values file handed to
+  `helm install`).
+- `block node upgrade` defaults to reusing the previous release's values (Helm
+  `ResetThenReuseValues`): chart defaults → **old release values (still `LoadBalancer`)** → the
+  freshly rendered values on top. Since the #926 fix means weaver's rendered values no longer set
+  `service.type`, nothing overrides the reused `LoadBalancer`, so the main service stays a
+  LoadBalancer after the upgrade.
+
+To flip an existing split install to `ClusterIP`, do **one** of:
+
+- **Upgrade with `--no-reuse-values`** — resets to chart defaults and applies only the freshly
+  rendered values (which omit `service.type`, so the chart's `ClusterIP` default stands):
+
+  ```bash
+  solo-provisioner block node upgrade --no-reuse-values -f split-values.yaml ...
+  ```
+
+  Re-supply your **full** `-f` on this path — `--no-reuse-values` does not carry forward values you
+  set only at the original install time.
+
+- **Re-assert `service.type: ClusterIP` explicitly** in your `-f`, which overrides the reused value
+  on a normal (reuse-values) upgrade:
+
+  ```yaml
+  service:
+    type: ClusterIP
+    port: 40840
+  loadBalancer:
+    enabled: true
+    port: "40840"
+    annotations:
+      metallb.io/address-pool: "public-address-pool"
+  ```
+
+The same reasoning applies to a no-MetalLB (`--load-balancer-enabled=false`) install upgraded from
+an older provisioner: the reused `LoadBalancer` persists until you upgrade with `--no-reuse-values`
+or set `service.type: ClusterIP` explicitly.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -196,7 +196,7 @@ sudo solo-provisioner block node install \
 | `--plugins-path`          | Path for plugins storage                                                                                                              |
 | `--historic-retention`    | Historic block retention threshold (`0` = unlimited)                                                                                  |
 | `--recent-retention`      | Recent block retention threshold (default: `96000`)                                                                                   |
-| `--load-balancer-enabled` | Inject MetalLB address-pool annotation into the block node service; set to `false` for environments without MetalLB (default: `true`) |
+| `--load-balancer-enabled` | Inject MetalLB address-pool annotation into the block node service; set to `false` for environments without MetalLB (default: `true`). See [Block-node service exposure](./block-node-service-exposure.md) for how this interacts with `service.type` and the chart's split topology. |
 | `--firewall-enabled`      | Apply the node-level host firewall (`inet host` table: SSH/mgmt allowlist, ICMP policy, in-cluster ports). Opt-in (default: `false`); set to `true` to have this tool manage the host firewall |
 | `--mgmt-cidrs`            | Host firewall SSH/management allowlist CIDRs. Empty skips the host firewall.                                                          |
 | `--blocked-cidrs`         | Host firewall operator-curated block list CIDRs, dropped before any other rule including established connections. Distinct from the BN workload plane's `bn-restricted` set, which the traffic-shaper daemon manages automatically. |

--- a/internal/blocknode/manager_test.go
+++ b/internal/blocknode/manager_test.go
@@ -942,8 +942,13 @@ func TestInjectRetentionConfig_OverridesExistingValues(t *testing.T) {
 
 // ── injectServiceAnnotations ──────────────────────────────────────────────────
 
-// TestInjectServiceAnnotations_Disabled tests that nothing is injected when LoadBalancerEnabled is false.
-func TestInjectServiceAnnotations_Disabled(t *testing.T) {
+// TestInjectServiceAnnotations_DisabledPreservesLoadBalancerType is case C (issue #926): with
+// --load-balancer-enabled=false (no MetalLB) and no operator service.type, weaver preserves the
+// historical LoadBalancer main service (best-effort; the auto-allocated NodePort still serves)
+// but must NOT inject a MetalLB address-pool annotation — the pool tag is meaningless without
+// MetalLB. This preserves pre-#926 behavior for the no-MetalLB path now that the base template
+// no longer hardcodes service.type.
+func TestInjectServiceAnnotations_DisabledPreservesLoadBalancerType(t *testing.T) {
 	manager := &Manager{
 		blockNodeInputs: models.BlockNodeInputs{
 			LoadBalancerEnabled: false,
@@ -951,16 +956,110 @@ func TestInjectServiceAnnotations_Disabled(t *testing.T) {
 		logger: testLogger(),
 	}
 
-	input := []byte(`blockNode:
-  config: {}
+	// Mirrors the base template after #926: service block present with a port but no type.
+	input := []byte(`service:
+  port: 40840
 `)
 
 	result, err := manager.injectServiceAnnotations(input)
 	require.NoError(t, err)
 
-	// Content must be returned byte-identical — nothing was parsed or rewritten.
-	assert.Equal(t, input, result)
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+	service := vals["service"].(map[string]interface{})
+	assert.Equal(t, "LoadBalancer", service["type"], "case C: main service type preserved as LoadBalancer")
+	assert.EqualValues(t, 40840, service["port"], "port preserved")
+	assert.NotContains(t, string(result), "metallb.io/address-pool", "no MetalLB annotation when --load-balancer-enabled=false")
+}
+
+// TestInjectServiceAnnotations_DisabledPreservesExplicitClusterIP is case C with an explicit
+// operator service.type: ClusterIP (and no chart loadBalancer block). Weaver injects nothing —
+// the operator's choice is honored and, since MetalLB is disabled, there is no annotation to
+// add — so the values come back byte-identical.
+func TestInjectServiceAnnotations_DisabledPreservesExplicitClusterIP(t *testing.T) {
+	manager := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{
+			LoadBalancerEnabled: false,
+		},
+		logger: testLogger(),
+	}
+
+	input := []byte(`service:
+  type: ClusterIP
+  port: 40840
+`)
+
+	result, err := manager.injectServiceAnnotations(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, input, result, "explicit ClusterIP + MetalLB disabled → byte-identical, nothing to mutate")
 	assert.NotContains(t, string(result), "metallb.io/address-pool")
+}
+
+// TestInjectServiceAnnotations_SplitTopologyNoOperatorTypeStaysChartDefault is the heart of
+// issue #926 and its criterion 1: split topology (loadBalancer.enabled: true) with the operator
+// silent on service.type. Weaver must NOT force service.type: LoadBalancer onto the main service
+// — it defers to the chart so the chart's ClusterIP default stands. The values come back
+// byte-identical with no service.type key at all.
+func TestInjectServiceAnnotations_SplitTopologyNoOperatorTypeStaysChartDefault(t *testing.T) {
+	manager := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{
+			LoadBalancerEnabled: true,
+		},
+		logger: testLogger(),
+	}
+
+	// Mirrors the base template (service has a port but no type) merged with an operator -f that
+	// only enables the chart's own external LoadBalancer.
+	input := []byte(`service:
+  port: 40840
+loadBalancer:
+  enabled: true
+  annotations:
+    metallb.io/address-pool: "public-address-pool"
+`)
+
+	result, err := manager.injectServiceAnnotations(input)
+	require.NoError(t, err)
+
+	// Deferred to the chart → byte-identical, no service.* mutation.
+	assert.Equal(t, input, result)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+	service := vals["service"].(map[string]interface{})
+	_, hasType := service["type"]
+	assert.False(t, hasType, "weaver must not force service.type on the split path — chart keeps ClusterIP")
+	_, hasServiceAnnotations := service["annotations"]
+	assert.False(t, hasServiceAnnotations, "weaver must not inject service.annotations on the split path")
+}
+
+// TestInjectServiceAnnotations_SplitTopologyDisabledStillDefers pins that the split-topology
+// defer holds even when --load-balancer-enabled=false: the chart still owns the external
+// LoadBalancer, so weaver leaves the main service to the chart's ClusterIP default.
+func TestInjectServiceAnnotations_SplitTopologyDisabledStillDefers(t *testing.T) {
+	manager := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{
+			LoadBalancerEnabled: false,
+		},
+		logger: testLogger(),
+	}
+
+	input := []byte(`service:
+  port: 40840
+loadBalancer:
+  enabled: true
+`)
+
+	result, err := manager.injectServiceAnnotations(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, input, result, "split topology defers regardless of --load-balancer-enabled")
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(result, &vals))
+	service := vals["service"].(map[string]interface{})
+	_, hasType := service["type"]
+	assert.False(t, hasType, "chart keeps ClusterIP even with MetalLB disabled")
 }
 
 // TestInjectServiceAnnotations_InjectsWhenAbsent tests that the annotation is injected

--- a/internal/blocknode/reachability.go
+++ b/internal/blocknode/reachability.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashgraph/solo-weaver/internal/kube"
 	"github.com/hashgraph/solo-weaver/internal/network"
+	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/joomcode/errorx"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -92,7 +93,14 @@ func (m *Manager) findLoadBalancerEndpoint(ctx context.Context) (string, int64, 
 	if lb == nil {
 		return "", 0, errorx.IllegalState.New(
 			"no LoadBalancer Service found in namespace %s; cannot probe reachability",
-			m.blockNodeInputs.Namespace)
+			m.blockNodeInputs.Namespace).
+			WithProperty(models.ErrPropertyResolution, []string{
+				"The block node's main Service is not a LoadBalancer, so there is no external endpoint to probe.",
+				"This usually means the values set 'service.type: ClusterIP' (or another non-LoadBalancer type) while --load-balancer-enabled is true (the default), which is what enables this probe.",
+				"If a ClusterIP main service is intended, re-run with --load-balancer-enabled=false to skip the reachability probe.",
+				"If external reachability is intended, remove the service.type override so the main Service is a LoadBalancer.",
+				"For a split topology (chart owns a separate external LoadBalancer), set loadBalancer.enabled: true in your -f values so the chart renders the '-external' Service.",
+			})
 	}
 
 	ingress, found, _ := unstructured.NestedSlice(lb.Object, "status", "loadBalancer", "ingress")

--- a/internal/blocknode/values.go
+++ b/internal/blocknode/values.go
@@ -399,38 +399,42 @@ func (m *Manager) injectPluginsConfig(valuesContent []byte) ([]byte, error) {
 	return result, nil
 }
 
-// injectServiceAnnotations ensures the merged values express a LoadBalancer service when
-// LoadBalancerEnabled is true. It (a) sets service.type to LoadBalancer if absent — defense
-// in depth so the type can never go missing regardless of which values path is taken — and
-// (b) merges the MetalLB address-pool annotation into service.annotations.
+// injectServiceAnnotations resolves the main block-node service's exposure in the merged
+// Helm values. It owns two independent decisions:
 //
-// When the operator's values file already contains either field, the existing value is
-// left untouched. An explicit non-LoadBalancer service.type triggers a warning so the
-// mismatch is visible in logs without weaver clobbering an explicit operator choice.
-// When LoadBalancerEnabled is false the values are returned unchanged.
+//  1. service.type — weaver's single source of truth for the main service type (the base
+//     values template no longer hardcodes it; see issue #926). When the operator left the
+//     type unset it defaults to LoadBalancer; an explicit operator service.type is honored.
+//  2. the MetalLB metallb.io/address-pool annotation — injected onto service.annotations
+//     only when LoadBalancerEnabled is true (the environment has MetalLB). When false, the
+//     main service is left a plain LoadBalancer (best-effort; the auto-allocated NodePort
+//     still serves) with no pool tag.
 //
-// Exception (issue #900): when the operator enables the chart's own loadBalancer block
-// (loadBalancer.enabled: true — the "split topology": a ClusterIP main Service plus a
-// separate "-external" LoadBalancer Service), the chart renders that external Service and
-// applies its annotations from .Values.loadBalancer.annotations. In that case weaver defers
-// entirely to the chart: it does not warn about a ClusterIP service.type and does not inject
-// a MetalLB annotation onto the main service (which would be inert there, since MetalLB
-// ignores non-LoadBalancer services). The reachability probe already locates the chart's
-// "-external" Service, so no service.* injection is needed.
+// Decoupling the two is deliberate: --load-balancer-enabled governs MetalLB annotation
+// injection, not the base service type. So a no-MetalLB install (LoadBalancerEnabled=false)
+// preserves the historical LoadBalancer main service without a pool annotation, rather than
+// silently dropping to the chart's ClusterIP default.
+//
+// Split topology (issues #900 / #926): when the operator enables the chart's own
+// loadBalancer block (loadBalancer.enabled: true — a ClusterIP main Service plus a separate
+// "-external" LoadBalancer Service), the chart renders that external Service and applies its
+// annotations from .Values.loadBalancer.annotations, and the main service keeps the chart's
+// ClusterIP default. Weaver defers entirely: it imposes no service.type (so the chart's
+// ClusterIP stands) and injects no MetalLB annotation onto the main service (which would be
+// inert, since MetalLB ignores non-LoadBalancer services). This defer holds regardless of
+// LoadBalancerEnabled. The reachability probe already locates the chart's "-external"
+// Service, so no service.* injection is needed.
 func (m *Manager) injectServiceAnnotations(valuesContent []byte) ([]byte, error) {
-	if !m.blockNodeInputs.LoadBalancerEnabled {
-		return valuesContent, nil
-	}
-
 	var vals map[string]interface{}
 	if err := yaml.Unmarshal(valuesContent, &vals); err != nil {
 		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse values YAML for service annotation injection")
 	}
 
-	// Issue #900: if the operator drives the external endpoint through the chart's own
-	// loadBalancer block, the chart owns the "-external" Service and its annotations. Weaver
-	// must not warn about a ClusterIP main service.type or inject an inert MetalLB annotation
-	// onto it — defer entirely to the chart.
+	// Split topology (#900/#926): the operator drives the external endpoint through the
+	// chart's own loadBalancer block, so the chart owns the "-external" Service and its
+	// annotations while the main service keeps the chart's ClusterIP default. Weaver must not
+	// impose a service.type or inject an inert MetalLB annotation onto the main service —
+	// defer entirely to the chart, whether or not MetalLB is enabled.
 	if chartOwnsLoadBalancer(vals) {
 		logx.As().Debug().Msg("values enable the chart's loadBalancer block; deferring the external Service and its MetalLB annotation to the chart (skipping service.* injection)")
 		return valuesContent, nil
@@ -449,38 +453,52 @@ func (m *Manager) injectServiceAnnotations(valuesContent []byte) ([]byte, error)
 		defaultPool   = "public-address-pool"
 	)
 
+	lbEnabled := m.blockNodeInputs.LoadBalancerEnabled
 	mutated := false
 
+	// Default the main service to LoadBalancer when the operator left the type unset. This
+	// holds regardless of --load-balancer-enabled: on the non-split path weaver always wants a
+	// LoadBalancer-shaped main service. An explicit operator service.type is honored; when
+	// MetalLB is enabled a non-LoadBalancer type also warns, since verify-block-node-reachable
+	// will then find no external IP.
 	switch t := service[typeKey].(type) {
 	case nil:
 		service[typeKey] = typeLB
-		logx.As().Info().Msg("Injecting service.type: LoadBalancer (LoadBalancerEnabled=true and no operator override)")
+		logx.As().Info().Msg("Defaulting service.type: LoadBalancer (no operator override)")
 		mutated = true
 	case string:
-		if t != typeLB {
+		if t != typeLB && lbEnabled {
 			logx.As().Warn().
 				Str("service.type", t).
 				Msg("LoadBalancerEnabled=true but operator values set service.type to a non-LoadBalancer value; leaving as-is — verify-block-node-reachable will fail")
 		}
 	default:
+		// A non-string service.type is malformed regardless of MetalLB — warn
+		// unconditionally so it can't slip through silently when
+		// --load-balancer-enabled=false and cause confusing Helm behavior.
 		logx.As().Warn().
 			Str("service.type", fmt.Sprintf("%v", t)).
-			Msg("LoadBalancerEnabled=true but operator values set service.type to a non-string value; leaving as-is")
+			Msg("operator values set service.type to a non-string value; leaving as-is — this is almost certainly a values-file mistake")
 	}
 
-	annotations, ok := service["annotations"].(map[string]interface{})
-	if !ok {
-		annotations = make(map[string]interface{})
-	}
-	if existing, alreadySet := annotations[annotationKey]; alreadySet {
-		logx.As().Debug().
-			Str(annotationKey, fmt.Sprintf("%v", existing)).
-			Msg("metallb.io/address-pool already set in values file; skipping injection")
-	} else {
-		annotations[annotationKey] = defaultPool
-		service["annotations"] = annotations
-		logx.As().Info().Msg("Injecting MetalLB address-pool annotation into service.annotations")
-		mutated = true
+	// The MetalLB address-pool annotation is only meaningful when the environment has MetalLB
+	// (--load-balancer-enabled, default true). When disabled, leave the main service a plain
+	// LoadBalancer without tagging a pool.
+	if lbEnabled {
+		annotations, ok := service["annotations"].(map[string]interface{})
+		if !ok {
+			annotations = make(map[string]interface{})
+		}
+		if existing, alreadySet := annotations[annotationKey]; alreadySet {
+			logx.As().Debug().
+				Str(annotationKey, fmt.Sprintf("%v", existing)).
+				Msg("metallb.io/address-pool already set in values file; skipping injection")
+		} else {
+			annotations[annotationKey] = defaultPool
+			service["annotations"] = annotations
+			logx.As().Info().Msg("Injecting MetalLB address-pool annotation into service.annotations")
+			mutated = true
+		}
 	}
 
 	if !mutated {

--- a/internal/templates/files/block-node/full-values.yaml
+++ b/internal/templates/files/block-node/full-values.yaml
@@ -99,9 +99,13 @@ plugins:
       url: https://central.sonatype.com/repository/maven-snapshots
       snapshots: true
 
+# service.type is intentionally NOT set here. Weaver decides the main service type at
+# deploy time (internal/blocknode/values.go: injectServiceAnnotations): it defaults to
+# LoadBalancer on the single-service path, and defers to the chart's ClusterIP default on
+# the split topology (loadBalancer.enabled: true). Hardcoding it here would override the
+# chart's ClusterIP default for split installs — see issue #926.
 service:
-  type: LoadBalancer
   port: 40840
-  
+
 loadBalancer:
   enabled: false

--- a/internal/templates/files/block-node/nano-values.yaml
+++ b/internal/templates/files/block-node/nano-values.yaml
@@ -118,8 +118,12 @@ loki:
 promtail:
   enabled: false
 
+# service.type is intentionally NOT set here. Weaver decides the main service type at
+# deploy time (internal/blocknode/values.go: injectServiceAnnotations): it defaults to
+# LoadBalancer on the single-service path, and defers to the chart's ClusterIP default on
+# the split topology (loadBalancer.enabled: true). Hardcoding it here would override the
+# chart's ClusterIP default for split installs — see issue #926.
 service:
-  type: LoadBalancer
   port: 40840
 
 loadBalancer:


### PR DESCRIPTION
## Description

In the block-node **split topology** — the operator sets `loadBalancer.enabled: true` so the chart renders its own `<release>-block-node-server-external` LoadBalancer and relies on the chart's `service.type: ClusterIP` default for the main service — the main `<release>-block-node-server` service came up as `LoadBalancer` too, externally publishing the internal metrics (`16007`) and plugin (`40983`) ports and wasting a second MetalLB IP.

Root cause: weaver's base values templates hardcoded `service.type: LoadBalancer`, and weaver writes that template through Helm's `-f` layer, which overrides the chart's own `values.yaml` (`ClusterIP`). The [#900](https://github.com/hashgraph/solo-weaver/issues/900) fix deferred to the chart *after* the base template had already forced the type, so the value stood.

This removes the hardcode from `nano/full-values.yaml` and makes `injectServiceAnnotations` the single source of truth for the main service type. The key design decision is **decoupling the two concerns the old code conflated**: `--load-balancer-enabled` now governs only MetalLB annotation injection, not the base service type. So:

- single-service path → `service.type` defaults to `LoadBalancer` (+ MetalLB annotation when enabled) — **unchanged**;
- split path (`loadBalancer.enabled: true`) → weaver imposes no type, so the chart's `ClusterIP` stands — **the fix**;
- `--load-balancer-enabled=false` (no MetalLB) → main service stays `LoadBalancer` **without** a pool annotation, preserving prior behavior rather than silently dropping to `ClusterIP`;
- an explicit operator `service.type` is always honored — and removing the base-template pre-seed is what finally makes an explicit operator value distinguishable from the base default.

Observed before the fix (provisioner v0.26.0, split topology):

```
NAME                                    TYPE           EXTERNAL-IP     PORT(S)
block-node-block-node-server            LoadBalancer   192.168.99.0    40840,16007,40983
block-node-block-node-server-external   LoadBalancer   152.236.24.7    40840
```

### Files changed

| File | Change |
|---|---|
| `internal/templates/files/block-node/nano-values.yaml` | Drop hardcoded `service.type: LoadBalancer` (keep `port`); comment explaining weaver owns the type |
| `internal/templates/files/block-node/full-values.yaml` | Same |
| `internal/blocknode/values.go` | Restructure `injectServiceAnnotations`: type default decoupled from `--load-balancer-enabled`; defer to chart on split path; preserve LoadBalancer (no annotation) when MetalLB disabled |
| `internal/blocknode/manager_test.go` | Rework the disabled-case test; add split-no-operator-type, split-disabled, and explicit-ClusterIP cases |
| `docs/block-node-service-exposure.md` | New operator doc: decision table + three showcases with `kubectl get svc` output |
| `docs/quickstart.md` | Cross-link the new doc from the `--load-balancer-enabled` flag row |

### Review guide

**Checklist**
- `internal/blocknode/values.go` — `chartOwnsLoadBalancer` gate now runs *before* the `--load-balancer-enabled` check, so the split path defers regardless of the flag.
- `injectServiceAnnotations` sets `service.type: LoadBalancer` for the `nil` (unset) case only; an explicit operator string is left untouched (warns only when MetalLB is enabled and the type is non-LoadBalancer).
- MetalLB annotation injection is gated on `lbEnabled`; case C mutates the type but injects no annotation.
- Templates: `service.type` removed, `port: 40840` retained.

**Test commands**
```bash
go test ./internal/blocknode/ -run TestInjectServiceAnnotations -tags='!integration' -v
task test:unit            # or task vm:test:unit for the full Linux suite
```

#### Manual UAT

Run on a UTM VM (or any host) where `block node install` provisions the cluster including MetalLB. All cases share these settings so the `kubectl` output is deterministic:

```bash
export PROFILE=mainnet          # a profile whose cluster install lays down MetalLB
export NS=block-node            # --namespace
export REL=block-node           # --release-name  → services are named <REL>-block-node-server
```

Between cases, tear down so each install is clean:

```bash
sudo solo-provisioner block node uninstall --profile="$PROFILE" --namespace="$NS" --release-name="$REL"
```

---

**Case 1 — Split topology (the fix): main service must be `ClusterIP`, only `-external` is the LB.**

Create the operator values file:

```bash
cat > /tmp/split-values.yaml <<'EOF'
service:
  port: 40840
loadBalancer:
  enabled: true
  port: "40840"
  annotations:
    metallb.io/address-pool: "public-address-pool"
EOF
```

Install (leave `--load-balancer-enabled` at its default of `true`):

```bash
sudo solo-provisioner block node install \
  --profile="$PROFILE" \
  --namespace="$NS" \
  --release-name="$REL" \
  --values=/tmp/split-values.yaml
```

Verify:

```bash
kubectl get svc -n "$NS"
```

Expected — main service `ClusterIP` (no external IP), only `-external` is a `LoadBalancer` with a single external IP (verified on a live VM):

```
NAME                                    TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)               AGE
block-node-block-node-server            ClusterIP      10.0.255.197   <none>          40840/TCP,16007/TCP   14m
block-node-block-node-server-external   LoadBalancer   10.0.12.108    192.168.8.247   40840:30698/TCP       14m
```

---

**Case 2 — Default single-service: main service stays `LoadBalancer` + MetalLB annotation (unchanged).**

No `-f` needed — install with defaults:

```bash
sudo solo-provisioner block node install \
  --profile="$PROFILE" \
  --namespace="$NS" \
  --release-name="$REL"
```

Verify the type and the injected annotation:

```bash
kubectl get svc -n "$NS"
kubectl get svc "$REL-block-node-server" -n "$NS" \
  -o jsonpath='{.metadata.annotations.metallb\.io/address-pool}{"\n"}'
```

Expected — one `LoadBalancer` service, annotation present (verified on a live VM):

```
NAME                           TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                           AGE
block-node-block-node-server   LoadBalancer   10.0.218.108   192.168.8.247   40840:32429/TCP,16007:32339/TCP   26s
```
```
public-address-pool
```

---

**Case 3 — Explicit operator `service.type: ClusterIP` is honored.**

Because the reachability probe is gated on `--load-balancer-enabled` (it dials the main LoadBalancer's external IP), forcing the main service to `ClusterIP` only makes sense together with `--load-balancer-enabled=false` — otherwise the probe correctly fails the install (see the note below). Install with both:

```bash
cat > /tmp/clusterip-values.yaml <<'EOF'
service:
  type: ClusterIP
  port: 40840
EOF

sudo solo-provisioner block node install \
  --profile="$PROFILE" \
  --namespace="$NS" \
  --release-name="$REL" \
  --load-balancer-enabled=false \
  --values=/tmp/clusterip-values.yaml
```

Expected — install succeeds, the reachability probe is skipped, and the main service is `ClusterIP` with no MetalLB annotation:

```bash
kubectl get svc "$REL-block-node-server" -n "$NS"
```
```
NAME                           TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)
block-node-block-node-server   ClusterIP   10.0.x.x      <none>        40840/TCP,16007/TCP
```

> **Note (pre-existing, by design):** setting `service.type: ClusterIP` while leaving
> `--load-balancer-enabled=true` (the default) is a contradictory request — weaver honors the
> ClusterIP and logs `… service.type to a non-LoadBalancer value; leaving as-is`, but the
> `verify-block-node-reachable` step (which only runs when `--load-balancer-enabled=true`) then
> finds no LoadBalancer Service and fails the install:
> ```
> ✗ Verifying Block Node external reachability
>   common.illegal_state: no LoadBalancer Service found in namespace block-node; cannot probe reachability
> ```
> This behavior is unchanged by this PR. If you want a ClusterIP main service, disable the probe
> with `--load-balancer-enabled=false` as above.

---

**Case 4 — Upgrading an existing (broken) split install: needs `--no-reuse-values`.**

Install with a provisioner build **before** this fix using `/tmp/split-values.yaml` (main service comes up `LoadBalancer` — the bug baked into the release's stored values). A **default** upgrade with this build does **not** fix it: `block node upgrade` reuses the old release's values (Helm `ResetThenReuseValues`), so the stale `service.type: LoadBalancer` is retained and weaver's freshly rendered values no longer set `service.type` to override it. To heal it, reset the reused values:

```bash
sudo solo-provisioner block node upgrade --no-reuse-values \
  --profile="$PROFILE" \
  --namespace="$NS" \
  --release-name="$REL" \
  --values=/tmp/split-values.yaml

kubectl get svc -n "$NS"
```

Expected — after the `--no-reuse-values` upgrade the main service is `ClusterIP` and MetalLB releases the redundant second external IP (only `-external` keeps one). (A plain `upgrade` without `--no-reuse-values` leaves the main service `LoadBalancer` — reused stale value — which is the correct, documented behavior; re-supply the full `-f` when using `--no-reuse-values`.)

**Risks / rollback**
- **This fix corrects fresh installs only; it does not auto-heal existing installs on a default upgrade.** Because `block node upgrade` reuses the previous release's values, a split (or no-MetalLB) cluster installed with an older provisioner keeps its baked-in `service.type: LoadBalancer` until the operator upgrades with `--no-reuse-values` or re-asserts `service.type: ClusterIP` in their `-f`. Documented in `docs/block-node-service-exposure.md`. Fresh installs and the default single-LB path are unaffected/unchanged.
- Rollback is template + test only; revert the commit. No state/schema migration to unwind.

### Related Issues

* Closes #926
