### PR TITLE
feat(blocknode): enable/disable firewall & traffic shaping on reconfigure/upgrade

### DIFF
--- a/cmd/cli/commands/block/node/install.go
+++ b/cmd/cli/commands/block/node/install.go
@@ -45,7 +45,7 @@ var installCmd = &cobra.Command{
 		// The traffic-shaping gate is independent of the host firewall — it
 		// covers the BN workload network-policy plane and tc HTB shaping, not
 		// the host's own SSH/mgmt firewall.
-		trafficShapingEnabled, err := common.ResolveTrafficShapingConfig(cmd, args, cv)
+		trafficShapingEnabled, err := common.ResolveTrafficShapingConfig(cmd, args, cv, false)
 		if err != nil {
 			return err
 		}
@@ -70,7 +70,7 @@ var installCmd = &cobra.Command{
 
 		// Host firewall is independently gated from traffic shaping above — it
 		// applies regardless of whether the BN policy plane/tc shaping is enabled.
-		if err := common.ResolveHostFirewallConfig(cmd, args, cv); err != nil {
+		if err := common.ResolveHostFirewallConfig(cmd, args, cv, false); err != nil {
 			return err
 		}
 

--- a/cmd/cli/commands/block/node/reconfigure.go
+++ b/cmd/cli/commands/block/node/reconfigure.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/network/firewall"
 	"github.com/hashgraph/solo-weaver/internal/state"
-	workflowsteps "github.com/hashgraph/solo-weaver/internal/workflows/steps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/spf13/cobra"
 )
@@ -67,16 +66,14 @@ var (
 			}
 			inputs.Custom.TrafficShapingEnabled = trafficShapingEnabled
 
-			// Egress NIC/bandwidth and the daemon binary source are only needed when
-			// enabling traffic shaping — declining or disabling leaves nothing to
-			// configure or activate here.
-			var daemonSource workflowsteps.DaemonBinarySource
+			// Egress NIC/bandwidth is needed before the workflow because its tc steps
+			// consume EgressInterface/LinkRate — declining or disabling leaves nothing
+			// to configure here. The daemon binary source is resolved later, AFTER the
+			// workflow (see below): resolving it here would let a missing --daemon-bin
+			// on --profile=local preempt the clearer "block node is not installed"
+			// precondition error on a fresh host.
 			if trafficShapingEnabled {
 				if err := common.ResolveEgressConfig(cmd, args, cv, &flagEgressInterface, &flagLinkRate); err != nil {
-					return err
-				}
-				daemonSource, err = resolveDaemonBinarySource(cmd, args, inputs.Custom.Profile, cv)
-				if err != nil {
 					return err
 				}
 			}
@@ -129,6 +126,15 @@ var (
 			// daemon-config step turns the block-node monitor off without uninstalling
 			// the shared service.
 			if trafficShapingEnabled {
+				// Resolve the daemon binary source now — only after the reconfigure
+				// workflow (including its "block node is not installed" precondition) has
+				// succeeded — so a missing --daemon-bin on --profile=local cannot mask
+				// that clearer precondition error. This mirrors upgrade, which likewise
+				// activates the daemon post-workflow.
+				daemonSource, err := resolveDaemonBinarySource(cmd, args, inputs.Custom.Profile, cv)
+				if err != nil {
+					return err
+				}
 				// bnNamespace is only a fallback orbit for provisionBlockNodeDaemon: the
 				// workflow's daemon-config step already persisted the resolved namespace
 				// (never empty — it defaults to the block-node orbit) into daemon.yaml,

--- a/cmd/cli/commands/block/node/reconfigure.go
+++ b/cmd/cli/commands/block/node/reconfigure.go
@@ -3,11 +3,15 @@
 package node
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/internal/network/firewall"
+	"github.com/hashgraph/solo-weaver/internal/state"
+	workflowsteps "github.com/hashgraph/solo-weaver/internal/workflows/steps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/spf13/cobra"
 )
@@ -30,19 +34,57 @@ var (
 				return err
 			}
 
-			inputs, cv, err := prepareBlocknodeInputs(cmd, args)
+			shapeOverrides, err := common.ParseShapeOverrides(flagShape)
 			if err != nil {
 				return err
 			}
 
-			if err := common.ResolveEgressConfig(cmd, args, cv, &flagEgressInterface, &flagLinkRate); err != nil {
+			inputs, cv, err := prepareBlocknodeInputs(cmd, args)
+			if err != nil {
 				return err
+			}
+			inputs.Custom.ShapeOverrides = shapeOverrides
+
+			// Seed the enable/disable prompts from the block node's CURRENT state so a
+			// no-flag / default-accept reconfigure keeps whatever is already deployed
+			// and only an explicit toggle enables or tears a feature down. Traffic
+			// shaping's current state comes from the persisted install decision; the
+			// host firewall's from whether the inet host table currently exists.
+			stateDefaults, err := state.ReadPromptDefaultsFromDisk()
+			if err != nil {
+				logx.As().Debug().Err(err).Msg("could not read state file for reconfigure seeds; using conservative defaults")
+			}
+			currentTrafficShaping := !stateDefaults.BlockNode.TrafficShapingDisabled
+			firewallSeed := currentFirewallEnabledSeed(cmd, cmd.Context())
+
+			// Traffic shaping is independently gated from the host firewall — it covers
+			// the BN workload network-policy plane, tc HTB shaping, and the daemon's
+			// traffic-shaper monitor. Enabling on a previously-declined install creates
+			// all three; explicitly disabling tears them down (see networkPlaneSteps).
+			trafficShapingEnabled, err := common.ResolveTrafficShapingConfig(cmd, args, cv, currentTrafficShaping)
+			if err != nil {
+				return err
+			}
+			inputs.Custom.TrafficShapingEnabled = trafficShapingEnabled
+
+			// Egress NIC/bandwidth and the daemon binary source are only needed when
+			// enabling traffic shaping — declining or disabling leaves nothing to
+			// configure or activate here.
+			var daemonSource workflowsteps.DaemonBinarySource
+			if trafficShapingEnabled {
+				if err := common.ResolveEgressConfig(cmd, args, cv, &flagEgressInterface, &flagLinkRate); err != nil {
+					return err
+				}
+				daemonSource, err = resolveDaemonBinarySource(cmd, args, inputs.Custom.Profile, cv)
+				if err != nil {
+					return err
+				}
 			}
 			// prepareBlocknodeInputs ran before the prompts; patch in the final values.
 			inputs.Custom.EgressInterface = flagEgressInterface
 			inputs.Custom.LinkRate = flagLinkRate
 
-			if err := common.ResolveHostFirewallConfig(cmd, args, cv); err != nil {
+			if err := common.ResolveHostFirewallConfig(cmd, args, cv, firewallSeed); err != nil {
 				return err
 			}
 
@@ -78,10 +120,51 @@ var (
 			}
 
 			logx.As().Info().Msg("Successfully reconfigured Hedera Block Node")
+
+			// Daemon activation is part of the traffic-shaping bundle (mirroring
+			// install): when traffic shaping is enabled, ensure the daemon service is
+			// installed and running so the block-node traffic-shaper monitor written
+			// into daemon.yaml by the workflow actually runs. It is a no-op when the
+			// daemon is already up. Disabling leaves the daemon alone — the workflow's
+			// daemon-config step turns the block-node monitor off without uninstalling
+			// the shared service.
+			if trafficShapingEnabled {
+				// bnNamespace is only a fallback orbit for provisionBlockNodeDaemon: the
+				// workflow's daemon-config step already persisted the resolved namespace
+				// (never empty — it defaults to the block-node orbit) into daemon.yaml,
+				// which provisionBlockNodeDaemon reads as the source of truth. So an empty
+				// value here (e.g. a state-read miss) does not produce an empty orbit.
+				bnNamespace := inputs.Custom.Namespace
+				if bnNamespace == "" {
+					bnNamespace = stateDefaults.BlockNode.Namespace
+				}
+				if err := ensureBlockNodeDaemon(cmd, bnNamespace, daemonSource); err != nil {
+					return err
+				}
+			}
+
 			return nil
 		},
 	}
 )
+
+// currentFirewallEnabledSeed returns the default the reconfigure host-firewall
+// prompt should fall back to: whether the inet host table is currently present on
+// the host. When the flag was set on the CLI the seed is unused (the flag wins),
+// so it returns false without probing. If the probe fails it biases to enabled so
+// an unreadable state never leads to an accidental teardown on default-accept.
+func currentFirewallEnabledSeed(cmd *cobra.Command, ctx context.Context) bool {
+	if cmd.Flags().Changed(common.FlagNameFirewallEnabled) {
+		return false
+	}
+	active, err := firewall.NewManager().IsActive(ctx)
+	if err != nil {
+		logx.As().Debug().Err(err).Msg(
+			"could not probe the inet host table; seeding the firewall prompt as enabled to avoid accidental teardown")
+		return true
+	}
+	return active
+}
 
 func init() {
 	common.FlagWithStorageReset().SetVarP(reconfigureCmd, &flagWithReset, false)
@@ -90,5 +173,11 @@ func init() {
 	common.FlagNoReuseValues().SetVarP(reconfigureCmd, &flagNoReuseValues, false)
 	common.FlagNoRestart().SetVar(reconfigureCmd, &flagNoRestart, false)
 	common.RegisterHostFirewallFlags(reconfigureCmd)
+	common.RegisterTrafficShapingFlags(reconfigureCmd)
 	common.RegisterEgressFlags(reconfigureCmd, &flagEgressInterface, &flagLinkRate)
+	reconfigureCmd.Flags().StringArrayVar(&flagShape, common.FlagNameShape, nil,
+		"Per-class HTB bandwidth override, repeatable: --shape <class>=rate=<r>,ceil=<c>,prio=<p> "+
+			"(e.g. --shape publisher=rate=800mbit,ceil=1gbit,prio=0). Only applied when traffic shaping is enabled.")
+	common.FlagDaemonBin().SetVarP(reconfigureCmd, &flagDaemonBin, false)
+	common.FlagDaemonVersion().SetVarP(reconfigureCmd, &flagDaemonVersion, false)
 }

--- a/cmd/cli/commands/block/node/upgrade.go
+++ b/cmd/cli/commands/block/node/upgrade.go
@@ -8,6 +8,8 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/internal/state"
+	workflowsteps "github.com/hashgraph/solo-weaver/internal/workflows/steps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/spf13/cobra"
 )
@@ -62,6 +64,30 @@ var (
 			}
 
 			logx.As().Info().Msg("Successfully upgraded Hedera Block Node")
+
+			// Silent convergence: upgrade does not prompt or expose a gate — it reads
+			// the persisted install-time traffic-shaping decision. When that decision
+			// was "enabled", ensure the daemon service is running so the block-node
+			// traffic-shaper monitor (re-asserted in daemon.yaml by the workflow)
+			// actually runs. It is a no-op when the daemon is already up, which is the
+			// normal case for an already-shaped block node.
+			//
+			// If the persisted decision can't be read, skip activation rather than
+			// guessing: TrafficShapingDisabled's zero value reads as "enabled" (negative
+			// polarity), so proceeding on a read error would wrongly activate the daemon
+			// (with an empty namespace) for a node that may have traffic shaping disabled.
+			// The workflow already re-asserted daemon.yaml from the authoritative
+			// state-manager view, and a running daemon is unaffected.
+			stateDefaults, sErr := state.ReadPromptDefaultsFromDisk()
+			switch {
+			case sErr != nil:
+				logx.As().Warn().Err(sErr).Msg(
+					"skipping traffic-shaper daemon activation on upgrade: could not read the persisted traffic-shaping decision")
+			case !stateDefaults.BlockNode.TrafficShapingDisabled:
+				if err := ensureBlockNodeDaemon(cmd, stateDefaults.BlockNode.Namespace, workflowsteps.DaemonBinarySource{}); err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}

--- a/cmd/cli/commands/common/host_firewall.go
+++ b/cmd/cli/commands/common/host_firewall.go
@@ -113,19 +113,23 @@ func RegisterHostFirewallFlags(cmd *cobra.Command) {
 // summary after all prompt sections complete. When cv is nil a local collector
 // is used and printed as "Host Firewall" immediately.
 //
+// seedEnabled is the default the enable/disable choice falls back to when neither
+// the flag nor an interactive prompt decides it. `install` passes false (opt-in —
+// a fresh install without the flag installs no firewall), while `reconfigure`
+// passes whether the inet host table currently exists on the host, so a no-flag /
+// default-accept reconfigure keeps the current state rather than silently tearing
+// an established firewall down. It is intentionally NOT derived from cfg.Disabled:
+// config.yaml's zero value cannot distinguish "enabled" from "never configured".
+//
 // It requires RegisterHostFirewallFlags to have been called on cmd.
-func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues) error {
+func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues, seedEnabled bool) error {
 	force, err := FlagForce().Value(cmd, args)
 	if err != nil {
 		return errorx.IllegalArgument.Wrap(err, "failed to get %s flag", FlagForce().Name)
 	}
 
 	cfg := config.Get().Host
-	// Seeded false (opt-in), not derived from cfg.Disabled: this is a one-shot
-	// default for "nothing specified anywhere," not a round-tripped decision —
-	// config.yaml's zero value is indistinguishable from "not mentioned," so it
-	// can never safely override this default toward "enabled."
-	firewallEnabled := effectiveBool(cmd, FlagNameFirewallEnabled, false)
+	firewallEnabled := effectiveBool(cmd, FlagNameFirewallEnabled, seedEnabled)
 
 	// Prompt for the enable/disable choice only when it wasn't already decided
 	// on the CLI. Declining here skips the allowlist/port prompts below entirely

--- a/cmd/cli/commands/common/traffic_shaping.go
+++ b/cmd/cli/commands/common/traffic_shaping.go
@@ -36,17 +36,23 @@ func RegisterTrafficShapingFlags(cmd *cobra.Command) {
 // Declining skips all of it: there is nothing for any of them to configure
 // once the policy plane itself is off.
 //
+// seedEnabled is the default the choice falls back to when neither the flag nor
+// an interactive prompt decides it: `install` passes false (opt-in — a fresh
+// install without the flag stays unshaped), while `reconfigure` passes the block
+// node's CURRENT traffic-shaping state (from BlockNodeState.TrafficShapingDisabled)
+// so a no-flag / default-accept reconfigure keeps the existing decision rather than
+// silently tearing an established plane down.
+//
 // It requires RegisterTrafficShapingFlags to have been called on cmd.
-func ResolveTrafficShapingConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues) (bool, error) {
+func ResolveTrafficShapingConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues, seedEnabled bool) (bool, error) {
 	force, err := FlagForce().Value(cmd, args)
 	if err != nil {
 		return false, errorx.IllegalArgument.Wrap(err, "failed to get %s flag", FlagForce().Name)
 	}
 
-	// Seeded false (opt-in) so existing non-interactive/scripted installs that
-	// don't pass this flag keep today's behavior rather than silently picking
-	// up the policy plane, tc shaping, and daemon install.
-	enabled := effectiveBool(cmd, FlagNameTrafficShapingEnabled, false)
+	// Seeded from the caller-supplied default (opt-in false for install; the
+	// current persisted state for reconfigure), overridden by the flag when set.
+	enabled := effectiveBool(cmd, FlagNameTrafficShapingEnabled, seedEnabled)
 
 	// Prompt for the enable/disable choice only when it wasn't already decided
 	// on the CLI. Declining here skips the egress prompts below entirely —

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -310,6 +310,13 @@ sudo solo-provisioner block node upgrade \
 | `--with-reset`      | Wipe block node data directories; PVs and PVCs are preserved | `false` |
 | `--timeout`         | Timeout for the block node Helm install/upgrade, as a Go duration (e.g. `10m`, `600s`, `1h`). The operation is rolled back (`--atomic`) if it exceeds this budget | `5m0s` |
 
+> **Firewall & traffic shaping on upgrade**: `upgrade` does **not** expose the
+> `--firewall-enabled` / `--traffic-shaping-enabled` gates and never prompts for
+> them — a version bump is a routine operation, so it reads the persisted install
+> decision and silently re-asserts the matching network plane (host firewall,
+> BN policy plane, tc shaping, daemon monitor) create-if-missing. It never turns a
+> feature on or off from an upgrade; to change enablement, use `reconfigure`.
+
 #### Reset Block Node
 
 Reset Block Node storage by clearing all data files. This is useful for re-provisioning or when you need to start fresh:
@@ -373,6 +380,16 @@ sudo solo-provisioner block node reconfigure \
   --profile=mainnet \
   --values=/path/to/values.yaml \
   --no-restart
+
+# Enable traffic shaping on a block node that was installed without it
+sudo solo-provisioner block node reconfigure \
+  --profile=mainnet \
+  --traffic-shaping-enabled=true
+
+# Disable the host firewall that was previously enabled (tears the table down)
+sudo solo-provisioner block node reconfigure \
+  --profile=mainnet \
+  --firewall-enabled=false
 ```
 
 **Additional Flags**:
@@ -383,11 +400,29 @@ sudo solo-provisioner block node reconfigure \
 | `--no-restart`      | Skip rollout-restart of the block node pod after reconfiguring                                        | `false` |
 | `--with-reset`      | Wipe block node data directories; PVs and PVCs are preserved                                          | `false` |
 | `--purge-storage`   | Delete PersistentVolumes and PersistentVolumeClaims in addition to wiping data (implies --with-reset) | `false` |
+| `--firewall-enabled` | Enable or disable the node-level host firewall (`inet host` table) on an existing install. Seeded from the firewall's current on-host state, so a no-flag reconfigure keeps it as-is; pass `=false` to tear the table down, `=true` (with `--mgmt-cidrs`) to create it. Same sub-flags as `install` (`--mgmt-cidrs`, `--blocked-cidrs`, `--ssh-port`, `--pod-cidr`, `--in-cluster-ports`). | current state |
+| `--traffic-shaping-enabled` | Enable or disable the BN traffic-shaping bundle (network-policy plane + tc HTB shaping + daemon traffic-shaper monitor) on an existing install. Seeded from the persisted install decision, so a no-flag reconfigure keeps it; pass `=true` to create it (with `--egress-interface`/`--link-rate`/`--shape`/`--daemon-bin` as on `install`), `=false` to tear it down. | persisted state |
 
 > **Storage path changes**: Local PV `hostPath.path` is immutable. If your
 > reconfigure changes any storage path, you must pass `--purge-storage` so the
 > existing PV/PVCs are deleted and recreated at the new paths. Running
 > `reconfigure --with-reset` with a path change is rejected with a clear error.
+
+> **Enabling/disabling firewall & traffic shaping after install**: `reconfigure`
+> exposes the same `--firewall-enabled` / `--traffic-shaping-enabled` gates as
+> `install`, so an operator can turn either feature on or off on an
+> already-deployed block node without a full `install --force` reinstall. Both
+> gates are seeded from the block node's **current** state — the host firewall from
+> whether the `inet host` table exists, traffic shaping from the persisted install
+> decision — so a routine reconfigure that doesn't pass the flag (or accepts the
+> interactive default) never changes enablement. Teardown only happens on an
+> explicit toggle: answering **No** (or passing `=false`) for a currently-enabled
+> feature removes it — the `inet host` table for the firewall; every `bn-*` policy,
+> the tc egress shaping, and the daemon's block-node traffic-shaper monitor for
+> traffic shaping. Disabling the traffic-shaper monitor does **not** uninstall the
+> shared daemon service, so a co-located component (e.g. consensus-node monitoring)
+> keeps running. Enabling traffic shaping activates the daemon automatically, just
+> like `install`.
 
 #### Uninstall Block Node
 

--- a/internal/bll/blocknode/helpers.go
+++ b/internal/bll/blocknode/helpers.go
@@ -52,17 +52,18 @@ func patchBlockNodeState() func(st *state.State, effectiveInputs models.UserInpu
 	}
 }
 
-// patchBlockNodeStateAfterInstall extends patchBlockNodeState with the one
-// field that only `block node install` ever decides: TrafficShapingDisabled.
-// It must NOT live in the shared patchBlockNodeState — that callback is also
-// used by reconfigure/upgrade/reset/uninstall's HandleIntent, none of which
-// resolve or carry TrafficShapingEnabled, so their effectiveInputs.Custom
-// value is always the unset zero value and would silently flip a
-// true-at-install decision back to "disabled" on every later run. Recording it
-// only here, and only from InstallHandler, is what lets reconfigure/upgrade
-// read back the original decision (via currentState.BlockNodeState) without
-// ever having the chance to overwrite it themselves.
-func patchBlockNodeStateAfterInstall() func(st *state.State, effectiveInputs models.UserInputs[models.BlockNodeInputs]) error {
+// patchBlockNodeStateWithTrafficShaping extends patchBlockNodeState with the
+// TrafficShapingDisabled field, persisting the caller's resolved
+// TrafficShapingEnabled decision. It is used by the two commands that resolve a
+// real traffic-shaping target: `block node install` and `block node reconfigure`.
+//
+// It must NOT be used by upgrade/reset/uninstall — those do not resolve
+// TrafficShapingEnabled, so their effectiveInputs.Custom value is the unset zero
+// value and would silently flip a true decision back to "disabled" on every run.
+// Upgrade in particular reads the persisted decision (via
+// currentState.BlockNodeState) to drive its silent convergence and therefore keeps
+// the plain patchBlockNodeState, which leaves this field untouched.
+func patchBlockNodeStateWithTrafficShaping() func(st *state.State, effectiveInputs models.UserInputs[models.BlockNodeInputs]) error {
 	base := patchBlockNodeState()
 	return func(st *state.State, effectiveInputs models.UserInputs[models.BlockNodeInputs]) error {
 		st.BlockNodeState.TrafficShapingDisabled = !effectiveInputs.Custom.TrafficShapingEnabled

--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -135,7 +135,7 @@ func (h *InstallHandler) HandleIntent(
 	intent models.Intent,
 	inputs models.UserInputs[models.BlockNodeInputs],
 ) (*automa.Report, error) {
-	return h.BaseHandler.HandleIntent(ctx, intent, inputs, h, patchBlockNodeStateAfterInstall())
+	return h.BaseHandler.HandleIntent(ctx, intent, inputs, h, patchBlockNodeStateWithTrafficShaping())
 }
 
 func NewInstallHandler(

--- a/internal/bll/blocknode/network_plane.go
+++ b/internal/bll/blocknode/network_plane.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package blocknode
+
+import (
+	"github.com/automa-saga/automa"
+	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
+	"github.com/hashgraph/solo-weaver/pkg/config"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+)
+
+// networkPlaneSteps builds the static network-plane step list shared by
+// `block node reconfigure` and `block node upgrade`. Both converge the host
+// firewall and the BN traffic-shaping bundle (policy plane + tc HTB shaping +
+// daemon traffic-shaper monitor) to a desired target, differing only in how that
+// target is resolved and whether teardown is permitted:
+//
+//   - reconfigure resolves the target from the operator (prompt/flags) and passes
+//     allowTeardown=true, so turning a feature off deletes it.
+//   - upgrade resolves the target from persisted state and passes
+//     allowTeardown=false: it re-asserts (create-if-missing) whatever the install
+//     decision was, but never tears anything down from a routine version bump.
+//
+// Every step is idempotent, so the same list is safe to re-run: create steps are
+// create-if-missing and teardown steps are delete-if-present. The step ordering
+// mirrors NetworkSetupWorkflow — firewall first, then NetworkPolicyCreate before
+// NftWeaverPersist so the policy registry is populated when the weaver table is
+// rendered.
+//
+// trafficShapingEnabled is the resolved traffic-shaping target. force is the
+// operator's --force, threaded into NetworkPolicyCreate for the enable path.
+func networkPlaneSteps(ins models.BlockNodeInputs, force, trafficShapingEnabled, allowTeardown bool) []automa.Builder {
+	var out []automa.Builder
+
+	// Host firewall: desired-state convergence. NetworkFirewallCreate self-gates
+	// on config.Host.Disabled, so it is always safe to include; a delete only runs
+	// when teardown is permitted (reconfigure) AND the operator resolved the
+	// firewall to disabled.
+	if allowTeardown && config.Get().Host.Disabled {
+		out = append(out, steps.NetworkFirewallDelete())
+	} else {
+		out = append(out, steps.NetworkFirewallCreate())
+	}
+
+	switch {
+	case trafficShapingEnabled:
+		// Enable: create the BN policy plane, persist the weaver table, (re)provision
+		// tc egress/ingress shaping, and enable the daemon's traffic-shaper monitor.
+		// Daemon binary/service activation itself is handled post-workflow in the CLI
+		// (ensureBlockNodeDaemon), mirroring install.
+		shapeOverrides := toClassOverrides(ins.ShapeOverrides)
+		out = append(out,
+			steps.NetworkPolicyCreate(force),
+			steps.NftWeaverPersist(),
+			steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate, shapeOverrides),
+			steps.TcIngressRecord(ins.EgressInterface, ins.LinkRate, shapeOverrides),
+			steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace, true),
+		)
+	case allowTeardown:
+		// Disable: remove every BN policy (the last delete tears the inet weaver
+		// table down, so no NftWeaverPersist is needed), drop the tc egress hierarchy,
+		// and turn the daemon's block-node traffic-shaper monitor off without
+		// uninstalling the shared daemon service.
+		out = append(out,
+			steps.NetworkPolicyDeleteAll(),
+			steps.TcEgressTeardown(),
+			steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace, false),
+		)
+	}
+
+	return out
+}

--- a/internal/bll/blocknode/network_plane.go
+++ b/internal/bll/blocknode/network_plane.go
@@ -59,12 +59,19 @@ func networkPlaneSteps(ins models.BlockNodeInputs, force, trafficShapingEnabled,
 	case allowTeardown:
 		// Disable: remove every BN policy (the last delete tears the inet weaver
 		// table down, so no NftWeaverPersist is needed), drop the tc egress hierarchy,
-		// and turn the daemon's block-node traffic-shaper monitor off without
-		// uninstalling the shared daemon service.
+		// turn the daemon's block-node traffic-shaper monitor off, and restart the
+		// daemon so that change takes effect. The daemon reads daemon.yaml only at
+		// startup (no hot-reload), so without the restart the live monitor keeps
+		// running and re-applies the ingress $VETH HTB on the next BN pod create —
+		// which, on the default reconfigure path, is triggered by the rollout-restart
+		// that runs right after these network steps. Restarting here (before that pod
+		// churn) ensures the monitor is gone when the new veth appears, so it comes up
+		// unshaped. RestartDaemonServiceStep self-skips when the daemon is not running.
 		out = append(out,
 			steps.NetworkPolicyDeleteAll(),
 			steps.TcEgressTeardown(),
 			steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace, false),
+			steps.RestartDaemonServiceStep(),
 		)
 	}
 

--- a/internal/bll/blocknode/network_plane.go
+++ b/internal/bll/blocknode/network_plane.go
@@ -45,9 +45,17 @@ func networkPlaneSteps(ins models.BlockNodeInputs, force, trafficShapingEnabled,
 	switch {
 	case trafficShapingEnabled:
 		// Enable: create the BN policy plane, persist the weaver table, (re)provision
-		// tc egress/ingress shaping, and enable the daemon's traffic-shaper monitor.
-		// Daemon binary/service activation itself is handled post-workflow in the CLI
-		// (ensureBlockNodeDaemon), mirroring install.
+		// tc egress/ingress shaping, enable the daemon's traffic-shaper monitor, and
+		// restart the daemon so that change takes effect. The daemon reads daemon.yaml
+		// only at startup (no hot-reload) and the post-workflow ensureBlockNodeDaemon
+		// is a no-op when the daemon is already running — so re-enabling on a host
+		// where the daemon is up (e.g. a prior disable left it running with the
+		// monitor off) would otherwise never start the monitor, and the ingress $VETH
+		// HTB would never be (re)installed. Restarting here reloads daemon.yaml; the
+		// monitor's initial pod list then shapes the current pod's veth immediately,
+		// and the subsequent rollout-restart's new veth via a watch event.
+		// RestartDaemonServiceStep self-skips when the daemon is not running (fresh
+		// enable), where post-workflow ensureBlockNodeDaemon installs and starts it.
 		shapeOverrides := toClassOverrides(ins.ShapeOverrides)
 		out = append(out,
 			steps.NetworkPolicyCreate(force),
@@ -55,6 +63,7 @@ func networkPlaneSteps(ins models.BlockNodeInputs, force, trafficShapingEnabled,
 			steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate, shapeOverrides),
 			steps.TcIngressRecord(ins.EgressInterface, ins.LinkRate, shapeOverrides),
 			steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace, true),
+			steps.RestartDaemonServiceStep(),
 		)
 	case allowTeardown:
 		// Disable: remove every BN policy (the last delete tears the inet weaver

--- a/internal/bll/blocknode/reconfigure_handler.go
+++ b/internal/bll/blocknode/reconfigure_handler.go
@@ -56,17 +56,11 @@ func (h *ReconfigureHandler) BuildWorkflow(
 	ins := inputs.Custom
 
 	// networkSteps is the shared network-plane prefix for every branch below.
-	// TcEgressPersist is omitted when the install-time TrafficShapingEnabled
-	// decision (persisted onto BlockNodeState — see patchBlockNodeStateAfterInstall)
-	// was "no": reconfigure never resolves --traffic-shaping-enabled itself, so
-	// without this check it would silently re-provision tc shaping for a block
-	// node that was deliberately installed without it. NetworkFirewallCreate and
-	// NftWeaverPersist are always safe to include unconditionally — they
-	// self-gate (host-firewall disabled / empty policy registry respectively).
-	networkSteps := []automa.Builder{steps.NetworkFirewallCreate(), steps.NftWeaverPersist()}
-	if !currentState.BlockNodeState.TrafficShapingDisabled {
-		networkSteps = append(networkSteps, steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate, nil))
-	}
+	// Reconfigure resolves both --firewall-enabled and --traffic-shaping-enabled
+	// fresh (in the CLI layer, seeded from the current on-host state), so the
+	// convergence assembler is driven by the operator's decision and is allowed to
+	// tear a feature down when it is turned off. See networkPlaneSteps.
+	networkSteps := networkPlaneSteps(ins, inputs.Common.Force, ins.TrafficShapingEnabled, true)
 
 	var wb *automa.WorkflowBuilder
 	switch {
@@ -142,7 +136,7 @@ func (h *ReconfigureHandler) HandleIntent(
 	intent models.Intent,
 	inputs models.UserInputs[models.BlockNodeInputs],
 ) (*automa.Report, error) {
-	return h.BaseHandler.HandleIntent(ctx, intent, inputs, h, patchBlockNodeState())
+	return h.BaseHandler.HandleIntent(ctx, intent, inputs, h, patchBlockNodeStateWithTrafficShaping())
 }
 
 // NewReconfigureHandler creates a new ReconfigureHandler.

--- a/internal/bll/blocknode/reconfigure_handler_test.go
+++ b/internal/bll/blocknode/reconfigure_handler_test.go
@@ -227,6 +227,7 @@ func TestBuildWorkflow_TrafficShapingDisabled_TearsDown(t *testing.T) {
 		steps.NetworkPolicyDeleteAllStepId,
 		steps.TcEgressTeardownStepId,
 		steps.BlockNodeDaemonConfigStepId,
+		steps.RestartDaemonServiceStepId,
 		steps.UpgradeBlockNodeStepId,
 		steps.RolloutRestartBlockNodeStepId,
 	}, ids)

--- a/internal/bll/blocknode/reconfigure_handler_test.go
+++ b/internal/bll/blocknode/reconfigure_handler_test.go
@@ -98,6 +98,7 @@ var enableNetworkPrefix = []string{
 	steps.TcEgressPersistStepId,
 	steps.TcIngressRecordStepId,
 	steps.BlockNodeDaemonConfigStepId,
+	steps.RestartDaemonServiceStepId,
 }
 
 // workflowStepIDs builds the given WorkflowBuilder and returns the IDs of the

--- a/internal/bll/blocknode/reconfigure_handler_test.go
+++ b/internal/bll/blocknode/reconfigure_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/bll"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
+	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/joomcode/errorx"
 	"github.com/stretchr/testify/assert"
@@ -56,28 +57,47 @@ func deployedBlockNodeState(basePath string) state.State {
 	}
 }
 
-// reconfigureInputs returns minimal valid UserInputs for a reconfigure.
+// reconfigureInputs returns minimal valid UserInputs for a reconfigure. Traffic
+// shaping is enabled — the common case where a reconfigure re-asserts the plane.
 func reconfigureInputs(basePath string, resetStorage bool) models.UserInputs[models.BlockNodeInputs] {
 	return reconfigureInputsWithFlags(basePath, resetStorage, false)
 }
 
 // reconfigureInputsWithFlags is the full-flag variant for tests that need to
-// exercise --purge-storage paths.
+// exercise --purge-storage paths. Traffic shaping is enabled.
 func reconfigureInputsWithFlags(basePath string, resetStorage, purgeStorage bool) models.UserInputs[models.BlockNodeInputs] {
+	ins := reconfigureInputsTS(basePath, true)
+	ins.Custom.ResetStorage = resetStorage || purgeStorage
+	ins.Custom.PurgeStorage = purgeStorage
+	return ins
+}
+
+// reconfigureInputsTS builds reconfigure inputs with an explicit traffic-shaping
+// target, for exercising the enable vs disable convergence branches.
+func reconfigureInputsTS(basePath string, trafficShapingEnabled bool) models.UserInputs[models.BlockNodeInputs] {
 	return models.UserInputs[models.BlockNodeInputs]{
 		Custom: models.BlockNodeInputs{
-			Namespace:    "block-node-ns",
-			Release:      "block-node",
-			Chart:        "oci://example.com/block-node",
-			ChartVersion: "0.30.0",
-			Storage: models.BlockNodeStorage{
-				BasePath: basePath,
-			},
-			ResetStorage: resetStorage || purgeStorage,
-			PurgeStorage: purgeStorage,
-			ReuseValues:  true,
+			Namespace:             "block-node-ns",
+			Release:               "block-node",
+			Chart:                 "oci://example.com/block-node",
+			ChartVersion:          "0.30.0",
+			Storage:               models.BlockNodeStorage{BasePath: basePath},
+			ReuseValues:           true,
+			TrafficShapingEnabled: trafficShapingEnabled,
 		},
 	}
+}
+
+// enableNetworkPrefix is the network-plane step prefix the convergence assembler
+// emits when traffic shaping is enabled and the host firewall is not being torn
+// down (the default in these tests, where config.Host.Disabled is false).
+var enableNetworkPrefix = []string{
+	steps.NetworkFirewallCreateStepId,
+	steps.NetworkPolicyCreateStepId,
+	steps.NftWeaverPersistStepId,
+	steps.TcEgressPersistStepId,
+	steps.TcIngressRecordStepId,
+	steps.BlockNodeDaemonConfigStepId,
 }
 
 // workflowStepIDs builds the given WorkflowBuilder and returns the IDs of the
@@ -112,13 +132,10 @@ func TestBuildWorkflow_WithReset_PathsUnchanged_DataOnly(t *testing.T) {
 	assert.Equal(t, "block-node-reconfigure-with-reset", wb.Id())
 
 	ids := workflowStepIDs(t, wb)
-	assert.Equal(t, []string{
-		steps.NetworkFirewallCreateStepId,
-		steps.NftWeaverPersistStepId,
-		steps.TcEgressPersistStepId,
+	assert.Equal(t, append(append([]string{}, enableNetworkPrefix...),
 		steps.PurgeBlockNodeStorageStepId,
 		steps.UpgradeBlockNodeStepId,
-	}, ids)
+	), ids)
 }
 
 // TestBuildWorkflow_WithReset_PathsChanged_ReturnsError verifies that
@@ -163,14 +180,11 @@ func TestBuildWorkflow_PurgeStorage_IncludesRecreateStep(t *testing.T) {
 			assert.Equal(t, "block-node-reconfigure-purge-storage", wb.Id())
 
 			ids := workflowStepIDs(t, wb)
-			assert.Equal(t, []string{
-				steps.NetworkFirewallCreateStepId,
-				steps.NftWeaverPersistStepId,
-				steps.TcEgressPersistStepId,
+			assert.Equal(t, append(append([]string{}, enableNetworkPrefix...),
 				steps.PurgeBlockNodeStorageStepId,
 				steps.RecreateBlockNodeStorageStepId,
 				steps.UpgradeBlockNodeStepId,
-			}, ids)
+			), ids)
 		})
 	}
 }
@@ -189,13 +203,52 @@ func TestBuildWorkflow_NoReset_SamePathsUpgradeAndRestart(t *testing.T) {
 	assert.Equal(t, "block-node-reconfigure", wb.Id())
 
 	ids := workflowStepIDs(t, wb)
+	assert.Equal(t, append(append([]string{}, enableNetworkPrefix...),
+		steps.UpgradeBlockNodeStepId,
+		steps.RolloutRestartBlockNodeStepId,
+	), ids)
+}
+
+// TestBuildWorkflow_TrafficShapingDisabled_TearsDown verifies that resolving
+// traffic shaping to disabled emits the teardown branch (policy delete, tc
+// teardown, daemon-config disable) instead of the enable steps.
+func TestBuildWorkflow_TrafficShapingDisabled_TearsDown(t *testing.T) {
+	h := newMinimalReconfigureHandler()
+
+	currentState := deployedBlockNodeState("/mnt/storage")
+	inputs := reconfigureInputsTS("/mnt/storage", false)
+
+	wb, err := h.BuildWorkflow(currentState, inputs)
+	require.NoError(t, err)
+
+	ids := workflowStepIDs(t, wb)
 	assert.Equal(t, []string{
 		steps.NetworkFirewallCreateStepId,
-		steps.NftWeaverPersistStepId,
-		steps.TcEgressPersistStepId,
+		steps.NetworkPolicyDeleteAllStepId,
+		steps.TcEgressTeardownStepId,
+		steps.BlockNodeDaemonConfigStepId,
 		steps.UpgradeBlockNodeStepId,
 		steps.RolloutRestartBlockNodeStepId,
 	}, ids)
+}
+
+// TestBuildWorkflow_FirewallDisabled_DeletesTable verifies that when the resolved
+// host-firewall config is disabled (config.Host.Disabled=true), the convergence
+// assembler emits NetworkFirewallDelete instead of NetworkFirewallCreate.
+func TestBuildWorkflow_FirewallDisabled_DeletesTable(t *testing.T) {
+	config.OverrideHostConfig(models.HostConfig{Disabled: true})
+	t.Cleanup(func() { config.OverrideHostConfig(models.HostConfig{}) })
+
+	h := newMinimalReconfigureHandler()
+	currentState := deployedBlockNodeState("/mnt/storage")
+	inputs := reconfigureInputsTS("/mnt/storage", false)
+
+	wb, err := h.BuildWorkflow(currentState, inputs)
+	require.NoError(t, err)
+
+	ids := workflowStepIDs(t, wb)
+	assert.Equal(t, steps.NetworkFirewallDeleteStepId, ids[0],
+		"host firewall disabled should emit the delete step first")
 }
 
 // TestBuildWorkflow_NoReset_ChangedPathsReturnsError verifies that changing

--- a/internal/bll/blocknode/upgrade_handler.go
+++ b/internal/bll/blocknode/upgrade_handler.go
@@ -89,13 +89,23 @@ func (h *UpgradeHandler) BuildWorkflow(
 	}
 
 	ins := inputs.Custom
+
+	// Silent network-plane convergence: re-assert the persisted host-firewall and
+	// traffic-shaping decision on every upgrade, create-if-missing only
+	// (allowTeardown=false), so a routine version bump neither regresses the network
+	// plane nor tears it down. The traffic-shaping target comes from the install-time
+	// decision recorded on BlockNodeState — upgrade never prompts and never resolves
+	// its own gate (only reconfigure does). Daemon activation, when traffic shaping is
+	// enabled, is handled post-workflow in the CLI layer.
+	networkSteps := networkPlaneSteps(ins, inputs.Common.Force, !currentState.BlockNodeState.TrafficShapingDisabled, false)
+
 	var wb *automa.WorkflowBuilder
 	if ins.ResetStorage {
 		wb = automa.NewWorkflowBuilder().WithId("block-node-upgrade-with-reset").
-			Steps(steps.PurgeBlockNodeStorage(ins), steps.UpgradeBlockNode(ins))
+			Steps(append(networkSteps, steps.PurgeBlockNodeStorage(ins), steps.UpgradeBlockNode(ins))...)
 	} else {
 		wb = automa.NewWorkflowBuilder().WithId("block-node-upgrade").
-			Steps(steps.UpgradeBlockNode(ins))
+			Steps(append(networkSteps, steps.UpgradeBlockNode(ins))...)
 	}
 	return wb, nil
 }

--- a/internal/bll/blocknode/upgrade_handler_test.go
+++ b/internal/bll/blocknode/upgrade_handler_test.go
@@ -67,6 +67,7 @@ func TestUpgrade_TrafficShapingEnabled_ReAssertsPlane(t *testing.T) {
 		steps.TcEgressPersistStepId,
 		steps.TcIngressRecordStepId,
 		steps.BlockNodeDaemonConfigStepId,
+		steps.RestartDaemonServiceStepId,
 		steps.UpgradeBlockNodeStepId,
 	}, ids)
 }

--- a/internal/bll/blocknode/upgrade_handler_test.go
+++ b/internal/bll/blocknode/upgrade_handler_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package blocknode
+
+import (
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/internal/state"
+	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/release"
+)
+
+func newMinimalUpgradeHandler() *UpgradeHandler {
+	return &UpgradeHandler{}
+}
+
+// deployedStateForUpgrade returns a deployed block-node state at chart version
+// 0.30.0 with the given traffic-shaping-disabled decision recorded.
+func deployedStateForUpgrade(trafficShapingDisabled bool) state.State {
+	return state.State{
+		StateRecord: state.StateRecord{
+			BlockNodeState: state.BlockNodeState{
+				ReleaseInfo: state.HelmReleaseInfo{
+					Status:       release.StatusDeployed,
+					ChartRef:     "oci://example.com/block-node",
+					ChartVersion: "0.30.0",
+				},
+				Storage:                models.BlockNodeStorage{BasePath: "/mnt/storage"},
+				TrafficShapingDisabled: trafficShapingDisabled,
+			},
+		},
+	}
+}
+
+func upgradeInputs() models.UserInputs[models.BlockNodeInputs] {
+	return models.UserInputs[models.BlockNodeInputs]{
+		Custom: models.BlockNodeInputs{
+			Namespace:    "block-node-ns",
+			Release:      "block-node",
+			Chart:        "oci://example.com/block-node",
+			ChartVersion: "0.31.0",
+			Storage:      models.BlockNodeStorage{BasePath: "/mnt/storage"},
+			ReuseValues:  true,
+		},
+	}
+}
+
+// TestUpgrade_TrafficShapingEnabled_ReAssertsPlane verifies that an upgrade of a
+// block node that had traffic shaping enabled at install re-asserts the full
+// network plane (create-if-missing) ahead of the chart upgrade.
+func TestUpgrade_TrafficShapingEnabled_ReAssertsPlane(t *testing.T) {
+	h := newMinimalUpgradeHandler()
+
+	wb, err := h.BuildWorkflow(deployedStateForUpgrade(false), upgradeInputs())
+	require.NoError(t, err)
+
+	ids := workflowStepIDs(t, wb)
+	assert.Equal(t, []string{
+		steps.NetworkFirewallCreateStepId,
+		steps.NetworkPolicyCreateStepId,
+		steps.NftWeaverPersistStepId,
+		steps.TcEgressPersistStepId,
+		steps.TcIngressRecordStepId,
+		steps.BlockNodeDaemonConfigStepId,
+		steps.UpgradeBlockNodeStepId,
+	}, ids)
+}
+
+// TestUpgrade_TrafficShapingDisabled_NoTeardown verifies that upgrading a block
+// node that had traffic shaping disabled at install re-asserts only the
+// self-gating host firewall and never emits teardown steps — a routine version
+// bump must not disarm anything.
+func TestUpgrade_TrafficShapingDisabled_NoTeardown(t *testing.T) {
+	h := newMinimalUpgradeHandler()
+
+	wb, err := h.BuildWorkflow(deployedStateForUpgrade(true), upgradeInputs())
+	require.NoError(t, err)
+
+	ids := workflowStepIDs(t, wb)
+	assert.Equal(t, []string{
+		steps.NetworkFirewallCreateStepId,
+		steps.UpgradeBlockNodeStepId,
+	}, ids)
+}

--- a/internal/network/firewall/manager.go
+++ b/internal/network/firewall/manager.go
@@ -140,6 +140,15 @@ func (m *Manager) Set(ctx context.Context, mgmtCIDRs, blockedCIDRs []string, por
 	})
 }
 
+// IsActive reports whether the inet host table is currently present in the
+// kernel. It is a read-only probe (no lock, no mutation) used by callers that
+// need the firewall's current on-host state — e.g. seeding the reconfigure
+// enable/disable prompt from ground truth rather than from config.yaml, whose
+// zero value cannot distinguish "enabled" from "never configured".
+func (m *Manager) IsActive(ctx context.Context) (bool, error) {
+	return m.runner.Exists(ctx)
+}
+
 // Show returns the live inet host table. If the table is not active it returns
 // a human-readable message (not an error) so the caller can print it cleanly.
 func (m *Manager) Show(ctx context.Context) (string, error) {

--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -496,9 +496,13 @@ func (m *Manager) TeardownEgress(ctx context.Context) error {
 		if err := removeDevice(DirEgress); err != nil {
 			return err
 		}
-		// Re-render with the default (empty) egress config so the boot script and
-		// the live kernel hierarchy are both reset to unshaped.
-		if err := m.renderAndApplyEgress(ctx); err != nil {
+		// Re-render an unshape boot script (delete root qdisc, re-add nothing) and
+		// apply it so both the boot script and the live kernel hierarchy are reset
+		// to unshaped. This must NOT go through renderAndApplyEgress: with the
+		// device/class registry now empty, that path falls through to the default
+		// shaping render and would re-apply the stock HTB hierarchy instead of
+		// removing it.
+		if err := m.renderAndApplyUnshapeEgress(ctx); err != nil {
 			return errorx.Decorate(err,
 				"egress shape config removed but boot script re-render failed; restart tc-egress.service to sync")
 		}
@@ -557,6 +561,26 @@ func (m *Manager) renderAndApplyEgress(ctx context.Context) error {
 		return errorx.Decorate(err, "cannot re-render tc-egress script: egress NIC detection failed")
 	}
 	return m.renderAndApplyScript(ctx, nic)
+}
+
+// renderAndApplyUnshapeEgress renders the teardown-only (unshape) boot script for
+// the detected egress NIC, persists it, and restarts the tc-egress oneshot so the
+// kernel drops the live HTB hierarchy. Used exclusively by TeardownEgress — the
+// registry is already empty at that point, so the normal render would re-apply
+// default shaping instead of removing it.
+func (m *Manager) renderAndApplyUnshapeEgress(ctx context.Context) error {
+	nic, err := m.nicDetect()
+	if err != nil {
+		return errorx.Decorate(err, "cannot re-render tc-egress script: egress NIC detection failed")
+	}
+	rendered, err := renderTcEgressUnshapeScript(nic)
+	if err != nil {
+		return err
+	}
+	if err := m.writeEgressScript(rendered); err != nil {
+		return err
+	}
+	return m.applyEgress(ctx)
 }
 
 // renderEgressScript renders the tc-egress boot script for nic from the current

--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -471,6 +471,41 @@ func (m *Manager) DeleteDevice(ctx context.Context, dir string) error {
 	})
 }
 
+// TeardownEgress removes the entire egress tc shape configuration — every egress
+// class and the egress device root — then re-renders the boot script to its empty
+// default and applies it, dropping the live HTB hierarchy on the physical NIC.
+//
+// Unlike DeleteClass/DeleteDevice (the operator-facing single-object verbs, which
+// deliberately refuse to delete a device's default class or a still-referenced
+// class), this is the wholesale teardown used when traffic shaping is disabled on
+// an existing block node: the caller has already removed the BN network policies
+// that reference these classes, so the per-object safety guards no longer apply.
+// It is idempotent — with no egress config present it re-renders the empty script
+// and returns nil.
+func (m *Manager) TeardownEgress(ctx context.Context) error {
+	return m.withLock(func() error {
+		classes, err := loadClassesForDir(DirEgress)
+		if err != nil {
+			return err
+		}
+		for _, c := range classes {
+			if err := removeClass(c.Name); err != nil {
+				return err
+			}
+		}
+		if err := removeDevice(DirEgress); err != nil {
+			return err
+		}
+		// Re-render with the default (empty) egress config so the boot script and
+		// the live kernel hierarchy are both reset to unshaped.
+		if err := m.renderAndApplyEgress(ctx); err != nil {
+			return errorx.Decorate(err,
+				"egress shape config removed but boot script re-render failed; restart tc-egress.service to sync")
+		}
+		return nil
+	})
+}
+
 // isAutoRate reports whether rate is the literal "auto" (case-insensitive),
 // the operator-facing request to detect the egress link speed at create time.
 func isAutoRate(rate string) bool {

--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -564,10 +564,17 @@ func (m *Manager) renderAndApplyEgress(ctx context.Context) error {
 }
 
 // renderAndApplyUnshapeEgress renders the teardown-only (unshape) boot script for
-// the detected egress NIC, persists it, and restarts the tc-egress oneshot so the
-// kernel drops the live HTB hierarchy. Used exclusively by TeardownEgress — the
-// registry is already empty at that point, so the normal render would re-apply
-// default shaping instead of removing it.
+// the detected egress NIC, persists it, drops the live HTB hierarchy directly,
+// and restarts the tc-egress oneshot so the on-disk state matches. Used
+// exclusively by TeardownEgress — the registry is already empty at that point, so
+// the normal render would re-apply default shaping instead of removing it.
+//
+// The live root qdisc is deleted directly via the tc runner rather than relying
+// solely on the systemd oneshot re-running the (now unshape) boot script: the
+// boot script's job is to ADD the hierarchy, so using a service restart to REMOVE
+// it is indirect. A direct `tc qdisc del dev <nic> root` makes the teardown
+// immediate and deterministic; the unshape boot script written above keeps the
+// NIC unshaped across reboots.
 func (m *Manager) renderAndApplyUnshapeEgress(ctx context.Context) error {
 	nic, err := m.nicDetect()
 	if err != nil {
@@ -579,6 +586,11 @@ func (m *Manager) renderAndApplyUnshapeEgress(ctx context.Context) error {
 	}
 	if err := m.writeEgressScript(rendered); err != nil {
 		return err
+	}
+	// Drop the live hierarchy now, independent of systemd. Best-effort: a NIC with
+	// no root qdisc is not an error (see TCRunner.QdiscDelRoot).
+	if err := m.tcRunner.QdiscDelRoot(ctx, nic); err != nil {
+		return errorx.Decorate(err, "failed to delete live tc-egress root qdisc on %s", nic)
 	}
 	return m.applyEgress(ctx)
 }

--- a/internal/network/shape/render.go
+++ b/internal/network/shape/render.go
@@ -21,6 +21,11 @@ type scriptData struct {
 	SpeedMbit int // <0 omits the SPEED block (explicit per-class rates); >=0 emits sysfs auto-detect
 	Device    deviceRenderData
 	Classes   []classRenderData
+	// Unshape, when true, renders a teardown-only script: it deletes the root
+	// qdisc and re-adds nothing, leaving the NIC unshaped. Used by TeardownEgress
+	// so disabling traffic shaping does not fall through to the default-shaping
+	// render (which would re-apply the stock HTB hierarchy instead of removing it).
+	Unshape bool
 }
 
 // deviceRenderData is the device-level template context.
@@ -43,6 +48,15 @@ type classRenderData struct {
 // shape config exists. SpeedMbit is left at 0 (sysfs auto-detect at boot).
 func renderTcEgressScript(nicName string) (string, error) {
 	return renderTcEgressScriptFromData(defaultScriptData(nicName))
+}
+
+// renderTcEgressUnshapeScript renders a teardown-only tc-egress.sh: it deletes
+// the root qdisc and re-adds nothing, leaving the NIC unshaped both live (on
+// service restart) and across reboots. TeardownEgress uses this instead of the
+// default-shaping render so disabling traffic shaping actually removes the HTB
+// hierarchy rather than replacing it with the stock default classes.
+func renderTcEgressUnshapeScript(nicName string) (string, error) {
+	return renderTcEgressScriptFromData(scriptData{NIC: nicName, SpeedMbit: -1, Unshape: true})
 }
 
 // renderTcEgressScriptFromConfig renders the tc-egress.sh template from the

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -115,6 +115,52 @@ func TestRenderTcEgressUnshapeScript(t *testing.T) {
 	}
 }
 
+// TestRenderAndApplyUnshapeEgress_DeletesLiveRootAndPersists verifies the egress
+// teardown drops the live hierarchy directly (tc qdisc del root, independent of
+// systemd), writes the unshape boot script for reboot persistence, and triggers
+// the apply. This is the runtime half of the fix for TeardownEgress leaving the
+// NIC shaped.
+func TestRenderAndApplyUnshapeEgress_DeletesLiveRootAndPersists(t *testing.T) {
+	tc := &recordingTCRunner{}
+	scriptPath := filepath.Join(t.TempDir(), "tc-egress.sh")
+	applied := false
+
+	m := NewManagerWithConfig(Config{
+		ScriptPath:  scriptPath,
+		LockPath:    filepath.Join(t.TempDir(), ".tc-applying"),
+		NICDetect:   func() (string, error) { return "enp0s1", nil },
+		TCRunner:    tc,
+		ApplyEgress: func(_ context.Context) error { applied = true; return nil },
+	})
+
+	if err := m.renderAndApplyUnshapeEgress(context.Background()); err != nil {
+		t.Fatalf("renderAndApplyUnshapeEgress: %v", err)
+	}
+
+	// Live hierarchy dropped directly on the detected NIC.
+	if len(tc.calls) != 1 || tc.calls[0] != "qdisc-del-root enp0s1" {
+		t.Errorf("expected a single qdisc-del-root enp0s1 call, got %v", tc.calls)
+	}
+	if !applied {
+		t.Error("expected applyEgress to be invoked to sync the boot script")
+	}
+
+	// Unshape boot script persisted for reboot: deletes root, re-adds nothing.
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(content)
+	if !strings.Contains(got, `tc qdisc del dev "$NIC" root 2>/dev/null || true`) {
+		t.Errorf("boot script must delete the root qdisc:\n%s", got)
+	}
+	for _, forbidden := range []string{"root handle 1: htb default", "tc class  add dev"} {
+		if strings.Contains(got, forbidden) {
+			t.Errorf("boot script must not re-shape (%q):\n%s", forbidden, got)
+		}
+	}
+}
+
 func TestAtomicWriteFile_SecondWritePreservesContent(t *testing.T) {
 	dir := t.TempDir()
 	const testNIC = "ens3"

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -76,6 +76,45 @@ func TestRenderTcEgressScript_EmptyNIC(t *testing.T) {
 	}
 }
 
+// TestRenderTcEgressUnshapeScript verifies the teardown render deletes the root
+// qdisc and re-adds nothing — the fix for TeardownEgress re-applying the default
+// HTB hierarchy instead of removing it. It also funnels through the same NIC
+// validation as the shaping render.
+func TestRenderTcEgressUnshapeScript(t *testing.T) {
+	rendered, err := renderTcEgressUnshapeScript("enp0s1")
+	if err != nil {
+		t.Fatalf("renderTcEgressUnshapeScript: %v", err)
+	}
+
+	if !strings.Contains(rendered, `NIC="enp0s1"`) {
+		t.Errorf("unshape script missing NIC assignment:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `tc qdisc del dev "$NIC" root 2>/dev/null || true`) {
+		t.Errorf("unshape script must delete the root qdisc:\n%s", rendered)
+	}
+	// The whole point: no hierarchy is re-added, so none of the qdisc/class add
+	// verbs may appear (checked against command lines, not the shared banner).
+	for _, forbidden := range []string{
+		"root handle 1: htb default",
+		"tc qdisc add dev",
+		"tc class  add dev",
+		"handle 140: fq_codel",
+		"SPEED=$(cat",
+	} {
+		if strings.Contains(rendered, forbidden) {
+			t.Errorf("unshape script must not contain %q (would re-shape the NIC):\n%s", forbidden, rendered)
+		}
+	}
+
+	// NIC validation still applies on the teardown path.
+	if _, err := renderTcEgressUnshapeScript(""); err == nil {
+		t.Error("expected error for empty NIC name, got nil")
+	}
+	if _, err := renderTcEgressUnshapeScript(`eth0";reboot;#`); err == nil {
+		t.Error("expected error for injection-style NIC name, got nil")
+	}
+}
+
 func TestAtomicWriteFile_SecondWritePreservesContent(t *testing.T) {
 	dir := t.TempDir()
 	const testNIC = "ens3"

--- a/internal/reality/blocknode_checker.go
+++ b/internal/reality/blocknode_checker.go
@@ -70,6 +70,14 @@ func (b *blockNodeChecker) RefreshState(ctx context.Context) (state.BlockNodeSta
 	}
 
 	logx.As().Debug().Msg("Found BlockNode Helm release; building BlockNodeState")
+	// TrafficShapingDisabled is a weaver-only install decision that cannot be
+	// recovered from the Helm release or the live cluster (see its doc on
+	// state.BlockNodeState). Capture the persisted value before rebuilding the
+	// struct so a reality refresh does not silently reset it to the enabled
+	// default — which would make reconfigure/upgrade re-provision tc shaping (and
+	// attempt to install the daemon) for a block node deliberately installed
+	// without it.
+	trafficShapingDisabled := bn.TrafficShapingDisabled
 	bn = state.BlockNodeState{
 		ReleaseInfo: state.HelmReleaseInfo{
 			Name:          re.Name,
@@ -83,8 +91,9 @@ func (b *blockNodeChecker) RefreshState(ctx context.Context) (state.BlockNodeSta
 			DeletedAt:     re.Info.Deleted,
 			Status:        re.Info.Status,
 		},
-		Storage:  models.BlockNodeStorage{},
-		LastSync: now,
+		Storage:                models.BlockNodeStorage{},
+		TrafficShapingDisabled: trafficShapingDisabled,
+		LastSync:               now,
 	}
 
 	b.populateRetentionFromHelmValues(re.Config, &bn)

--- a/internal/reality/blocknode_checker_test.go
+++ b/internal/reality/blocknode_checker_test.go
@@ -5,9 +5,14 @@
 package reality
 
 import (
+	"context"
 	"testing"
 
+	"github.com/hashgraph/solo-weaver/internal/kube"
+	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/pkg/models"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -115,5 +120,80 @@ func TestPopulateStorageFromPVs_NilInputsNoError(t *testing.T) {
 
 	if err := checker.populateStorageFromPVs(nil, "ns", nil); err != nil {
 		t.Fatalf("unexpected error for nil inputs: %v", err)
+	}
+}
+
+// fakeStateManager satisfies state.Manager by embedding the interface (nil) and
+// overriding only State(), the single method RefreshState calls. Any other call
+// would panic, which keeps the fake honest about what the checker actually uses.
+type fakeStateManager struct {
+	state.Manager
+	st state.State
+}
+
+func (f fakeStateManager) State() state.State { return f.st }
+
+// fakeHelmManager returns a fixed release list from ListAll.
+type fakeHelmManager struct {
+	releases []*release.Release
+}
+
+func (f fakeHelmManager) ListAll() ([]*release.Release, error) { return f.releases, nil }
+
+// fakeKubeClient returns an empty PV list so populateStorageFromPVs is a no-op.
+type fakeKubeClient struct{}
+
+func (f fakeKubeClient) List(_ context.Context, _ kube.ResourceKind, _ string, _ kube.WaitOptions) (*unstructured.UnstructuredList, error) {
+	return &unstructured.UnstructuredList{}, nil
+}
+
+// TestRefreshState_PreservesTrafficShapingDisabled verifies that the weaver-only
+// install decision (which cannot be recovered from the Helm release or cluster)
+// survives a reality refresh that rebuilds BlockNodeState from a found release.
+// Without preservation, the rebuild resets it to the enabled default (false),
+// which wrongly makes reconfigure/upgrade re-provision tc shaping and attempt a
+// daemon install for a block node deliberately installed without it.
+func TestRefreshState_PreservesTrafficShapingDisabled(t *testing.T) {
+	const manifest = `apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: block-node-block-node-server
+  namespace: block-node
+  labels:
+    app.kubernetes.io/instance: block-node
+`
+	re := &release.Release{
+		Name:      "block-node",
+		Namespace: "block-node",
+		Info:      &release.Info{Status: release.StatusDeployed},
+		Chart: &chart.Chart{
+			Metadata: &chart.Metadata{Name: "block-node-server", Version: "0.28.0", AppVersion: "0.28.0"},
+		},
+		Manifest: manifest,
+	}
+
+	persisted := state.NewBlockNodeState()
+	persisted.ReleaseInfo.Status = release.StatusDeployed
+	persisted.TrafficShapingDisabled = true
+
+	full := state.State{}
+	full.BlockNodeState = persisted
+
+	checker := &blockNodeChecker{
+		sm:            fakeStateManager{st: full},
+		newHelm:       func() (HelmManager, error) { return fakeHelmManager{releases: []*release.Release{re}}, nil },
+		newKube:       func() (KubeClient, error) { return fakeKubeClient{}, nil },
+		clusterExists: func() (bool, error) { return true, nil },
+	}
+
+	got, err := checker.RefreshState(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ReleaseInfo.Name != "block-node" {
+		t.Fatalf("expected release to be found and rebuilt, got name %q", got.ReleaseInfo.Name)
+	}
+	if !got.TrafficShapingDisabled {
+		t.Error("TrafficShapingDisabled must be preserved as true across a reality refresh, got false")
 	}
 }

--- a/internal/state/state_reader.go
+++ b/internal/state/state_reader.go
@@ -68,14 +68,15 @@ type PromptDefaultsDoc struct {
 			Profile string `yaml:"profile"`
 		} `yaml:"machineState"`
 		BlockNodeState struct {
-			Name              string `yaml:"name"`
-			Namespace         string `yaml:"namespace"`
-			ChartVersion      string `yaml:"version"`
-			HistoricRetention string `yaml:"historicRetention"`
-			RecentRetention   string `yaml:"recentRetention"`
-			PluginPreset      string `yaml:"pluginPreset"`
-			PluginList        string `yaml:"pluginList"`
-			Storage           struct {
+			Name                   string `yaml:"name"`
+			Namespace              string `yaml:"namespace"`
+			ChartVersion           string `yaml:"version"`
+			HistoricRetention      string `yaml:"historicRetention"`
+			RecentRetention        string `yaml:"recentRetention"`
+			PluginPreset           string `yaml:"pluginPreset"`
+			PluginList             string `yaml:"pluginList"`
+			TrafficShapingDisabled bool   `yaml:"trafficShapingDisabled"`
+			Storage                struct {
 				BasePath             string `yaml:"basePath"`
 				ArchivePath          string `yaml:"archivePath"`
 				LivePath             string `yaml:"livePath"`
@@ -158,14 +159,15 @@ func softwareVersionFromDoc(doc SoftwareVersionsDoc, name string) string {
 // inside BlockNodeState, so its keys (name, namespace, version) live
 // directly under blockNodeState in the YAML.
 type BlockNodeSummary struct {
-	ReleaseName       string
-	Namespace         string
-	ChartVersion      string
-	HistoricRetention string
-	RecentRetention   string
-	PluginPreset      string
-	PluginList        string
-	Storage           models.BlockNodeStorage
+	ReleaseName            string
+	Namespace              string
+	ChartVersion           string
+	HistoricRetention      string
+	RecentRetention        string
+	PluginPreset           string
+	PluginList             string
+	TrafficShapingDisabled bool
+	Storage                models.BlockNodeStorage
 }
 
 // PromptDefaults holds all prompt-relevant fields extracted from the on-disk
@@ -195,13 +197,14 @@ func ReadPromptDefaultsFromDisk() (PromptDefaults, error) {
 	return PromptDefaults{
 		Profile: doc.State.MachineState.Profile,
 		BlockNode: BlockNodeSummary{
-			ReleaseName:       bn.Name,
-			Namespace:         bn.Namespace,
-			ChartVersion:      bn.ChartVersion,
-			HistoricRetention: bn.HistoricRetention,
-			RecentRetention:   bn.RecentRetention,
-			PluginPreset:      bn.PluginPreset,
-			PluginList:        bn.PluginList,
+			ReleaseName:            bn.Name,
+			Namespace:              bn.Namespace,
+			ChartVersion:           bn.ChartVersion,
+			HistoricRetention:      bn.HistoricRetention,
+			RecentRetention:        bn.RecentRetention,
+			PluginPreset:           bn.PluginPreset,
+			PluginList:             bn.PluginList,
+			TrafficShapingDisabled: bn.TrafficShapingDisabled,
 			Storage: models.BlockNodeStorage{
 				BasePath:             bn.Storage.BasePath,
 				ArchivePath:          bn.Storage.ArchivePath,

--- a/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
+++ b/internal/templates/files/network/solo-provisioner-tc-egress.sh.tmpl
@@ -8,6 +8,12 @@
 set -e
 
 NIC="{{.NIC}}"
+{{- if .Unshape}}
+
+# Traffic shaping disabled: remove any existing root qdisc (cascading to all
+# classes and leaf qdiscs) and leave the NIC unshaped. No hierarchy is re-added.
+tc qdisc del dev "$NIC" root 2>/dev/null || true
+{{- else}}
 
 {{- if lt .SpeedMbit 0}}
 {{- /* All tc rates are explicit strings; SPEED variable is not used. */}}
@@ -32,3 +38,4 @@ tc class  add dev "$NIC" parent 1:   classid 1:1  htb rate "{{.Device.Rate}}" ce
 tc class  add dev "$NIC" parent 1:1  classid 1:{{.Minor}} htb rate "{{.Rate}}" ceil "{{.Ceil}}" prio {{.Prio}}
 tc qdisc  add dev "$NIC" parent 1:{{.Minor}} handle {{.Handle}}: fq_codel
 {{end}}
+{{- end}}

--- a/internal/workflows/network_setup.go
+++ b/internal/workflows/network_setup.go
@@ -64,7 +64,7 @@ func BlockNodeDaemonConfigWorkflow(namespace string) *automa.WorkflowBuilder {
 	return automa.NewWorkflowBuilder().
 		WithId("block-node-daemon-config").
 		Steps(
-			steps.WriteBlockNodeDaemonConfigStep(models.Paths(), namespace),
+			steps.WriteBlockNodeDaemonConfigStep(models.Paths(), namespace, true),
 		).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
 			notify.As().PhaseStart(ctx, stp, "Traffic-shaper Monitor")

--- a/internal/workflows/steps/step_daemon.go
+++ b/internal/workflows/steps/step_daemon.go
@@ -587,6 +587,53 @@ func StopDaemonServiceStep() *automa.StepBuilder {
 		})
 }
 
+// RestartDaemonServiceStepId is the step ID for RestartDaemonServiceStep.
+const RestartDaemonServiceStepId = "restart-daemon-service"
+
+// RestartDaemonServiceStep restarts the solo-provisioner-daemon systemd service
+// so it re-reads daemon.yaml. The daemon loads its component config (including
+// whether the block-node traffic-shaper monitor runs) only at startup — there is
+// no hot-reload — so a config change such as disabling the traffic-shaper monitor
+// only takes effect after a restart. Restart (not stop) is used deliberately: the
+// daemon is shared, so co-located components must keep running; the now-disabled
+// block-node monitor simply is not rebuilt.
+//
+// It is best-effort with respect to installation state: when the service is not
+// running (e.g. the daemon was never installed) there is nothing to reload, so the
+// step is skipped rather than failing.
+func RestartDaemonServiceStep() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(RestartDaemonServiceStepId).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if running, _ := pkgos.IsServiceRunning(ctx, daemonServiceName); !running {
+				logx.As().Info().Msgf("Service %s is not running; skipping restart", daemonServiceName)
+				return automa.SkippedReport(stp,
+					automa.WithDetail("daemon service not running; nothing to reload"))
+			}
+			if err := pkgos.RestartService(ctx, daemonServiceName); err != nil {
+				return automa.StepFailureReport(stp.Id(),
+					automa.WithError(errorx.InternalError.Wrap(err, "failed to restart service %s", daemonServiceName).
+						WithProperty(models.ErrPropertyResolution, []string{
+							fmt.Sprintf("Check daemon logs: sudo journalctl -u %s -n 50 --no-pager", daemonServiceName),
+							fmt.Sprintf("Check service status: sudo systemctl status %s", daemonServiceName),
+							"Verify daemon config: cat /opt/solo/weaver/config/daemon.yaml",
+							fmt.Sprintf("Restart manually: sudo systemctl restart %s", daemonServiceName),
+						})))
+			}
+			logx.As().Info().Msgf("Service %s restarted", daemonServiceName)
+			return automa.StepSuccessReport(stp.Id())
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Restarting solo-provisioner-daemon to apply config")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to restart solo-provisioner-daemon service")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Solo Provisioner Daemon service restarted")
+		})
+}
+
 // CheckDaemonServiceStep verifies the daemon installation and runtime health:
 //  1. Sandbox unit file exists at $home/sandbox/usr/lib/systemd/system/solo-provisioner-daemon.service
 //  2. System symlink exists at /usr/lib/systemd/system/solo-provisioner-daemon.service → sandbox file

--- a/internal/workflows/steps/step_daemon_block_node.go
+++ b/internal/workflows/steps/step_daemon_block_node.go
@@ -34,34 +34,51 @@ const (
 	daemonConfigPriorContentKey = "daemon-config-prior-content"
 )
 
-// WriteBlockNodeDaemonConfigStep enables the block-node traffic-shaper monitor
-// in daemon.yaml at install time. It loads the existing config (or starts a
-// fresh one), merges in the block_node component block — enabled, the scoped
-// daemon-bn.kubeconfig, the BN orbit (namespace), and monitors.traffic_shaper —
-// while preserving any operator-set statusz block and the consensus_node block,
+// WriteBlockNodeDaemonConfigStep records the block-node component's enablement
+// in daemon.yaml. It loads the existing config (or starts a fresh one), merges in
+// the block_node component block — enabled/monitors.traffic_shaper set to the
+// requested state, the scoped daemon-bn.kubeconfig, and the BN orbit (namespace)
+// — while preserving any operator-set statusz block and the consensus_node block,
 // then writes it back.
 //
+// enabled drives both Components.BlockNode.Enabled and Monitors.TrafficShaper:
+//   - true  (install / reconfigure enable): the traffic-shaper monitor runs once
+//     the daemon is up.
+//   - false (reconfigure disable): the block-node component and its traffic-shaper
+//     monitor are turned off WITHOUT uninstalling the daemon binary/service, so a
+//     co-located component (e.g. consensus-node monitoring) that shares the same
+//     daemon keeps running.
+//
 // The daemon binary and systemd service are installed separately by `daemon
-// service install`; this step only records the enablement so the traffic-shaper
-// monitor starts once the daemon runs. The write is fully reversed on rollback
-// (the file is restored to its prior content, or removed if it did not exist).
-func WriteBlockNodeDaemonConfigStep(paths models.WeaverPaths, orbit string) *automa.StepBuilder {
+// service install`; this step only records the enablement. The write is fully
+// reversed on rollback (the file is restored to its prior content, or removed if
+// it did not exist).
+func WriteBlockNodeDaemonConfigStep(paths models.WeaverPaths, orbit string, enabled bool) *automa.StepBuilder {
 	cfgPath := paths.DaemonConfigPath
 	kubeconfig := paths.DaemonBNKubeconfigPath
 	if orbit == "" {
 		orbit = defaultBlockNodeOrbit
 	}
 
+	startMsg := "Enabling traffic-shaper monitor in daemon.yaml"
+	failMsg := "Failed to enable traffic-shaper monitor in daemon.yaml"
+	doneMsg := "Traffic-shaper monitor enabled in daemon.yaml"
+	if !enabled {
+		startMsg = "Disabling traffic-shaper monitor in daemon.yaml"
+		failMsg = "Failed to disable traffic-shaper monitor in daemon.yaml"
+		doneMsg = "Traffic-shaper monitor disabled in daemon.yaml"
+	}
+
 	return automa.NewStepBuilder().WithId(BlockNodeDaemonConfigStepId).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
-			notify.As().StepStart(ctx, stp, "Enabling traffic-shaper monitor in daemon.yaml")
+			notify.As().StepStart(ctx, stp, startMsg)
 			return ctx, nil
 		}).
 		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepFailure(ctx, stp, rpt, "Failed to enable traffic-shaper monitor in daemon.yaml")
+			notify.As().StepFailure(ctx, stp, rpt, failMsg)
 		}).
 		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
-			notify.As().StepCompletion(ctx, stp, rpt, "Traffic-shaper monitor enabled in daemon.yaml")
+			notify.As().StepCompletion(ctx, stp, rpt, doneMsg)
 		}).
 		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
 			prior, err := os.ReadFile(cfgPath)
@@ -96,10 +113,10 @@ func WriteBlockNodeDaemonConfigStep(paths models.WeaverPaths, orbit string) *aut
 			// Preserve an operator-set statusz block (local-fallback source) if
 			// one already exists; this step only owns the enablement fields.
 			bn := &daemon.BlockNodeComponentConfig{
-				Enabled:    true,
+				Enabled:    enabled,
 				Kubeconfig: kubeconfig,
 				Orbit:      orbit,
-				Monitors:   daemon.BlockNodeMonitors{TrafficShaper: true},
+				Monitors:   daemon.BlockNodeMonitors{TrafficShaper: enabled},
 			}
 			if cfg.Components.BlockNode != nil {
 				bn.Statusz = cfg.Components.BlockNode.Statusz
@@ -108,7 +125,7 @@ func WriteBlockNodeDaemonConfigStep(paths models.WeaverPaths, orbit string) *aut
 
 			if err := cfg.Validate(); err != nil {
 				return automa.FailureReport(stp, automa.WithError(
-					errorx.Decorate(err, "daemon config is invalid after enabling block-node monitor").
+					errorx.Decorate(err, "daemon config is invalid after updating block-node monitor").
 						WithProperty(models.ErrPropertyResolution, []string{
 							"Inspect " + cfgPath,
 						})))
@@ -126,7 +143,8 @@ func WriteBlockNodeDaemonConfigStep(paths models.WeaverPaths, orbit string) *aut
 			logx.As().Info().
 				Str("path", cfgPath).
 				Str("orbit", orbit).
-				Msg("Enabled block-node traffic-shaper monitor in daemon.yaml")
+				Bool("enabled", enabled).
+				Msg("Updated block-node traffic-shaper monitor in daemon.yaml")
 			return automa.SuccessReport(stp)
 		}).
 		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {

--- a/internal/workflows/steps/step_daemon_block_node_test.go
+++ b/internal/workflows/steps/step_daemon_block_node_test.go
@@ -27,7 +27,7 @@ func blockNodeConfigPaths(t *testing.T) models.WeaverPaths {
 func TestWriteBlockNodeDaemonConfig_FreshFile(t *testing.T) {
 	paths := blockNodeConfigPaths(t)
 
-	step, err := WriteBlockNodeDaemonConfigStep(paths, "block-node").Build()
+	step, err := WriteBlockNodeDaemonConfigStep(paths, "block-node", true).Build()
 	require.NoError(t, err)
 
 	report := step.Execute(context.Background())
@@ -52,13 +52,56 @@ func TestWriteBlockNodeDaemonConfig_FreshFile(t *testing.T) {
 func TestWriteBlockNodeDaemonConfig_EmptyOrbitDefaults(t *testing.T) {
 	paths := blockNodeConfigPaths(t)
 
-	step, err := WriteBlockNodeDaemonConfigStep(paths, "").Build()
+	step, err := WriteBlockNodeDaemonConfigStep(paths, "", true).Build()
 	require.NoError(t, err)
 	require.NoError(t, step.Execute(context.Background()).Error)
 
 	cfg, err := daemon.LoadDaemonConfig(paths.DaemonConfigPath)
 	require.NoError(t, err)
 	assert.Equal(t, defaultBlockNodeOrbit, cfg.Components.BlockNode.Orbit)
+}
+
+func TestWriteBlockNodeDaemonConfig_DisableTurnsMonitorOff(t *testing.T) {
+	paths := blockNodeConfigPaths(t)
+
+	// Seed an enabled block_node component with an operator-set statusz block and a
+	// co-located consensus_node component that must survive the disable.
+	seed := daemon.DaemonConfig{
+		Components: daemon.DaemonComponents{
+			ConsensusNode: &daemon.ConsensusNodeComponentConfig{
+				Enabled:    true,
+				Kubeconfig: "/opt/solo/weaver/config/daemon-cn.kubeconfig",
+				NodeID:     "3",
+				Orbit:      "hedera-network",
+				Monitors:   daemon.ConsensusNodeMonitors{Upgrade: true},
+			},
+			BlockNode: &daemon.BlockNodeComponentConfig{
+				Enabled:    true,
+				Kubeconfig: "/opt/solo/weaver/config/daemon-bn.kubeconfig",
+				Orbit:      "block-node",
+				Monitors:   daemon.BlockNodeMonitors{TrafficShaper: true},
+				Statusz:    &daemon.StatuszConfig{BaseURL: "http://127.0.0.1:8080", PollInterval: "3s"},
+			},
+		},
+	}
+	require.NoError(t, daemon.WriteDaemonConfig(paths.DaemonConfigPath, seed))
+
+	step, err := WriteBlockNodeDaemonConfigStep(paths, "block-node", false).Build()
+	require.NoError(t, err)
+	require.NoError(t, step.Execute(context.Background()).Error)
+
+	cfg, err := daemon.LoadDaemonConfig(paths.DaemonConfigPath)
+	require.NoError(t, err)
+	// block_node traffic-shaper monitor is off, statusz preserved.
+	require.NotNil(t, cfg.Components.BlockNode)
+	assert.False(t, cfg.Components.BlockNode.Enabled)
+	assert.False(t, cfg.Components.BlockNode.Monitors.TrafficShaper)
+	require.NotNil(t, cfg.Components.BlockNode.Statusz)
+	assert.Equal(t, "http://127.0.0.1:8080", cfg.Components.BlockNode.Statusz.BaseURL)
+	// consensus_node component is untouched — disabling BN must not affect it.
+	require.NotNil(t, cfg.Components.ConsensusNode)
+	assert.True(t, cfg.Components.ConsensusNode.Enabled)
+	assert.Equal(t, "3", cfg.Components.ConsensusNode.NodeID)
 }
 
 func TestWriteBlockNodeDaemonConfig_PreservesExistingBlocks(t *testing.T) {
@@ -84,7 +127,7 @@ func TestWriteBlockNodeDaemonConfig_PreservesExistingBlocks(t *testing.T) {
 	priorBytes, err := os.ReadFile(paths.DaemonConfigPath)
 	require.NoError(t, err)
 
-	step, err := WriteBlockNodeDaemonConfigStep(paths, "block-node").Build()
+	step, err := WriteBlockNodeDaemonConfigStep(paths, "block-node", true).Build()
 	require.NoError(t, err)
 	require.NoError(t, step.Execute(context.Background()).Error)
 

--- a/internal/workflows/steps/step_network_firewall_delete.go
+++ b/internal/workflows/steps/step_network_firewall_delete.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/network/firewall"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// NetworkFirewallDeleteStepId is the step ID for NetworkFirewallDelete.
+const NetworkFirewallDeleteStepId = "network-firewall-delete"
+
+// NetworkFirewallDelete removes the node-level `inet host` nftables table (the
+// same teardown as `network firewall delete`). It is the disable counterpart to
+// NetworkFirewallCreate, wired into `block node reconfigure` when the operator
+// turns the host firewall off on an already-provisioned host.
+//
+// The delete is idempotent (firewall.Manager.Delete existence-checks before
+// removing), so running it when no table is present is a no-op. It deliberately
+// does NOT disable the shared solo-provisioner-network-nft.service — that unit is
+// also used by the `inet weaver` plane and is only torn down by a full cluster
+// uninstall.
+func NetworkFirewallDelete() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(NetworkFirewallDeleteStepId).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Removing host firewall (inet host)")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to remove host firewall")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Host firewall removed")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if err := newFirewallManager().Delete(ctx); err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to remove the host firewall (inet host) table").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Inspect the live table: nft list table inet host",
+							"Remove it manually if needed: nft delete table inet host",
+							"Check the persisted artifact: ls -la " + firewall.HostNftPath,
+						})))
+			}
+			logx.As().Info().Msg("host firewall (inet host) table removed")
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			// Rollback is a no-op: the table was rendered from the resolved host
+			// config, which this step does not snapshot. Re-enabling the firewall is
+			// an explicit operator decision (block node reconfigure --firewall-enabled),
+			// not something to silently reconstruct on rollback.
+			return automa.SkippedReport(stp,
+				automa.WithDetail("host firewall delete rollback is a no-op; re-enable via block node reconfigure --firewall-enabled"))
+		})
+}

--- a/internal/workflows/steps/step_network_firewall_delete_test.go
+++ b/internal/workflows/steps/step_network_firewall_delete_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/automa-saga/automa"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNetworkFirewallDelete_RemovesTable verifies the step deletes the live inet
+// host table (and its on-disk artifact) via the firewall manager.
+func TestNetworkFirewallDelete_RemovesTable(t *testing.T) {
+	r := &fakeFwRunner{exists: true}
+	nftPath := withStubbedFirewall(t, r)
+	// Seed an on-disk artifact so we can assert the delete removes it.
+	require.NoError(t, os.MkdirAll(filepath.Dir(nftPath), 0o755))
+	require.NoError(t, os.WriteFile(nftPath, []byte("table inet host {}\n"), 0o644))
+
+	step, err := NetworkFirewallDelete().Build()
+	require.NoError(t, err)
+
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+	require.True(t, r.deleted, "delete step should remove the live table")
+	require.NoFileExists(t, nftPath, "delete step should remove the on-disk nft artifact")
+}
+
+// TestNetworkFirewallDelete_Idempotent verifies deleting when no table is present
+// is a no-op success (firewall.Manager.Delete existence-checks first).
+func TestNetworkFirewallDelete_Idempotent(t *testing.T) {
+	r := &fakeFwRunner{exists: false}
+	withStubbedFirewall(t, r)
+
+	step, err := NetworkFirewallDelete().Build()
+	require.NoError(t, err)
+
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+	require.False(t, r.deleted, "no live table present, nothing to delete")
+}

--- a/internal/workflows/steps/step_network_policy_delete.go
+++ b/internal/workflows/steps/step_network_policy_delete.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/network/policy"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// NetworkPolicyDeleteAllStepId is the step ID for NetworkPolicyDeleteAll.
+const NetworkPolicyDeleteAllStepId = "network-policy-delete-all"
+
+// NetworkPolicyDeleteAll tears down the BN workload classification plane (the
+// `inet weaver` table) by deleting every canonical BN policy. It is the disable
+// counterpart to NetworkPolicyCreate, wired into `block node reconfigure` when
+// the operator turns traffic shaping off on an already-provisioned block node.
+//
+// It walks canonicalBNPolicies and deletes only those that currently exist
+// (Manager.Delete errors on a missing policy, so each is Exists-checked first),
+// making the step idempotent. Each delete re-renders the live weaver chain
+// without that policy; deleting the last remaining policy tears the whole `inet
+// weaver` table down and removes the persisted network-weaver.nft, so no
+// separate NftWeaverPersist is needed on the disable path.
+func NetworkPolicyDeleteAll() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(NetworkPolicyDeleteAllStepId).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Removing network policies (inet weaver)")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to remove network policies")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Network policies removed")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			mgr := newPolicyManager()
+			var deleted int
+			for _, c := range canonicalBNPolicies {
+				exists, err := policy.Exists(c.name)
+				if err != nil {
+					return automa.FailureReport(stp, automa.WithError(
+						errorx.Decorate(err, "failed to check whether network policy %q exists", c.name).
+							WithProperty(models.ErrPropertyResolution, []string{
+								"Inspect the policy registry: ls " + policy.RegistryDir,
+							})))
+				}
+				if !exists {
+					continue
+				}
+				if err := mgr.Delete(ctx, c.name); err != nil {
+					return automa.FailureReport(stp, automa.WithError(
+						errorx.Decorate(err, "failed to delete network policy %q", c.name).
+							WithProperty(models.ErrPropertyResolution, []string{
+								"Inspect the live weaver table: nft list table inet weaver",
+								"Check the policy registry for leftover entries: ls " + policy.RegistryDir,
+								"Re-run the reconfigure; policy deletion is idempotent (delete-if-present)",
+							})))
+				}
+				deleted++
+			}
+			logx.As().Info().Int("deleted", deleted).Int("total", len(canonicalBNPolicies)).
+				Msg("network policies removed")
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			// Rollback is a no-op: re-creating the BN policy plane requires the pod
+			// CIDR and management allowlist that this teardown step does not carry.
+			// Re-enabling traffic shaping is an explicit operator decision (block node
+			// reconfigure --traffic-shaping-enabled), not a silent rollback action.
+			return automa.SkippedReport(stp,
+				automa.WithDetail("network policy delete rollback is a no-op; re-enable via block node reconfigure --traffic-shaping-enabled"))
+		})
+}

--- a/internal/workflows/steps/step_network_tc_egress_teardown.go
+++ b/internal/workflows/steps/step_network_tc_egress_teardown.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// TcEgressTeardownStepId is the step ID for TcEgressTeardown.
+const TcEgressTeardownStepId = "tc-egress-teardown"
+
+// TcEgressTeardown removes the egress tc HTB hierarchy (device root + all egress
+// classes) and re-renders the boot script to its empty default, dropping the live
+// shaping on the physical NIC. It is the disable counterpart to TcEgressPersist,
+// wired into `block node reconfigure` when traffic shaping is turned off.
+//
+// It must run after NetworkPolicyDeleteAll: the policy plane's --stamp rules
+// reference these classes, and the underlying shape teardown assumes those
+// references are already gone. The teardown is idempotent — with no egress config
+// present it re-renders the empty script and succeeds.
+func TcEgressTeardown() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(TcEgressTeardownStepId).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Removing tc-egress HTB hierarchy")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to remove tc-egress hierarchy")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "tc-egress hierarchy removed")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if err := shape.NewManager().TeardownEgress(ctx); err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to tear down the tc-egress HTB hierarchy").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Check the tc-egress service journal: journalctl -u solo-provisioner-tc-egress.service -n 20",
+							"Inspect the live qdisc: tc qdisc show",
+							"Verify the egress NIC is detectable: ip route get 8.8.8.8 | grep dev",
+						})))
+			}
+			logx.As().Info().Msg("tc-egress HTB hierarchy removed")
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			// Rollback is a no-op: the shaped hierarchy was provisioned from the
+			// operator's link-rate/--shape inputs, which this teardown step does not
+			// snapshot. Re-enabling shaping is an explicit reconfigure decision.
+			return automa.SkippedReport(stp,
+				automa.WithDetail("tc-egress teardown rollback is a no-op; re-enable via block node reconfigure --traffic-shaping-enabled"))
+		})
+}


### PR DESCRIPTION
## Summary

`block node install` gates the host firewall (`--firewall-enabled`) and the traffic-shaping bundle (network-policy plane + tc HTB shaping + traffic-shaper daemon monitor, `--traffic-shaping-enabled`) behind opt-in flags. `reconfigure` and `upgrade` had no equivalent, and no teardown existed short of a full uninstall — so an operator with an already-deployed block node couldn't turn either feature on or off without a `--force` reinstall.

This PR extends `reconfigure` and `upgrade` to enable **and** disable both features, modeled as **desired-state convergence**: a resolved `(firewall, traffic-shaping)` target drives one shared assembler (`networkPlaneSteps`) that emits create-if-missing steps to enable and delete-if-present steps to disable. The enable path reuses the existing install steps verbatim; only four small, idempotent teardown primitives are new.

### Behavior

- **`reconfigure`** — exposes `--firewall-enabled` / `--traffic-shaping-enabled` (interactive prompt + flags) and performs real teardown. Both prompts are **seeded from the block node's current state** (firewall from whether the `inet host` table exists; traffic shaping from the persisted `BlockNodeState.TrafficShapingDisabled`), so a no-flag / default-accept run never changes enablement. Teardown fires only on an explicit enabled→disabled toggle.
- **`upgrade`** — stays non-interactive. It reads the persisted install decision and re-asserts the matching plane create-if-missing, never prompting and never tearing anything down from a routine version bump.
- **Disable is non-destructive to the shared daemon** — it flips `block_node.enabled` / `monitors.traffic_shaper` to `false` in `daemon.yaml` without uninstalling the daemon service, so a co-located component (e.g. consensus-node monitoring) keeps running.
- **State polarity** — `reconfigure` persists the resolved traffic-shaping decision (shared patch helper renamed `patchBlockNodeStateWithTrafficShaping`, used by install + reconfigure); `upgrade` keeps the non-persisting patch so it never overwrites the decision from its zero-value input.

### Reuse

The change deliberately avoids duplicating the install path: a single `networkPlaneSteps` assembler serves both handlers; the two CLI resolvers gained one `seedEnabled` parameter rather than forking; and the teardown steps delegate to existing manager verbs (`firewall.Manager.Delete`, `policy.Manager.Delete`) plus one new `shape.Manager.TeardownEgress`.

## Test plan

### Automated

- [x] `task lint` — golangci-lint 0 issues, gofmt clean.
- [x] Native unit tests: `internal/network/{firewall,shape,policy}`, `internal/state`.
- [x] Linux-only packages (`internal/workflows/steps`, `internal/bll/blocknode`) — full suites pass, including:
  - `TestBuildWorkflow_TrafficShapingDisabled_TearsDown`, `TestBuildWorkflow_FirewallDisabled_DeletesTable`
  - `TestUpgrade_TrafficShapingEnabled_ReAssertsPlane`, `TestUpgrade_TrafficShapingDisabled_NoTeardown`
  - `TestNetworkFirewallDelete_{RemovesTable,Idempotent}`
  - `TestWriteBlockNodeDaemonConfig_DisableTurnsMonitorOff` (confirms the co-located consensus-node component is untouched)

```bash
go test -tags='!integration' ./internal/network/... ./internal/state/
task vm:test:unit   # steps + bll/blocknode (Linux-only)
```

### Manual UAT

Run on a provisioned single-node host (VM UAT env). Paths below assume the default weaver home `/opt/solo/weaver`; pick your own `--profile`, `--mgmt-cidrs`, and `--egress-interface` as appropriate. Helper commands used throughout:

```bash
# firewall table (host) / policy plane (weaver)
sudo nft list table inet host        # host firewall
sudo nft list table inet weaver      # BN classification plane
# tc egress shaping on the physical NIC
tc qdisc show dev <egress-nic>; tc class show dev <egress-nic>
# daemon component config + service state
sudo grep -A6 'block_node:' /opt/solo/weaver/config/daemon.yaml
systemctl is-active solo-provisioner-daemon.service
# persisted traffic-shaping decision (negative polarity: absent/false = enabled)
sudo grep trafficShapingDisabled /opt/solo/weaver/state/state.yaml || echo "absent → enabled"
```

#### Scenario 1 — Enable traffic shaping on a previously-declined install

```bash
# Install without traffic shaping
sudo solo-provisioner block node install --profile=<p> --traffic-shaping-enabled=false
sudo nft list table inet weaver 2>&1        # expect: No such file or directory
grep trafficShapingDisabled /opt/solo/weaver/state/state.yaml   # expect: trafficShapingDisabled: true

# Enable it via reconfigure (no reinstall)
sudo solo-provisioner block node reconfigure --profile=<p> \
  --traffic-shaping-enabled=true --egress-interface=<nic> --mgmt-cidrs=<cidr>
```

**Expect after reconfigure:**
- `sudo nft list table inet weaver` lists the 10 `bn-*` policies (`bn-publisher`, `bn-subscriber-in`, …, `bn-backfill`).
- `tc qdisc show dev <nic>` shows the HTB root (`qdisc htb 1: root … default …`); `tc class show dev <nic>` lists the egress classes.
- `daemon.yaml` `block_node.enabled: true`, `monitors.traffic_shaper: true`.
- `systemctl is-active solo-provisioner-daemon.service` → `active`.
- `state.yaml` `trafficShapingDisabled` is now `false`/absent.

#### Scenario 2 — Disable traffic shaping on an enabled node (co-located daemon safe)

Precondition: scenario 1 state, and (to prove the daemon isn't uninstalled) a co-located consensus-node component present in `daemon.yaml` (`consensus_node.enabled: true`).

```bash
sudo solo-provisioner block node reconfigure --profile=<p> --traffic-shaping-enabled=false
```

**Expect:**
- `sudo nft list table inet weaver` → `No such file or directory` (last policy delete tore the table down).
- `tc qdisc show dev <nic>` shows no HTB root (egress unshaped / default qdisc only).
- `daemon.yaml` `block_node.enabled: false`, `monitors.traffic_shaper: false`, **but** `consensus_node.enabled: true` is untouched.
- `systemctl is-active solo-provisioner-daemon.service` → still `active` (service NOT uninstalled).
- `state.yaml` `trafficShapingDisabled: true`.

> Note: the daemon reads `daemon.yaml` on its next config cycle/restart; to force the block-node monitor to stop immediately, `sudo systemctl restart solo-provisioner-daemon.service` (see Risks).

#### Scenario 3 — Host firewall toggle

```bash
# Enable on a node that had no firewall
sudo solo-provisioner block node reconfigure --profile=<p> \
  --firewall-enabled=true --mgmt-cidrs=<your-mgmt-cidr>
sudo nft list table inet host        # expect: table present with the SSH/mgmt allowlist

# Disable it (explicit toggle → teardown)
sudo solo-provisioner block node reconfigure --profile=<p> --firewall-enabled=false
sudo nft list table inet host 2>&1   # expect: No such file or directory
```

**Also verify no accidental teardown:** with the firewall enabled, run a reconfigure that does **not** pass `--firewall-enabled` (e.g. `reconfigure --profile=<p> --values=...`) and confirm `nft list table inet host` still shows the table — the prompt/flag is seeded from current state, so a no-flag run keeps it.

#### Scenario 4 — Upgrade re-asserts silently, never toggles

```bash
# On a TS-enabled node:
sudo solo-provisioner block node upgrade --profile=<p> --chart-version=<newer>
```

**Expect:** no firewall/traffic-shaping prompt; `inet weaver` policies and tc shaping still present afterward (re-asserted create-if-missing); `daemon.yaml` unchanged in enablement; daemon still `active`. On a TS-**disabled** node, the same upgrade adds no policy/tc/daemon config and tears nothing down (only the self-gating `inet host` firewall step runs, which no-ops without mgmt CIDRs).

## Risks

- **Daemon monitor reload on disable:** disabling traffic shaping edits `daemon.yaml` but does not restart the daemon, so the block-node traffic-shaper monitor stops on the daemon's next config read / restart rather than instantly. This matches the issue's "disable the monitor in daemon.yaml — without uninstalling" scope (a restart would briefly interrupt co-located components). If immediate effect is required, restart `solo-provisioner-daemon.service`.
- **Teardown rollbacks are no-ops:** re-enabling a feature is an explicit operator action, and reconstructing the plane needs inputs the teardown steps don't snapshot; each teardown step documents this.
- **`shape.TeardownEgress` has no hermetic unit test** (shape registry paths are `const`); it is covered by UAT step 2.

Closes #911
Closes #805