### PR TITLE
feat(block-node): skip managed plugins PVC for plugins-baked images

### DIFF
--- a/internal/bll/blocknode/install_handler.go
+++ b/internal/bll/blocknode/install_handler.go
@@ -56,7 +56,8 @@ func (h *InstallHandler) BuildWorkflow(
 	}
 
 	// Fail fast if storage paths can't be resolved — don't set up a cluster for nothing.
-	if err := bnpkg.ValidateStorageCompleteness(inputs.Custom.Storage, inputs.Custom.ChartVersion); err != nil {
+	if err := bnpkg.ValidateStorageCompleteness(inputs.Custom.Storage, inputs.Custom.ChartVersion,
+		!bnpkg.EffectivePluginsNamesEmpty(inputs.Custom.PluginList, inputs.Custom.ValuesFile)); err != nil {
 		return nil, err
 	}
 

--- a/internal/bll/blocknode/reconfigure_handler.go
+++ b/internal/bll/blocknode/reconfigure_handler.go
@@ -49,7 +49,8 @@ func (h *ReconfigureHandler) BuildWorkflow(
 	}
 
 	// Fail fast if storage paths can't be resolved.
-	if err := bnpkg.ValidateStorageCompleteness(inputs.Custom.Storage, inputs.Custom.ChartVersion); err != nil {
+	if err := bnpkg.ValidateStorageCompleteness(inputs.Custom.Storage, inputs.Custom.ChartVersion,
+		!bnpkg.EffectivePluginsNamesEmpty(inputs.Custom.PluginList, inputs.Custom.ValuesFile)); err != nil {
 		return nil, err
 	}
 

--- a/internal/bll/blocknode/upgrade_handler.go
+++ b/internal/bll/blocknode/upgrade_handler.go
@@ -84,7 +84,8 @@ func (h *UpgradeHandler) BuildWorkflow(
 	}
 
 	// Fail fast if storage paths can't be resolved.
-	if err := bnpkg.ValidateStorageCompleteness(inputs.Custom.Storage, inputs.Custom.ChartVersion); err != nil {
+	if err := bnpkg.ValidateStorageCompleteness(inputs.Custom.Storage, inputs.Custom.ChartVersion,
+		!bnpkg.EffectivePluginsNamesEmpty(inputs.Custom.PluginList, inputs.Custom.ValuesFile)); err != nil {
 		return nil, err
 	}
 

--- a/internal/blocknode/migration_storage.go
+++ b/internal/blocknode/migration_storage.go
@@ -33,6 +33,10 @@ const (
 	ctxKeyManager    = "blocknode.manager"
 	ctxKeyProfile    = "blocknode.profile"
 	ctxKeyValuesFile = "blocknode.valuesFile"
+	// ctxKeyManagePlugins carries the #913 plugins-baked signal (a bool) into
+	// StorageMigration.Applies. It is set before migration filtering, unlike
+	// ctxKeyManager which is only available for Execute/Rollback.
+	ctxKeyManagePlugins = "blocknode.managePlugins"
 )
 
 // StorageMigration handles the breaking change pattern where a new storage PV/PVC
@@ -75,7 +79,27 @@ func (m *StorageMigration) Applies(mctx *migration.Context) (bool, error) {
 	}
 
 	targetVersion, _ := mctx.Data.String(migration.CtxKeyTargetVersion)
-	return m.storage.RequiredByVersion(targetVersion), nil
+	if !m.storage.RequiredByVersion(targetVersion) {
+		return false, nil
+	}
+
+	// #913: the plugins storage is only managed when the effective plugins.names
+	// is non-empty. For a plugins-baked image (empty names) the chart renders no
+	// plugins volume, so an upgrade must not (re-)provision the plugins PV/PVC —
+	// otherwise the empty managed PVC would shadow the image's baked plugins.
+	// The signal is read from a context bool set by BuildMigrationWorkflow before
+	// migration filtering (the Manager itself is only added to the context later,
+	// for Execute/Rollback). When the key is absent (e.g. unit tests exercising
+	// pure version logic) the migration stays applicable — the pre-#913 default.
+	if m.storage.Name == "plugins" {
+		if v, ok := mctx.Data.Get(ctxKeyManagePlugins); ok {
+			if managePlugins, isBool := v.(bool); isBool && !managePlugins {
+				return false, nil
+			}
+		}
+	}
+
+	return true, nil
 }
 
 // Execute creates the storage directory on the host and the PV/PVC in Kubernetes.

--- a/internal/blocknode/migrations.go
+++ b/internal/blocknode/migrations.go
@@ -61,6 +61,10 @@ func BuildMigrationWorkflow(manager *Manager, profile, valuesFile string) (*auto
 	}
 	mctx.Data.Set(migration.CtxKeyInstalledVersion, installedVersion)
 	mctx.Data.Set(migration.CtxKeyTargetVersion, manager.blockNodeInputs.ChartVersion)
+	// #913: expose the plugins-baked signal to StorageMigration.Applies. It must be
+	// set before GetApplicableMigrations (which evaluates Applies); the Manager
+	// itself is only added to the context afterwards, for Execute/Rollback.
+	mctx.Data.Set(ctxKeyManagePlugins, manager.managesPluginsStorage())
 
 	migrations, err := migration.GetApplicableMigrations(migration.ScopeBlockNode, mctx)
 	if err != nil {

--- a/internal/blocknode/optional_storage.go
+++ b/internal/blocknode/optional_storage.go
@@ -185,7 +185,7 @@ func (o *OptionalStorage) RequiredByVersion(targetVersion string) bool {
 // be set (to derive missing paths) or all required individual paths must be
 // explicit. This includes core paths (archive, live, log) and version-dependent
 // optional paths (verification, plugins, application-state).
-func ValidateStorageCompleteness(storage models.BlockNodeStorage, chartVersion string) error {
+func ValidateStorageCompleteness(storage models.BlockNodeStorage, chartVersion string, managePlugins bool) error {
 	// If basePath is set, all missing paths can be derived.
 	if strings.TrimSpace(storage.BasePath) != "" {
 		return nil
@@ -199,6 +199,11 @@ func ValidateStorageCompleteness(storage models.BlockNodeStorage, chartVersion s
 	}
 	// Without basePath, version-dependent optional paths must also be explicit.
 	for _, opt := range GetApplicableOptionalStorages(chartVersion) {
+		// #913: a plugins-baked image provisions no managed plugins PVC, so a
+		// plugins path is not required for it.
+		if opt.Name == "plugins" && !managePlugins {
+			continue
+		}
 		if strings.TrimSpace(opt.GetPath(&storage)) == "" {
 			return errorx.IllegalArgument.New(
 				"%s storage path is required for chart version %s; set --base-path (or storage.basePath in config) or --%s-path",

--- a/internal/blocknode/plugins_baked_test.go
+++ b/internal/blocknode/plugins_baked_test.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package blocknode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/automa-saga/automa"
+	"github.com/hashgraph/solo-weaver/internal/migration"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	"helm.sh/helm/v3/pkg/chartutil"
+)
+
+// writeValuesFile writes content to a temp values file and returns its path.
+func writeValuesFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "values.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// ── EffectivePluginsNamesEmpty ─────────────────────────────────────────────────
+
+func TestEffectivePluginsNamesEmpty(t *testing.T) {
+	tests := []struct {
+		name       string
+		pluginList string
+		fileBody   string // empty => no --values file
+		want       bool
+	}{
+		{"resolved list wins over empty values", "health,verification", "plugins:\n  names: \"\"\n", false},
+		{"values sets explicit empty string", "", "plugins:\n  names: \"\"\n", true},
+		{"values sets explicit null", "", "plugins:\n  names: null\n", true},
+		{"values sets empty sequence", "", "plugins:\n  names: []\n", true},
+		{"values sets a concrete list", "", "plugins:\n  names: \"health\"\n", false},
+		{"values does not define names", "", "plugins:\n  mavenImage: img\n", false},
+		{"no list and no values file", "", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			valuesFile := ""
+			if tc.fileBody != "" {
+				valuesFile = writeValuesFile(t, tc.fileBody)
+			}
+			assert.Equal(t, tc.want, EffectivePluginsNamesEmpty(tc.pluginList, valuesFile))
+		})
+	}
+}
+
+// ── injectPersistenceOverrides: baked image omits the plugins claim ────────────
+
+func TestInjectPersistenceOverrides_PluginsBakedSkipsPluginsClaim(t *testing.T) {
+	valuesFile := writeValuesFile(t, "plugins:\n  names: \"\"\n")
+	m := &Manager{
+		// 0.28.1 makes both verification and plugins applicable; the baked signal
+		// must drop only plugins, leaving verification managed.
+		blockNodeInputs: models.BlockNodeInputs{ChartVersion: "0.28.1", ValuesFile: valuesFile},
+		logger:          testLogger(),
+	}
+
+	out, err := m.injectPersistenceOverrides([]byte("blockNode:\n  persistence: {}\n"))
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(out, &vals))
+	persistence := vals["blockNode"].(map[string]interface{})["persistence"].(map[string]interface{})
+
+	_, hasPlugins := persistence["plugins"]
+	assert.False(t, hasPlugins, "baked image must not force a plugins existingClaim")
+	_, hasVerification := persistence["verification"]
+	assert.True(t, hasVerification, "verification storage must still be managed")
+}
+
+func TestInjectPersistenceOverrides_ManagedKeepsPluginsClaim(t *testing.T) {
+	// No --values file and no resolved empty → plugins stays managed (today's behavior).
+	m := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{ChartVersion: "0.28.1"},
+		logger:          testLogger(),
+	}
+
+	out, err := m.injectPersistenceOverrides([]byte("blockNode:\n  persistence: {}\n"))
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(out, &vals))
+	persistence := vals["blockNode"].(map[string]interface{})["persistence"].(map[string]interface{})
+
+	plugins, ok := persistence["plugins"].(map[string]interface{})
+	require.True(t, ok, "plugins storage must be managed when not a baked image")
+	assert.Equal(t, "plugins-storage-pvc", plugins["existingClaim"])
+	assert.Equal(t, false, plugins["create"])
+}
+
+// ── injectPluginsConfig: baked image forces an explicit empty plugins.names ────
+
+func TestInjectPluginsConfig_BakedForcesEmptyNames(t *testing.T) {
+	valuesFile := writeValuesFile(t, "plugins:\n  names: null\n")
+	m := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{ChartVersion: "0.28.1", ValuesFile: valuesFile},
+		logger:          testLogger(),
+	}
+
+	// Base carries a non-empty default (as weaver's base template does).
+	out, err := m.injectPluginsConfig([]byte("plugins:\n  names: \"health,verification\"\n"))
+	require.NoError(t, err)
+
+	var vals map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(out, &vals))
+	names, ok := vals["plugins"].(map[string]interface{})["names"]
+	require.True(t, ok, "plugins.names must be present (explicitly empty), not absent")
+	assert.Equal(t, "", names, "baked image must force plugins.names to an explicit empty string")
+}
+
+func TestInjectPluginsConfig_NoOverrideLeavesDefault(t *testing.T) {
+	// No resolved list, no values file → leave the base/chart default untouched.
+	m := &Manager{
+		blockNodeInputs: models.BlockNodeInputs{ChartVersion: "0.28.1"},
+		logger:          testLogger(),
+	}
+	in := []byte("plugins:\n  names: \"health,verification\"\n")
+	out, err := m.injectPluginsConfig(in)
+	require.NoError(t, err)
+	assert.Equal(t, string(in), string(out), "default list must be left intact")
+}
+
+// ── Two-layer merge: prove the CHART ends up seeing an empty plugins.names ──────
+//
+// This is the load-bearing invariant for #913: removing weaver's forced
+// existingClaim is only safe if the chart's own gate (plugins.names OR
+// existingClaim) is also false. Helm re-applies the chart's own non-empty
+// values.yaml plugins.names default unless weaver's -f output carries an explicit
+// empty. This test runs weaver's real pipeline (renderDefaultValues →
+// mergeValues(operator) → injectPluginsConfig) and then simulates Helm coalescing
+// weaver's output over the chart's non-empty default.
+func TestPluginsBakedTwoLayerMerge_ChartSeesEmpty(t *testing.T) {
+	// Stand-in for the chart's values.yaml default (a non-empty plugin list).
+	chartDefault := func() map[string]interface{} {
+		return map[string]interface{}{
+			"plugins": map[string]interface{}{
+				"names": "backfill,facility-messaging,health,server-status",
+			},
+		}
+	}
+
+	// pluginsNames extracts the effective plugins.names Helm would render with.
+	effectiveNames := func(t *testing.T, m *Manager, operatorBody string) interface{} {
+		t.Helper()
+		base, err := m.renderDefaultValues(models.ProfileLocal)
+		require.NoError(t, err)
+		merged, err := mergeValues(base, []byte(operatorBody))
+		require.NoError(t, err)
+		final, err := m.injectPluginsConfig(merged)
+		require.NoError(t, err)
+
+		var weaverVals map[string]interface{}
+		require.NoError(t, yaml.Unmarshal(final, &weaverVals))
+		// Helm: user-supplied -f values (dst) coalesced over chart defaults (src).
+		coalesced := chartutil.CoalesceTables(weaverVals, chartDefault())
+		return coalesced["plugins"].(map[string]interface{})["names"]
+	}
+
+	t.Run("baked image: operator empties names → chart sees empty", func(t *testing.T) {
+		operatorBody := "plugins:\n  names: \"\"\n"
+		valuesFile := writeValuesFile(t, operatorBody)
+		m := &Manager{
+			blockNodeInputs: models.BlockNodeInputs{ChartVersion: "0.28.1", ValuesFile: valuesFile},
+			logger:          testLogger(),
+		}
+		names := effectiveNames(t, m, operatorBody)
+		assert.Equal(t, "", names, "chart must render with an empty plugins.names (no volume, baked plugins used)")
+	})
+
+	t.Run("default: no override → chart sees weaver base default (non-empty)", func(t *testing.T) {
+		m := &Manager{
+			blockNodeInputs: models.BlockNodeInputs{ChartVersion: "0.28.1"},
+			logger:          testLogger(),
+		}
+		names := effectiveNames(t, m, "blockNode:\n  config: {}\n")
+		assert.NotEmpty(t, names, "chart must keep a non-empty plugins.names (managed/maven mode)")
+	})
+}
+
+// ── plugins StorageMigration.Applies honors the baked signal ───────────────────
+
+func TestPluginsStorageMigration_Applies_BakedSignal(t *testing.T) {
+	m := NewPluginsStorageMigration()
+
+	// An upgrade that crosses the plugins boundary and would otherwise apply.
+	newCtx := func(managePluginsSet, managePlugins bool) *migration.Context {
+		ctx := &migration.Context{Data: &automa.SyncStateBag{}}
+		ctx.Data.Set(migration.CtxKeyInstalledVersion, "0.27.0")
+		ctx.Data.Set(migration.CtxKeyTargetVersion, "0.28.1")
+		if managePluginsSet {
+			ctx.Data.Set(ctxKeyManagePlugins, managePlugins)
+		}
+		return ctx
+	}
+
+	t.Run("baked image (managePlugins=false) → does not apply", func(t *testing.T) {
+		applies, err := m.Applies(newCtx(true, false))
+		require.NoError(t, err)
+		assert.False(t, applies)
+	})
+
+	t.Run("managed (managePlugins=true) → applies", func(t *testing.T) {
+		applies, err := m.Applies(newCtx(true, true))
+		require.NoError(t, err)
+		assert.True(t, applies)
+	})
+
+	t.Run("signal absent → applies (pre-#913 default)", func(t *testing.T) {
+		applies, err := m.Applies(newCtx(false, false))
+		require.NoError(t, err)
+		assert.True(t, applies)
+	})
+}

--- a/internal/blocknode/storage.go
+++ b/internal/blocknode/storage.go
@@ -88,9 +88,15 @@ func (m *Manager) CreatePersistentVolumes(ctx context.Context, tempDir string) e
 			verificationPath = p
 			verificationSize = s
 		case "plugins":
-			includePlugins = true
-			pluginsPath = p
-			pluginsSize = s
+			// #913: skip the managed plugins PV/PVC when the effective
+			// plugins.names is empty (plugins-baked image). The chart renders no
+			// plugins volume in that case, so a forced empty PVC would only
+			// shadow the image's baked plugins directory.
+			if m.managesPluginsStorage() {
+				includePlugins = true
+				pluginsPath = p
+				pluginsSize = s
+			}
 		case "application-state":
 			includeApplicationState = true
 			applicationStatePath = p
@@ -169,6 +175,11 @@ func (m *Manager) CreatePersistentVolumes(ctx context.Context, tempDir string) e
 
 	pvcNames := []string{"live-storage-pvc", "archive-storage-pvc", "logging-storage-pvc"}
 	for _, os := range applicable {
+		// #913: the plugins PVC is not provisioned for a plugins-baked image, so
+		// do not wait on it (it would never bind).
+		if os.Name == "plugins" && !m.managesPluginsStorage() {
+			continue
+		}
 		pvcNames = append(pvcNames, os.PVCName)
 	}
 

--- a/internal/blocknode/values.go
+++ b/internal/blocknode/values.go
@@ -7,6 +7,7 @@ import (
 	oslib "os"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/templates"
@@ -98,7 +99,10 @@ func (m *Manager) renderDefaultValues(profile string) ([]byte, error) {
 		case "verification":
 			includeVerification = true
 		case "plugins":
-			includePlugins = true
+			// #913: only mount the plugins volume when the effective plugins.names
+			// is non-empty. For a plugins-baked image the chart reads the image's
+			// baked plugins directly, so weaver must not render the volume/mount.
+			includePlugins = m.managesPluginsStorage()
 		case "application-state":
 			includeApplicationState = true
 		}
@@ -196,28 +200,88 @@ func mergeValues(base, operator []byte) ([]byte, error) {
 // to decide a smart default, and the deploy-time path (ComputeValuesFile) surfaces any
 // real read/parse error later.
 func ValuesFileDefinesPlugins(valuesFile string) bool {
+	_, defined := pluginsNamesFromValuesFile(valuesFile)
+	return defined
+}
+
+// pluginsNamesFromValuesFile reads plugins.names from an operator values file,
+// returning its raw value and whether the key is defined at all. It is the
+// shared parse behind ValuesFileDefinesPlugins and EffectivePluginsNamesEmpty.
+// It is intentionally error-tolerant: an empty path, an unreadable file, a parse
+// failure, or a missing plugins/names key all return (nil, false) rather than an
+// error — callers use it only for smart-defaults and provisioning gates, and the
+// deploy-time path surfaces any real read/parse error later.
+func pluginsNamesFromValuesFile(valuesFile string) (value interface{}, defined bool) {
 	if valuesFile == "" {
-		return false
+		return nil, false
 	}
 	sanitizedPath, err := sanity.ValidateInputFile(valuesFile)
 	if err != nil {
-		return false
+		return nil, false
 	}
 	content, err := oslib.ReadFile(sanitizedPath)
 	if err != nil {
-		return false
+		return nil, false
 	}
 
 	var vals map[string]interface{}
 	if err := yaml.Unmarshal(content, &vals); err != nil {
-		return false
+		return nil, false
 	}
 	plugins, ok := vals["plugins"].(map[string]interface{})
 	if !ok {
+		return nil, false
+	}
+	v, ok := plugins["names"]
+	return v, ok
+}
+
+// pluginsNamesValueEmpty reports whether a plugins.names value read from a values
+// file is empty — nil (a YAML `names:` with no value), a blank/whitespace string,
+// or an empty sequence. Any other shape (a non-blank string, a non-empty list) is
+// treated as non-empty.
+func pluginsNamesValueEmpty(v interface{}) bool {
+	switch t := v.(type) {
+	case nil:
+		return true
+	case string:
+		return strings.TrimSpace(t) == ""
+	case []interface{}:
+		return len(t) == 0
+	default:
 		return false
 	}
-	_, ok = plugins["names"]
-	return ok
+}
+
+// EffectivePluginsNamesEmpty reports whether the plugins.names that will reach the
+// block-node chart is empty — the "plugins-baked image" signal for issue #913.
+// Precedence mirrors how weaver builds the final values:
+//  1. A weaver-resolved PluginList (from --plugins/--plugin-preset) is injected
+//     into plugins.names, so a non-empty list means non-empty.
+//  2. Otherwise an operator --values file that defines plugins.names decides: an
+//     explicit empty/null empties it (baked image), a concrete value keeps it.
+//  3. Otherwise weaver's base-template default (a non-empty list) reaches the chart.
+//
+// When true, weaver must skip provisioning the managed plugins PVC and injecting
+// existingClaim, and must emit an explicit empty plugins.names, so the chart
+// renders no plugins volume and the container reads the image's baked plugins.
+func EffectivePluginsNamesEmpty(pluginList, valuesFile string) bool {
+	if strings.TrimSpace(pluginList) != "" {
+		return false
+	}
+	if names, defined := pluginsNamesFromValuesFile(valuesFile); defined {
+		return pluginsNamesValueEmpty(names)
+	}
+	return false
+}
+
+// managesPluginsStorage reports whether weaver should provision and wire the
+// managed plugins PVC for this operation. It is the inverse of the baked-image
+// signal (EffectivePluginsNamesEmpty): when the effective plugins.names is empty
+// the chart needs no plugins volume (issue #913), so weaver provisions and
+// injects nothing.
+func (m *Manager) managesPluginsStorage() bool {
+	return !EffectivePluginsNamesEmpty(m.blockNodeInputs.PluginList, m.blockNodeInputs.ValuesFile)
 }
 
 // persistenceEntry represents the required persistence settings for a storage type.
@@ -250,6 +314,13 @@ func (m *Manager) injectPersistenceOverrides(valuesContent []byte) ([]byte, erro
 	// leaving its StatefulSet to fall back to a volumeClaimTemplate (PVC stuck
 	// Pending). PersistenceKey defaults to Name when unset (verification, plugins).
 	for _, optStor := range GetApplicableOptionalStorages(m.blockNodeInputs.ChartVersion) {
+		// #913: when the effective plugins.names is empty (plugins-baked image)
+		// the chart renders no plugins volume, so weaver must not force an
+		// existingClaim — doing so would mount an empty PVC read-only over the
+		// image's baked plugins directory.
+		if optStor.Name == "plugins" && !m.managesPluginsStorage() {
+			continue
+		}
 		key := optStor.PersistenceKey
 		if key == "" {
 			key = optStor.Name
@@ -368,7 +439,17 @@ func (m *Manager) injectRetentionConfig(valuesContent []byte) ([]byte, error) {
 // leaving the chart's built-in default plugin list intact.
 func (m *Manager) injectPluginsConfig(valuesContent []byte) ([]byte, error) {
 	pluginList := m.blockNodeInputs.PluginList
-	if pluginList == "" {
+
+	// #913: for a plugins-baked image the effective plugins.names is empty, and we
+	// must set it explicitly to "" so Helm does not re-apply the chart's own
+	// non-empty plugins.names default (which would render a plugins volume/mount +
+	// the Maven resolve init). bakedEmpty implies pluginList == "".
+	bakedEmpty := !m.managesPluginsStorage()
+
+	// Nothing to inject unless we have a resolved list to set, or must force an
+	// explicit empty for a baked image. Leaving it untouched keeps the base
+	// template's / chart's default plugin list intact.
+	if pluginList == "" && !bakedEmpty {
 		return valuesContent, nil
 	}
 
@@ -384,12 +465,17 @@ func (m *Manager) injectPluginsConfig(valuesContent []byte) ([]byte, error) {
 		vals["plugins"] = plugins
 	}
 
-	logx.As().Info().
-		Str("preset", m.blockNodeInputs.PluginPreset).
-		Str("plugins_names", pluginList).
-		Msg("Applying plugin list to block node config")
-
-	plugins["names"] = pluginList
+	if bakedEmpty {
+		logx.As().Info().
+			Msg("Plugins-baked image (effective plugins.names empty): forcing plugins.names=\"\" and skipping the managed plugins PVC")
+		plugins["names"] = ""
+	} else {
+		logx.As().Info().
+			Str("preset", m.blockNodeInputs.PluginPreset).
+			Str("plugins_names", pluginList).
+			Msg("Applying plugin list to block node config")
+		plugins["names"] = pluginList
+	}
 
 	result, err := yaml.Marshal(vals)
 	if err != nil {


### PR DESCRIPTION
## Summary

For a plugins-baked block-node image (e.g. the `-solo-dev` variant, `plugins.names: ""`), the
provisioner still provisioned a managed `plugins-storage` PVC and forced
`blockNode.persistence.plugins.existingClaim` into the chart values. The chart then mounted that empty
PVC **read-only over the image's baked** `app-<ver>/plugins` directory (→ `No BlockMessagingFacility
provided`), and because the PVC is persistent it carried **stale jars across upgrades**.

This PR makes the provisioner **mirror the chart's own plugins-volume condition**: it provisions the
plugins PV/PVC and injects `existingClaim` **iff the effective `plugins.names` is non-empty**. When
empty, it provisions nothing, injects no `existingClaim`, and emits an explicit `plugins.names: ""` so
Helm does not re-apply the chart's own non-empty default — the chart then renders no plugins volume and
the container reads the image's baked plugins directly. No new CLI flag; the trigger is the plugins
signal the provisioner already resolves (`--plugins`/`--plugin-preset`, else the `--values`
`plugins.names`, else the non-empty default).

Closes #913.

## Problem

The `plugins` optional storage was gated only on chart version (`>=0.28.1`), independent of whether any
plugins are actually being managed. The block-node chart, however, already distinguishes the modes
(`charts/block-node-server/templates/statefulset.yaml`):

| Chart element | Condition |
|---|---|
| pod volume (existingClaim ref) | `if persistence.plugins.existingClaim` |
| main-container read-only mount over `app-<ver>/plugins` | `if (plugins.names OR existingClaim)` |
| chart's own volumeClaimTemplate | `if (plugins.names AND NOT existingClaim)` |
| Maven `resolve-plugins` init | `if plugins.names` |

So with `plugins.names` empty **and** no `existingClaim`, the chart renders **no** plugins volume, mount,
VCT, or Maven init — the baked plugins are used. The only thing defeating that was the provisioner's
unconditional `existingClaim` injection. The volumeClaimTemplate cannot fire without a non-empty
`plugins.names`, so the `Pending`-PVC failure that originally justified the forced PVC (#381) **cannot
recur** in the baked case.

## Solution

A single predicate, `Manager.managesPluginsStorage()` (inverse of the pure
`EffectivePluginsNamesEmpty(pluginList, valuesFile)`), gates the five plugins consumers:

- `renderDefaultValues` — `IncludePlugins` (base-template volume/mount) only when managed.
- `injectPersistenceOverrides` — skip the plugins `existingClaim` entry when not managed.
- `injectPluginsConfig` — emit an explicit `plugins.names: ""` in the baked case.
- `CreatePersistentVolumes` — skip the plugins PV/PVC and its PVC-bind wait.
- `StorageMigration.Applies` — the plugins upgrade migration does not apply in the baked case (signal
  passed via a context bool set before migration filtering).

`verification` and `application-state` storage are untouched. `emptyDir` (issue option b) is intentionally
not implemented — the chart has no emptyDir source for the plugins volume (only `existingClaim` or its own
VCT), so it would require an upstream chart change; option (a) is implemented here.

## Test plan

### Tier 0 — unit (no cluster; the core logic)

```bash
go test -tags='!integration' ./internal/blocknode/ -v -run \
  'EffectivePluginsNamesEmpty|InjectPersistence|InjectPluginsConfig|PluginsBakedTwoLayerMerge|PluginsStorageMigration_Applies_BakedSignal'
# full unit suite (bll/blocknode pulls in linux-only internal/mount):
task vm:test:unit
```

`TestPluginsBakedTwoLayerMerge_ChartSeesEmpty` is the load-bearing one: it runs the real value pipeline
then simulates Helm coalescing over the chart's non-empty default and asserts the chart ends up with an
empty `plugins.names` in the baked case (non-empty otherwise).

### Tier 1 — local dev UAT (executable)

**Pinned versions:** chart `0.39.0` (>= 0.37.0, so `application-state` is active and `verification` is
retired), baked image `ghcr.io/hiero-ledger/hiero-block-node-solo-dev:0.39.0`.

**Prerequisites.** A Linux host **with systemd** where the provisioner has installed a cluster
(`solo-provisioner kube cluster install --profile local`). The UTM VM (`task vm:start`) is the standard
environment and is what these steps assume. Note: bare `kind` on Docker is *not* suitable yet — the
provisioner installs a tc-egress systemd service that fails on systemd-less nodes (#915).

**The observable outcome does not need a healthy pod.** The PVC/PV set and the rendered StatefulSet spec
land the moment Helm applies, so the assertions below hold even if the BN pod stays `Pending`/`CrashLoop`
under local resource limits.

#### Case 1 — baked image uses its own plugins (the fix)

Save `baked-values.yaml`:

```yaml
# baked-values.yaml — solo-dev ships ALL plugins in the image; the empty
# plugins.names is the signal to skip the managed plugins PVC (#913).
image:
  repository: ghcr.io/hiero-ledger/hiero-block-node-solo-dev
  tag: "0.39.0"

plugins:
  names: ""

resources:
  requests:
    cpu: "500m"
    memory: "1Gi"
  limits:
    cpu: "1"
    memory: "1.5Gi"

blockNode:
  config:
    JAVA_OPTS: '-Xms1G -Xmx1G'
  logs:
    level: "INFO"

kubepromstack:
  enabled: false
loki:
  enabled: false
promtail:
  enabled: false
```

Install:

```bash
sudo solo-provisioner block node install \
  --profile local \
  --chart-version 0.39.0 \
  --base-path /opt/weaver/block-node-storage \
  --values baked-values.yaml \
  --load-balancer-enabled=false \
  --skip-hardware-checks
```

Assert (each line prints `PASS: ...` on success):

```bash
kubectl -n block-node get pvc -o name | grep -q plugins && echo 'FAIL: plugins PVC exists' || echo 'PASS: no plugins PVC'
kubectl -n block-node get pv  -o name | grep -q plugins-storage && echo 'FAIL: plugins PV exists' || echo 'PASS: no plugins PV'
kubectl -n block-node get statefulset -o yaml | grep -q 'plugins-storage' && echo 'FAIL: plugins volume/mount rendered' || echo 'PASS: no plugins volume/mount'
kubectl -n block-node get statefulset -o yaml | grep -Eq 'app-[0-9.]+/plugins' && echo 'FAIL: baked-plugins shadow mount present' || echo 'PASS: no shadow mount over baked plugins'
```

Expected `kubectl -n block-node get pvc` (note: **no** `plugins-storage-pvc`; `application-state` present at 0.39.0):

```
NAME                            STATUS   VOLUME                          ...
archive-storage-pvc             Bound    archive-storage-pv
live-storage-pvc                Bound    live-storage-pv
logging-storage-pvc             Bound    logging-storage-pv
application-state-storage-pvc   Bound    application-state-storage-pv
```

Optional (Tier 2, needs the pod to start): `kubectl -n block-node logs sts/block-node-block-node-server`
contains no `No BlockMessagingFacility provided`.

#### Case 2 — managed/download mode unchanged (regression)

Save `managed-values.yaml` (plain image, chart-default `plugins.names` → Maven download → managed PVC):

```yaml
# managed-values.yaml — no plugins.names override; the provisioner manages the plugins PVC as before.
resources:
  requests:
    cpu: "500m"
    memory: "1Gi"
  limits:
    cpu: "1"
    memory: "1.5Gi"

kubepromstack:
  enabled: false
loki:
  enabled: false
promtail:
  enabled: false
```

```bash
sudo solo-provisioner block node install \
  --profile local \
  --chart-version 0.39.0 \
  --base-path /opt/weaver/block-node-storage \
  --values managed-values.yaml \
  --load-balancer-enabled=false \
  --skip-hardware-checks

# Assert the managed PVC is back exactly as before:
kubectl -n block-node get pvc plugins-storage-pvc -o jsonpath='{.status.phase}' | grep -q Bound \
  && echo 'PASS: plugins-storage-pvc Bound (managed mode unchanged)' || echo 'FAIL'
```

> This path is unchanged by the PR and includes the ~4-min Maven resolve. If resources/time are tight,
> Case 2 is safe to **skip** — it is covered by `TestInjectPersistenceOverrides_ManagedKeepsPluginsClaim`
> and `TestPluginsStorageMigration_Applies_BakedSignal` (managed sub-case).

#### Case 3 — upgrade managed → baked (optional; also unit-covered)

After a Case-2 install:

```bash
sudo solo-provisioner block node upgrade \
  --profile local --chart-version 0.39.0 \
  --base-path /opt/weaver/block-node-storage \
  --values baked-values.yaml --load-balancer-enabled=false --skip-hardware-checks
```

Expected: no new plugins PV/PVC provisioned; the old `plugins-storage-pvc`/`-pv` remain but are orphaned
and inert (the chart no longer references them). The migration-skip is unit-covered by
`TestPluginsStorageMigration_Applies_BakedSignal`, so this case can be reasoned about rather than run.

### Minimum I actually recommend

**Tier 0 always**, plus **Tier 1 Case 1** on the UTM VM. Case 2/3 are the unchanged/heavy paths and are
unit-covered; skip them if resources are tight. CI runs the full Linux build + unit suite for
`internal/bll/blocknode` (which can't compile on macOS due to linux-only `internal/mount`).

## Risks

- The load-bearing behavior is the explicit `plugins.names: ""` (Helm re-applies the chart's non-empty
  default if the provisioner's `-f` output omits the key). Covered by
  `TestPluginsBakedTwoLayerMerge_ChartSeesEmpty`.
- **Upgrade path:** an existing managed install upgraded to a baked image leaves an orphaned (inert)
  plugins PV/PVC. Non-baked upgrades are unchanged (gate returns managed=true → identical to today).
- No CLI flag added or changed → no `docs/quickstart.md` change.
