### PR TITLE
feat(blocknode): derive BN inbound listener ports from statusz; bootstrap health port from Helm

### DIFF
--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -62,6 +62,15 @@ func (h *InstallHandler) BuildWorkflow(
 
 	ins := inputs.Custom
 
+	// Resolve the health/statusz port from the operator's effective --values so the
+	// bn-mgmt policy set allows the port the BN actually listens on rather than a
+	// value baked into solo-weaver; falls back to the chart default when the
+	// operator supplies no override.
+	healthPort, err := bnpkg.ResolveHealthPort(ins.ValuesFile)
+	if err != nil {
+		return nil, err
+	}
+
 	// Enable the traffic-shaper monitor in daemon.yaml only when the policy
 	// plane it reconciles against was actually created — with traffic shaping
 	// disabled there is no inet weaver classification for the daemon to watch.
@@ -84,7 +93,7 @@ func (h *InstallHandler) BuildWorkflow(
 			// The host firewall is owned by the block-node workflow (not the generic
 			// kube cluster install); nftables is already installed/enabled by prior
 			// cluster provisioning, so it's safe to apply here.
-			workflows.NetworkSetupWorkflow(ins.EgressInterface, ins.LinkRate, toClassOverrides(ins.ShapeOverrides), inputs.Common.Force, ins.TrafficShapingEnabled),
+			workflows.NetworkSetupWorkflow(ins.EgressInterface, ins.LinkRate, toClassOverrides(ins.ShapeOverrides), inputs.Common.Force, ins.TrafficShapingEnabled, healthPort),
 			steps.SetupBlockNode(ins),
 		}
 		stepList = append(stepList, daemonConfigStep...)
@@ -106,7 +115,7 @@ func (h *InstallHandler) BuildWorkflow(
 			// nftables was just installed/enabled by NodeSetupWorkflow's
 			// systemSetupWorkflow, so applying the host firewall here (rather than
 			// in that generic, node-type-agnostic workflow) is safe.
-			workflows.NetworkSetupWorkflow(ins.EgressInterface, ins.LinkRate, toClassOverrides(ins.ShapeOverrides), inputs.Common.Force, ins.TrafficShapingEnabled),
+			workflows.NetworkSetupWorkflow(ins.EgressInterface, ins.LinkRate, toClassOverrides(ins.ShapeOverrides), inputs.Common.Force, ins.TrafficShapingEnabled, healthPort),
 			steps.SetupBlockNode(ins),
 		}
 		stepList = append(stepList, daemonConfigStep...)

--- a/internal/bll/blocknode/network_plane.go
+++ b/internal/bll/blocknode/network_plane.go
@@ -29,7 +29,11 @@ import (
 //
 // trafficShapingEnabled is the resolved traffic-shaping target. force is the
 // operator's --force, threaded into NetworkPolicyCreate for the enable path.
-func networkPlaneSteps(ins models.BlockNodeInputs, force, trafficShapingEnabled, allowTeardown bool) []automa.Builder {
+// healthPort is the resolved block-node health/statusz port (from
+// blocknode.ResolveHealthPort against the operator's effective values), threaded
+// into NetworkPolicyCreate so the bn-mgmt set tracks the port the BN actually
+// listens on — matching the install path.
+func networkPlaneSteps(ins models.BlockNodeInputs, force, trafficShapingEnabled, allowTeardown bool, healthPort string) []automa.Builder {
 	var out []automa.Builder
 
 	// Host firewall: desired-state convergence. NetworkFirewallCreate self-gates
@@ -58,7 +62,7 @@ func networkPlaneSteps(ins models.BlockNodeInputs, force, trafficShapingEnabled,
 		// enable), where post-workflow ensureBlockNodeDaemon installs and starts it.
 		shapeOverrides := toClassOverrides(ins.ShapeOverrides)
 		out = append(out,
-			steps.NetworkPolicyCreate(force),
+			steps.NetworkPolicyCreate(force, healthPort),
 			steps.NftWeaverPersist(),
 			steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate, shapeOverrides),
 			steps.TcIngressRecord(ins.EgressInterface, ins.LinkRate, shapeOverrides),

--- a/internal/bll/blocknode/reconfigure_handler.go
+++ b/internal/bll/blocknode/reconfigure_handler.go
@@ -55,12 +55,21 @@ func (h *ReconfigureHandler) BuildWorkflow(
 
 	ins := inputs.Custom
 
+	// Resolve the health/statusz port from the operator's effective --values so the
+	// bn-mgmt policy set allows the port the BN actually listens on rather than a
+	// value baked into solo-weaver; falls back to the chart default when the
+	// operator supplies no override. Mirrors the install path.
+	healthPort, err := bnpkg.ResolveHealthPort(ins.ValuesFile)
+	if err != nil {
+		return nil, err
+	}
+
 	// networkSteps is the shared network-plane prefix for every branch below.
 	// Reconfigure resolves both --firewall-enabled and --traffic-shaping-enabled
 	// fresh (in the CLI layer, seeded from the current on-host state), so the
 	// convergence assembler is driven by the operator's decision and is allowed to
 	// tear a feature down when it is turned off. See networkPlaneSteps.
-	networkSteps := networkPlaneSteps(ins, inputs.Common.Force, ins.TrafficShapingEnabled, true)
+	networkSteps := networkPlaneSteps(ins, inputs.Common.Force, ins.TrafficShapingEnabled, true, healthPort)
 
 	var wb *automa.WorkflowBuilder
 	switch {

--- a/internal/bll/blocknode/upgrade_handler.go
+++ b/internal/bll/blocknode/upgrade_handler.go
@@ -90,6 +90,15 @@ func (h *UpgradeHandler) BuildWorkflow(
 
 	ins := inputs.Custom
 
+	// Resolve the health/statusz port from the operator's effective --values so the
+	// re-asserted bn-mgmt policy set tracks the port the BN actually listens on
+	// rather than a value baked into solo-weaver; falls back to the chart default
+	// when the operator supplies no override. Mirrors the install path.
+	healthPort, err := bnpkg.ResolveHealthPort(ins.ValuesFile)
+	if err != nil {
+		return nil, err
+	}
+
 	// Silent network-plane convergence: re-assert the persisted host-firewall and
 	// traffic-shaping decision on every upgrade, create-if-missing only
 	// (allowTeardown=false), so a routine version bump neither regresses the network
@@ -97,7 +106,7 @@ func (h *UpgradeHandler) BuildWorkflow(
 	// decision recorded on BlockNodeState — upgrade never prompts and never resolves
 	// its own gate (only reconfigure does). Daemon activation, when traffic shaping is
 	// enabled, is handled post-workflow in the CLI layer.
-	networkSteps := networkPlaneSteps(ins, inputs.Common.Force, !currentState.BlockNodeState.TrafficShapingDisabled, false)
+	networkSteps := networkPlaneSteps(ins, inputs.Common.Force, !currentState.BlockNodeState.TrafficShapingDisabled, false, healthPort)
 
 	var wb *automa.WorkflowBuilder
 	if ins.ResetStorage {

--- a/internal/blocknode/ports.go
+++ b/internal/blocknode/ports.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package blocknode
+
+import (
+	"fmt"
+	oslib "os"
+
+	"github.com/joomcode/errorx"
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultBlockNodeHealthPort is the upstream hiero-block-node chart's
+// `blockNode.ports.health` default — the /healthz + statusz port
+// (oci://ghcr.io/hiero-ledger/hiero-block-node/block-node-server). It is the one
+// block-node facility port solo-weaver pins a-priori rather than reading back
+// from statusz: it bootstraps discovery (you fetch statusz *on* it, so it can't
+// itself come from the statusz payload) and it gates the bn-mgmt policy set. The
+// same value is templated into the rendered chart values (blockNode.ports.health)
+// as an explicit default, so absent any operator override the port solo-weaver
+// allows and the port the BN listens on can never diverge, and the traffic-shaper
+// daemon builds its statusz base URL on it.
+//
+// The publisher / subscriber / block-access / server-status listener ports are
+// deliberately NOT pinned here: the daemon reconciles them into the inet weaver
+// `<name>_ports` sets from the BN's statusz `local.port` at runtime.
+const DefaultBlockNodeHealthPort = "40983"
+
+// ResolveHealthPort returns the block-node health/statusz port solo-weaver should
+// allow (bn-mgmt) and, later, dial for statusz. It reads `blockNode.ports.health`
+// from the operator's effective --values file when one is supplied, so the
+// allowed port follows whatever the operator configured the BN to listen on
+// rather than a value baked into solo-weaver; it falls back to
+// DefaultBlockNodeHealthPort (which solo-weaver also templates into its base
+// values as the explicit default) when the file omits it or none is supplied.
+//
+// Only `blockNode.ports.health` is consulted — not `blockNode.config.SERVER_PORT`,
+// which is the main gRPC/service port (a different port from the /healthz +
+// statusz endpoint); using it as a fallback would point bn-mgmt at the wrong port
+// whenever an operator overrode SERVER_PORT but left the health port at its chart
+// default.
+func ResolveHealthPort(valuesFile string) (string, error) {
+	if valuesFile == "" {
+		return DefaultBlockNodeHealthPort, nil
+	}
+	data, err := oslib.ReadFile(valuesFile)
+	if err != nil {
+		return "", errorx.ExternalError.Wrap(err, "read block node values file %s", valuesFile)
+	}
+	var v struct {
+		BlockNode struct {
+			Ports struct {
+				Health any `yaml:"health"`
+			} `yaml:"ports"`
+		} `yaml:"blockNode"`
+	}
+	if err := yaml.Unmarshal(data, &v); err != nil {
+		return "", errorx.IllegalFormat.Wrap(err, "parse block node values file %s", valuesFile)
+	}
+	if p := scalarPort(v.BlockNode.Ports.Health); p != "" {
+		return p, nil
+	}
+	return DefaultBlockNodeHealthPort, nil
+}
+
+// scalarPort renders a YAML scalar port value (which may decode as an int or a
+// string) as a string, or "" when unset/null so the caller falls back to the
+// default. Any invalid value is left for the policy layer's ValidatePort to
+// reject with a precise error at create time.
+func scalarPort(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case int:
+		return fmt.Sprintf("%d", t)
+	case int64:
+		return fmt.Sprintf("%d", t)
+	case float64:
+		return fmt.Sprintf("%d", int64(t))
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}

--- a/internal/blocknode/ports_test.go
+++ b/internal/blocknode/ports_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package blocknode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeValues(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "values.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+	return p
+}
+
+func TestResolveHealthPort_NoFileReturnsDefault(t *testing.T) {
+	p, err := ResolveHealthPort("")
+	require.NoError(t, err)
+	require.Equal(t, DefaultBlockNodeHealthPort, p)
+}
+
+func TestResolveHealthPort_ReadsOperatorOverride(t *testing.T) {
+	// The operator's effective values win, so bn-mgmt follows the BN's real port.
+	f := writeValues(t, "blockNode:\n  ports:\n    health: 41000\n")
+	p, err := ResolveHealthPort(f)
+	require.NoError(t, err)
+	require.Equal(t, "41000", p)
+}
+
+func TestResolveHealthPort_StringValueSupported(t *testing.T) {
+	f := writeValues(t, "blockNode:\n  ports:\n    health: \"41234\"\n")
+	p, err := ResolveHealthPort(f)
+	require.NoError(t, err)
+	require.Equal(t, "41234", p)
+}
+
+func TestResolveHealthPort_MissingKeyFallsBackToDefault(t *testing.T) {
+	// SERVER_PORT is deliberately NOT consulted (it is the main gRPC port, not the
+	// health/statusz port), so this falls through to the chart default.
+	f := writeValues(t, "blockNode:\n  config:\n    SERVER_PORT: \"40840\"\n")
+	p, err := ResolveHealthPort(f)
+	require.NoError(t, err)
+	require.Equal(t, DefaultBlockNodeHealthPort, p)
+}
+
+func TestResolveHealthPort_MissingFileErrors(t *testing.T) {
+	_, err := ResolveHealthPort(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	require.Error(t, err)
+}

--- a/internal/blocknode/reachability.go
+++ b/internal/blocknode/reachability.go
@@ -16,11 +16,11 @@ import (
 )
 
 // BlockNodePublicPort is the well-known TCP port the block-node gRPC service
-// listens on. It's an ecosystem-wide contract (the chart defaults to it, every
-// SDK and tool assumes it), so the reachability probe dials it directly instead
-// of trying to look the port up by name on the Service — chart versions have
-// used `http`, `grpc`, and other names for it, and matching any of those is
-// more fragile than dialing the well-known number.
+// listens on (the chart's `service.port` default; every SDK and tool assumes
+// it). The reachability probe prefers the LoadBalancer Service's own advertised
+// port and falls back to this constant only when the Service exposes no port, so
+// a chart that publishes the service on a non-default port is probed on the port
+// it actually announces rather than a stale hardcoded number.
 const BlockNodePublicPort int64 = 40840
 
 // VerifyExternalReachable opens a TCP connection from the host running
@@ -118,5 +118,24 @@ func (m *Manager) findLoadBalancerEndpoint(ctx context.Context) (string, int64, 
 		return "", 0, errorx.IllegalState.New("loadBalancer.ingress[0].ip is empty on Service %s", lb.GetName())
 	}
 
-	return ip, BlockNodePublicPort, nil
+	return ip, loadBalancerPort(lb), nil
+}
+
+// loadBalancerPort returns the port the LoadBalancer Service advertises (its
+// first spec.ports entry), falling back to the well-known BlockNodePublicPort
+// when the Service exposes no ports — so the probe targets the port the Service
+// actually announces rather than a hardcoded number.
+func loadBalancerPort(lb *unstructured.Unstructured) int64 {
+	ports, found, _ := unstructured.NestedSlice(lb.Object, "spec", "ports")
+	if !found || len(ports) == 0 {
+		return BlockNodePublicPort
+	}
+	entry, ok := ports[0].(map[string]interface{})
+	if !ok {
+		return BlockNodePublicPort
+	}
+	if port, ok, _ := unstructured.NestedInt64(entry, "port"); ok && port > 0 {
+		return port
+	}
+	return BlockNodePublicPort
 }

--- a/internal/blocknode/reachability_port_test.go
+++ b/internal/blocknode/reachability_port_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package blocknode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestLoadBalancerPort_UsesServiceAdvertisedPort(t *testing.T) {
+	lb := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"ports": []interface{}{
+				map[string]interface{}{"port": int64(50051)},
+			},
+		},
+	}}
+	require.Equal(t, int64(50051), loadBalancerPort(lb),
+		"the probe targets the port the Service actually announces")
+}
+
+func TestLoadBalancerPort_FallsBackWhenNoPorts(t *testing.T) {
+	lb := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{},
+	}}
+	require.Equal(t, BlockNodePublicPort, loadBalancerPort(lb),
+		"a Service with no ports falls back to the well-known public port")
+}

--- a/internal/blocknode/shaper/policy_map.go
+++ b/internal/blocknode/shaper/policy_map.go
@@ -82,6 +82,69 @@ var categoryBindings = map[bindingKey]categoryBinding{
 	{Outbound, CategoryPartner}:   {policyName: "bn-backfill", compound: true},
 }
 
+// portBindings maps an INBOUND statusz category to the managed-ports policy sets
+// its endpoints' local.port values feed. It is a listener-port binding, separate
+// from categoryBindings (membership): the public category has no membership
+// binding (bn-subscriber-in / bn-public-out match any source), but its listener
+// ports — subscriber, block-access, AND server-status, which is public to
+// everyone — drive those two sets' `<name>_ports` match. Only inbound local.ports
+// are listener ports; an outbound connection originates from an ephemeral local
+// port ("*") and never feeds a listener-port set.
+//
+// Each mapped policy's ports set is reconciled every tick with present/absent
+// semantics: seeded present (empty) so a category the BN stops reporting clears
+// the set rather than leaving stale ports behind.
+var portBindings = map[Category][]string{
+	CategoryPublisher: {"bn-publisher"},
+	CategoryPartner:   {"bn-partner-out"},
+	CategoryPublic:    {"bn-subscriber-in", "bn-public-out"},
+}
+
+// managedPortsPolicyNames returns every policy name whose `<name>_ports` set the
+// daemon reconciles (the de-duplicated, sorted union of portBindings' targets).
+func managedPortsPolicyNames() []string {
+	seen := make(map[string]struct{})
+	for _, names := range portBindings {
+		for _, n := range names {
+			seen[n] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// computePortDeltas diffs each managed-ports policy's desired listener ports
+// (desiredPortsByPolicy[name]) against its live `<name>_ports` nft set and
+// returns the non-empty deltas, ordered by policy name. Like computePolicyDeltas
+// it reads live state via lister and mutates nothing; the delta's Policy field
+// carries the POLICY name (not the set name) so callers can look the desired
+// ports back up.
+func computePortDeltas(ctx context.Context, lister elementLister, desiredPortsByPolicy map[string][]string) ([]PolicyDelta, error) {
+	names := make([]string, 0, len(desiredPortsByPolicy))
+	for name := range desiredPortsByPolicy {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var deltas []PolicyDelta
+	for _, name := range names {
+		live, err := lister.ListElements(ctx, policy.PortsSetName(name))
+		if err != nil {
+			return nil, errorx.Decorate(err, "read live listener ports for policy %s", name)
+		}
+		delta := policy.DiffElements(desiredPortsByPolicy[name], live)
+		if delta.Empty() {
+			continue
+		}
+		deltas = append(deltas, PolicyDelta{Policy: name, SetDelta: delta})
+	}
+	return deltas, nil
+}
+
 // categoryEndpoints is one poll's desired membership view, keyed by the
 // (direction, category) each endpoint set was read from. For each key PRESENT in
 // the map, the slice is its active endpoints: plain IPv4 hosts/CIDRs for the

--- a/internal/blocknode/shaper/reconciler.go
+++ b/internal/blocknode/shaper/reconciler.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"net/netip"
 	"sort"
 	"strings"
 
@@ -191,7 +192,8 @@ func (r *Reconciler) fetchEndpoints(ctx context.Context) (categoryEndpoints, Net
 // bucketizeEndpoints folds one statusz snapshot into the desired membership,
 // keyed by (direction, category). Inbound endpoints are matched against the
 // inbound bindings (publisher/partner/restricted) and contribute their remote
-// host/CIDR; outbound endpoints are matched against the outbound bindings. The
+// host as an explicit-mask CIDR (a bare host IP is normalized to /32, see
+// hostCIDR); outbound endpoints are matched against the outbound bindings. The
 // compound bn-backfill set (outbound partner) contributes compound
 // "remote.Address:remote.Port" pairs, skipping any endpoint whose port is empty
 // or "*" (a wildcard port cannot key a compound set).
@@ -214,9 +216,10 @@ func bucketizeEndpoints(inbound, outbound NetworkData) categoryEndpoints {
 }
 
 // bucketize appends one direction's endpoints into ce under their owned
-// bindings, rendering compound "ip:port" tokens for compound sets and plain
-// host/CIDR otherwise. Endpoints with no owned binding for (dir, category) are
-// dropped; a compound endpoint with an empty or wildcard port is skipped.
+// bindings, rendering compound "ip:port" tokens for compound sets and an
+// explicit-mask CIDR (a bare host IP normalized to /32 via hostCIDR) otherwise.
+// Endpoints with no owned binding for (dir, category) are dropped; a compound
+// endpoint with an empty or wildcard port is skipped.
 func bucketize(ce categoryEndpoints, dir Direction, data NetworkData) {
 	for _, conn := range data.ActiveEndpoints {
 		k := bindingKey{dir: dir, cat: Category(conn.Category)}
@@ -225,7 +228,7 @@ func bucketize(ce categoryEndpoints, dir Direction, data NetworkData) {
 			continue
 		}
 		if !b.compound {
-			ce[k] = append(ce[k], conn.Remote.Address)
+			ce[k] = append(ce[k], hostCIDR(conn.Remote.Address))
 			continue
 		}
 		if conn.Remote.Port == "" || conn.Remote.Port == "*" {
@@ -235,10 +238,34 @@ func bucketize(ce categoryEndpoints, dir Direction, data NetworkData) {
 	}
 }
 
+// hostCIDR normalizes a statusz plain-set membership address into the
+// explicit-mask form the policy layer requires. statusz reports a connected peer
+// as a bare host IP ("198.51.100.7"), but policy.Manager.ApplySets validates
+// every plain-set element as a CIDR and rejects a bare IP outright
+// (sanity.ValidateCIDR: callers must be explicit about the mask). A bare IPv4
+// host is therefore rendered as an explicit /32; a value that already carries a
+// prefix ("10.0.0.0/24"), or that does not parse as a bare IPv4 address (an
+// unexpected wildcard or IPv6 token), is returned unchanged so the downstream
+// validator surfaces a precise error rather than this stage silently mangling
+// it. The /32 is diff-stable: policy.CanonicalizeElements collapses it back to
+// the bare address nft prints, so digests and membership deltas are identical to
+// the pre-normalization form.
+func hostCIDR(addr string) string {
+	if strings.Contains(addr, "/") {
+		return addr
+	}
+	if a, err := netip.ParseAddr(addr); err == nil && a.Is4() {
+		return addr + "/32"
+	}
+	return addr
+}
+
 // desiredMembership maps each owned key present in ce to its nft policy name,
-// carrying the raw statusz endpoints through unchanged (the policy Manager and
-// the diff engine canonicalize them on the way to the kernel). Keys with no
-// policy binding are dropped.
+// carrying the endpoints through unchanged (bucketize has already normalized
+// plain-set hosts to explicit-mask CIDRs and folded compound sets to "ip:port"
+// pairs; the policy Manager and the diff engine canonicalize ordering and the
+// /32 collapse on the way to the kernel). Keys with no policy binding are
+// dropped.
 func desiredMembership(ce categoryEndpoints) map[string][]string {
 	m := make(map[string][]string, len(ce))
 	for k, endpoints := range ce {

--- a/internal/blocknode/shaper/reconciler.go
+++ b/internal/blocknode/shaper/reconciler.go
@@ -21,12 +21,14 @@ type endpointFetcher interface {
 	OutboundClients(ctx context.Context) (NetworkData, error)
 }
 
-// membershipApplier writes desired per-policy nft set membership to the kernel.
+// setApplier writes desired per-policy nft set state to the kernel — CIDR
+// membership sets and managed listener-port sets — under a single lock
+// acquisition, so a reconcile tick is atomic (both dimensions or neither).
 // Satisfied by *policy.Manager; a fake is injected in tests. The bool return
-// distinguishes "applied" from "skipped because the operator apply lock was
-// held" (see policy.Manager.ApplyMembership).
-type membershipApplier interface {
-	ApplyMembership(ctx context.Context, desired map[string][]string) (bool, error)
+// distinguishes "applied" from "skipped because the operator apply lock was held"
+// (see policy.Manager.ApplySets).
+type setApplier interface {
+	ApplySets(ctx context.Context, membership, ports map[string][]string) (bool, error)
 }
 
 // Reconciler drives one reconcile of the block node traffic-shaper's nft policy
@@ -40,7 +42,7 @@ type membershipApplier interface {
 type Reconciler struct {
 	fetcher endpointFetcher
 	lister  elementLister
-	applier membershipApplier
+	applier setApplier
 }
 
 // NewReconciler wires the production Reconciler: statusz is read over HTTP from
@@ -66,21 +68,25 @@ type Result struct {
 	Digest    string   `json:"digest"`
 }
 
-// CheckResult is the unprivileged detect path's output: the sha256 digest of
-// the desired policy membership, and the canonical desired membership itself
-// (policy name -> nft-rendered elements) so `--check --output json` is useful
-// for daemon-side introspection and debugging, not just change detection.
+// CheckResult is the unprivileged detect path's output: the sha256 digest of the
+// desired policy state, the canonical desired CIDR membership (policy name ->
+// nft-rendered elements), and the desired per-policy listener ports derived from
+// statusz local.port, so `--check --output json` is useful for daemon-side
+// introspection and debugging, not just change detection. The digest covers BOTH
+// membership and ports, so a ports-only change is still detected.
 type CheckResult struct {
-	Digest  string              `json:"desired-digest"`
-	Desired map[string][]string `json:"desired"`
+	Digest       string              `json:"desired-digest"`
+	Desired      map[string][]string `json:"desired"`
+	DesiredPorts map[string][]string `json:"desired-ports"`
 }
 
 // Check fetches both statusz endpoints, buckets them into the desired
-// per-category membership, and returns the sha256 digest of the canonical
-// desired policy membership alongside that canonical membership. It reads no
-// nft state and requires no privilege — it is the unprivileged detect path.
+// per-category membership, derives the desired per-policy listener ports from
+// the inbound local.port values, and returns the sha256 digest over both. It
+// reads no nft state and requires no privilege — it is the unprivileged detect
+// path.
 func (r *Reconciler) Check(ctx context.Context) (CheckResult, error) {
-	ce, err := r.fetchEndpoints(ctx)
+	ce, inbound, err := r.fetchEndpoints(ctx)
 	if err != nil {
 		return CheckResult{}, err
 	}
@@ -88,16 +94,26 @@ func (r *Reconciler) Check(ctx context.Context) (CheckResult, error) {
 	if err != nil {
 		return CheckResult{}, err
 	}
-	return CheckResult{Digest: membershipDigest(canon), Desired: canon}, nil
+	portsDesired := desiredPorts(inbound)
+	return CheckResult{
+		Digest:       membershipDigest(combinedCanonical(canon, portsDesired)),
+		Desired:      canon,
+		DesiredPorts: portsDesired,
+	}, nil
 }
 
-// Apply fetches both statusz endpoints, buckets them into the desired
-// membership, reads the live nft sets to find which owned policies actually
-// changed, and rewrites only those. Policies already in the desired state are
-// not touched. The returned Result records the applied/unchanged split and the
-// desired-membership digest.
+// Apply fetches both statusz endpoints, derives the desired CIDR membership and
+// listener ports, reads the live nft sets to find which owned sets actually
+// changed, and rewrites only those. Sets already in the desired state are not
+// touched. Both dimensions' changes are applied together under a single lock
+// acquisition (see setApplier.ApplySets), so a tick is atomic — either both the
+// changed membership sets and the changed listener-port sets are written, or the
+// whole tick is skipped because an operator holds the lock. The returned Result
+// folds both into its applied/skipped/unchanged lists — a membership set reported
+// by its policy name (`bn-publisher`), a listener-port set by its nft set name
+// (`bn-publisher_ports`) — alongside the digest, which covers both dimensions.
 func (r *Reconciler) Apply(ctx context.Context) (Result, error) {
-	ce, err := r.fetchEndpoints(ctx)
+	ce, inbound, err := r.fetchEndpoints(ctx)
 	if err != nil {
 		return Result{}, err
 	}
@@ -106,53 +122,70 @@ func (r *Reconciler) Apply(ctx context.Context) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	digest := membershipDigest(canon)
+	portsDesired := desiredPorts(inbound)
+	digest := membershipDigest(combinedCanonical(canon, portsDesired))
 
-	deltas, err := computePolicyDeltas(ctx, r.lister, ce)
+	memDeltas, err := computePolicyDeltas(ctx, r.lister, ce)
+	if err != nil {
+		return Result{}, err
+	}
+	portDeltas, err := computePortDeltas(ctx, r.lister, portsDesired)
 	if err != nil {
 		return Result{}, err
 	}
 
-	changed := make(map[string][]string, len(deltas))
-	changedNames := make([]string, 0, len(deltas))
-	for _, d := range deltas {
-		changed[d.Policy] = desired[d.Policy]
-		changedNames = append(changedNames, d.Policy)
+	// Membership sets are keyed and reported by policy name; listener-port sets
+	// are keyed by policy name for the apply batch but reported by their
+	// `<name>_ports` nft set name.
+	changedMem := make(map[string][]string, len(memDeltas))
+	changedPorts := make(map[string][]string, len(portDeltas))
+	changed := make([]string, 0, len(memDeltas)+len(portDeltas))
+	for _, d := range memDeltas {
+		changedMem[d.Policy] = desired[d.Policy]
+		changed = append(changed, d.Policy)
 	}
-	sort.Strings(changedNames)
+	for _, d := range portDeltas {
+		changedPorts[d.Policy] = portsDesired[d.Policy]
+		changed = append(changed, policy.PortsSetName(d.Policy))
+	}
+	sort.Strings(changed)
 
-	res := Result{Digest: digest, Unchanged: unchangedPolicyNames(changedNames)}
-	if len(changed) == 0 {
+	res := Result{Digest: digest, Unchanged: unchangedSetNames(changed)}
+	if len(changedMem) == 0 && len(changedPorts) == 0 {
 		return res, nil
 	}
 
-	applied, err := r.applier.ApplyMembership(ctx, changed)
+	// One lock acquisition for both dimensions: the tick is atomic.
+	applied, err := r.applier.ApplySets(ctx, changedMem, changedPorts)
 	if err != nil {
-		return Result{}, errorx.ExternalError.Wrap(err, "apply reconciled traffic-shaper membership")
+		return Result{}, errorx.ExternalError.Wrap(err, "apply reconciled traffic-shaper sets")
 	}
+	// The operator apply lock being held (applied == false) means nothing was
+	// written, so the changed sets are still out of sync — report them as skipped
+	// rather than dropping them from both Applied and Unchanged.
 	if applied {
-		res.Applied = changedNames
+		res.Applied = changed
 	} else {
-		// The operator apply lock was held: nothing was written, so these
-		// policies are still out of sync — report them as skipped rather than
-		// silently dropping them from both Applied and Unchanged.
-		res.Skipped = changedNames
+		res.Skipped = changed
 	}
 	return res, nil
 }
 
-// fetchEndpoints reads both statusz endpoints and buckets them into the desired
-// per-category membership view.
-func (r *Reconciler) fetchEndpoints(ctx context.Context) (categoryEndpoints, error) {
+// fetchEndpoints reads both statusz endpoints, buckets them into the desired
+// per-category membership view, and returns the raw inbound NetworkData too:
+// listener-port derivation reads local.port straight off the inbound endpoints
+// (which the membership bucketize discards), so the port pass needs the raw
+// inbound payload rather than the bucketized view.
+func (r *Reconciler) fetchEndpoints(ctx context.Context) (categoryEndpoints, NetworkData, error) {
 	inbound, err := r.fetcher.InboundClients(ctx)
 	if err != nil {
-		return nil, err
+		return nil, NetworkData{}, err
 	}
 	outbound, err := r.fetcher.OutboundClients(ctx)
 	if err != nil {
-		return nil, err
+		return nil, NetworkData{}, err
 	}
-	return bucketizeEndpoints(inbound, outbound), nil
+	return bucketizeEndpoints(inbound, outbound), inbound, nil
 }
 
 // bucketizeEndpoints folds one statusz snapshot into the desired membership,
@@ -218,6 +251,71 @@ func desiredMembership(ce categoryEndpoints) map[string][]string {
 	return m
 }
 
+// desiredPorts derives each managed-ports policy's desired listener ports from
+// the inbound statusz local.port values, per the portBindings table. It is the
+// port-dimension counterpart to desiredMembership, and carries the same
+// present/absent semantics: every policy in portBindings is seeded present (with
+// an empty, de-duplicated slice), so a category the BN stops reporting collapses
+// its ports set to empty — clearing it — rather than leaving stale ports behind.
+//
+// Only local.port is read (the BN's own listener port); an endpoint whose
+// local.port is empty or "*" (an unspecified/wildcard port) is skipped, since a
+// wildcard cannot key an inet_service set. Outbound endpoints are never
+// consulted: an outbound connection originates from an ephemeral local port and
+// is not a listener.
+func desiredPorts(inbound NetworkData) map[string][]string {
+	perPolicy := make(map[string]map[string]struct{})
+	for _, names := range portBindings {
+		for _, name := range names {
+			if _, ok := perPolicy[name]; !ok {
+				perPolicy[name] = make(map[string]struct{})
+			}
+		}
+	}
+
+	for _, conn := range inbound.ActiveEndpoints {
+		names, ok := portBindings[Category(conn.Category)]
+		if !ok {
+			continue
+		}
+		port := conn.Local.Port
+		if port == "" || port == "*" {
+			continue
+		}
+		for _, name := range names {
+			perPolicy[name][port] = struct{}{}
+		}
+	}
+
+	out := make(map[string][]string, len(perPolicy))
+	for name, set := range perPolicy {
+		ports := make([]string, 0, len(set))
+		for p := range set {
+			ports = append(ports, p)
+		}
+		out[name] = sortedUnique(ports)
+	}
+	return out
+}
+
+// combinedCanonical merges the canonical desired CIDR membership (keyed by policy
+// name) with the desired listener ports (keyed by `<name>_ports`, the actual nft
+// set name) into one map, canonicalizing the ports the same way membership is.
+// Digesting this combined view means the digest changes when EITHER membership or
+// ports change, so the daemon's digest-based change detection never misses a
+// ports-only update. Keying ports under the `_ports` set name keeps them from
+// colliding with a policy's membership entry.
+func combinedCanonical(canon, portsDesired map[string][]string) map[string][]string {
+	combined := make(map[string][]string, len(canon)+len(portsDesired))
+	for name, elems := range canon {
+		combined[name] = elems
+	}
+	for name, ports := range portsDesired {
+		combined[policy.PortsSetName(name)] = policy.CanonicalizeElements(ports)
+	}
+	return combined
+}
+
 // membershipDigest returns a sha256 hex digest over a canonical serialization of
 // the desired membership: policy names sorted, each membership list sorted and
 // de-duplicated, rendered as `name\n<comma-joined members>\n` per policy. The
@@ -272,15 +370,29 @@ func ownedPolicyNames() []string {
 	return names
 }
 
-// unchangedPolicyNames returns the owned policy names not present in changed,
-// sorted.
-func unchangedPolicyNames(changed []string) []string {
+// ownedSetNames returns every nft set the traffic-shaper reconciles, sorted: the
+// CIDR membership sets (ownedPolicyNames, keyed by policy name) plus the managed
+// listener-port sets (`<name>_ports` for each managedPortsPolicyNames entry). It
+// is the denominator for the Apply Result's unchanged accounting across both
+// dimensions.
+func ownedSetNames() []string {
+	names := ownedPolicyNames()
+	for _, p := range managedPortsPolicyNames() {
+		names = append(names, policy.PortsSetName(p))
+	}
+	sort.Strings(names)
+	return names
+}
+
+// unchangedSetNames returns the owned set names (membership + listener-port sets)
+// not present in changed, sorted.
+func unchangedSetNames(changed []string) []string {
 	changedSet := make(map[string]struct{}, len(changed))
 	for _, c := range changed {
 		changedSet[c] = struct{}{}
 	}
 	var out []string
-	for _, name := range ownedPolicyNames() {
+	for _, name := range ownedSetNames() {
 		if _, ok := changedSet[name]; !ok {
 			out = append(out, name)
 		}

--- a/internal/blocknode/shaper/reconciler_test.go
+++ b/internal/blocknode/shaper/reconciler_test.go
@@ -40,27 +40,41 @@ func (f *fakeFetcher) OutboundClients(context.Context) (NetworkData, error) {
 	return f.outbound, nil
 }
 
-// fakeApplier records the membership it was asked to apply and returns a
-// configurable (applied, err).
+// fakeApplier records the membership and listener ports it was asked to apply in
+// a single ApplySets call and returns a configurable (applied, err).
 type fakeApplier struct {
-	got     map[string][]string
-	applied bool
-	err     error
-	calls   int
+	got      map[string][]string // last ApplySets membership input
+	gotPorts map[string][]string // last ApplySets ports input
+	applied  bool                // returned by ApplySets
+	err      error               // returned by ApplySets
+	calls    int                 // ApplySets calls
 }
 
-func (a *fakeApplier) ApplyMembership(_ context.Context, desired map[string][]string) (bool, error) {
+func (a *fakeApplier) ApplySets(_ context.Context, membership, ports map[string][]string) (bool, error) {
 	a.calls++
-	a.got = desired
+	a.got = membership
+	a.gotPorts = ports
 	if a.err != nil {
 		return false, a.err
 	}
 	return a.applied, nil
 }
 
-// conn is a small helper to build an inbound/outbound NetworkConnection.
+// conn is a small helper to build an inbound/outbound NetworkConnection with only
+// a remote (its local port is unset, so it drives membership but not listener
+// ports).
 func conn(category, addr, port string) NetworkConnection {
 	return NetworkConnection{Remote: Endpoint{Address: addr, Port: port}, Category: category}
+}
+
+// inconn builds an inbound NetworkConnection carrying a local listener port (the
+// BN side), used to exercise listener-port derivation.
+func inconn(category, localPort string) NetworkConnection {
+	return NetworkConnection{
+		Local:    Endpoint{Address: "192.168.1.119", Port: localPort},
+		Remote:   Endpoint{Address: "*", Port: "*"},
+		Category: category,
+	}
 }
 
 func TestMembershipDigest_Deterministic(t *testing.T) {
@@ -177,14 +191,16 @@ func TestReconciler_Check_DigestsDesired(t *testing.T) {
 	result, err := r.Check(context.Background())
 	require.NoError(t, err)
 
-	// The digest is exactly the digest of the canonical desired membership
-	// derived from the same snapshot — no nft read/write happened (nil
-	// lister/applier untouched).
+	// The digest is exactly the digest of the canonical desired membership AND
+	// listener ports derived from the same snapshot — no nft read/write happened
+	// (nil lister/applier untouched).
 	ce := bucketizeEndpoints(f.inbound, f.outbound)
 	wantCanon, err := canonicalDesiredMembership(ce)
 	require.NoError(t, err)
-	require.Equal(t, membershipDigest(wantCanon), result.Digest)
+	wantPorts := desiredPorts(f.inbound)
+	require.Equal(t, membershipDigest(combinedCanonical(wantCanon, wantPorts)), result.Digest)
 	require.Equal(t, wantCanon, result.Desired)
+	require.Equal(t, wantPorts, result.DesiredPorts)
 }
 
 func TestReconciler_Check_DigestIgnoresSpellingEquivalence(t *testing.T) {
@@ -236,13 +252,17 @@ func TestReconciler_Apply_AppliesOnlyChangedPolicies(t *testing.T) {
 	res, err := r.Apply(context.Background())
 	require.NoError(t, err)
 
-	// Only bn-publisher changed; it is the only policy handed to the applier.
+	// Only bn-publisher changed; it is the only policy in the membership batch. No
+	// inbound local.port was reported, so every managed-ports set is desired-empty
+	// and live-empty → the ports batch is empty (one atomic ApplySets call).
 	require.Equal(t, 1, applier.calls)
 	require.Equal(t, map[string][]string{"bn-publisher": {"10.1.0.1/32"}}, applier.got)
+	require.Empty(t, applier.gotPorts, "no port change → empty ports batch")
 
 	assert.Equal(t, []string{"bn-publisher"}, res.Applied)
-	// The other three owned policies are reported unchanged.
-	assert.Equal(t, []string{"bn-backfill", "bn-partner-out", "bn-restricted"}, res.Unchanged)
+	// Every other owned set — membership sets and the managed `_ports` sets — is
+	// reported unchanged.
+	assert.Equal(t, exclude(ownedSetNames(), "bn-publisher"), res.Unchanged)
 	assert.NotEmpty(t, res.Digest)
 }
 
@@ -254,9 +274,9 @@ func TestReconciler_Apply_NoChangesTakesNoApply(t *testing.T) {
 
 	res, err := r.Apply(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, 0, applier.calls, "no deltas → applier must not be called")
+	require.Equal(t, 0, applier.calls, "no deltas in either dimension → applier must not be called")
 	assert.Empty(t, res.Applied)
-	assert.Equal(t, ownedPolicyNames(), res.Unchanged)
+	assert.Equal(t, ownedSetNames(), res.Unchanged)
 }
 
 func TestReconciler_Apply_LockHeldReportsNothingApplied(t *testing.T) {
@@ -275,7 +295,24 @@ func TestReconciler_Apply_LockHeldReportsNothingApplied(t *testing.T) {
 	// The changed policy must not silently vanish from the result: it is
 	// reported skipped (still out of sync), not folded into unchanged.
 	assert.Equal(t, []string{"bn-publisher"}, res.Skipped)
-	assert.Equal(t, []string{"bn-backfill", "bn-partner-out", "bn-restricted"}, res.Unchanged)
+	assert.Equal(t, exclude(ownedSetNames(), "bn-publisher"), res.Unchanged)
+}
+
+// exclude returns all minus the dropped names, preserving order — a small helper
+// so unchanged-set expectations track ownedSetNames() rather than hardcoding the
+// full list.
+func exclude(all []string, drop ...string) []string {
+	dropSet := make(map[string]struct{}, len(drop))
+	for _, d := range drop {
+		dropSet[d] = struct{}{}
+	}
+	out := make([]string, 0, len(all))
+	for _, s := range all {
+		if _, ok := dropSet[s]; !ok {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func TestReconciler_Apply_PropagatesApplyError(t *testing.T) {
@@ -290,4 +327,141 @@ func TestReconciler_Apply_PropagatesApplyError(t *testing.T) {
 	_, err := r.Apply(context.Background())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "nft boom")
+}
+
+func TestDesiredPorts_DerivesPerFacilityFromInboundLocalPort(t *testing.T) {
+	inbound := NetworkData{ActiveEndpoints: []NetworkConnection{
+		inconn("publisher", "40984"),
+		inconn("partner", "40980"),
+		inconn("public", "40980"),     // subscriber
+		inconn("public", "40981"),     // block-access
+		inconn("public", "40982"),     // server-status — public to everyone
+		inconn("restricted", "49999"), // no port binding → ignored
+	}}
+
+	got := desiredPorts(inbound)
+
+	// publisher and partner map to a single set each; the public union
+	// (including server-status 40982) feeds both public-facing sets.
+	assert.Equal(t, map[string][]string{
+		"bn-publisher":     {"40984"},
+		"bn-partner-out":   {"40980"},
+		"bn-subscriber-in": {"40980", "40981", "40982"},
+		"bn-public-out":    {"40980", "40981", "40982"},
+	}, got)
+}
+
+func TestDesiredPorts_SeedsAllManagedPresentAndSkipsWildcardEmpty(t *testing.T) {
+	inbound := NetworkData{ActiveEndpoints: []NetworkConnection{
+		inconn("publisher", "*"), // wildcard local port → skipped
+		inconn("partner", ""),    // empty local port → skipped
+	}}
+
+	got := desiredPorts(inbound)
+
+	// Every managed-ports policy is present but empty (present-vs-absent is load
+	// bearing: present-empty clears the set, matching the membership contract).
+	require.Len(t, got, 4)
+	for _, name := range []string{"bn-publisher", "bn-partner-out", "bn-subscriber-in", "bn-public-out"} {
+		require.Contains(t, got, name)
+		assert.Empty(t, got[name], name)
+	}
+}
+
+func TestReconciler_Apply_ReconcilesListenerPorts(t *testing.T) {
+	// The public category has no membership binding, so a public inbound endpoint
+	// drives ONLY the listener-port pass — an isolated ports-only reconcile.
+	f := &fakeFetcher{inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+		inconn("public", "40982"),
+	}}}
+	lister := newFakeLister() // all sets live-empty
+	applier := &fakeApplier{applied: true}
+	r := &Reconciler{fetcher: f, lister: lister, applier: applier}
+
+	res, err := r.Apply(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, 1, applier.calls)
+	require.Empty(t, applier.got, "public has no membership binding → empty membership batch")
+	require.Equal(t, map[string][]string{
+		"bn-subscriber-in": {"40982"},
+		"bn-public-out":    {"40982"},
+	}, applier.gotPorts)
+
+	// The changed ports are reported by their `<name>_ports` nft set names.
+	assert.Equal(t, []string{"bn-public-out_ports", "bn-subscriber-in_ports"}, res.Applied)
+	assert.NotContains(t, res.Unchanged, "bn-public-out_ports")
+}
+
+func TestReconciler_Apply_PortLockHeldReportsPortsSkipped(t *testing.T) {
+	f := &fakeFetcher{inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+		inconn("public", "40982"),
+	}}}
+	lister := newFakeLister()
+	applier := &fakeApplier{applied: false} // operator lock held → skipped
+	r := &Reconciler{fetcher: f, lister: lister, applier: applier}
+
+	res, err := r.Apply(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, applier.calls)
+	assert.Empty(t, res.Applied)
+	assert.Equal(t, []string{"bn-public-out_ports", "bn-subscriber-in_ports"}, res.Skipped)
+}
+
+func TestReconciler_Apply_PropagatesPortApplyError(t *testing.T) {
+	f := &fakeFetcher{inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+		inconn("public", "40982"),
+	}}}
+	lister := newFakeLister()
+	applier := &fakeApplier{err: errors.New("nft ports boom")}
+	r := &Reconciler{fetcher: f, lister: lister, applier: applier}
+
+	_, err := r.Apply(context.Background())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "nft ports boom")
+}
+
+func TestReconciler_Check_DigestChangesOnPortsOnly(t *testing.T) {
+	// Two snapshots with identical membership (public has no membership binding)
+	// but different derived listener ports — the digest must still differ so the
+	// daemon's digest-based change detection never misses a ports-only update.
+	base := &fakeFetcher{inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+		inconn("public", "40982"),
+	}}}
+	changed := &fakeFetcher{inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+		inconn("public", "40999"),
+	}}}
+	resBase, err := (&Reconciler{fetcher: base}).Check(context.Background())
+	require.NoError(t, err)
+	resChanged, err := (&Reconciler{fetcher: changed}).Check(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, resBase.Desired, resChanged.Desired, "membership is identical")
+	require.NotEqual(t, resBase.Digest, resChanged.Digest, "ports-only change must move the digest")
+}
+
+func TestReconciler_Apply_MembershipAndPortsAppliedInOneAtomicCall(t *testing.T) {
+	// A publisher inbound endpoint carries both a remote (membership) and a
+	// local.port (listener port), so both dimensions change this tick — and must
+	// be handed to the applier in a SINGLE ApplySets call, so an operator cannot
+	// grab the lock between a membership write and a ports write and leave one
+	// dimension stale.
+	f := &fakeFetcher{inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+		{
+			Local:    Endpoint{Address: "192.0.2.10", Port: "40984"},
+			Remote:   Endpoint{Address: "198.51.100.1", Port: "*"},
+			Category: "publisher",
+		},
+	}}}
+	lister := newFakeLister()
+	applier := &fakeApplier{applied: true}
+	r := &Reconciler{fetcher: f, lister: lister, applier: applier}
+
+	res, err := r.Apply(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, 1, applier.calls, "both dimensions go through one atomic ApplySets call")
+	require.Equal(t, map[string][]string{"bn-publisher": {"198.51.100.1"}}, applier.got)
+	require.Equal(t, map[string][]string{"bn-publisher": {"40984"}}, applier.gotPorts)
+	assert.Equal(t, []string{"bn-publisher", "bn-publisher_ports"}, res.Applied)
 }

--- a/internal/blocknode/shaper/reconciler_test.go
+++ b/internal/blocknode/shaper/reconciler_test.go
@@ -156,6 +156,48 @@ func TestBucketizeEndpoints_SkipsWildcardAndEmptyBackfillPort(t *testing.T) {
 	assert.Equal(t, []string{"10.30.5.7:43473"}, ce[bindingKey{Outbound, CategoryPartner}])
 }
 
+// TestBucketizeEndpoints_NormalizesBareHostToSlash32 pins the fix for the
+// statusz-derived membership apply: a connected peer is reported by statusz as a
+// bare host IP, but the policy layer validates every plain-set element as a CIDR
+// and rejects a bare address. bucketize must therefore normalize a bare IPv4
+// host to an explicit /32 while leaving an already-masked CIDR untouched, so the
+// desired membership fed to ApplySets is always valid.
+func TestBucketizeEndpoints_NormalizesBareHostToSlash32(t *testing.T) {
+	inbound := NetworkData{ActiveEndpoints: []NetworkConnection{
+		conn("publisher", "198.51.100.234", "*"), // bare host → /32
+		conn("partner", "198.51.100.0/24", "*"),  // already a CIDR → unchanged
+	}}
+
+	ce := bucketizeEndpoints(inbound, NetworkData{})
+
+	assert.Equal(t, []string{"198.51.100.234/32"}, ce[bindingKey{Inbound, CategoryPublisher}])
+	assert.Equal(t, []string{"198.51.100.0/24"}, ce[bindingKey{Inbound, CategoryPartner}])
+}
+
+// TestReconciler_Apply_NormalizesBareHostMembership is the end-to-end guard: a
+// statusz snapshot carrying a bare host IP must reach ApplySets as an explicit
+// /32 CIDR (the form policy.Manager.ApplySets accepts), not the bare address
+// that surfaced the original apply failure.
+func TestReconciler_Apply_NormalizesBareHostMembership(t *testing.T) {
+	f := &fakeFetcher{
+		inbound: NetworkData{ActiveEndpoints: []NetworkConnection{
+			conn("publisher", "198.51.100.234", "*"),
+		}},
+		outbound: NetworkData{},
+	}
+	lister := newFakeLister()
+	lister.elements["bn-publisher"] = []string{"10.9.9.9"} // differs → change
+
+	applier := &fakeApplier{applied: true}
+	r := &Reconciler{fetcher: f, lister: lister, applier: applier}
+
+	res, err := r.Apply(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, map[string][]string{"bn-publisher": {"198.51.100.234/32"}}, applier.got)
+	assert.Equal(t, []string{"bn-publisher"}, res.Applied)
+}
+
 func TestBucketizeEndpoints_EmptySnapshotSeedsAllOwnedEmpty(t *testing.T) {
 	ce := bucketizeEndpoints(NetworkData{}, NetworkData{})
 	require.Len(t, ce, 4)
@@ -461,7 +503,7 @@ func TestReconciler_Apply_MembershipAndPortsAppliedInOneAtomicCall(t *testing.T)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, applier.calls, "both dimensions go through one atomic ApplySets call")
-	require.Equal(t, map[string][]string{"bn-publisher": {"198.51.100.1"}}, applier.got)
+	require.Equal(t, map[string][]string{"bn-publisher": {"198.51.100.1/32"}}, applier.got)
 	require.Equal(t, map[string][]string{"bn-publisher": {"40984"}}, applier.gotPorts)
 	assert.Equal(t, []string{"bn-publisher", "bn-publisher_ports"}, res.Applied)
 }

--- a/internal/blocknode/values.go
+++ b/internal/blocknode/values.go
@@ -124,10 +124,16 @@ func (m *Manager) renderDefaultValues(profile string) ([]byte, error) {
 		IncludeVerification     bool
 		IncludePlugins          bool
 		IncludeApplicationState bool
+		HealthPort              string
 	}{
 		IncludeVerification:     includeVerification,
 		IncludePlugins:          includePlugins,
 		IncludeApplicationState: includeApplicationState,
+		// Pin the BN's health/statusz port from the single Go source of truth so
+		// the port solo-weaver allows (bn-mgmt) and dials for statusz always
+		// matches the port the BN listens on, even if the upstream chart default
+		// changes underneath us.
+		HealthPort: DefaultBlockNodeHealthPort,
 	})
 	if err != nil {
 		return nil, errorx.InternalError.Wrap(err, "failed to render block node values template")

--- a/internal/daemon/blocknode/statuszmock/cmd/main.go
+++ b/internal/daemon/blocknode/statuszmock/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/hashgraph/solo-weaver/internal/daemon/blocknode/statuszmock"
 )
@@ -31,7 +32,22 @@ func main() {
 	roster := flag.String("roster", "roster.json", "path to the JSON roster file (re-read on every request)")
 	flag.Parse()
 
-	handler := statuszmock.Handler(statuszmock.FileRoster(*roster))
+	// Fall back to the built-in DefaultRoster only when the roster file is genuinely
+	// absent, so the demo serves a realistic per-facility roster (with listener
+	// ports) out of the box; drop in a roster.json to override it live. Any other
+	// stat error (permission denied, IO fault) is a real misconfiguration — fail
+	// fast rather than silently masking it behind the default roster.
+	var provider statuszmock.RosterProvider
+	switch _, err := os.Stat(*roster); {
+	case err == nil:
+		provider = statuszmock.FileRoster(*roster)
+	case os.IsNotExist(err):
+		log.Printf("roster file %s not found; serving the built-in default roster", *roster)
+		provider = statuszmock.StaticRoster(statuszmock.DefaultRoster())
+	default:
+		log.Fatalf("cannot stat roster file %s: %v", *roster, err)
+	}
+	handler := statuszmock.Handler(provider)
 
 	log.Printf("mock statusz server listening on %s, serving roster %s", *addr, *roster)
 	log.Printf("  GET %s/statusz/inbound-clients", *addr)

--- a/internal/daemon/blocknode/statuszmock/default_roster_test.go
+++ b/internal/daemon/blocknode/statuszmock/default_roster_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package statuszmock_test
+
+import (
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/internal/daemon/blocknode/statuszmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultRoster_CarriesPerFacilityListenerPorts(t *testing.T) {
+	r := statuszmock.DefaultRoster()
+
+	// Collect the local (BN-side) listener ports reported per category so the
+	// traffic-shaper derivation has realistic per-facility ports to reconcile.
+	ports := map[string]map[string]bool{}
+	for _, c := range r.Inbound {
+		if ports[c.Category] == nil {
+			ports[c.Category] = map[string]bool{}
+		}
+		ports[c.Category][c.Local.Port] = true
+	}
+
+	assert.True(t, ports["publisher"]["40984"], "publisher listens on 40984")
+	assert.True(t, ports["partner"]["40980"], "partners subscribe on 40980")
+	assert.True(t, ports["public"]["40980"], "public subscriber on 40980")
+	assert.True(t, ports["public"]["40981"], "public block-access on 40981")
+	assert.True(t, ports["public"]["40982"], "public server-status on 40982")
+
+	require.NotEmpty(t, r.Outbound, "the backfill peer appears as an outbound partner")
+}

--- a/internal/daemon/blocknode/statuszmock/server.go
+++ b/internal/daemon/blocknode/statuszmock/server.go
@@ -59,6 +59,42 @@ func StaticRoster(r Roster) RosterProvider {
 	return func() (Roster, error) { return r, nil }
 }
 
+// DefaultRoster returns a representative roster with realistic per-facility
+// listener ports, so a developer or UAT run gets a BN that exercises both the
+// membership and the listener-port reconciliation out of the box. It mirrors the
+// facility→port contract the traffic-shaper derives from `local.port`:
+//
+//   - publisher listens on 40984 (category publisher)
+//   - subscriber listens on 40980 (categories partner and public)
+//   - block-access listens on 40981 (category public)
+//   - server-status listens on 40982 (category public; public to everyone)
+//
+// Addresses are RFC 5737 documentation ranges (192.0.2.0/24 for the BN,
+// 198.51.100.0/24 for peers), deliberately NOT a real private range: a default
+// fixture must not pin host-network IPs that shift with the developer's actual
+// subnet (e.g. changing wifi) or collide with a live network. Only `local.port`
+// (listener ports) and `remote.address` (membership) are consumed by the
+// reconciler — `local.address` is never read. The dual-role backfill peer
+// (198.51.100.140) appears both inbound as a partner and outbound as the peer
+// this BN backfills from. For an environment-specific roster, drop in a
+// roster.json (FileRoster) to override this default.
+func DefaultRoster() Roster {
+	const bn = "192.0.2.10"
+	return Roster{
+		Inbound: []Connection{
+			{Local: Endpoint{bn, "40984"}, Remote: Endpoint{"198.51.100.234", "*"}, Category: "publisher"},
+			{Local: Endpoint{bn, "40980"}, Remote: Endpoint{"198.51.100.192", "*"}, Category: "partner"},
+			{Local: Endpoint{bn, "40980"}, Remote: Endpoint{"198.51.100.208", "*"}, Category: "public"},
+			{Local: Endpoint{bn, "40981"}, Remote: Endpoint{"*", "*"}, Category: "public"},
+			{Local: Endpoint{bn, "40982"}, Remote: Endpoint{"*", "*"}, Category: "public"},
+			{Local: Endpoint{bn, "40980"}, Remote: Endpoint{"198.51.100.140", "*"}, Category: "partner"},
+		},
+		Outbound: []Connection{
+			{Local: Endpoint{bn, "*"}, Remote: Endpoint{"198.51.100.140", "50980"}, Category: "partner"},
+		},
+	}
+}
+
 // FileRoster returns a provider that reads and decodes the JSON roster at path
 // on every call, so external edits take effect on the next poll without a
 // restart. A missing file yields an empty roster (the BN "has no clients yet"

--- a/internal/network/policy/manager.go
+++ b/internal/network/policy/manager.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
 	"github.com/joomcode/errorx"
 )
 
@@ -405,6 +406,144 @@ func (m *Manager) ApplyMembership(ctx context.Context, desired map[string][]stri
 	return acquired, nil
 }
 
+// ApplySets pushes desired CIDR membership AND listener ports to the live nft
+// sets under a SINGLE non-blocking acquisition of the shared apply flock, so a
+// reconcile tick is atomic: either both dimensions are written, or the whole tick
+// is skipped because an operator command holds the lock. It is the traffic-shaper
+// daemon's write path. Applying the two dimensions under two separate
+// acquisitions (ApplyMembership then ApplyPorts) would open a partial-apply
+// window where an operator could take the lock between them and leave one
+// dimension stale until the next force-resync.
+//
+// membership maps a policy name to its desired CIDR set; ports maps a
+// managed-ports policy name to its desired `<name>_ports` set. Each entry is a
+// full-list replace (an empty slice clears that set). Membership sets are applied
+// first, then port sets, each one `nft -f` transaction, in sorted name order. The
+// return contract matches ApplyMembership:
+//   - (false, nil): the lock was held by a hand-run operator command, nothing was
+//     written, the caller skips this tick;
+//   - (true, nil):  the lock was acquired and both dimensions applied cleanly;
+//   - (false, err): the lock was acquired but a set failed mid-batch.
+//
+// It acquires the lock itself, so it must NOT be called while the caller already
+// holds withLock/withLockNB.
+func (m *Manager) ApplySets(ctx context.Context, membership, ports map[string][]string) (applied bool, err error) {
+	if len(membership) == 0 && len(ports) == 0 {
+		return true, nil
+	}
+	memNames := sortedMapKeys(membership)
+	portNames := sortedMapKeys(ports)
+
+	acquired, err := m.withLockNB(func() error {
+		for _, name := range memNames {
+			if err := m.applySet(ctx, name, membership[name]); err != nil {
+				return err
+			}
+		}
+		for _, name := range portNames {
+			if err := m.applyPortsSet(ctx, name, ports[name]); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return acquired, nil
+}
+
+// sortedMapKeys returns m's keys in sorted order, for deterministic apply order.
+func sortedMapKeys(m map[string][]string) []string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ApplyPorts pushes desired listener ports into one or more managed-ports
+// policies' live `<name>_ports` sets. It is the traffic-shaper daemon's
+// listener-port write path — the exact counterpart of ApplyMembership for the
+// CIDR sets — reconciling each set from the BN's statusz local.port. It shares
+// ApplyMembership's batching, single non-blocking acquisition of the shared
+// apply flock, and return contract:
+//   - (false, nil): the lock was already held by a hand-run operator command, so
+//     nothing was written and the caller skips this tick;
+//   - (true, nil):  the lock was acquired and every policy applied cleanly;
+//   - (false, err): the lock was acquired but a policy failed mid-batch.
+//
+// Each map entry is a full-list replace: an empty slice clears that policy's
+// ports set. A name absent from the registry, or one whose ports are static
+// rather than daemon-managed, is an error (the policy structure is fixed by
+// `block node install`). Like ApplyMembership it acquires the lock itself, so it
+// must NOT be called while the caller already holds withLock/withLockNB.
+func (m *Manager) ApplyPorts(ctx context.Context, desired map[string][]string) (applied bool, err error) {
+	if len(desired) == 0 {
+		return true, nil
+	}
+	names := make([]string, 0, len(desired))
+	for name := range desired {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	acquired, err := m.withLockNB(func() error {
+		for _, name := range names {
+			if err := m.applyPortsSet(ctx, name, desired[name]); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return acquired, nil
+}
+
+// applyPortsSet replaces the live `<name>_ports` set for one managed-ports
+// policy with ports via a single `flush set + add element` transaction. Like
+// applySet (its CIDR-membership sibling) it performs NO locking: callers must
+// already hold the shared apply lock. Every port is validated before the write
+// so a malformed statusz value can never poison the nft transaction.
+func (m *Manager) applyPortsSet(ctx context.Context, name string, ports []string) error {
+	p, err := m.requirePolicyWithPortsSet(name)
+	if err != nil {
+		return err
+	}
+	for _, port := range ports {
+		if err := sanity.ValidatePort(port); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid listener port %q for policy %q", port, name)
+		}
+	}
+	if err := m.requireTableExists(ctx, name); err != nil {
+		return err
+	}
+	return m.runner.SetElements(ctx, PortsSetName(p.Name), ports)
+}
+
+// requirePolicyWithPortsSet loads the named policy and verifies it carries a
+// daemon-managed ports set (ManagedPorts). Returns an error if the policy is
+// missing or its ports are static/none — the daemon must only ever write the
+// managed-ports sets `block node install` declared, never a static or absent one.
+func (m *Manager) requirePolicyWithPortsSet(name string) (*Policy, error) {
+	p, err := readEntry(m.registryDir, name)
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, errorx.IllegalState.New(
+			"policy %q not found; run `network policy create` with --name and the original policy flags first", name)
+	}
+	if !p.ManagedPorts {
+		return nil, errorx.IllegalArgument.New(
+			"policy %q has no daemon-managed ports set; its listener ports are static, not reconciled from statusz", name)
+	}
+	return p, nil
+}
+
 // Show returns a human-readable summary of a named policy: its registry config
 // (action, class, ports, created_at) followed by the live set membership from
 // the kernel (`nft list set inet weaver <name>`). No lock is taken — Show is
@@ -432,6 +571,17 @@ func (m *Manager) Show(ctx context.Context, name string) (string, error) {
 	}
 	if len(p.Ports) > 0 {
 		fmt.Fprintf(&b, "  ports:   %s\n", strings.Join(p.Ports, ", "))
+	}
+	if p.ManagedPorts {
+		ports, err := m.runner.ListElements(ctx, PortsSetName(p.Name))
+		if err != nil {
+			return "", err
+		}
+		if len(ports) == 0 {
+			b.WriteString("  ports:   managed (reconciled from statusz; none yet)\n")
+		} else {
+			fmt.Fprintf(&b, "  ports:   managed (reconciled from statusz): %s\n", strings.Join(ports, ", "))
+		}
 	}
 	if p.FromEntityWorld {
 		b.WriteString("  from-entity: world\n")

--- a/internal/network/policy/manager_apply_ports_test.go
+++ b/internal/network/policy/manager_apply_ports_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// seedManagedPortsPolicy creates a --stamp policy whose listener ports are
+// daemon-managed (empty <name>_ports set at render, filled by ApplyPorts).
+func seedManagedPortsPolicy(t *testing.T, m *Manager, name, stamp string) {
+	t.Helper()
+	_, err := m.Create(context.Background(),
+		&Policy{Name: name, Action: ActionStamp, Stamp: stamp, ManagedPorts: true},
+		nil, "10.4.0.0/24", false)
+	require.NoError(t, err)
+}
+
+func TestApplyPorts_WritesManagedPortsSet(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedManagedPortsPolicy(t, m, "bn-publisher", "publisher")
+
+	applied, err := m.ApplyPorts(context.Background(), map[string][]string{
+		"bn-publisher": {"40984"},
+	})
+	require.NoError(t, err)
+	require.True(t, applied)
+	require.Equal(t, []string{"40984"}, r.elements["bn-publisher_ports"],
+		"ApplyPorts writes the <name>_ports set, not the membership set")
+	require.Empty(t, r.elements["bn-publisher"], "the CIDR membership set is untouched")
+}
+
+func TestApplyPorts_EmptyClearsPortsSet(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedManagedPortsPolicy(t, m, "bn-publisher", "publisher")
+
+	_, err := m.ApplyPorts(context.Background(), map[string][]string{"bn-publisher": {"40984"}})
+	require.NoError(t, err)
+	_, err = m.ApplyPorts(context.Background(), map[string][]string{"bn-publisher": {}})
+	require.NoError(t, err)
+	require.Empty(t, r.elements["bn-publisher_ports"], "an empty desired list clears the ports set")
+}
+
+func TestApplyPorts_RejectsNonManagedPolicy(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	// A static-ports policy is not daemon-managed; ApplyPorts must refuse it.
+	seedPolicy(t, m, "bn-mgmt", "reserve-ingress", []string{"40983"}, nil, "10.4.0.0/24")
+
+	_, err := m.ApplyPorts(context.Background(), map[string][]string{"bn-mgmt": {"40983"}})
+	require.ErrorContains(t, err, "no daemon-managed ports set")
+}
+
+func TestApplyPorts_RejectsInvalidPort(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedManagedPortsPolicy(t, m, "bn-publisher", "publisher")
+
+	_, err := m.ApplyPorts(context.Background(), map[string][]string{"bn-publisher": {"99999999"}})
+	require.ErrorContains(t, err, "invalid listener port")
+	require.Empty(t, r.elements["bn-publisher_ports"], "an invalid port must not be written")
+}
+
+func TestApplySets_WritesBothDimensionsUnderOneLock(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedManagedPortsPolicy(t, m, "bn-publisher", "publisher")
+
+	applied, err := m.ApplySets(context.Background(),
+		map[string][]string{"bn-publisher": {"10.1.0.1/32"}},
+		map[string][]string{"bn-publisher": {"40984"}})
+	require.NoError(t, err)
+	require.True(t, applied)
+	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"], "membership set written")
+	require.Equal(t, []string{"40984"}, r.elements["bn-publisher_ports"], "ports set written")
+}
+
+func TestApplySets_SkipsBothDimensionsWhenLockHeld(t *testing.T) {
+	r := newFakeRunner()
+	m, nftPath, _ := newTestManager(t, r)
+	seedManagedPortsPolicy(t, m, "bn-publisher", "publisher")
+
+	lf, err := os.OpenFile(lockPathFor(nftPath), os.O_CREATE|os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	defer func() { _ = lf.Close() }()
+	require.NoError(t, syscall.Flock(int(lf.Fd()), syscall.LOCK_EX))
+	defer func() { _ = syscall.Flock(int(lf.Fd()), syscall.LOCK_UN) }()
+
+	applied, err := m.ApplySets(context.Background(),
+		map[string][]string{"bn-publisher": {"10.1.0.1/32"}},
+		map[string][]string{"bn-publisher": {"40984"}})
+	require.NoError(t, err, "a held lock is not an error — the whole tick is skipped")
+	require.False(t, applied)
+	require.Empty(t, r.elements["bn-publisher"], "membership not written when the tick is skipped")
+	require.Empty(t, r.elements["bn-publisher_ports"], "ports not written either — the skip is atomic")
+}
+
+func TestApplyPorts_SkipsWhenLockHeld(t *testing.T) {
+	r := newFakeRunner()
+	m, nftPath, _ := newTestManager(t, r)
+	seedManagedPortsPolicy(t, m, "bn-publisher", "publisher")
+
+	lf, err := os.OpenFile(lockPathFor(nftPath), os.O_CREATE|os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	defer func() { _ = lf.Close() }()
+	require.NoError(t, syscall.Flock(int(lf.Fd()), syscall.LOCK_EX))
+	defer func() { _ = syscall.Flock(int(lf.Fd()), syscall.LOCK_UN) }()
+
+	applied, err := m.ApplyPorts(context.Background(), map[string][]string{"bn-publisher": {"40984"}})
+	require.NoError(t, err, "a held lock is not an error — the tick is skipped")
+	require.False(t, applied)
+	require.Empty(t, r.elements["bn-publisher_ports"], "nothing is written when the tick is skipped")
+}

--- a/internal/network/policy/policy.go
+++ b/internal/network/policy/policy.go
@@ -52,7 +52,8 @@ type Policy struct {
 	Stamp           string    `json:"stamp"`             // HTB class (from --stamp); "" for deny
 	ReplyStamp      string    `json:"reply_stamp"`       // reply class (from --reply-stamp); "" if unset
 	Direction       Direction `json:"direction"`         // derived from Stamp's class by Validate; "" for deny
-	Ports           []string  `json:"ports"`             // workload listener ports (from --ports); nil if none
+	Ports           []string  `json:"ports"`             // static workload listener ports (from --ports); nil if none or ManagedPorts
+	ManagedPorts    bool      `json:"managed_ports"`     // true when <name>_ports is filled by the daemon from statusz, not seeded here
 	FromEntityWorld bool      `json:"from_entity_world"` // true if --from-entity world (no IP-set clause)
 	CreatedAt       time.Time `json:"created_at"`        // tiebreaker within a tier, preserved across a --force replace
 }
@@ -91,6 +92,15 @@ func (p *Policy) Validate(cidrs []string) error {
 	for _, port := range p.Ports {
 		if err := sanity.ValidatePort(port); err != nil {
 			return errorx.IllegalArgument.Wrap(err, "invalid --ports entry %q", port)
+		}
+	}
+
+	if p.ManagedPorts {
+		if p.Action != ActionStamp {
+			return errorx.IllegalArgument.New("managed ports are only valid with --stamp")
+		}
+		if len(p.Ports) > 0 {
+			return errorx.IllegalArgument.New("managed ports are mutually exclusive with static --ports (the daemon fills the set from statusz)")
 		}
 	}
 
@@ -140,6 +150,9 @@ func (p *Policy) validateDeny() error {
 	if len(p.Ports) > 0 {
 		return errorx.IllegalArgument.New("--ports does not apply to --deny")
 	}
+	if p.ManagedPorts {
+		return errorx.IllegalArgument.New("managed ports do not apply to --deny")
+	}
 	if p.FromEntityWorld {
 		return errorx.IllegalArgument.New("--from-entity world does not apply to --deny")
 	}
@@ -182,6 +195,13 @@ func (p *Policy) hasCIDRSet() bool {
 	return !p.FromEntityWorld
 }
 
+// hasPortsSet reports whether the policy renders a named `@<name>_ports`
+// listener-port set — either statically seeded (len(Ports) > 0) or daemon-managed
+// (ManagedPorts, filled from statusz at runtime and declared empty at render).
+func (p *Policy) hasPortsSet() bool {
+	return len(p.Ports) > 0 || p.ManagedPorts
+}
+
 func validateIPPort(s string) error {
 	host, port, err := net.SplitHostPort(s)
 	if err != nil {
@@ -220,6 +240,13 @@ func portElements(ports []string) string {
 	return strings.Join(ports, ", ")
 }
 
+// PortsSetName returns the nft set name that holds a policy's listener ports
+// (`<name>_ports`). Rendered by renderSetDecls, referenced by the stamp rule's
+// `tcp dport/sport @<name>_ports` clause, and written by Manager.ApplyPorts.
+func PortsSetName(policyName string) string {
+	return policyName + "_ports"
+}
+
 // isSpecific reports whether p is a "specific" stamp policy for tier-3/4
 // grouping and overlap purposes: an --stamp policy that is not --from-entity
 // world (i.e. one that renders an IP-set clause). Deny policies and
@@ -238,8 +265,16 @@ func portsKey(ports []string) string {
 }
 
 // groupKey returns the (Direction, Ports) grouping key used both by
-// renderChain's tier-3/4 ordering and by the overlap check below.
+// renderChain's tier-3/4 ordering and by the overlap check below. A
+// managed-ports policy carries no static ports — its real listener ports are
+// reconciled from statusz at runtime and are distinct per policy by design — so
+// each is keyed to its own group: two managed-ports policies can never be seen
+// as overlapping statically (their empty static port lists would otherwise
+// collide), and the runtime distinction they actually have is invisible here.
 func groupKey(p *Policy) string {
+	if p.ManagedPorts {
+		return string(p.Direction) + "|managed:" + p.Name
+	}
 	return string(p.Direction) + "|" + portsKey(p.Ports)
 }
 

--- a/internal/network/policy/render.go
+++ b/internal/network/policy/render.go
@@ -16,8 +16,10 @@ import (
 // registry policies, in tier order. The same output feeds both the kernel apply
 // (`nft -f`) and the on-disk artifact, so the live table and the persisted file
 // can never diverge. Set *membership* is deliberately not rendered here — only
-// set schemas and the static `--ports` elements — because membership is owned
-// by the daemon poll loop and never persisted.
+// set schemas and any static `--ports` elements — because membership is owned
+// by the daemon poll loop and never persisted. A managed-ports set
+// (`<name>_ports` for a ManagedPorts policy) is likewise declared empty here and
+// filled from statusz at runtime, exactly like the CIDR membership set.
 //
 // Rule position is determined by action type and match specificity, never by
 // creation order:
@@ -92,8 +94,9 @@ func sortedByName(policies []*Policy) []*Policy {
 }
 
 // renderSetDecls emits the schema for each policy's sets, name-sorted for a
-// deterministic render. Membership set elements are omitted; only the static
-// `--ports` set carries elements.
+// deterministic render. Membership set elements are omitted; only a static
+// `--ports` set carries inline elements — a managed-ports set is declared empty
+// and filled by the daemon.
 func renderSetDecls(policies []*Policy) ([]string, error) {
 	var lines []string
 	for _, p := range policies {
@@ -106,8 +109,16 @@ func renderSetDecls(policies []*Policy) ([]string, error) {
 			}
 		}
 		if len(p.Ports) > 0 {
-			lines = append(lines, fmt.Sprintf("\tset %s_ports { type inet_service; elements = { %s }; }",
-				p.Name, portElements(p.Ports)))
+			lines = append(lines, fmt.Sprintf("\tset %s { type inet_service; elements = { %s }; }",
+				PortsSetName(p.Name), portElements(p.Ports)))
+		} else if p.ManagedPorts {
+			// Daemon-managed listener ports: the set is declared but empty,
+			// exactly like the CIDR membership set above. The traffic-shaper
+			// poll loop fills it from the BN's statusz local.port each tick;
+			// nothing is seeded (or persisted) here. Until the first poll the
+			// set is empty, so the `tcp dport @<name>_ports` clause matches
+			// nothing — the same bootstrap behavior the membership sets have.
+			lines = append(lines, fmt.Sprintf("\tset %s { type inet_service; }", PortsSetName(p.Name)))
 		}
 	}
 	return lines, nil
@@ -294,16 +305,16 @@ func renderStampRule(p *Policy, podCIDR string) (string, error) {
 		if p.hasCIDRSet() {
 			b.WriteString(" ip saddr @" + p.Name)
 		}
-		if len(p.Ports) > 0 {
-			b.WriteString(" tcp dport @" + p.Name + "_ports")
+		if p.hasPortsSet() {
+			b.WriteString(" tcp dport @" + PortsSetName(p.Name))
 		}
 	case DirectionEgress:
 		b.WriteString("ip saddr " + podCIDR)
 		if p.hasCIDRSet() {
 			b.WriteString(" ip daddr @" + p.Name)
 		}
-		if len(p.Ports) > 0 {
-			b.WriteString(" tcp sport @" + p.Name + "_ports")
+		if p.hasPortsSet() {
+			b.WriteString(" tcp sport @" + PortsSetName(p.Name))
 		}
 	default:
 		return "", errorx.AssertionFailed.New("stamp policy %q has no direction", p.Name)

--- a/internal/network/policy/render_managed_ports_test.go
+++ b/internal/network/policy/render_managed_ports_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRender_ManagedPortsSetDeclaredEmptyWithDportClause(t *testing.T) {
+	// A managed-ports policy: its <name>_ports set is declared but empty (the
+	// daemon fills it from statusz), yet the classification rule still references
+	// it so the port match takes effect once populated.
+	managed := &Policy{
+		Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher",
+		Direction: DirectionIngress, ManagedPorts: true,
+	}
+	doc, err := Render([]*Policy{managed}, "10.4.0.0/24")
+	require.NoError(t, err)
+
+	require.Contains(t, doc, "set bn-publisher_ports { type inet_service; }",
+		"managed ports set is declared empty (no inline elements)")
+	require.NotContains(t, doc, "bn-publisher_ports { type inet_service; elements",
+		"managed ports set must not carry inline elements")
+	require.Contains(t, doc, "tcp dport @bn-publisher_ports",
+		"the classification rule references the ports set even while it is empty")
+}
+
+func TestRender_StaticPortsSetKeepsInlineElements(t *testing.T) {
+	static := &Policy{
+		Name: "bn-mgmt-in", Action: ActionStamp, Stamp: "reserve-ingress",
+		Direction: DirectionIngress, Ports: []string{"40983"},
+	}
+	doc, err := Render([]*Policy{static}, "10.4.0.0/24")
+	require.NoError(t, err)
+
+	require.Contains(t, doc, "set bn-mgmt-in_ports { type inet_service; elements = { 40983 }; }")
+	require.Contains(t, doc, "tcp dport @bn-mgmt-in_ports")
+}

--- a/internal/templates/files/block-node/full-values.yaml
+++ b/internal/templates/files/block-node/full-values.yaml
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 blockNode:
+  # Pin the health/statusz port so the port solo-weaver allows (bn-mgmt) and dials
+  # for statusz always matches the port the block node listens on. Rendered from
+  # DefaultBlockNodeHealthPort so this stays a single source of truth. The other
+  # facility ports (publisher/subscriber/block-access/server-status) are read back
+  # from statusz and reconciled at runtime, so they are not pinned here.
+  ports:
+    health: {{ .HealthPort }}
   config:
     BLOCK_NODE_EARLIEST_MANAGED_BLOCK: "100000000"
     MESSAGING_BLOCK_NOTIFICATION_QUEUE_SIZE: "512"

--- a/internal/templates/files/block-node/nano-values.yaml
+++ b/internal/templates/files/block-node/nano-values.yaml
@@ -9,6 +9,13 @@ resources:
     memory: "1.5Gi"
 
 blockNode:
+  # Pin the health/statusz port so the port solo-weaver allows (bn-mgmt) and dials
+  # for statusz always matches the port the block node listens on. Rendered from
+  # DefaultBlockNodeHealthPort so this stays a single source of truth. The other
+  # facility ports (publisher/subscriber/block-access/server-status) are read back
+  # from statusz and reconciled at runtime, so they are not pinned here.
+  ports:
+    health: {{ .HealthPort }}
   config:
     JAVA_OPTS: '-Xms1G -Xmx1G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="/tmp/dump.hprof"'
     MESSAGING_BLOCK_ITEM_QUEUE_SIZE: "128"

--- a/internal/workflows/network_setup.go
+++ b/internal/workflows/network_setup.go
@@ -30,11 +30,11 @@ import (
 // included — it is gated separately by hostCfg.Disabled inside its own step).
 // When false, none of the four steps are added: there is no inet weaver table
 // to persist and no tc config to shape traffic with.
-func NetworkSetupWorkflow(egressInterface, linkRate string, shapeOverrides map[string]shape.ClassOverride, force bool, trafficShapingEnabled bool) *automa.WorkflowBuilder {
+func NetworkSetupWorkflow(egressInterface, linkRate string, shapeOverrides map[string]shape.ClassOverride, force bool, trafficShapingEnabled bool, healthPort string) *automa.WorkflowBuilder {
 	stepList := []automa.Builder{steps.NetworkFirewallCreate()}
 	if trafficShapingEnabled {
 		stepList = append(stepList,
-			steps.NetworkPolicyCreate(force),
+			steps.NetworkPolicyCreate(force, healthPort),
 			steps.NftWeaverPersist(),
 			steps.TcEgressPersist(egressInterface, linkRate, shapeOverrides),
 			steps.TcIngressRecord(egressInterface, linkRate, shapeOverrides),

--- a/internal/workflows/steps/step_network_policy.go
+++ b/internal/workflows/steps/step_network_policy.go
@@ -51,6 +51,18 @@ type canonicalPolicy struct {
 	deny       bool   // --deny (drop both directions)
 	fromWorld  bool   // --from-entity world (no IP-set clause)
 	ports      []string
+	// managedPorts marks a policy whose `<name>_ports` listener-port set is
+	// reconciled by the traffic-shaper daemon from the BN's statusz local.port,
+	// not seeded here. Such a set is rendered empty at install and filled on the
+	// first poll tick (the same empty-and-fill contract the CIDR membership sets
+	// have), so no port literal is baked into the inet weaver chain.
+	managedPorts bool
+	// healthPort marks the bn-mgmt sets, whose ports come from the resolved
+	// block-node health port (chart blockNode.ports.health) rather than a literal
+	// or from statusz. The health port is the one a-priori facility port: it
+	// bootstraps statusz discovery (you fetch statusz on it), so it cannot itself
+	// be read back from statusz.
+	healthPort bool
 	// curated marks an operator-curated set (bn-mgmt-*) that receives its
 	// initial membership from operator input at create time rather than from
 	// the daemon's statusz poll loop. bn-restricted is NOT curated: it reflects
@@ -67,28 +79,51 @@ type canonicalPolicy struct {
 // categories at runtime; these definitions are statusz-agnostic. --stamp
 // references the class names in the stable mark map; each class fixes its own
 // direction, so there is no direction flag.
+//
+// Listener ports are no longer baked in as literals: the publisher, subscriber,
+// block-access and server-status ports are read back from the BN's statusz
+// local.port and reconciled into the per-policy `<name>_ports` sets by the
+// daemon (managedPorts). Server-status is public to everyone, so it rides the
+// public port union on bn-subscriber-in (ingress) and bn-public-out (egress)
+// rather than a dedicated set — the old bn-status-in/bn-status-out policies are
+// folded away (see obsoleteBNPolicies). Only the bn-mgmt health port is pinned
+// here, from the chart's blockNode.ports.health (healthPort), because it
+// bootstraps statusz discovery and cannot come from statusz itself.
 var canonicalBNPolicies = []canonicalPolicy{
-	{name: "bn-publisher", ports: []string{"40840"}, stamp: "publisher"},
-	{name: "bn-subscriber-in", ports: []string{"40980", "40981"}, stamp: "reserve-ingress", fromWorld: true},
-	{name: "bn-partner-out", ports: []string{"40980", "40981"}, stamp: "partner"},
-	{name: "bn-public-out", ports: []string{"40980", "40981"}, stamp: "public", fromWorld: true},
-	{name: "bn-status-in", ports: []string{"40982"}, stamp: "reserve-ingress", fromWorld: true},
-	{name: "bn-status-out", ports: []string{"40982"}, stamp: "public", fromWorld: true},
-	{name: "bn-mgmt-in", ports: []string{"40983"}, stamp: "reserve-ingress", curated: true},
-	{name: "bn-mgmt-out", ports: []string{"40983"}, stamp: "reserve-egress", curated: true},
+	{name: "bn-publisher", managedPorts: true, stamp: "publisher"},
+	{name: "bn-subscriber-in", managedPorts: true, stamp: "reserve-ingress", fromWorld: true},
+	{name: "bn-partner-out", managedPorts: true, stamp: "partner"},
+	{name: "bn-public-out", managedPorts: true, stamp: "public", fromWorld: true},
+	{name: "bn-mgmt-in", healthPort: true, stamp: "reserve-ingress", curated: true},
+	{name: "bn-mgmt-out", healthPort: true, stamp: "reserve-egress", curated: true},
 	{name: "bn-restricted", deny: true},
 	{name: "bn-backfill", stamp: "reserve-egress", replyStamp: "backfill-response"},
 }
 
-// toPolicy builds the policy.Policy for a canonical entry. Action/Direction are
-// resolved from the stamp/deny fields; Validate (called inside Manager.Create)
-// derives Direction from the class and rejects any invalid combination.
-func (c canonicalPolicy) toPolicy() *policy.Policy {
+// obsoleteBNPolicies are policies a prior solo-weaver release created that this
+// release no longer owns. On upgrade they still sit in the policy registry (and
+// the live table, which Manager re-renders from the registry), so the install
+// step deletes them explicitly rather than leaving orphaned sets behind.
+// bn-status-in / bn-status-out were folded into the public port union on
+// bn-subscriber-in / bn-public-out (server-status is public to everyone).
+var obsoleteBNPolicies = []string{"bn-status-in", "bn-status-out"}
+
+// toPolicy builds the policy.Policy for a canonical entry, resolving a
+// healthPort entry's ports to the given block-node health port. Action/Direction
+// are resolved from the stamp/deny fields; Validate (called inside
+// Manager.Create) derives Direction from the class and rejects any invalid
+// combination.
+func (c canonicalPolicy) toPolicy(healthPort string) *policy.Policy {
+	ports := c.ports
+	if c.healthPort {
+		ports = []string{healthPort}
+	}
 	p := &policy.Policy{
 		Name:            c.name,
 		Stamp:           c.stamp,
 		ReplyStamp:      c.replyStamp,
-		Ports:           c.ports,
+		Ports:           ports,
+		ManagedPorts:    c.managedPorts,
 		FromEntityWorld: c.fromWorld,
 	}
 	if c.deny {
@@ -112,7 +147,11 @@ func (c canonicalPolicy) toPolicy() *policy.Policy {
 // initial membership here from the host management allowlist (--mgmt-cidrs).
 // bn-restricted starts empty and is left entirely to the daemon's statusz poll
 // loop — see canonicalPolicy.curated.
-func NetworkPolicyCreate(force bool) *automa.StepBuilder {
+// healthPort is the resolved block-node health/statusz port (from
+// blocknode.ResolveHealthPort against the operator's effective values), used to
+// seed the bn-mgmt sets so the port solo-weaver allows tracks the port the BN
+// actually listens on rather than a value baked into solo-weaver.
+func NetworkPolicyCreate(force bool, healthPort string) *automa.StepBuilder {
 	return automa.NewStepBuilder().WithId(NetworkPolicyCreateStepId).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
 			notify.As().StepStart(ctx, stp, "Creating network policies (inet weaver)")
@@ -165,7 +204,7 @@ func NetworkPolicyCreate(force bool) *automa.StepBuilder {
 				}
 
 				cidrs := initialCIDRs(c, mgmtCIDRs)
-				changed, err := mgr.Create(ctx, c.toPolicy(), cidrs, podCIDR, force)
+				changed, err := mgr.Create(ctx, c.toPolicy(healthPort), cidrs, podCIDR, force)
 				if err != nil {
 					stp.State().Local().Set(policyCreatedNamesKey, created)
 					return automa.FailureReport(stp, automa.WithError(
@@ -180,6 +219,37 @@ func NetworkPolicyCreate(force bool) *automa.StepBuilder {
 					created = append(created, c.name)
 				}
 			}
+			// Remove policies a prior release created that this release folded
+			// away (bn-status-*). On upgrade they still sit in the registry, and
+			// Manager re-renders the whole table from it, so leaving them would
+			// keep orphaned sets alive. Idempotent: absent policies are skipped,
+			// so a fresh install (where they never existed) is a no-op.
+			for _, name := range obsoleteBNPolicies {
+				exists, err := policy.Exists(name)
+				if err != nil {
+					stp.State().Local().Set(policyCreatedNamesKey, created)
+					return automa.FailureReport(stp, automa.WithError(
+						errorx.Decorate(err, "failed to check whether obsolete network policy %q exists", name).
+							WithProperty(models.ErrPropertyResolution, []string{
+								"Inspect the policy registry: ls " + policy.RegistryDir,
+							})))
+				}
+				if !exists {
+					continue
+				}
+				if err := mgr.Delete(ctx, name); err != nil {
+					stp.State().Local().Set(policyCreatedNamesKey, created)
+					return automa.FailureReport(stp, automa.WithError(
+						errorx.Decorate(err, "failed to remove obsolete network policy %q", name).
+							WithProperty(models.ErrPropertyResolution, []string{
+								"Inspect the live weaver table: nft list table inet weaver",
+								"Check the policy registry for leftover entries: ls " + policy.RegistryDir,
+							})))
+				}
+				logx.As().Info().Str("policy", name).
+					Msg("removed obsolete network policy (folded into the public port union)")
+			}
+
 			stp.State().Local().Set(policyCreatedNamesKey, created)
 			logx.As().Info().Int("created", len(created)).Int("total", len(canonicalBNPolicies)).
 				Msg("network policies reconciled")

--- a/internal/workflows/steps/step_network_policy_test.go
+++ b/internal/workflows/steps/step_network_policy_test.go
@@ -10,12 +10,17 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/network/policy"
 )
 
+// testHealthPort is a representative resolved health port for toPolicy in tests.
+const testHealthPort = "40983"
+
 // TestCanonicalBNPolicies_Names pins the fixed BN static-plane policy set so a
-// change to the design list is a deliberate, reviewed edit.
+// change to the design list is a deliberate, reviewed edit. bn-status-in/out are
+// folded into the public port union (server-status is public to everyone), so
+// they are no longer in the canonical set.
 func TestCanonicalBNPolicies_Names(t *testing.T) {
 	want := []string{
 		"bn-publisher", "bn-subscriber-in", "bn-partner-out", "bn-public-out",
-		"bn-status-in", "bn-status-out", "bn-mgmt-in", "bn-mgmt-out",
+		"bn-mgmt-in", "bn-mgmt-out",
 		"bn-restricted", "bn-backfill",
 	}
 	if len(canonicalBNPolicies) != len(want) {
@@ -35,23 +40,32 @@ func TestCanonicalBNPolicies_Names(t *testing.T) {
 func TestCanonicalBNPolicies_Valid(t *testing.T) {
 	mgmt := []string{"10.0.0.0/8"}
 
-	seen := map[string]string{} // (direction|ports) → policy name, for specific stamps
+	seen := map[string]string{} // group key → policy name, for specific stamps
 	for _, c := range canonicalBNPolicies {
-		p := c.toPolicy()
+		p := c.toPolicy(testHealthPort)
 		cidrs := initialCIDRs(c, mgmt)
 		if err := p.Validate(cidrs); err != nil {
 			t.Fatalf("policy %q failed validation: %v", c.name, err)
 		}
 
 		// A "specific" stamp policy renders an IP-set clause (not deny, not
-		// --from-entity world). Two such policies sharing a (direction, ports)
-		// group would have ambiguous classification.
+		// --from-entity world). Two such policies sharing a group would have
+		// ambiguous classification.
 		if p.Action != policy.ActionStamp || p.FromEntityWorld {
 			continue
 		}
-		ports := append([]string(nil), p.Ports...)
-		sort.Strings(ports)
-		key := string(p.Direction) + "|" + strings.Join(ports, ",")
+		// Mirror policy.groupKey: managed-ports policies are keyed per-name (their
+		// real listener ports are reconciled from statusz and distinct by design),
+		// so they never statically overlap; static-ports policies key on
+		// (direction, ports).
+		var key string
+		if p.ManagedPorts {
+			key = string(p.Direction) + "|managed:" + p.Name
+		} else {
+			ports := append([]string(nil), p.Ports...)
+			sort.Strings(ports)
+			key = string(p.Direction) + "|" + strings.Join(ports, ",")
+		}
 		if other, dup := seen[key]; dup {
 			t.Errorf("policies %q and %q overlap on group %q", c.name, other, key)
 		}
@@ -77,5 +91,35 @@ func TestInitialCIDRs(t *testing.T) {
 	}
 	if got := initialCIDRs(byName["bn-publisher"], mgmt); got != nil {
 		t.Errorf("bn-publisher cidrs: got %v, want nil (daemon-reconciled)", got)
+	}
+}
+
+// TestCanonicalBNPolicies_ManagedPortsAndHealth pins which sets have
+// daemon-reconciled listener ports (no static literals) versus the bn-mgmt sets,
+// whose ports are seeded from the resolved health port.
+func TestCanonicalBNPolicies_ManagedPortsAndHealth(t *testing.T) {
+	byName := map[string]canonicalPolicy{}
+	for _, c := range canonicalBNPolicies {
+		byName[c.name] = c
+	}
+
+	for _, n := range []string{"bn-publisher", "bn-subscriber-in", "bn-partner-out", "bn-public-out"} {
+		p := byName[n].toPolicy(testHealthPort)
+		if !p.ManagedPorts {
+			t.Errorf("%s: want ManagedPorts (statusz-derived)", n)
+		}
+		if len(p.Ports) != 0 {
+			t.Errorf("%s: a managed-ports policy must carry no static port literals, got %v", n, p.Ports)
+		}
+	}
+
+	for _, n := range []string{"bn-mgmt-in", "bn-mgmt-out"} {
+		p := byName[n].toPolicy(testHealthPort)
+		if p.ManagedPorts {
+			t.Errorf("%s: bn-mgmt ports come from Helm, not statusz", n)
+		}
+		if len(p.Ports) != 1 || p.Ports[0] != testHealthPort {
+			t.Errorf("%s: want resolved health port %q, got %v", n, testHealthPort, p.Ports)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

The block node's per-facility API listener ports were **hardcoded** in three frozen places and had drifted from the real BN contract (publisher was `40840`, not `40984`; subscriber `40980` and block-access `40981` were lumped together). The BN already reports its true listener ports on the wire — statusz `inbound-clients` carries `local.port` per active connection — but solo-weaver decoded that field and threw it away.

This PR **derives the inbound listener ports from statusz at runtime** and **bootstraps only the health/statusz port from Helm** (the one port you fetch statusz *on*, so it cannot come from statusz itself).

### Daemon-side port reconciliation

- The traffic-shaper reads inbound statusz `local.port` and reconciles it into each policy's `<name>_ports` nft set, with the same present/absent semantics as CIDR membership. Mapping (`portBindings`): `publisher → bn-publisher`, `partner → bn-partner-out`, `public → bn-subscriber-in + bn-public-out`.
- New `Policy.ManagedPorts` + `Manager.ApplyPorts` (the `ApplyMembership` counterpart) writes the `<name>_ports` set. Managed ports sets render **empty-but-referenced** (empty-and-fill, exactly like the CIDR sets): filled on the first poll, re-derived after reboot, never persisted.
- Ports are folded into the reconcile **digest**, so a ports-only change is still detected by the daemon's digest-based change detection.
- `groupKey` keys managed-ports policies per-name so they don't falsely overlap now that their static port lists are empty.

### Install-side

- Dropped the frozen port literals; the publisher / subscriber / partner / public sets are now `managedPorts`.
- **Folded `bn-status-in` / `bn-status-out` into the public port union** (server-status is public to everyone), with idempotent cleanup of the obsolete sets on upgrade.
- The health/statusz port is **resolved from the operator's effective `--values`** (`blockNode.ports.health`), falling back to the chart default `40983` — so `bn-mgmt` tracks the port the BN actually listens on rather than a value baked into solo-weaver. It is `NOT` sourced from `config.SERVER_PORT` (the main gRPC port, a different port). The default is also templated into the base values as an explicit pin.
- The reachability probe now targets the LoadBalancer Service's advertised port, falling back to the well-known public port.
- The statusz mock ships a `DefaultRoster()` with realistic per-facility `local.port` (40984/40980/40981/40982), so a UAT run exercises the derivation out of the box.

## Test plan

- [x] **Unit (macOS):** `internal/network/policy/...`, `internal/blocknode/...`, `internal/blocknode/shaper/...`, `internal/daemon/blocknode/statuszmock/...` — all pass.
- [x] **Unit (Linux, via container):** `internal/workflows/steps`, `internal/workflows`, `internal/bll/blocknode` — all pass (canonical-policy pins, workflow wiring).
- [x] `task lint` → 0 issues; full Linux build clean.
- [ ] **Integration (UTM VM):** `task vm:test:integration TEST_NAME='^Test_StepNetworkPolicy.*$'`

### Manual UAT

Run on a UTM VM (or host) where `block node install --traffic-shaping-enabled` has run and both binaries are built (`task build`).

**1. Static plane after install** — managed `_ports` sets are declared **empty** (filled only once the daemon polls), `bn-status-*` is gone, and `bn-mgmt` carries the health port:

```console
$ sudo nft list table inet weaver | grep -E 'set bn-.*_ports'
	set bn-partner-out_ports { type inet_service; }
	set bn-public-out_ports { type inet_service; }
	set bn-publisher_ports { type inet_service; }
	set bn-subscriber-in_ports { type inet_service; }
	set bn-mgmt-in_ports { type inet_service; elements = { 40983 }; }
	set bn-mgmt-out_ports { type inet_service; elements = { 40983 }; }
$ sudo nft list table inet weaver | grep -c bn-status   # → 0 (folded into the public union)
```

**2. Serve a mock BN statusz** with realistic per-facility ports (no `roster.json` → serves the built-in `DefaultRoster`):

```console
$ go run ./internal/daemon/blocknode/statuszmock/cmd --addr 127.0.0.1:8080 &
$ curl -s 127.0.0.1:8080/statusz/inbound-clients | jq -c '.active_endpoints[] | {category, local: .local.port}'
{"category":"publisher","local":"40984"}
{"category":"partner","local":"40980"}
{"category":"public","local":"40980"}
{"category":"public","local":"40981"}
{"category":"public","local":"40982"}
{"category":"partner","local":"40980"}
```

**3. Dry-run reconcile (unprivileged)** — inspect the derived desired ports + digest, no nft writes:

```console
$ solo-provisioner block node reconcile-shaper --statusz-url http://127.0.0.1:8080 --check --output json \
    | jq '{digest: ."desired-digest", ports: ."desired-ports"}'
{
  "digest": "…",
  "ports": {
    "bn-publisher": ["40984"],
    "bn-partner-out": ["40980"],
    "bn-subscriber-in": ["40980","40981","40982"],
    "bn-public-out": ["40980","40981","40982"]
  }
}
```

**4. Apply (root)** — the live `_ports` sets are populated from statusz; publisher is 40984, **not** the old 40840:

```console
$ sudo solo-provisioner block node reconcile-shaper --statusz-url http://127.0.0.1:8080
applied:   bn-partner-out_ports, bn-public-out_ports, bn-publisher_ports, bn-subscriber-in_ports
$ sudo nft list set inet weaver bn-publisher_ports   # → elements = { 40984 }
$ sudo nft list set inet weaver bn-public-out_ports  # → elements = { 40980, 40981, 40982 }
```

**5. Ports-only digest change** — drop a `roster.json` that only changes a `local.port` (leave every `remote.address` untouched), re-run `--check`, and confirm the `desired-digest` changes even though membership is identical (guards the daemon's digest-gated apply against missing a ports-only update).

**6. Operator health-port override** — install with `-f values.yaml` setting `blockNode.ports.health: 41000`; confirm `bn-mgmt` follows the BN rather than the baked-in default:

```console
$ sudo nft list set inet weaver bn-mgmt-in_ports    # → elements = { 41000 }
```

## Risks

- **Bootstrap gap:** inbound facility ports are empty until the first statusz tick (~5 s), so a freshly-installed or just-rebooted BN classifies no inbound facility traffic for that window — the same property the CIDR membership sets already have.
- **Upgrade path:** removing `bn-status-in/out` from the canonical set is handled by explicit cleanup in the install step; the template edit to `*-values.yaml` (adding `blockNode.ports.health`) re-renders on the existing-cluster upgrade path but only pins the chart's own default (no behavior change absent an operator override).
- **Stacked on #921** (now squash-merged); this PR is rebased onto `main`.

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)
