### PR TITLE
fix(daemon): correct NetworkUpgradeExecute CRD API group 

### DIFF
--- a/docs/dev/daemon/daemon-testing-guide.md
+++ b/docs/dev/daemon/daemon-testing-guide.md
@@ -97,9 +97,9 @@ sudo kubectl apply -f - <<'CRDEOF'
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: networkupgradeexecutes.hedera.com
+  name: networkupgradeexecutes.operator.solo.hedera.com
 spec:
-  group: hedera.com
+  group: operator.solo.hedera.com
   names:
     kind: NetworkUpgradeExecute
     listKind: NetworkUpgradeExecuteList
@@ -158,8 +158,8 @@ spec:
 CRDEOF
 
 # Verify:
-sudo kubectl get crd networkupgradeexecutes.hedera.com
-# expected: networkupgradeexecutes.hedera.com   <age>
+sudo kubectl get crd networkupgradeexecutes.operator.solo.hedera.com
+# expected: networkupgradeexecutes.operator.solo.hedera.com   <age>
 ```
 
 Once all six steps complete, proceed to TC-01.
@@ -1013,7 +1013,7 @@ and starts the execute workflow (currently a stub).
 - Daemon installed and running with `consensus-node` component enabled.
 - The `NetworkUpgradeExecute` CRD is installed in the cluster:
   ```bash
-  kubectl get crd networkupgradeexecutes.hedera.com
+  kubectl get crd networkupgradeexecutes.operator.solo.hedera.com
   ```
 
 ### Steps
@@ -1025,7 +1025,7 @@ and starts the execute workflow (currently a stub).
 2. Create a `NetworkUpgradeExecute` CR and set its status via the status subresource:
    ```bash
    kubectl apply -f - <<'EOF'
-   apiVersion: hedera.com/v1alpha1
+   apiVersion: operator.solo.hedera.com/v1alpha1
    kind: NetworkUpgradeExecute
    metadata:
      name: test-upgrade-01
@@ -1081,7 +1081,7 @@ kubectl delete networkupgradeexecute test-upgrade-01 -n $ORBIT
    if not already present from TC-23):
    ```bash
    kubectl apply -f - <<'EOF'
-   apiVersion: hedera.com/v1alpha1
+   apiVersion: operator.solo.hedera.com/v1alpha1
    kind: NetworkUpgradeExecute
    metadata:
      name: test-upgrade-01
@@ -1172,7 +1172,7 @@ and restoring RBAC clears the degraded state within one watch cycle — without 
    ```
    Expected output (truncated):
    ```
-   WRN List error — retrying error="...networkupgradeexecutes.hedera.com is forbidden..." reason=UpgradeMonitorListError
+   WRN List error — retrying error="...networkupgradeexecutes.operator.solo.hedera.com is forbidden..." reason=UpgradeMonitorListError
    ```
 
 4. Confirm the daemon is still alive and `/health` still responds, and that `/status` and
@@ -1196,7 +1196,7 @@ and restoring RBAC clears the degraded state within one watch cycle — without 
              "state": "degraded",
              "error": {
                "reason": "UpgradeMonitorListError",
-               "message": "...: networkupgradeexecutes.hedera.com is forbidden: ...",
+               "message": "...: networkupgradeexecutes.operator.solo.hedera.com is forbidden: ...",
                "resolution": "Verify RBAC for NetworkUpgradeExecute resources in namespace <orbit>: kubectl get clusterrolebinding solo-provisioner-daemon-cn",
                "since": "<RFC3339 timestamp>"
              }

--- a/internal/daemon/consensus/upgrade_monitor.go
+++ b/internal/daemon/consensus/upgrade_monitor.go
@@ -28,7 +28,7 @@ import (
 )
 
 var networkUpgradeExecuteGVR = schema.GroupVersionResource{
-	Group:    "hedera.com",
+	Group:    "operator.solo.hedera.com",
 	Version:  "v1alpha1",
 	Resource: "networkupgradeexecutes",
 }
@@ -74,7 +74,7 @@ const (
 // coordinates the daemon needs to watch NetworkUpgradeExecute CRs. Used by
 // RequiredProbe to build the KubeRBACProbe for this monitor.
 const (
-	networkUpgradeExecuteGroup    = "hedera.com"
+	networkUpgradeExecuteGroup    = "operator.solo.hedera.com"
 	networkUpgradeExecuteResource = "networkupgradeexecutes"
 )
 

--- a/internal/daemon/consensus/upgrade_monitor_test.go
+++ b/internal/daemon/consensus/upgrade_monitor_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var upgradeExecuteGVR = schema.GroupVersionResource{
-	Group:    "hedera.com",
+	Group:    "operator.solo.hedera.com",
 	Version:  "v1alpha1",
 	Resource: "networkupgradeexecutes",
 }
@@ -36,11 +36,11 @@ func newFakeUpgradeMonitor(t *testing.T, namespace string, objects ...runtime.Ob
 
 	// Register the CR's GVK so the fake client can handle watch events.
 	scheme.AddKnownTypeWithName(
-		schema.GroupVersionKind{Group: "hedera.com", Version: "v1alpha1", Kind: "NetworkUpgradeExecute"},
+		schema.GroupVersionKind{Group: "operator.solo.hedera.com", Version: "v1alpha1", Kind: "NetworkUpgradeExecute"},
 		&unstructured.Unstructured{},
 	)
 	scheme.AddKnownTypeWithName(
-		schema.GroupVersionKind{Group: "hedera.com", Version: "v1alpha1", Kind: "NetworkUpgradeExecuteList"},
+		schema.GroupVersionKind{Group: "operator.solo.hedera.com", Version: "v1alpha1", Kind: "NetworkUpgradeExecuteList"},
 		&unstructured.UnstructuredList{},
 	)
 
@@ -55,7 +55,7 @@ func newFakeUpgradeMonitor(t *testing.T, namespace string, objects ...runtime.Ob
 func makeExecuteCR(name, namespace, operationID, phase string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "hedera.com/v1alpha1",
+			"apiVersion": "operator.solo.hedera.com/v1alpha1",
 			"kind":       "NetworkUpgradeExecute",
 			"metadata": map[string]interface{}{
 				"name":      name,
@@ -308,7 +308,7 @@ func Test_UpgradeMonitor_SeedsCompletedFromList(t *testing.T) {
 func Test_isAuthError_DetectsUnauthorizedAndForbidden(t *testing.T) {
 	unauthorized := k8serrors.NewUnauthorized("token expired")
 	forbidden := k8serrors.NewForbidden(
-		schema.GroupResource{Group: "hedera.com", Resource: "networkupgradeexecutes"},
+		schema.GroupResource{Group: "operator.solo.hedera.com", Resource: "networkupgradeexecutes"},
 		"upgrade-execute",
 		fmt.Errorf("denied"),
 	)

--- a/internal/daemon/probes/kube_rbac.go
+++ b/internal/daemon/probes/kube_rbac.go
@@ -40,7 +40,7 @@ type KubeRBACProbe struct {
 	// Namespace is the Kubernetes namespace to check permissions in.
 	Namespace string
 
-	// Group is the API group (e.g. "hedera.com"). Use "" for core resources.
+	// Group is the API group (e.g. "operator.solo.hedera.com"). Use "" for core resources.
 	Group string
 
 	// Resource is the plural resource name (e.g. "networkupgradeexecutes").

--- a/internal/workflows/daemon.go
+++ b/internal/workflows/daemon.go
@@ -26,7 +26,7 @@ func buildComponentSpecs(cfg daemon.DaemonConfig, paths models.WeaverPaths) []st
 			Namespace:      cn.Orbit,
 			KubeconfigPath: paths.DaemonCNKubeconfigPath,
 			PolicyRules: []rbacv1.PolicyRule{{
-				APIGroups: []string{"hedera.com"},
+				APIGroups: []string{"operator.solo.hedera.com"},
 				Resources: []string{"networkupgradeexecutes"},
 				Verbs:     []string{"list", "watch"},
 			}},


### PR DESCRIPTION
## Description

This pull request changes the following:

* Corrects the `NetworkUpgradeExecute` CRD API group from `hedera.com` to `operator.solo.hedera.com` across the daemon, so the upgrade monitor watches the group solo-operator actually installs. Fixes the GVR in `upgrade_monitor.go`, the KubeRBAC policy rules in `internal/workflows/daemon.go`, and the doc/comment references in `kube_rbac.go`.
* Updates the daemon testing guide.

### Related Issues

* Closes #850

- [x]  unit test
- [x] manual UAT (with solo-operator version 0.3.1)

## Test plan


1. Build and install the binaries (daemon carries the watch fix, CLI carries the RBAC fix)

Host:
```sh
task build:cli    GOOS=linux GOARCH=arm64
task build:daemon GOOS=linux GOARCH=arm64
```

VM:
```sh
ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
sudo /mnt/solo-weaver/bin/solo-provisioner-linux-$ARCH install
```

2. Install the Kubernetes cluster (skip if one is already up)

`config_with_solo_operator.yaml` enables the solo-operator (installed as a Helm chart), so the cluster matches the target topology

```sh
sudo solo-provisioner kube cluster install -p local -c /mnt/solo-weaver/test/config/config_with_solo_operator.yaml
kubectl get nodes
# expect a Ready node before continuing
```

3. Ensure the CRD is present

The solo-operator chart installed in step 2 should already ship the NetworkUpgradeExecute CRD (in version 0.3.2). Check for it first, and only hand-apply the stand-in below if it's missing

```sh
kubectl get crd networkupgradeexecutes.operator.solo.hedera.com -o jsonpath='{.spec.group}{"\n"}' 2>/dev/null
# expected: operator.solo.hedera.com
```

only if the CRD is missing, apply this stand-in (group/version/plural/scope + status subresource must match the daemon's GVR exactly):

```yml
kubectl apply -f - <<EOF
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: networkupgradeexecutes.operator.solo.hedera.com
spec:
  group: operator.solo.hedera.com
  scope: Namespaced
  names:
    kind: NetworkUpgradeExecute
    listKind: NetworkUpgradeExecuteList
    plural: networkupgradeexecutes
    singular: networkupgradeexecute
  versions:
  - name: v1alpha1
    served: true
    storage: true
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            x-kubernetes-preserve-unknown-fields: true
          status:
            type: object
            x-kubernetes-preserve-unknown-fields: true
EOF
```

```sh
kubectl get crd networkupgradeexecutes.operator.solo.hedera.com -o jsonpath='{.spec.group}{"\n"}'
# expected: operator.solo.hedera.com
```

4. Create the orbit namespace

```sh
export ORBIT=hedera-network
kubectl create ns "$ORBIT" 2>/dev/null || true
```

5. Install the daemon (creates RBAC + starts the watch)

Point at the local binary with --daemon-bin

```sh
ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')

sudo solo-provisioner daemon service install --components=consensus-node --cn-node-id=0.0.3 --cn-orbit="$ORBIT" \
  --daemon-bin /mnt/solo-weaver/bin/solo-provisioner-daemon-linux-$ARCH

sudo usermod -aG hedera weaver && sudo systemctl restart solo-provisioner-daemon
sudo solo-provisioner daemon service check
# a red check here may reflect unrelated disk/ownership setup, not this fix
```

Confirm the running binary is the freshly-built one (guards against a stale install):

```sh
sha256sum /opt/solo/weaver/bin/solo-provisioner-daemon /mnt/solo-weaver/bin/solo-provisioner-daemon-linux-$ARCH
# expect identical hashes
```

6. RBAC regression check (the daemon's own ClusterRole)

Assert against the exact object the fix produces: solo-provisioner-daemon-cn
Positive (correct group present):
```sh
kubectl get clusterrole solo-provisioner-daemon-cn -o yaml
# expect a rule with:
#   apiGroups: ["operator.solo.hedera.com"]
#   resources: ["networkupgradeexecutes"]
#   verbs:     ["list","watch"]
```

Negative (old group gone) 
```sh
kubectl get clusterrole solo-provisioner-daemon-cn -o jsonpath='{range .rules[*]}{.apiGroups}{"\n"}{end}'
# expect: ["operator.solo.hedera.com"]
```

7. Watch established, no list errors

```sh
sudo journalctl -u solo-provisioner-daemon -n 120 --no-pager | grep -iE "UpgradeMonitorStarted|WatchEstablished|UpgradeMonitorListError"
# expect: UpgradeMonitorStarted, and (at debug) WatchEstablished
# must not see: UpgradeMonitorListError
```

8. End-to-end - daemon detects a CR

```sh
kubectl apply -f - <<EOF
apiVersion: operator.solo.hedera.com/v1alpha1
kind: NetworkUpgradeExecute
metadata:
  name: uat-upgrade-1
  namespace: $ORBIT
spec:
  operationId: uat-op-001
  orbit: $ORBIT
EOF

kubectl patch networkupgradeexecute uat-upgrade-1 -n "$ORBIT" --subresource=status --type=merge \
  -p '{"status":{"phase":"ReadyForProvisionerDaemon"}}'

sudo journalctl -u solo-provisioner-daemon -f

# expected:
# reason=ReadyForProvisionerDaemon ... NetworkUpgradeExecute entered ReadyForProvisionerDaemon - triggering execute workflow
# reason=ExecuteWorkflowStarted   ... Execute workflow stub
```

