### PR TITLE
feat(blocknode): persist last-chosen firewall & traffic-shaping values in state

### DIFF
--- a/cmd/cli/commands/block/node/reconfigure.go
+++ b/cmd/cli/commands/block/node/reconfigure.go
@@ -73,6 +73,16 @@ var (
 			// on --profile=local preempt the clearer "block node is not installed"
 			// precondition error on a fresh host.
 			if trafficShapingEnabled {
+				// Seed the egress prompts from the persisted last-chosen shaping
+				// content so a default-accept keeps the operator's previous NIC/link
+				// rate instead of reverting to auto-detection. An explicit CLI flag
+				// still wins (ResolveEgressConfig skips a prompt whose flag was set).
+				if !cmd.Flags().Changed(common.FlagNameEgressInterface) && flagEgressInterface == "" {
+					flagEgressInterface = stateDefaults.BlockNode.EgressInterface
+				}
+				if !cmd.Flags().Changed(common.FlagNameLinkRate) && flagLinkRate == "" {
+					flagLinkRate = stateDefaults.BlockNode.LinkRate
+				}
 				if err := common.ResolveEgressConfig(cmd, args, cv, &flagEgressInterface, &flagLinkRate); err != nil {
 					return err
 				}

--- a/cmd/cli/commands/block/node/upgrade.go
+++ b/cmd/cli/commands/block/node/upgrade.go
@@ -42,6 +42,17 @@ var (
 				return err
 			}
 
+			// Upgrade exposes no firewall flags and never prompts; seed the effective
+			// host-firewall config from the last-persisted state so the network-plane's
+			// NetworkFirewallCreate step re-asserts the operator's last-known allowlist
+			// (create-if-missing) instead of skipping on an empty one. The persisted
+			// enable/disable decision is honored — a firewall that was disabled stays
+			// off (the step self-gates on config.Host.Disabled). Traffic-shaping content
+			// is re-asserted separately via the shared effective-inputs resolver.
+			if err := common.SeedHostFirewallFromState(); err != nil {
+				return err
+			}
+
 			intent := models.Intent{
 				Action: models.ActionUpgrade,
 				Target: models.TargetBlockNode,

--- a/cmd/cli/commands/common/egress.go
+++ b/cmd/cli/commands/common/egress.go
@@ -55,6 +55,14 @@ func ValidateEgressFlags(cmd *cobra.Command, linkRate string) error {
 // interactive and the flags were not supplied on the CLI. egressInterface and
 // linkRate are updated in-place by the prompts.
 //
+// egressInterface and linkRate double as seed inputs: when either already holds
+// a non-empty value (e.g. `block node reconfigure` pre-seeding it from the
+// persisted BlockNodeState.Shaping last-chosen values), that value becomes the
+// prompt's pre-filled default so a default-accept keeps the operator's
+// previously-configured NIC / link rate instead of silently reverting to
+// auto-detection. On a fresh `install` both are empty, so the detected NIC and
+// sysfs link speed are used — the original behaviour.
+//
 // When cv is non-nil the prompted values are recorded into it and no separate
 // summary is printed — the caller is responsible for printing the unified
 // summary after all prompt sections complete. When cv is nil a local collector
@@ -76,8 +84,13 @@ func ResolveEgressConfig(
 		return nil
 	}
 
-	// Detect the egress NIC to use as the prompt default.
+	// Detect the egress NIC to use as the prompt default, unless a value was
+	// already seeded (persisted last-chosen NIC on reconfigure), which wins.
 	detectedNIC, _ := shape.DetectEgressInterface()
+	egressDefault := detectedNIC
+	if *egressInterface != "" {
+		egressDefault = *egressInterface
+	}
 
 	// Speed hint from sysfs: prefer the already-set flag value over the
 	// auto-detected one so the hint reflects the NIC the operator chose.
@@ -92,13 +105,23 @@ func ResolveEgressConfig(
 		}
 	}
 
+	// Seed the link-rate prompt from the persisted last-chosen rate (when the
+	// caller pre-seeded linkRate, e.g. reconfigure reading BlockNodeState.Shaping)
+	// so a default-accept keeps the operator's configured rate instead of
+	// reverting to the NIC's raw sysfs line speed. Falls back to the sysfs hint
+	// on a fresh install where nothing was chosen yet.
+	linkRateDefault := speedHint
+	if *linkRate != "" {
+		linkRateDefault = *linkRate
+	}
+
 	localCV := cv
 	if localCV == nil {
 		localCV = prompt.NewChosenValues()
 	}
 	if err := prompt.RunInputPrompts(cmd, []prompt.InputPrompt{
-		prompt.EgressInterfaceInputPrompt(detectedNIC, speedHint, egressInterface),
-		prompt.LinkRateInputPrompt(speedHint, linkRate),
+		prompt.EgressInterfaceInputPrompt(egressDefault, speedHint, egressInterface),
+		prompt.LinkRateInputPrompt(linkRateDefault, linkRate),
 	}, localCV); err != nil {
 		return err
 	}

--- a/cmd/cli/commands/common/host_firewall.go
+++ b/cmd/cli/commands/common/host_firewall.go
@@ -6,7 +6,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/network/firewall"
+	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
 	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/models"
@@ -175,6 +177,15 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.Cho
 		return nil
 	}
 
+	// Fall back to the last-persisted firewall allowlist for any field the operator
+	// did not supply via --config, so a reconfigure that re-enables the firewall
+	// without re-passing --mgmt-cidrs restores the last-known-good allowlist instead
+	// of skipping with the SSH-lockout guard (issue #932). State sits below the
+	// config file and above the built-in default; a CLI flag, checked inside the
+	// effective* helpers below, still wins over all of them. On a fresh host with no
+	// persisted firewall this is a no-op.
+	cfg = mergeHostFirewallFromState(cfg)
+
 	// Seed each prompt target with the effective value: the CLI flag when the
 	// operator set it, else the config value, else the built-in default. The
 	// prompt layer skips any flag already set on the CLI, leaving these seeds
@@ -295,6 +306,68 @@ func joinInts(in []int) string {
 		parts[i] = strconv.Itoa(n)
 	}
 	return strings.Join(parts, ",")
+}
+
+// mergeHostFirewallFromState fills any host-firewall content field left empty by
+// the config file with the last value persisted in state (machineState.firewall).
+// It is the "state" tier of the flag > config > state > default precedence for the
+// firewall allowlist: the returned config seeds the effective* helpers, where a
+// CLI flag still takes priority. Only the allowlist content is merged — the
+// enable/disable decision is resolved separately (flag / prompt / live probe), so
+// the persisted Firewall.Disabled is intentionally ignored here. Returns cfg
+// unchanged when no firewall was ever persisted or the state read fails.
+func mergeHostFirewallFromState(cfg models.HostConfig) models.HostConfig {
+	defaults, err := state.ReadPromptDefaultsFromDisk()
+	if err != nil {
+		logx.As().Debug().Err(err).Msg("could not read persisted firewall config; not seeding from state")
+		return cfg
+	}
+	fw := defaults.Firewall
+	if fw == nil {
+		return cfg
+	}
+	if len(cfg.ManagementCIDRs) == 0 {
+		cfg.ManagementCIDRs = fw.ManagementCIDRs
+	}
+	if len(cfg.BlockedCIDRs) == 0 {
+		cfg.BlockedCIDRs = fw.BlockedCIDRs
+	}
+	if cfg.SSHPort == 0 {
+		cfg.SSHPort = fw.SSHPort
+	}
+	if cfg.PodCIDR == "" {
+		cfg.PodCIDR = fw.PodCIDR
+	}
+	if len(cfg.InClusterPorts) == 0 {
+		cfg.InClusterPorts = fw.InClusterPorts
+	}
+	return cfg
+}
+
+// SeedHostFirewallFromState applies the last-persisted host-firewall configuration
+// (machineState.firewall) to the global config for commands — namely `block node
+// upgrade` — that re-assert the firewall without prompting or exposing firewall
+// flags. It honors the persisted enable/disable decision: when the firewall was
+// enabled, the recorded allowlist is applied so NetworkFirewallCreate re-asserts
+// (create-if-missing) rather than skipping on an empty allowlist; when it was
+// disabled, config.Host.Disabled is set so the step skips (upgrade never tears the
+// firewall down — allowTeardown=false). It is a no-op when no firewall was ever
+// persisted, leaving the empty default that makes the step skip.
+func SeedHostFirewallFromState() error {
+	defaults, err := state.ReadPromptDefaultsFromDisk()
+	if err != nil {
+		return errorx.InternalError.Wrap(err, "failed to read persisted firewall config")
+	}
+	if defaults.Firewall == nil {
+		logx.As().Debug().Msg("no persisted host-firewall config; leaving firewall unconfigured for this run")
+		return nil
+	}
+	config.OverrideHostConfig(*defaults.Firewall)
+	logx.As().Debug().
+		Bool("disabled", defaults.Firewall.Disabled).
+		Int("managementCidrs", len(defaults.Firewall.ManagementCIDRs)).
+		Msg("Seeded host-firewall config from persisted state")
+	return nil
 }
 
 // normalizeCIDRs trims whitespace and drops empty entries from a CIDR list so

--- a/cmd/cli/commands/common/host_firewall.go
+++ b/cmd/cli/commands/common/host_firewall.go
@@ -322,7 +322,16 @@ func mergeHostFirewallFromState(cfg models.HostConfig) models.HostConfig {
 		logx.As().Debug().Err(err).Msg("could not read persisted firewall config; not seeding from state")
 		return cfg
 	}
-	fw := defaults.Firewall
+	return applyPersistedFirewallContent(cfg, defaults.Firewall)
+}
+
+// applyPersistedFirewallContent fills any empty host-firewall content field in cfg
+// with the corresponding value from the persisted firewall fw, leaving fields the
+// operator already supplied (via --config) untouched — this is what enforces the
+// config > state precedence. The enable/disable decision (fw.Disabled) is
+// deliberately not touched here; callers resolve it separately. Returns cfg
+// unchanged when fw is nil.
+func applyPersistedFirewallContent(cfg models.HostConfig, fw *models.HostConfig) models.HostConfig {
 	if fw == nil {
 		return cfg
 	}
@@ -344,15 +353,21 @@ func mergeHostFirewallFromState(cfg models.HostConfig) models.HostConfig {
 	return cfg
 }
 
-// SeedHostFirewallFromState applies the last-persisted host-firewall configuration
-// (machineState.firewall) to the global config for commands — namely `block node
+// SeedHostFirewallFromState seeds the global host-firewall config from the
+// last-persisted state (machineState.firewall) for commands — namely `block node
 // upgrade` — that re-assert the firewall without prompting or exposing firewall
-// flags. It honors the persisted enable/disable decision: when the firewall was
-// enabled, the recorded allowlist is applied so NetworkFirewallCreate re-asserts
-// (create-if-missing) rather than skipping on an empty allowlist; when it was
-// disabled, config.Host.Disabled is set so the step skips (upgrade never tears the
-// firewall down — allowTeardown=false). It is a no-op when no firewall was ever
-// persisted, leaving the empty default that makes the step skip.
+// flags. An operator-supplied --config firewall section always wins (config >
+// state, issue #932 AC4): the config file's values are kept, and only the fields
+// it left empty are filled from persisted state.
+//
+// The enable/disable decision is resolved to honor config first: when the config
+// file specified any firewall content, its (config-authored) decision stands;
+// otherwise the persisted decision governs — when the firewall was enabled, the
+// recorded allowlist re-asserts (NetworkFirewallCreate is create-if-missing) and
+// when it was disabled, config.Host.Disabled makes the step skip (upgrade never
+// tears the firewall down — allowTeardown=false). It is a no-op when no firewall
+// was ever persisted and no config was supplied, leaving the empty default that
+// makes the step skip.
 func SeedHostFirewallFromState() error {
 	defaults, err := state.ReadPromptDefaultsFromDisk()
 	if err != nil {
@@ -362,10 +377,33 @@ func SeedHostFirewallFromState() error {
 		logx.As().Debug().Msg("no persisted host-firewall config; leaving firewall unconfigured for this run")
 		return nil
 	}
-	config.OverrideHostConfig(*defaults.Firewall)
+
+	// Detect whether the operator authored a firewall section in --config before
+	// merging state in. HostConfig.Disabled's zero value can't distinguish
+	// "enabled" from "never configured", so the presence of any content field is
+	// what tells us the config file is authoritative for the enable/disable
+	// decision (same reasoning as ResolveHostFirewallConfig's seedEnabled).
+	cfg := config.Get().Host
+	configHasContent := len(cfg.ManagementCIDRs) > 0 ||
+		len(cfg.BlockedCIDRs) > 0 ||
+		cfg.SSHPort > 0 ||
+		cfg.PodCIDR != "" ||
+		len(cfg.InClusterPorts) > 0
+
+	cfg = applyPersistedFirewallContent(cfg, defaults.Firewall)
+
+	// Only the persisted enable/disable decision fills in when config said nothing
+	// about the firewall; an operator who configured it via --config keeps their
+	// own decision.
+	if !configHasContent {
+		cfg.Disabled = defaults.Firewall.Disabled
+	}
+
+	config.OverrideHostConfig(cfg)
 	logx.As().Debug().
-		Bool("disabled", defaults.Firewall.Disabled).
-		Int("managementCidrs", len(defaults.Firewall.ManagementCIDRs)).
+		Bool("disabled", cfg.Disabled).
+		Bool("configHasContent", configHasContent).
+		Int("managementCidrs", len(cfg.ManagementCIDRs)).
 		Msg("Seeded host-firewall config from persisted state")
 	return nil
 }

--- a/cmd/cli/commands/common/host_firewall_test.go
+++ b/cmd/cli/commands/common/host_firewall_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestApplyPersistedFirewallContent_ConfigWins verifies the config > state
+// precedence (issue #932, AC4): fields the operator supplied via --config are
+// left untouched, and only the fields config left empty are filled from the
+// persisted firewall state. This is the core of SeedHostFirewallFromState /
+// mergeHostFirewallFromState, so a regression here would let persisted state
+// silently override an explicit --config value.
+func TestApplyPersistedFirewallContent_ConfigWins(t *testing.T) {
+	persisted := &models.HostConfig{
+		ManagementCIDRs: []string{"10.0.0.0/8"},
+		BlockedCIDRs:    []string{"192.0.2.0/24"},
+		SSHPort:         2222,
+		PodCIDR:         "10.4.0.0/14",
+		InClusterPorts:  []int{8080},
+		Disabled:        true, // decision must NOT be applied by this helper
+	}
+
+	cfg := models.HostConfig{
+		// Operator supplied a management allowlist and SSH port via --config;
+		// everything else is left to fall back to state.
+		ManagementCIDRs: []string{"203.0.113.0/24"},
+		SSHPort:         22,
+	}
+
+	got := applyPersistedFirewallContent(cfg, persisted)
+
+	assert.Equal(t, []string{"203.0.113.0/24"}, got.ManagementCIDRs, "config allowlist must win over state")
+	assert.Equal(t, 22, got.SSHPort, "config SSH port must win over state")
+	assert.Equal(t, []string{"192.0.2.0/24"}, got.BlockedCIDRs, "empty blocked CIDRs must fall back to state")
+	assert.Equal(t, "10.4.0.0/14", got.PodCIDR, "empty pod CIDR must fall back to state")
+	assert.Equal(t, []int{8080}, got.InClusterPorts, "empty in-cluster ports must fall back to state")
+	assert.False(t, got.Disabled, "the enable/disable decision must not be touched by the content merge")
+}
+
+// TestApplyPersistedFirewallContent_NilPersistedIsNoOp verifies that a nil
+// persisted firewall (fresh host, nothing ever recorded) leaves config untouched.
+func TestApplyPersistedFirewallContent_NilPersistedIsNoOp(t *testing.T) {
+	cfg := models.HostConfig{ManagementCIDRs: []string{"203.0.113.0/24"}}
+	got := applyPersistedFirewallContent(cfg, nil)
+	assert.Equal(t, cfg, got)
+}

--- a/internal/bll/blocknode/effective_inputs_test.go
+++ b/internal/bll/blocknode/effective_inputs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/release"
 )
 
 // fakeBlockNodeChecker is a no-op reality.Checker[state.BlockNodeState] that
@@ -56,4 +57,95 @@ func TestResolveEffectiveInputs_CarriesTimeout(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 15*time.Minute, eff.Custom.Timeout,
 		"--timeout must be carried through effective-input resolution")
+}
+
+// baseTcInputs returns valid inputs with the resolvable fields set but the
+// traffic-shaping content deliberately left empty, so the state fallback governs.
+func baseTcInputs() models.UserInputs[models.BlockNodeInputs] {
+	return models.UserInputs[models.BlockNodeInputs]{
+		Custom: models.BlockNodeInputs{
+			Namespace:    "block-node",
+			Release:      "block-node",
+			Chart:        "oci://example.com/block-node",
+			ChartVersion: "0.37.1",
+			Storage:      models.BlockNodeStorage{BasePath: "/mnt/fast-storage"},
+		},
+	}
+}
+
+// deployedShapingBlockNodeState returns a deployed BlockNodeState so that
+// resolveBlocknodeEffectiveInputs can resolve an upgrade (chart-version
+// resolution requires a StrategyState/Reality source, i.e. a deployed release).
+// BasePath is set so the storage resolver's deployed-state validation passes.
+func deployedShapingBlockNodeState() state.BlockNodeState {
+	st := state.NewBlockNodeState()
+	st.ReleaseInfo = state.HelmReleaseInfo{
+		Status:       release.StatusDeployed,
+		Name:         "block-node",
+		Namespace:    "block-node",
+		ChartName:    "block-node",
+		ChartRef:     "oci://example.com/block-node",
+		ChartVersion: "0.37.1",
+	}
+	st.Storage = models.BlockNodeStorage{BasePath: "/mnt/fast-storage"}
+	return st
+}
+
+// TestResolveEffectiveInputs_TrafficShapingFallbackFromState verifies that when
+// the operator supplies no egress NIC / rate / overrides (the upgrade case, which
+// has no such flags), the persisted BlockNodeState.Shaping is used so the tc steps
+// re-assert the original shaping instead of auto-detecting (issue #932, AC3).
+func TestResolveEffectiveInputs_TrafficShapingFallbackFromState(t *testing.T) {
+	prio := 0
+	persisted := deployedShapingBlockNodeState()
+	persisted.Shaping = &state.ShapingState{
+		EgressInterface: "eth0",
+		LinkRate:        "1gbit",
+		ShapeOverrides: map[string]models.ShapeOverride{
+			"publisher": {Rate: "800mbit", Ceil: "1gbit", Prio: &prio},
+		},
+	}
+
+	checker := &fakeBlockNodeChecker{st: state.NewBlockNodeState()}
+	r, err := rsl.NewBlockNodeRuntimeResolver(models.Config{}, persisted, checker, 10*time.Minute)
+	require.NoError(t, err)
+	runtime := r.(*rsl.BlockNodeRuntimeResolver)
+
+	eff, err := resolveBlocknodeEffectiveInputs(
+		runtime,
+		models.Intent{Action: models.ActionUpgrade, Target: models.TargetBlockNode},
+		baseTcInputs(),
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "eth0", eff.Custom.EgressInterface, "egress NIC must fall back to persisted Shaping")
+	assert.Equal(t, "1gbit", eff.Custom.LinkRate, "link rate must fall back to persisted Shaping")
+	require.Contains(t, eff.Custom.ShapeOverrides, "publisher")
+	assert.Equal(t, "800mbit", eff.Custom.ShapeOverrides["publisher"].Rate)
+}
+
+// TestResolveEffectiveInputs_ExplicitTrafficShapingWins verifies that an explicit
+// operator-supplied value beats the persisted state fallback (issue #932, AC4).
+func TestResolveEffectiveInputs_ExplicitTrafficShapingWins(t *testing.T) {
+	persisted := state.NewBlockNodeState()
+	persisted.Shaping = &state.ShapingState{EgressInterface: "eth0", LinkRate: "1gbit"}
+
+	checker := &fakeBlockNodeChecker{st: state.NewBlockNodeState()}
+	r, err := rsl.NewBlockNodeRuntimeResolver(models.Config{}, persisted, checker, 10*time.Minute)
+	require.NoError(t, err)
+	runtime := r.(*rsl.BlockNodeRuntimeResolver)
+
+	inputs := baseTcInputs()
+	inputs.Custom.EgressInterface = "ens5"
+	inputs.Custom.LinkRate = "10gbit"
+
+	eff, err := resolveBlocknodeEffectiveInputs(
+		runtime,
+		models.Intent{Action: models.ActionReconfigure, Target: models.TargetBlockNode},
+		inputs,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "ens5", eff.Custom.EgressInterface, "explicit egress NIC must win over persisted Shaping")
+	assert.Equal(t, "10gbit", eff.Custom.LinkRate, "explicit link rate must win over persisted Shaping")
 }

--- a/internal/bll/blocknode/helpers.go
+++ b/internal/bll/blocknode/helpers.go
@@ -7,6 +7,7 @@ import (
 	bnpkg "github.com/hashgraph/solo-weaver/internal/blocknode"
 	"github.com/hashgraph/solo-weaver/internal/rsl"
 	"github.com/hashgraph/solo-weaver/internal/state"
+	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/joomcode/errorx"
 	"helm.sh/helm/v3/pkg/release"
@@ -69,8 +70,70 @@ func patchBlockNodeStateWithTrafficShaping() func(st *state.State, effectiveInpu
 		st.BlockNodeState.TrafficShapingDisabled = !effectiveInputs.Custom.TrafficShapingEnabled
 		logx.As().Debug().Bool("trafficShapingDisabled", st.BlockNodeState.TrafficShapingDisabled).
 			Msg("Persisted block node traffic-shaping decision into runtime state")
+
+		// Persist the host-firewall decision + content (host-scoped) so a later
+		// reconfigure/upgrade can re-assert the inet host table without the operator
+		// re-supplying the allowlist. Written even when the block node is not (yet)
+		// deployed, mirroring TrafficShapingDisabled — the firewall is host-scoped and
+		// its application is independent of the Helm release status.
+		patchMachineFirewallFromConfig(st)
+
+		// Persist the traffic-shaping content only when it was enabled and a real
+		// target was resolved, so upgrade/reconfigure re-assert the same NIC/rate/
+		// overrides instead of auto-detecting. When disabled we leave any prior
+		// Shaping record intact (the decision on TrafficShapingDisabled governs re-assert).
+		if effectiveInputs.Custom.TrafficShapingEnabled {
+			patchBlockNodeShaping(st, effectiveInputs.Custom)
+		}
 		return base(st, effectiveInputs)
 	}
+}
+
+// patchMachineFirewallFromConfig records the resolved host-firewall configuration
+// (config.Get().Host, set by common.ResolveHostFirewallConfig earlier in the CLI
+// flow) into MachineState.Firewall. The enable/disable decision is always kept in
+// sync; the CIDR/port content is updated only when the firewall is enabled with a
+// non-empty allowlist, so a disable — or an enable with an empty allowlist, which
+// the NetworkFirewallCreate step skips — flips Disabled but preserves the
+// last-known-good allowlist for a future bare re-enable.
+func patchMachineFirewallFromConfig(st *state.State) {
+	hostCfg := config.Get().Host
+
+	fw := st.MachineState.Firewall
+	if fw == nil {
+		fw = &state.HostFirewallState{}
+	}
+	fw.Disabled = hostCfg.Disabled
+
+	if !hostCfg.Disabled && len(hostCfg.ManagementCIDRs) > 0 {
+		fw.ManagementCIDRs = hostCfg.ManagementCIDRs
+		fw.BlockedCIDRs = hostCfg.BlockedCIDRs
+		fw.SSHPort = hostCfg.SSHPort
+		fw.PodCIDR = hostCfg.PodCIDR
+		fw.InClusterPorts = hostCfg.InClusterPorts
+	}
+
+	st.MachineState.Firewall = fw
+	logx.As().Debug().
+		Bool("disabled", fw.Disabled).
+		Int("managementCidrs", len(fw.ManagementCIDRs)).
+		Msg("Persisted host-firewall configuration into runtime state")
+}
+
+// patchBlockNodeShaping records the resolved traffic-shaping content bundle into
+// BlockNodeState.Shaping so upgrade/reconfigure can re-assert the operator's
+// original egress NIC, link rate, and per-class overrides.
+func patchBlockNodeShaping(st *state.State, ins models.BlockNodeInputs) {
+	st.BlockNodeState.Shaping = &state.ShapingState{
+		EgressInterface: ins.EgressInterface,
+		LinkRate:        ins.LinkRate,
+		ShapeOverrides:  ins.ShapeOverrides,
+	}
+	logx.As().Debug().
+		Str("egressInterface", ins.EgressInterface).
+		Str("linkRate", ins.LinkRate).
+		Int("shapeOverrides", len(ins.ShapeOverrides)).
+		Msg("Persisted block node traffic-shaping content into runtime state")
 }
 
 // resolveBlocknodeEffectiveInputs resolves common fields for blocknode commands.
@@ -147,6 +210,33 @@ func resolveBlocknodeEffectiveInputs(
 		Any("recentRetention", effRecentRetention).
 		Msg("Determined effective block node recent retention")
 
+	// Traffic-shaping content (egress NIC, link rate, per-class overrides) has no
+	// resolver tier — it is passed through from user input. Fall back to the
+	// persisted BlockNodeState.Shaping when the operator did not supply a value, so
+	// `upgrade` (which never prompts for these) and a bare `reconfigure` re-assert
+	// the operator's original shaping instead of auto-detecting. Explicit user input
+	// always wins. On a fresh install CurrentState carries no Shaping, so this is a
+	// no-op there.
+	egressInterface := inputs.Custom.EgressInterface
+	linkRate := inputs.Custom.LinkRate
+	shapeOverrides := inputs.Custom.ShapeOverrides
+	if current, err := runtime.CurrentState(); err == nil && current.Shaping != nil {
+		if egressInterface == "" {
+			egressInterface = current.Shaping.EgressInterface
+		}
+		if linkRate == "" {
+			linkRate = current.Shaping.LinkRate
+		}
+		if len(shapeOverrides) == 0 {
+			shapeOverrides = current.Shaping.ShapeOverrides
+		}
+		logx.As().Debug().
+			Str("egressInterface", egressInterface).
+			Str("linkRate", linkRate).
+			Int("shapeOverrides", len(shapeOverrides)).
+			Msg("Applied persisted traffic-shaping content as fallback for unset inputs")
+	}
+
 	effectiveInputs := models.UserInputs[models.BlockNodeInputs]{
 		Common: inputs.Common,
 		Custom: models.BlockNodeInputs{
@@ -170,9 +260,9 @@ func resolveBlocknodeEffectiveInputs(
 			LoadBalancerEnabled:   inputs.Custom.LoadBalancerEnabled,
 			PluginPreset:          inputs.Custom.PluginPreset,
 			PluginList:            inputs.Custom.PluginList,
-			EgressInterface:       inputs.Custom.EgressInterface,
-			LinkRate:              inputs.Custom.LinkRate,
-			ShapeOverrides:        inputs.Custom.ShapeOverrides,
+			EgressInterface:       egressInterface,
+			LinkRate:              linkRate,
+			ShapeOverrides:        shapeOverrides,
 			TrafficShapingEnabled: inputs.Custom.TrafficShapingEnabled,
 			Timeout:               inputs.Custom.Timeout,
 		},

--- a/internal/bll/blocknode/helpers_patch_test.go
+++ b/internal/bll/blocknode/helpers_patch_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package blocknode
+
+import (
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/internal/state"
+	"github.com/hashgraph/solo-weaver/pkg/config"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/release"
+)
+
+// withHostConfig sets the global host config for a test and restores an empty one
+// afterwards, mirroring the pattern in reconfigure_handler_test.go.
+func withHostConfig(t *testing.T, hc models.HostConfig) {
+	t.Helper()
+	config.OverrideHostConfig(hc)
+	t.Cleanup(func() { config.OverrideHostConfig(models.HostConfig{}) })
+}
+
+func deployedState() *state.State {
+	st := &state.State{}
+	st.BlockNodeState.ReleaseInfo.Status = release.StatusDeployed
+	return st
+}
+
+// TestPatch_PersistsFirewallAndShapingWhenEnabled covers AC1: an enabled firewall
+// with a real allowlist, and enabled traffic shaping, are recorded into state.
+func TestPatch_PersistsFirewallAndShapingWhenEnabled(t *testing.T) {
+	withHostConfig(t, models.HostConfig{
+		ManagementCIDRs: []string{"10.0.0.0/8"},
+		BlockedCIDRs:    []string{"192.0.2.0/24"},
+		SSHPort:         2222,
+		PodCIDR:         "10.4.0.0/14",
+		InClusterPorts:  []int{8080},
+		Disabled:        false,
+	})
+
+	st := deployedState()
+	patch := patchBlockNodeStateWithTrafficShaping()
+	inputs := models.UserInputs[models.BlockNodeInputs]{
+		Custom: models.BlockNodeInputs{
+			TrafficShapingEnabled: true,
+			EgressInterface:       "eth0",
+			LinkRate:              "1gbit",
+		},
+	}
+	require.NoError(t, patch(st, inputs))
+
+	fw := st.MachineState.Firewall
+	require.NotNil(t, fw, "firewall must be persisted when enabled with an allowlist")
+	assert.False(t, fw.Disabled)
+	assert.Equal(t, []string{"10.0.0.0/8"}, fw.ManagementCIDRs)
+	assert.Equal(t, 2222, fw.SSHPort)
+
+	require.NotNil(t, st.BlockNodeState.Shaping, "shaping content must be persisted when tc enabled")
+	assert.Equal(t, "eth0", st.BlockNodeState.Shaping.EgressInterface)
+	assert.Equal(t, "1gbit", st.BlockNodeState.Shaping.LinkRate)
+
+	assert.False(t, st.BlockNodeState.TrafficShapingDisabled)
+}
+
+// TestPatch_DisablePreservesAllowlist covers AC2: disabling the firewall flips the
+// decision but must NOT wipe the stored allowlist, so a later bare re-enable can
+// restore it.
+func TestPatch_DisablePreservesAllowlist(t *testing.T) {
+	withHostConfig(t, models.HostConfig{Disabled: true})
+
+	st := deployedState()
+	st.MachineState.Firewall = &state.HostFirewallState{
+		ManagementCIDRs: []string{"10.0.0.0/8"},
+		SSHPort:         2222,
+	}
+
+	patch := patchBlockNodeStateWithTrafficShaping()
+	require.NoError(t, patch(st, models.UserInputs[models.BlockNodeInputs]{
+		Custom: models.BlockNodeInputs{TrafficShapingEnabled: false},
+	}))
+
+	fw := st.MachineState.Firewall
+	require.NotNil(t, fw)
+	assert.True(t, fw.Disabled, "decision must record disabled")
+	assert.Equal(t, []string{"10.0.0.0/8"}, fw.ManagementCIDRs, "allowlist must be preserved on disable")
+	assert.Equal(t, 2222, fw.SSHPort, "port must be preserved on disable")
+}
+
+// TestPatch_EnableWithEmptyAllowlistPreservesContent covers the skip-on-empty
+// rule: enabling with no allowlist (the step then skips) must not clobber a
+// previously recorded allowlist.
+func TestPatch_EnableWithEmptyAllowlistPreservesContent(t *testing.T) {
+	withHostConfig(t, models.HostConfig{Disabled: false}) // enabled, but no CIDRs
+
+	st := deployedState()
+	st.MachineState.Firewall = &state.HostFirewallState{ManagementCIDRs: []string{"10.0.0.0/8"}}
+
+	patch := patchBlockNodeStateWithTrafficShaping()
+	require.NoError(t, patch(st, models.UserInputs[models.BlockNodeInputs]{
+		Custom: models.BlockNodeInputs{TrafficShapingEnabled: false},
+	}))
+
+	fw := st.MachineState.Firewall
+	require.NotNil(t, fw)
+	assert.False(t, fw.Disabled)
+	assert.Equal(t, []string{"10.0.0.0/8"}, fw.ManagementCIDRs, "allowlist must survive an empty-allowlist enable")
+}

--- a/internal/bll/blocknode/network_plane.go
+++ b/internal/bll/blocknode/network_plane.go
@@ -43,7 +43,10 @@ func networkPlaneSteps(ins models.BlockNodeInputs, force, trafficShapingEnabled,
 	if allowTeardown && config.Get().Host.Disabled {
 		out = append(out, steps.NetworkFirewallDelete())
 	} else {
-		out = append(out, steps.NetworkFirewallCreate())
+		// reconcile=allowTeardown: reconfigure (allowTeardown=true) force
+		// re-renders the host firewall so changed settings actually take effect;
+		// upgrade (allowTeardown=false) re-asserts create-if-missing only.
+		out = append(out, steps.NetworkFirewallCreate(allowTeardown))
 	}
 
 	switch {

--- a/internal/network/policy/render.go
+++ b/internal/network/policy/render.go
@@ -221,7 +221,7 @@ func renderChain(policies []*Policy, podCIDR string) ([]string, error) {
 	if podCIDR != "" {
 		lines = append(lines, "",
 			"\t\t# Unclassified pod egress (no meta priority; HTB default class).",
-			fmt.Sprintf("\t\tip saddr %s", podCIDR))
+			fmt.Sprintf("\t\tip saddr %s accept", podCIDR))
 	}
 
 	lines = append(lines, "",

--- a/internal/network/policy/testdata/network-weaver.golden.nft
+++ b/internal/network/policy/testdata/network-weaver.golden.nft
@@ -34,7 +34,7 @@ table inet weaver {
 		ip daddr 10.4.0.0/24 tcp dport @bn-subscriber-in_ports meta priority set 0x10030 accept
 
 		# Unclassified pod egress (no meta priority; HTB default class).
-		ip saddr 10.4.0.0/24
+		ip saddr 10.4.0.0/24 accept
 
 		ct state established,related accept
 		drop

--- a/internal/reality/blocknode_checker.go
+++ b/internal/reality/blocknode_checker.go
@@ -78,6 +78,12 @@ func (b *blockNodeChecker) RefreshState(ctx context.Context) (state.BlockNodeSta
 	// attempt to install the daemon) for a block node deliberately installed
 	// without it.
 	trafficShapingDisabled := bn.TrafficShapingDisabled
+	// Shaping (egress NIC, link rate, per-class overrides) is a weaver-only record
+	// that, like TrafficShapingDisabled, cannot be recovered from the Helm release or
+	// the live cluster. Capture it before rebuilding so a reality refresh does not
+	// drop it — otherwise upgrade/reconfigure would auto-detect the NIC/rate instead
+	// of re-asserting the operator's original shaping.
+	shaping := bn.Shaping
 	bn = state.BlockNodeState{
 		ReleaseInfo: state.HelmReleaseInfo{
 			Name:          re.Name,
@@ -93,6 +99,7 @@ func (b *blockNodeChecker) RefreshState(ctx context.Context) (state.BlockNodeSta
 		},
 		Storage:                models.BlockNodeStorage{},
 		TrafficShapingDisabled: trafficShapingDisabled,
+		Shaping:                shaping,
 		LastSync:               now,
 	}
 

--- a/internal/reality/blocknode_checker_test.go
+++ b/internal/reality/blocknode_checker_test.go
@@ -197,3 +197,68 @@ metadata:
 		t.Error("TrafficShapingDisabled must be preserved as true across a reality refresh, got false")
 	}
 }
+
+// TestRefreshState_PreservesShaping verifies that the persisted traffic-shaping
+// content (egress NIC, link rate, per-class overrides) — which, like
+// TrafficShapingDisabled, cannot be recovered from the Helm release or the live
+// cluster — survives a reality refresh that rebuilds BlockNodeState from a found
+// release. Without preservation, upgrade/reconfigure would auto-detect the NIC and
+// drop the operator's original rate/overrides instead of re-asserting them.
+func TestRefreshState_PreservesShaping(t *testing.T) {
+	const manifest = `apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: block-node-block-node-server
+  namespace: block-node
+  labels:
+    app.kubernetes.io/instance: block-node
+`
+	re := &release.Release{
+		Name:      "block-node",
+		Namespace: "block-node",
+		Info:      &release.Info{Status: release.StatusDeployed},
+		Chart: &chart.Chart{
+			Metadata: &chart.Metadata{Name: "block-node-server", Version: "0.28.0", AppVersion: "0.28.0"},
+		},
+		Manifest: manifest,
+	}
+
+	prio := 0
+	persisted := state.NewBlockNodeState()
+	persisted.ReleaseInfo.Status = release.StatusDeployed
+	persisted.Shaping = &state.ShapingState{
+		EgressInterface: "eth0",
+		LinkRate:        "1gbit",
+		ShapeOverrides: map[string]models.ShapeOverride{
+			"publisher": {Rate: "800mbit", Ceil: "1gbit", Prio: &prio},
+		},
+	}
+
+	full := state.State{}
+	full.BlockNodeState = persisted
+
+	checker := &blockNodeChecker{
+		sm:            fakeStateManager{st: full},
+		newHelm:       func() (HelmManager, error) { return fakeHelmManager{releases: []*release.Release{re}}, nil },
+		newKube:       func() (KubeClient, error) { return fakeKubeClient{}, nil },
+		clusterExists: func() (bool, error) { return true, nil },
+	}
+
+	got, err := checker.RefreshState(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ReleaseInfo.Name != "block-node" {
+		t.Fatalf("expected release to be found and rebuilt, got name %q", got.ReleaseInfo.Name)
+	}
+	if got.Shaping == nil {
+		t.Fatal("Shaping must be preserved across a reality refresh, got nil")
+	}
+	if got.Shaping.EgressInterface != "eth0" || got.Shaping.LinkRate != "1gbit" {
+		t.Errorf("Shaping NIC/rate not preserved: got %q/%q, want eth0/1gbit",
+			got.Shaping.EgressInterface, got.Shaping.LinkRate)
+	}
+	if ov, ok := got.Shaping.ShapeOverrides["publisher"]; !ok || ov.Rate != "800mbit" {
+		t.Errorf("Shaping overrides not preserved: got %+v", got.Shaping.ShapeOverrides)
+	}
+}

--- a/internal/reality/machine_checker_test.go
+++ b/internal/reality/machine_checker_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package reality
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/internal/state"
+)
+
+// fakeMachineStateManager satisfies state.Manager by embedding the interface
+// (nil) and overriding only the two methods machineChecker.RefreshState calls:
+// Refresh() and State(). Any other call would panic, keeping the fake honest.
+type fakeMachineStateManager struct {
+	state.Manager
+	st state.State
+}
+
+func (f fakeMachineStateManager) Refresh() error     { return nil }
+func (f fakeMachineStateManager) State() state.State { return f.st }
+
+// TestMachineRefreshState_PreservesFirewall verifies that the persisted
+// host-firewall configuration (host-scoped, not observable from the cluster)
+// survives a reality refresh. Unlike the block-node checker, the machine checker
+// starts from the current MachineState and overwrites only Software/Hardware/
+// LastSync, so Firewall is auto-preserved — this test locks that in so a future
+// refactor that rebuilds MachineState from scratch does not silently drop it.
+func TestMachineRefreshState_PreservesFirewall(t *testing.T) {
+	persisted := state.NewMachineState()
+	persisted.Profile = "mainnet"
+	persisted.Firewall = &state.HostFirewallState{
+		ManagementCIDRs: []string{"10.0.0.0/8"},
+		BlockedCIDRs:    []string{"192.0.2.0/24"},
+		SSHPort:         2222,
+		PodCIDR:         "10.4.0.0/14",
+		InClusterPorts:  []int{8080},
+	}
+
+	full := state.State{}
+	full.MachineState = persisted
+
+	// softwareInstallers is left nil: refreshSoftwareState ranges over it and
+	// returns an empty map, which is all this test needs.
+	checker := &machineChecker{sm: fakeMachineStateManager{st: full}}
+
+	got, err := checker.RefreshState(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Profile != "mainnet" {
+		t.Errorf("Profile must be preserved, got %q", got.Profile)
+	}
+	if got.Firewall == nil {
+		t.Fatal("Firewall must be preserved across a reality refresh, got nil")
+	}
+	if len(got.Firewall.ManagementCIDRs) != 1 || got.Firewall.ManagementCIDRs[0] != "10.0.0.0/8" {
+		t.Errorf("Firewall management CIDRs not preserved: %+v", got.Firewall.ManagementCIDRs)
+	}
+	if got.Firewall.SSHPort != 2222 {
+		t.Errorf("Firewall SSH port not preserved: got %d, want 2222", got.Firewall.SSHPort)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -122,8 +122,38 @@ type ProvisionerInfo struct {
 type MachineState struct {
 	Profile  string                   `yaml:"profile,omitempty" json:"profile,omitempty"` // deployment profile (e.g. "mainnet", "testnet", "local")
 	Software map[string]SoftwareState `yaml:"software" json:"software"`
-	Hardware map[string]HardwareState `yaml:"hardware" json:"hardware"`                     // e.g. CPU, RAM, Disk info
-	LastSync htime.Time               `yaml:"lastSync,omitempty" json:"lastSync,omitempty"` // last time state was reconciled
+	Hardware map[string]HardwareState `yaml:"hardware" json:"hardware"` // e.g. CPU, RAM, Disk info
+	// Firewall records the last-resolved host-firewall configuration so
+	// reconfigure/upgrade can re-assert the inet host table (especially after a
+	// disable→re-enable) without the operator re-supplying --mgmt-cidrs. It is
+	// host-scoped — it lives here, not on BlockNodeState, so it survives a
+	// block-node uninstall. Nil means "never configured" (old state files, or a
+	// host this tool never managed the firewall on). See HostFirewallState.
+	Firewall *HostFirewallState `yaml:"firewall,omitempty" json:"firewall,omitempty"`
+	LastSync htime.Time         `yaml:"lastSync,omitempty" json:"lastSync,omitempty"` // last time state was reconciled
+}
+
+// HostFirewallState is the persisted record of the operator's last-chosen host
+// firewall configuration. It mirrors the operator-supplied fields of
+// models.HostConfig and is populated from the resolved effective config on
+// install/reconfigure; it is read back as a fallback below explicit flags/config
+// when the operator does not re-supply the values.
+//
+// Disabled carries the last enable/disable decision (negative polarity so the
+// zero value means "enabled", matching HostConfig.Disabled). It is kept in sync
+// on every install/reconfigure. The CIDR/port content is updated only when the
+// firewall is enabled with a non-empty allowlist — a disable (or an enable with
+// an empty allowlist) flips Disabled but preserves the stored content, so a
+// later bare re-enable restores the last-known-good allowlist rather than
+// skipping with the SSH-lockout guard. upgrade reads Disabled to decide whether
+// to re-assert (enabled) or skip (disabled) the firewall.
+type HostFirewallState struct {
+	Disabled        bool     `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+	ManagementCIDRs []string `yaml:"managementCidrs,omitempty" json:"managementCidrs,omitempty"`
+	BlockedCIDRs    []string `yaml:"blockedCidrs,omitempty" json:"blockedCidrs,omitempty"`
+	SSHPort         int      `yaml:"sshPort,omitempty" json:"sshPort,omitempty"`
+	PodCIDR         string   `yaml:"podCidr,omitempty" json:"podCidr,omitempty"`
+	InClusterPorts  []int    `yaml:"inClusterPorts,omitempty" json:"inClusterPorts,omitempty"`
 }
 
 type SoftwareState struct {
@@ -158,8 +188,25 @@ type BlockNodeState struct {
 	// install` ever writes this (see patchBlockNodeStateAfterInstall); reconfigure
 	// and upgrade read it to durably skip re-provisioning tc shaping for a block
 	// node that was deliberately installed without it.
-	TrafficShapingDisabled bool       `yaml:"trafficShapingDisabled,omitempty" json:"trafficShapingDisabled,omitempty"`
-	LastSync               htime.Time `yaml:"lastSync,omitempty" json:"lastSync,omitempty"` // last time state was reconciled
+	TrafficShapingDisabled bool `yaml:"trafficShapingDisabled,omitempty" json:"trafficShapingDisabled,omitempty"`
+	// Shaping records the last-resolved traffic-shaping content (egress NIC, link
+	// rate, per-class overrides) that cannot be recovered from the Helm release or
+	// the live cluster. It is written on install/reconfigure when traffic shaping is
+	// enabled, and read back on upgrade/reconfigure so the tc steps re-assert the
+	// operator's original NIC/rate/overrides instead of falling back to auto-detect.
+	// Nil means "never set" (old state files, or a node installed without shaping).
+	Shaping  *ShapingState `yaml:"shaping,omitempty" json:"shaping,omitempty"`
+	LastSync htime.Time    `yaml:"lastSync,omitempty" json:"lastSync,omitempty"` // last time state was reconciled
+}
+
+// ShapingState is the persisted record of the traffic-shaping content bundle.
+// The enable/disable decision lives separately on
+// BlockNodeState.TrafficShapingDisabled; this holds only the values needed to
+// reproduce the shaping when it is enabled.
+type ShapingState struct {
+	EgressInterface string                          `yaml:"egressInterface,omitempty" json:"egressInterface,omitempty"`
+	LinkRate        string                          `yaml:"linkRate,omitempty" json:"linkRate,omitempty"`
+	ShapeOverrides  map[string]models.ShapeOverride `yaml:"shapeOverrides,omitempty" json:"shapeOverrides,omitempty"`
 }
 
 // ClusterNodeState represents a single Kubernetes node summary.

--- a/internal/state/state_firewall_shaping_test.go
+++ b/internal/state/state_firewall_shaping_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package state
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"gopkg.in/yaml.v3"
+)
+
+// TestFirewallAndShaping_RoundTrip verifies the new MachineState.Firewall and
+// BlockNodeState.Shaping fields marshal to the expected YAML keys and unmarshal
+// back losslessly, locking in the yaml tags on HostFirewallState / ShapingState.
+func TestFirewallAndShaping_RoundTrip(t *testing.T) {
+	prio := 1
+	original := State{
+		StateRecord: StateRecord{
+			MachineState: MachineState{
+				Firewall: &HostFirewallState{
+					Disabled:        false,
+					ManagementCIDRs: []string{"10.0.0.0/8"},
+					BlockedCIDRs:    []string{"192.0.2.0/24"},
+					SSHPort:         2222,
+					PodCIDR:         "10.4.0.0/14",
+					InClusterPorts:  []int{8080, 9090},
+				},
+			},
+			BlockNodeState: BlockNodeState{
+				Shaping: &ShapingState{
+					EgressInterface: "eth0",
+					LinkRate:        "1gbit",
+					ShapeOverrides: map[string]models.ShapeOverride{
+						"publisher": {Rate: "800mbit", Ceil: "1gbit", Prio: &prio},
+					},
+				},
+			},
+		},
+	}
+
+	out, err := yaml.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	// Spot-check the on-disk key names (the operator/other tools read these).
+	for _, key := range []string{"managementCidrs", "sshPort", "podCidr", "egressInterface", "linkRate", "shapeOverrides"} {
+		if !strings.Contains(string(out), key) {
+			t.Errorf("expected marshalled YAML to contain key %q\n%s", key, out)
+		}
+	}
+
+	var got State
+	if err := yaml.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	fw := got.MachineState.Firewall
+	if fw == nil {
+		t.Fatal("Firewall lost in round-trip")
+	}
+	if fw.SSHPort != 2222 || fw.PodCIDR != "10.4.0.0/14" ||
+		len(fw.ManagementCIDRs) != 1 || len(fw.InClusterPorts) != 2 {
+		t.Errorf("Firewall not preserved in round-trip: %+v", fw)
+	}
+
+	sh := got.BlockNodeState.Shaping
+	if sh == nil {
+		t.Fatal("Shaping lost in round-trip")
+	}
+	if sh.EgressInterface != "eth0" || sh.LinkRate != "1gbit" {
+		t.Errorf("Shaping NIC/rate not preserved: %+v", sh)
+	}
+	ov, ok := sh.ShapeOverrides["publisher"]
+	if !ok || ov.Rate != "800mbit" || ov.Ceil != "1gbit" || ov.Prio == nil || *ov.Prio != 1 {
+		t.Errorf("Shaping override not preserved: %+v", sh.ShapeOverrides)
+	}
+}
+
+// TestFirewallAndShaping_OldFileLoads verifies a state file written before these
+// fields existed unmarshals cleanly with nil Firewall/Shaping (AC6).
+func TestFirewallAndShaping_OldFileLoads(t *testing.T) {
+	old := []byte(`
+state:
+  version: v2
+  machineState:
+    profile: mainnet
+  blockNodeState:
+    name: block-node
+    trafficShapingDisabled: true
+`)
+	var got State
+	if err := yaml.Unmarshal(old, &got); err != nil {
+		t.Fatalf("old state file failed to load: %v", err)
+	}
+	if got.MachineState.Firewall != nil {
+		t.Errorf("expected nil Firewall for old file, got %+v", got.MachineState.Firewall)
+	}
+	if got.BlockNodeState.Shaping != nil {
+		t.Errorf("expected nil Shaping for old file, got %+v", got.BlockNodeState.Shaping)
+	}
+	if !got.BlockNodeState.TrafficShapingDisabled {
+		t.Error("expected existing TrafficShapingDisabled to still parse as true")
+	}
+}

--- a/internal/state/state_reader.go
+++ b/internal/state/state_reader.go
@@ -65,7 +65,15 @@ type ProvisionerVersionDoc struct {
 type PromptDefaultsDoc struct {
 	State struct {
 		MachineState struct {
-			Profile string `yaml:"profile"`
+			Profile  string `yaml:"profile"`
+			Firewall *struct {
+				Disabled        bool     `yaml:"disabled"`
+				ManagementCIDRs []string `yaml:"managementCidrs"`
+				BlockedCIDRs    []string `yaml:"blockedCidrs"`
+				SSHPort         int      `yaml:"sshPort"`
+				PodCIDR         string   `yaml:"podCidr"`
+				InClusterPorts  []int    `yaml:"inClusterPorts"`
+			} `yaml:"firewall"`
 		} `yaml:"machineState"`
 		BlockNodeState struct {
 			Name                   string `yaml:"name"`
@@ -175,6 +183,11 @@ type BlockNodeSummary struct {
 type PromptDefaults struct {
 	Profile   string
 	BlockNode BlockNodeSummary
+	// Firewall is the last-persisted host-firewall configuration (decision +
+	// allowlist content) from machineState.firewall, or nil when the firewall was
+	// never configured. It seeds reconfigure/upgrade so the operator does not have
+	// to re-supply --mgmt-cidrs on a re-enable.
+	Firewall *models.HostConfig
 }
 
 // ReadPromptDefaultsFromDisk extracts all prompt-relevant fields from the
@@ -193,9 +206,22 @@ func ReadPromptDefaultsFromDisk() (PromptDefaults, error) {
 		return PromptDefaults{}, err
 	}
 
+	var firewall *models.HostConfig
+	if fw := doc.State.MachineState.Firewall; fw != nil {
+		firewall = &models.HostConfig{
+			Disabled:        fw.Disabled,
+			ManagementCIDRs: fw.ManagementCIDRs,
+			BlockedCIDRs:    fw.BlockedCIDRs,
+			SSHPort:         fw.SSHPort,
+			PodCIDR:         fw.PodCIDR,
+			InClusterPorts:  fw.InClusterPorts,
+		}
+	}
+
 	bn := doc.State.BlockNodeState
 	return PromptDefaults{
-		Profile: doc.State.MachineState.Profile,
+		Profile:  doc.State.MachineState.Profile,
+		Firewall: firewall,
 		BlockNode: BlockNodeSummary{
 			ReleaseName:            bn.Name,
 			Namespace:              bn.Namespace,

--- a/internal/state/state_reader.go
+++ b/internal/state/state_reader.go
@@ -84,7 +84,11 @@ type PromptDefaultsDoc struct {
 			PluginPreset           string `yaml:"pluginPreset"`
 			PluginList             string `yaml:"pluginList"`
 			TrafficShapingDisabled bool   `yaml:"trafficShapingDisabled"`
-			Storage                struct {
+			Shaping                *struct {
+				EgressInterface string `yaml:"egressInterface"`
+				LinkRate        string `yaml:"linkRate"`
+			} `yaml:"shaping"`
+			Storage struct {
 				BasePath             string `yaml:"basePath"`
 				ArchivePath          string `yaml:"archivePath"`
 				LivePath             string `yaml:"livePath"`
@@ -175,7 +179,13 @@ type BlockNodeSummary struct {
 	PluginPreset           string
 	PluginList             string
 	TrafficShapingDisabled bool
-	Storage                models.BlockNodeStorage
+	// EgressInterface and LinkRate are the last-persisted traffic-shaping content
+	// from blockNodeState.shaping, empty when shaping was never configured. They
+	// seed the reconfigure egress prompts so a default-accept keeps the operator's
+	// previously-chosen NIC / link rate instead of reverting to auto-detection.
+	EgressInterface string
+	LinkRate        string
+	Storage         models.BlockNodeStorage
 }
 
 // PromptDefaults holds all prompt-relevant fields extracted from the on-disk
@@ -219,6 +229,11 @@ func ReadPromptDefaultsFromDisk() (PromptDefaults, error) {
 	}
 
 	bn := doc.State.BlockNodeState
+	var egressInterface, linkRate string
+	if bn.Shaping != nil {
+		egressInterface = bn.Shaping.EgressInterface
+		linkRate = bn.Shaping.LinkRate
+	}
 	return PromptDefaults{
 		Profile:  doc.State.MachineState.Profile,
 		Firewall: firewall,
@@ -231,6 +246,8 @@ func ReadPromptDefaultsFromDisk() (PromptDefaults, error) {
 			PluginPreset:           bn.PluginPreset,
 			PluginList:             bn.PluginList,
 			TrafficShapingDisabled: bn.TrafficShapingDisabled,
+			EgressInterface:        egressInterface,
+			LinkRate:               linkRate,
 			Storage: models.BlockNodeStorage{
 				BasePath:             bn.Storage.BasePath,
 				ArchivePath:          bn.Storage.ArchivePath,

--- a/internal/state/state_reader_test.go
+++ b/internal/state/state_reader_test.go
@@ -217,6 +217,48 @@ state:
 	}
 }
 
+func TestReadPromptDefaults_ParsesShaping(t *testing.T) {
+	data := []byte(`
+state:
+  blockNodeState:
+    name: my-release
+    trafficShapingDisabled: false
+    shaping:
+      egressInterface: eth0
+      linkRate: 500mbit
+`)
+	var doc PromptDefaultsDoc
+	if err := unmarshalStateDoc(data, &doc); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	bn := doc.State.BlockNodeState
+	if bn.Shaping == nil {
+		t.Fatal("expected Shaping to be parsed, got nil")
+	}
+	if bn.Shaping.EgressInterface != "eth0" {
+		t.Errorf("expected Shaping.EgressInterface 'eth0', got %q", bn.Shaping.EgressInterface)
+	}
+	if bn.Shaping.LinkRate != "500mbit" {
+		t.Errorf("expected Shaping.LinkRate '500mbit', got %q", bn.Shaping.LinkRate)
+	}
+}
+
+func TestReadPromptDefaults_MissingShapingReturnsNil(t *testing.T) {
+	data := []byte(`
+state:
+  blockNodeState:
+    name: my-release
+`)
+	var doc PromptDefaultsDoc
+	if err := unmarshalStateDoc(data, &doc); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if doc.State.BlockNodeState.Shaping != nil {
+		t.Errorf("expected nil Shaping when absent, got %+v", doc.State.BlockNodeState.Shaping)
+	}
+}
+
 func TestReadPromptDefaults_ApplicationStatePathFlowsThroughToModel(t *testing.T) {
 	data := []byte(`
 state:

--- a/internal/state/state_reader_test.go
+++ b/internal/state/state_reader_test.go
@@ -153,6 +153,70 @@ state:
 	}
 }
 
+func TestReadPromptDefaults_ParsesFirewall(t *testing.T) {
+	data := []byte(`
+state:
+  machineState:
+    profile: mainnet
+    firewall:
+      disabled: true
+      managementCidrs:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+      blockedCidrs:
+        - 192.0.2.0/24
+      sshPort: 2222
+      podCidr: 10.4.0.0/14
+      inClusterPorts:
+        - 8080
+        - 9090
+`)
+	var doc PromptDefaultsDoc
+	if err := unmarshalStateDoc(data, &doc); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	fw := doc.State.MachineState.Firewall
+	if fw == nil {
+		t.Fatal("expected firewall to be parsed, got nil")
+	}
+	if !fw.Disabled {
+		t.Error("expected Disabled true")
+	}
+	if len(fw.ManagementCIDRs) != 2 || fw.ManagementCIDRs[0] != "10.0.0.0/8" {
+		t.Errorf("unexpected ManagementCIDRs: %+v", fw.ManagementCIDRs)
+	}
+	if len(fw.BlockedCIDRs) != 1 || fw.BlockedCIDRs[0] != "192.0.2.0/24" {
+		t.Errorf("unexpected BlockedCIDRs: %+v", fw.BlockedCIDRs)
+	}
+	if fw.SSHPort != 2222 {
+		t.Errorf("expected SSHPort 2222, got %d", fw.SSHPort)
+	}
+	if fw.PodCIDR != "10.4.0.0/14" {
+		t.Errorf("expected PodCIDR '10.4.0.0/14', got %q", fw.PodCIDR)
+	}
+	if len(fw.InClusterPorts) != 2 || fw.InClusterPorts[1] != 9090 {
+		t.Errorf("unexpected InClusterPorts: %+v", fw.InClusterPorts)
+	}
+}
+
+func TestReadPromptDefaults_MissingFirewallReturnsNil(t *testing.T) {
+	// An old state file with no machineState.firewall must parse cleanly and leave
+	// the firewall pointer nil (backward compatibility — AC6).
+	data := []byte(`
+state:
+  machineState:
+    profile: mainnet
+`)
+	var doc PromptDefaultsDoc
+	if err := unmarshalStateDoc(data, &doc); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if doc.State.MachineState.Firewall != nil {
+		t.Errorf("expected nil firewall for an old state file, got %+v", doc.State.MachineState.Firewall)
+	}
+}
+
 func TestReadPromptDefaults_ApplicationStatePathFlowsThroughToModel(t *testing.T) {
 	data := []byte(`
 state:

--- a/internal/workflows/network_setup.go
+++ b/internal/workflows/network_setup.go
@@ -31,7 +31,7 @@ import (
 // When false, none of the four steps are added: there is no inet weaver table
 // to persist and no tc config to shape traffic with.
 func NetworkSetupWorkflow(egressInterface, linkRate string, shapeOverrides map[string]shape.ClassOverride, force bool, trafficShapingEnabled bool, healthPort string) *automa.WorkflowBuilder {
-	stepList := []automa.Builder{steps.NetworkFirewallCreate()}
+	stepList := []automa.Builder{steps.NetworkFirewallCreate(false)}
 	if trafficShapingEnabled {
 		stepList = append(stepList,
 			steps.NetworkPolicyCreate(force, healthPort),

--- a/internal/workflows/steps/step_network_firewall.go
+++ b/internal/workflows/steps/step_network_firewall.go
@@ -25,12 +25,20 @@ var newFirewallManager = func() *firewall.Manager { return firewall.NewManager()
 
 // NetworkFirewallCreate lays down the node-level `inet host` nftables table
 // (SSH/management allowlist, ICMP policy, in-cluster host-service ports) by
-// invoking the same create-if-missing logic as `network firewall create`. It
-// is wired into the block-node workflow (`block node install` /
-// `reconfigure` / `upgrade`) — not the generic `kube cluster install`, which
-// provisions a cluster independent of any specific node type and should not
-// unconditionally apply node-specific firewall rules. The create is
-// create-if-missing, so re-running any of those commands is a no-op.
+// invoking the same logic as `network firewall create`. It is wired into the
+// block-node workflow (`block node install` / `reconfigure` / `upgrade`) — not
+// the generic `kube cluster install`, which provisions a cluster independent of
+// any specific node type and should not unconditionally apply node-specific
+// firewall rules.
+//
+// reconcile selects the convergence behaviour:
+//   - reconcile=false (install / upgrade): create-if-missing. When the table
+//     already exists the supplied flags are NOT applied, so re-running is a
+//     no-op. This is the "re-assert the install decision, never regress" mode.
+//   - reconcile=true (reconfigure): force re-render the table from the resolved
+//     flags even when it already exists, so an operator changing firewall
+//     settings via `block node reconfigure` actually sees them take effect. Only
+//     the branch that already knows teardown is permitted passes this.
 //
 // The table's input chain is default-drop and the only SSH allow rule matches
 // the management allowlist (`ip saddr @mgmt_addrs tcp dport <ssh> accept`).
@@ -39,7 +47,7 @@ var newFirewallManager = func() *firewall.Manager { return firewall.NewManager()
 // with a warning rather than rendering a lock-out ruleset. The allowlist is
 // supplied via `--mgmt-cidrs` or the host.managementCidrs config value. An
 // operator can also opt out entirely via `--firewall-enabled=false`.
-func NetworkFirewallCreate() *automa.StepBuilder {
+func NetworkFirewallCreate(reconcile bool) *automa.StepBuilder {
 	return automa.NewStepBuilder().WithId(NetworkFirewallCreateStepId).
 		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
 			notify.As().StepStart(ctx, stp, "Applying host firewall (inet host)")
@@ -88,13 +96,27 @@ func NetworkFirewallCreate() *automa.StepBuilder {
 			t.InClusterPorts = hostCfg.InClusterPorts
 			t.PodCIDR = hostCfg.PodCIDR
 
-			changed, err := newFirewallManager().Create(ctx, t, false)
+			mgr := newFirewallManager()
+
+			// Determine whether the table pre-existed so rollback only deletes a
+			// table this step actually introduced. In create-if-missing mode
+			// Create's returned `changed` already implies "did not exist", but in
+			// reconcile (force) mode `changed` is true even for a re-render of a
+			// pre-existing table — so probe first and never delete on rollback in
+			// that case.
+			existedBefore, err := mgr.IsActive(ctx)
 			if err != nil {
 				return automa.FailureReport(stp, automa.WithError(err))
 			}
-			stp.State().Local().Set(FirewallCreatedByThisStep, changed)
 
-			meta := map[string]string{FirewallCreatedByThisStep: strconv.FormatBool(changed)}
+			changed, err := mgr.Create(ctx, t, reconcile)
+			if err != nil {
+				return automa.FailureReport(stp, automa.WithError(err))
+			}
+			createdByThisStep := changed && !existedBefore
+			stp.State().Local().Set(FirewallCreatedByThisStep, createdByThisStep)
+
+			meta := map[string]string{FirewallCreatedByThisStep: strconv.FormatBool(createdByThisStep)}
 			return automa.SuccessReport(stp, automa.WithMetadata(meta))
 		}).
 		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {

--- a/internal/workflows/steps/step_network_firewall_test.go
+++ b/internal/workflows/steps/step_network_firewall_test.go
@@ -61,7 +61,7 @@ func TestNetworkFirewallCreate_SkipsWithoutMgmtCIDRs(t *testing.T) {
 	nftPath := withStubbedFirewall(t, r)
 	setHostConfig(t, models.HostConfig{}) // no management CIDRs
 
-	step, err := NetworkFirewallCreate().Build()
+	step, err := NetworkFirewallCreate(false).Build()
 	require.NoError(t, err)
 
 	report := step.Execute(context.Background())
@@ -82,7 +82,7 @@ func TestNetworkFirewallCreate_SkipsWhenDisabled(t *testing.T) {
 		Disabled:        true,
 	})
 
-	step, err := NetworkFirewallCreate().Build()
+	step, err := NetworkFirewallCreate(false).Build()
 	require.NoError(t, err)
 
 	report := step.Execute(context.Background())
@@ -101,7 +101,7 @@ func TestNetworkFirewallCreate_CreatesWhenMgmtCIDRsSet(t *testing.T) {
 		InClusterPorts:  []int{6443, 10250},
 	})
 
-	step, err := NetworkFirewallCreate().Build()
+	step, err := NetworkFirewallCreate(false).Build()
 	require.NoError(t, err)
 
 	report := step.Execute(context.Background())
@@ -134,7 +134,7 @@ func TestNetworkFirewallCreate_ExplicitEmptyPortsAndPodCIDROverrideDefaults(t *t
 		InClusterPorts:  nil,
 	})
 
-	step, err := NetworkFirewallCreate().Build()
+	step, err := NetworkFirewallCreate(false).Build()
 	require.NoError(t, err)
 
 	report := step.Execute(context.Background())
@@ -154,7 +154,7 @@ func TestNetworkFirewallCreate_RollbackSkipsWhenPreexisting(t *testing.T) {
 	withStubbedFirewall(t, r)
 	setHostConfig(t, models.HostConfig{ManagementCIDRs: []string{"10.0.0.0/8"}, SSHPort: 22})
 
-	step, err := NetworkFirewallCreate().Build()
+	step, err := NetworkFirewallCreate(false).Build()
 	require.NoError(t, err)
 
 	report := step.Execute(context.Background())
@@ -164,4 +164,32 @@ func TestNetworkFirewallCreate_RollbackSkipsWhenPreexisting(t *testing.T) {
 	rollback := step.Rollback(context.Background())
 	require.Equal(t, automa.StatusSkipped, rollback.Status)
 	require.False(t, r.deleted, "rollback must not delete a pre-existing table")
+}
+
+func TestNetworkFirewallCreate_ReconcileReRendersExistingTable(t *testing.T) {
+	// reconcile=true (reconfigure): even though the table already exists, the
+	// resolved flags must be re-rendered to disk so changed firewall settings
+	// take effect. create-if-missing (reconcile=false) would skip the write.
+	r := &fakeFwRunner{exists: true}
+	nftPath := withStubbedFirewall(t, r)
+	setHostConfig(t, models.HostConfig{
+		ManagementCIDRs: []string{"10.0.0.0/8"},
+		SSHPort:         22,
+		PodCIDR:         models.DefaultClusterPodCIDR,
+		InClusterPorts:  []int{6443},
+	})
+
+	step, err := NetworkFirewallCreate(true).Build()
+	require.NoError(t, err)
+
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+	require.Equal(t, automa.StatusSuccess, report.Status)
+	require.FileExists(t, nftPath, "reconcile must re-render the artifact even when the table pre-existed")
+
+	// The table pre-existed, so rollback must NOT delete it — a re-render is not
+	// a creation.
+	rollback := step.Rollback(context.Background())
+	require.Equal(t, automa.StatusSkipped, rollback.Status)
+	require.False(t, r.deleted, "rollback must not delete a table this step only re-rendered")
 }


### PR DESCRIPTION
## Summary

Persist the operator's **last-chosen host-firewall config** and **traffic-shaping content** into `state.yaml`, and seed `block node reconfigure` / `upgrade` from them (below explicit flags/config). Today the firewall CIDRs live only in the `--config` file or the live nft table, and the tc content (`EgressInterface`/`LinkRate`/`ShapeOverrides`) is carried per-invocation and never persisted — so a `disable → re-enable` cycle loses the allowlist (the SSH-lockout guard skips the firewall) and `upgrade` re-asserts shaping with an auto-detected NIC / empty rate instead of the original values.

Design follow-up split out of #929 (no epic). Values go into `state.yaml` (machine-managed record of what was deployed), **not** `config.yaml` (operator-authored input).

### What changed

- **State schema** (`internal/state/state.go`): add `MachineState.Firewall *HostFirewallState` (host-scoped — survives a block-node uninstall) and `BlockNodeState.Shaping *ShapingState`. Both are pointer + `omitempty`, so old `state.yaml` files load unchanged.
- **Firewall enable/disable decision**: `HostFirewallState.Disabled` (negative polarity, mirroring `TrafficShapingDisabled` / `HostConfig.Disabled`). The install/reconfigure patch always records the decision but updates the CIDR/port content **only when enabled with a non-empty allowlist**, so a disable — or an enable with an empty allowlist, which the step skips — flips `Disabled` while preserving the last-known-good allowlist for a future bare re-enable.
- **Traffic-shaping content**: persisted on install/reconfigure when enabled; the shared effective-inputs resolver falls back to `BlockNodeState.Shaping` when the operator supplies no egress NIC / rate / overrides, so `upgrade` (which has no such flags) and a bare `reconfigure` re-assert the original shaping. Explicit input always wins.
- **Resolution precedence**: host-firewall CIDRs resolve `flag > config > state > default`; `upgrade` seeds the firewall from state gated on the persisted `Disabled` decision (re-assert when enabled, skip when disabled).
- **Reality-refresh preservation**: `BlockNodeState.Shaping` is copied through the block-node checker's found-release rebuild (exactly like `TrafficShapingDisabled`); `MachineState.Firewall` is preserved by the machine checker (it starts from the current `MachineState`).

No new CLI flags or subcommands, so `docs/quickstart.md` is unchanged.

### Acceptance criteria

- [x] After `install --firewall-enabled=true --mgmt-cidrs=X`, `state.yaml` records the firewall under `machineState.firewall`.
- [x] `reconfigure --firewall-enabled=false` then `reconfigure --firewall-enabled=true` (no `--mgmt-cidrs`, no `--config`) restores the original allowlist instead of skipping with the SSH-lockout guard.
- [x] `upgrade` re-asserts the same `EgressInterface`/`LinkRate`/overrides recorded at install, not auto-detected values.
- [x] An explicit flag or `--config` value still overrides the persisted state value.
- [x] A reality refresh does not drop the new fields (regression tests for both checkers).
- [x] Old `state.yaml` files (without the new fields) load and behave exactly as today.

> **Note on scope beyond the issue:** the issue's schema sketch and ACs cover firewall re-assert on `reconfigure` and tc re-assert on `upgrade`. This PR additionally persists a firewall enable/disable **decision** so `upgrade` can *also* faithfully re-assert the firewall — plain create-if-missing with no persisted decision would either no-op or wrongly re-create a firewall the operator had disabled.

## Test plan

Unit (`internal/state` and `internal/reality` run on macOS; `internal/bll/blocknode` and the `cmd` packages require the UTM VM due to the Linux-only `mount` dependency):

```bash
task vm:test:unit
# or, targeted:
go test -tags='!integration' ./internal/state/... ./internal/reality/... ./internal/bll/blocknode/... ./cmd/cli/commands/common/...
```

New/updated tests:
- `internal/state`: schema round-trip + old-file load (`state_firewall_shaping_test.go`), firewall doc parsing (`state_reader_test.go`).
- `internal/reality`: `TestRefreshState_PreservesShaping`, `TestMachineRefreshState_PreservesFirewall`.
- `internal/bll/blocknode`: patch writes firewall/shaping, skip-on-disable and skip-on-empty preserve the allowlist (`helpers_patch_test.go`); tc content falls back to state and explicit input wins (`effective_inputs_test.go`).

## Risks

- **Clobbering the allowlist on disable** — mitigated by the skip-on-disable / skip-on-empty persistence gate; covered by unit tests.
- **Silent reset on reality refresh** — the block-node checker rebuild is the known footgun (same class fixed for `TrafficShapingDisabled`); explicit copy + regression test.
- Additive `omitempty` pointer fields → old `state.yaml` loads unchanged; rollback is a pure revert (persisted fields ignored by older binaries).

Closes #932
