### PR TITLE
test(daemon): assert NetworkUpgradeExecute GVR group matches installe…

### DIFF
--- a/internal/daemon/consensus/upgrade_monitor.go
+++ b/internal/daemon/consensus/upgrade_monitor.go
@@ -33,6 +33,12 @@ var networkUpgradeExecuteGVR = schema.GroupVersionResource{
 	Resource: "networkupgradeexecutes",
 }
 
+// NetworkUpgradeExecuteGVR returns the GVR the monitor watches. Exported so
+// tests can assert it against the CRD solo-operator installs.
+func NetworkUpgradeExecuteGVR() schema.GroupVersionResource {
+	return networkUpgradeExecuteGVR
+}
+
 const (
 	// NetworkUpgradeExecute status.phase values are defined as the shared
 	// contract in internal/consensus (cn.Phase*). They are referenced directly

--- a/internal/daemon/consensus/upgrade_monitor_crd_it_test.go
+++ b/internal/daemon/consensus/upgrade_monitor_crd_it_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Guards against API-group drift between the GVR the UpgradeMonitor watches and
+// the NetworkUpgradeExecute CRD solo-operator installs (#851). Tagged
+// require_cluster; runs in Phase 3 of `test:integration:verbose`, after the CRDs
+// are provisioned in Phase 2 by Test_ClusterSetup (internal/workflows/cluster_it_test.go),
+// which enables SoloOperator so the solo-operator chart is deployed. Run standalone with:
+//   go test -v -tags='require_cluster' -run '^TestWithCluster_UpgradeMonitor_GVRMatchesInstalledCRD$' ./internal/daemon/consensus/...
+
+//go:build require_cluster
+
+package consensus_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashgraph/solo-weaver/internal/daemon/consensus"
+	"github.com/hashgraph/solo-weaver/internal/kube"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// crdGVR addresses CustomResourceDefinition objects themselves.
+var crdGVR = schema.GroupVersionResource{
+	Group:    "apiextensions.k8s.io",
+	Version:  "v1",
+	Resource: "customresourcedefinitions",
+}
+
+// TestWithCluster_UpgradeMonitor_GVRMatchesInstalledCRD asserts the group,
+// version, and resource in consensus.NetworkUpgradeExecuteGVR() match the CRD
+// solo-operator installs. The CRD is located by
+// plural name, not group, so the lookup still works when the group is wrong —
+// the exact failure mode being detected.
+func TestWithCluster_UpgradeMonitor_GVRMatchesInstalledCRD(t *testing.T) {
+	c, err := kube.NewClient()
+	if err != nil {
+		t.Skipf("skipping: failed to create kube client: %v", err)
+	}
+
+	gvr := consensus.NetworkUpgradeExecuteGVR()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Preferred, deterministic lookup: the CRD name is "<plural>.<group>".
+	crdName := gvr.Resource + "." + gvr.Group
+	crd, err := c.Dyn.Resource(crdGVR).Get(ctx, crdName, metav1.GetOptions{})
+	if kerrors.IsNotFound(err) {
+		// Scan by plural to distinguish "CRD not installed" (skip) from
+		// "installed under a different group" (fail); the exact-name lookup
+		// misses both cases.
+		crd = findCRDByPlural(ctx, t, c, gvr.Resource)
+		if crd == nil {
+			t.Skipf("skipping: no CRD with plural %q is installed (solo-operator not deployed?)", gvr.Resource)
+		}
+	} else if err != nil {
+		t.Fatalf("failed to get CRD %q: %v", crdName, err)
+	}
+
+	// .spec.group must equal the group the monitor watches.
+	specGroup, found, err := unstructured.NestedString(crd.Object, "spec", "group")
+	if err != nil || !found {
+		t.Fatalf("CRD %q has no .spec.group (found=%v, err=%v)", crd.GetName(), found, err)
+	}
+	if specGroup != gvr.Group {
+		t.Fatalf("GVR group drift: monitor watches group %q but installed CRD %q has .spec.group %q — update NetworkUpgradeExecuteGVR to match the CRD",
+			gvr.Group, crd.GetName(), specGroup)
+	}
+
+	// .spec.names.plural must equal the resource the monitor watches.
+	specPlural, _, _ := unstructured.NestedString(crd.Object, "spec", "names", "plural")
+	if specPlural != gvr.Resource {
+		t.Fatalf("GVR resource drift: monitor watches resource %q but installed CRD %q has .spec.names.plural %q",
+			gvr.Resource, crd.GetName(), specPlural)
+	}
+
+	// The monitor's version must be one the CRD actually serves.
+	if !crdServesVersion(crd, gvr.Version) {
+		t.Fatalf("GVR version drift: monitor watches version %q but installed CRD %q does not serve it",
+			gvr.Version, crd.GetName())
+	}
+}
+
+// findCRDByPlural scans all CRDs and returns the first whose .spec.names.plural
+// matches, or nil if none is installed.
+func findCRDByPlural(ctx context.Context, t *testing.T, c *kube.Client, plural string) *unstructured.Unstructured {
+	t.Helper()
+	list, err := c.Dyn.Resource(crdGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("failed to list CRDs: %v", err)
+	}
+	for i := range list.Items {
+		item := list.Items[i]
+		p, _, _ := unstructured.NestedString(item.Object, "spec", "names", "plural")
+		if p == plural {
+			return &item
+		}
+	}
+	return nil
+}
+
+// crdServesVersion reports whether the CRD serves the given version.
+func crdServesVersion(crd *unstructured.Unstructured, version string) bool {
+	versions, found, err := unstructured.NestedSlice(crd.Object, "spec", "versions")
+	if err != nil || !found {
+		return false
+	}
+	for _, v := range versions {
+		vm, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(vm, "name")
+		served, _, _ := unstructured.NestedBool(vm, "served")
+		if name == version && served {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workflows/cluster_it_test.go
+++ b/internal/workflows/cluster_it_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/automa-saga/automa"
 	"github.com/hashgraph/solo-weaver/internal/testutil"
 	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
+	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,6 +45,14 @@ import (
 // This test is run first via -tags='cluster_setup' before other cluster-dependent tests.
 func Test_ClusterSetup(t *testing.T) {
 	testutil.Reset(t)
+
+	// Enable solo-operator so its CRDs (incl. networkupgradeexecutes under
+	// operator.solo.hedera.com) are installed. This is what the require_cluster
+	// guard TestWithCluster_UpgradeMonitor_GVRMatchesInstalledCRD asserts against.
+	// The gate is evaluated when the workflow is built, so set it before the call.
+	cfg := config.Get()
+	cfg.SoloOperator.Enabled = true
+	require.NoError(t, config.Set(&cfg))
 
 	installWf, err := InstallClusterWorkflow(false, nil).
 		WithExecutionMode(automa.StopOnError).

--- a/internal/workflows/steps/step_health.go
+++ b/internal/workflows/steps/step_health.go
@@ -122,7 +122,11 @@ var soloOperatorCRDs = []string{
 	"envoyproxies.operator.solo.hedera.com",
 	"haproxycapsules.operator.solo.hedera.com",
 	"helmcapsules.operator.solo.hedera.com",
-	"networkoperations.operator.solo.hedera.com",
+	"networkgeneses.operator.solo.hedera.com",
+	"networkupgradeexecutes.operator.solo.hedera.com",
+	"networkupgradefreezeaborts.operator.solo.hedera.com",
+	"networkupgradefreezes.operator.solo.hedera.com",
+	"networkupgradeprepares.operator.solo.hedera.com",
 	"orbits.operator.solo.hedera.com",
 }
 

--- a/pkg/software/config_it_test.go
+++ b/pkg/software/config_it_test.go
@@ -386,7 +386,7 @@ func Test_Config_ClusterSection_Integration(t *testing.T) {
 		"external-secrets":         {ChartTypeClassic, "0.20.2"},
 		"node-exporter":            {ChartTypeOCI, "4.5.19"},
 		"prometheus-operator-crds": {ChartTypeOCI, "24.0.1"},
-		"solo-operator":            {ChartTypeOCI, "0.3.1"},
+		"solo-operator":            {ChartTypeOCI, "0.3.2"},
 	}
 
 	for name, expected := range expectedCharts {

--- a/pkg/software/infrastructure-catalog.yaml
+++ b/pkg/software/infrastructure-catalog.yaml
@@ -408,9 +408,6 @@ cluster:
   release: 'solo-operator'
   default: "0.3.2"
   versions:
-    0.3.1:
-      algorithm: 'sha256'
-      checksum: 'b77cb63d456e472d5ae8e1759e85fd6e4fbdeae12398b20f9df97d54f036a73a'
     0.3.2:
       algorithm: 'sha256'
       checksum: '943d7f9ad8bd868d16ad06c44c84f8d00e75a14dba472794177cf961fb7f4486'

--- a/pkg/software/infrastructure-catalog.yaml
+++ b/pkg/software/infrastructure-catalog.yaml
@@ -406,8 +406,11 @@ cluster:
   chart: 'oci://ghcr.io/hashgraph/charts/solo-operator'
   namespace: 'solo-operator'
   release: 'solo-operator'
-  default: "0.3.1"
+  default: "0.3.2"
   versions:
     0.3.1:
       algorithm: 'sha256'
       checksum: 'b77cb63d456e472d5ae8e1759e85fd6e4fbdeae12398b20f9df97d54f036a73a'
+    0.3.2:
+      algorithm: 'sha256'
+      checksum: '943d7f9ad8bd868d16ad06c44c84f8d00e75a14dba472794177cf961fb7f4486'

--- a/taskfiles/uat.yaml
+++ b/taskfiles/uat.yaml
@@ -536,7 +536,11 @@ tasks:
           envoyproxies.operator.solo.hedera.com \
           haproxycapsules.operator.solo.hedera.com \
           helmcapsules.operator.solo.hedera.com \
-          networkoperations.operator.solo.hedera.com \
+          networkgeneses.operator.solo.hedera.com \
+          networkupgradeexecutes.operator.solo.hedera.com \
+          networkupgradefreezeaborts.operator.solo.hedera.com \
+          networkupgradefreezes.operator.solo.hedera.com \
+          networkupgradeprepares.operator.solo.hedera.com \
           orbits.operator.solo.hedera.com; do
           kubectl get crd "$CRD" > /dev/null 2>&1 || { echo "FAIL: CRD $CRD not found"; exit 1; }
           echo "   $CRD ✓"


### PR DESCRIPTION
## Description

This pull request changes the following:

* Add a `require_cluster` integration test (`TestWithCluster_UpgradeMonitor_GVRMatchesInstalledCRD`) that asserts the monitor's `NetworkUpgradeExecute` GVR (group, resource, served version) matches the CRD solo-operator actually installs. The CRD is looked up by plural name, so a wrong group still resolves the installed CRD and the assertion fails — catching real API-group drift rather than silently skipping.
* Export `consensus.NetworkUpgradeExecuteGVR()` so the test asserts against the production GVR value instead of a copy.
* Enable `SoloOperator` in `Test_ClusterSetup` so its CRDs are provisioned in Phase 2, making the guard a real assertion (not a skip) in Phase 3.
* Refresh the solo-operator CRD lists in the cluster health check (`step_health.go`) and UAT task (`uat.yaml`) to the 0.3.2 set (drop `networkoperations`, add the `networkgeneses`/`networkupgrade*` CRDs).
* Bump solo-operator `0.3.1` → `0.3.2` in the infrastructure catalog (with checksum) and update the config integration-test expectation.

### Related Issues

* Closes #851

### Manual UAT
