### PR TITLE
fix(ide): stop forcing the SSH VM as the default GoLand run target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,6 +354,9 @@ secring.*
 dist/
 /bin/
 
+### Local Go toolchain version pin (goenv/asdf) — per-developer, not committed ###
+.go-version
+
 ### Generated Files ###
 **/mocks_generated.go
 unit-test-report.md

--- a/.idea/remote-targets.xml
+++ b/.idea/remote-targets.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="RemoteTargetsManager">
-    <option name="projectDefaultTargetUuid" value="4d518a08-043c-42fb-baa1-835e344234ae" />
     <targets>
       <target name="root@localhost:2222" type="ssh/sftp" uuid="4d518a08-043c-42fb-baa1-835e344234ae">
         <config>
@@ -13,7 +12,7 @@
           <config>
             <option name="goPath" value="/root/go" />
             <option name="goRoot" value="/usr/local/go/bin/go" />
-            <option name="goVersion" value="go1.24.3 linux/arm64" />
+            <option name="goVersion" value="go1.26.5 linux/arm64" />
           </config>
         </ContributedStateBase>
       </target>


### PR DESCRIPTION
## Description

`.idea/remote-targets.xml` is checked into the repo and set a project-wide `projectDefaultTargetUuid` pointing at the `root@localhost:2222` SSH VM target. Because that default is a committed, shared setting, every fresh checkout inherits "run everything on the VM" as its default run target — so launching a unit test from the GoLand / IntelliJ gutter fails to prepare its environment whenever the VM is not running and reachable on port 2222:

```
Error running '<test> in github.com/hashgraph/solo-weaver/...':
Failed to prepare environment.

com.intellij.execution.ExecutionException: Failed to prepare environment.
    at com.jetbrains.plugins.remotesdk.target.ssh.target.SshRemoteEnvironmentRequest.prepareEnvironment(...)
    at com.goide.util.GoExecutor.prepareRemoteEnvironment(GoExecutor.java:790)
    at com.goide.execution.GoRunningState.startProcess(...)
Caused by: com.intellij.ssh.SshException: Connection refused
Caused by: java.net.ConnectException: Connection refused
```

This PR removes the committed `projectDefaultTargetUuid` so the IDE default run target falls back to **Local machine** for everyone. The SSH target *definition* is kept intact, so developers who want to run on the VM can still select it explicitly. It also bumps the target's stale `goVersion` (`go1.24.3` → `go1.26.5`) so the tracked value matches what the VM actually provisions (`Taskfile.yaml` `GO_VERSION: 1.26.5`).

Finally, it gitignores the per-developer `.go-version` pin (goenv/asdf). Nothing in the repo or CI consumes `.go-version` — CI pins Go directly in the workflows and the source of truth is `go.mod` + `Taskfile.yaml` — so it should not be committed.

### Files changed

| File | Change |
|---|---|
| `.idea/remote-targets.xml` | Remove `projectDefaultTargetUuid` (forced SSH-VM default → Local machine); bump target `goVersion` `go1.24.3` → `go1.26.5` |
| `.gitignore` | Ignore the per-developer `.go-version` toolchain pin |

### Note / follow-up

`goVersion` is IDE-detected state that GoLand repopulates when it connects to the target, so a hand-maintained value in a tracked file will drift again on the next Go bump (that drift is what produced the stale `go1.24.3`). A cleaner long-term fix is to stop tracking the mutable per-developer target fields entirely; that is intentionally out of scope here to keep this change minimal.

### Related Issues

* Closes #939
