### PR TITLE
refactor(network/shape): de-duplicate the traffic-shaper engine and fix interactive daemon block-node wiring

### DIFF
--- a/cmd/cli/commands/block/node/reconfigure.go
+++ b/cmd/cli/commands/block/node/reconfigure.go
@@ -3,13 +3,11 @@
 package node
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
-	"github.com/hashgraph/solo-weaver/internal/network/firewall"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/spf13/cobra"
@@ -46,15 +44,23 @@ var (
 
 			// Seed the enable/disable prompts from the block node's CURRENT state so a
 			// no-flag / default-accept reconfigure keeps whatever is already deployed
-			// and only an explicit toggle enables or tears a feature down. Traffic
-			// shaping's current state comes from the persisted install decision; the
-			// host firewall's from whether the inet host table currently exists.
+			// and only an explicit toggle enables or tears a feature down. Both features
+			// now use the same source of truth — the persisted install/reconfigure
+			// decision (#947): traffic shaping from BlockNodeState.TrafficShapingDisabled,
+			// the host firewall from MachineState.Firewall. (The live inet-table probe is
+			// a reconciliation detail inside NetworkFirewallCreate, not a prompt seed.)
+			// On an unreadable state file, bias both to enabled so a default-accept never
+			// tears an established plane down.
 			stateDefaults, err := state.ReadPromptDefaultsFromDisk()
 			if err != nil {
 				logx.As().Debug().Err(err).Msg("could not read state file for reconfigure seeds; using conservative defaults")
 			}
-			currentTrafficShaping := !stateDefaults.BlockNode.TrafficShapingDisabled
-			firewallSeed := currentFirewallEnabledSeed(cmd, cmd.Context())
+			firewallSeed := true
+			currentTrafficShaping := true
+			if err == nil {
+				firewallSeed = stateDefaults.Firewall != nil && !stateDefaults.Firewall.Disabled
+				currentTrafficShaping = !stateDefaults.BlockNode.TrafficShapingDisabled
+			}
 
 			// Traffic shaping is independently gated from the host firewall — it covers
 			// the BN workload network-policy plane, tc HTB shaping, and the daemon's
@@ -163,24 +169,6 @@ var (
 		},
 	}
 )
-
-// currentFirewallEnabledSeed returns the default the reconfigure host-firewall
-// prompt should fall back to: whether the inet host table is currently present on
-// the host. When the flag was set on the CLI the seed is unused (the flag wins),
-// so it returns false without probing. If the probe fails it biases to enabled so
-// an unreadable state never leads to an accidental teardown on default-accept.
-func currentFirewallEnabledSeed(cmd *cobra.Command, ctx context.Context) bool {
-	if cmd.Flags().Changed(common.FlagNameFirewallEnabled) {
-		return false
-	}
-	active, err := firewall.NewManager().IsActive(ctx)
-	if err != nil {
-		logx.As().Debug().Err(err).Msg(
-			"could not probe the inet host table; seeding the firewall prompt as enabled to avoid accidental teardown")
-		return true
-	}
-	return active
-}
 
 func init() {
 	common.FlagWithStorageReset().SetVarP(reconfigureCmd, &flagWithReset, false)

--- a/cmd/cli/commands/common/gated_feature.go
+++ b/cmd/cli/commands/common/gated_feature.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+// gatedFeature describes a block-node "gated network feature" — the host
+// firewall and traffic shaping are the two instances. Each is toggled by a
+// single opt-in bool flag; the feature's other ("content") flags are only
+// meaningful once the gate is on. The descriptor supplies the per-feature
+// specifics as data so resolveFeatureGate can drive the identical
+// force-fetch → effective-bool → confirm-prompt → mismatch-guard skeleton for
+// both (issue #947).
+type gatedFeature struct {
+	// GateFlag is the opt-in bool flag that turns the feature on/off
+	// (e.g. FlagNameFirewallEnabled, FlagNameTrafficShapingEnabled).
+	GateFlag string
+	// Noun names the feature in prompts/errors, phrased so it reads correctly
+	// in both "<noun> is not enabled" and "configure <noun>"
+	// (e.g. "the host firewall", "traffic shaping").
+	Noun string
+	// PromptTitle / PromptDesc drive the interactive enable/disable confirm.
+	PromptTitle string
+	PromptDesc  string
+	// ContentFlags are the feature-only flags that do nothing without the gate.
+	// Supplying any of them non-interactively while the gate is off is a hard
+	// error (they would otherwise be silently dropped — there is no confirm
+	// prompt to catch the mismatch once the opt-in default resolves to false).
+	ContentFlags []string
+}
+
+// resolveFeatureGate resolves the enable/disable decision for a gated network
+// feature. Precedence: CLI gate flag > interactive confirm > seedEnabled
+// default. It also enforces the "content flag without the gate" guard for
+// non-interactive callers. Shared by ResolveHostFirewallConfig and
+// ResolveTrafficShapingConfig so the two features decide "on or off?" the same
+// way; each caller then resolves its own content once the gate is on.
+//
+// seedEnabled is the default the choice falls back to when neither the flag nor
+// a prompt decides it: `install` passes false (opt-in), while `reconfigure`
+// passes the block node's persisted install/reconfigure decision so a no-flag /
+// default-accept run keeps whatever was last chosen.
+//
+// It requires the feature's gate flag to have been registered on cmd.
+func resolveFeatureGate(cmd *cobra.Command, args []string, f gatedFeature, seedEnabled bool) (bool, error) {
+	force, err := FlagForce().Value(cmd, args)
+	if err != nil {
+		return false, errorx.IllegalArgument.Wrap(err, "failed to get %s flag", FlagForce().Name)
+	}
+
+	// Seeded from the caller-supplied default, overridden by the flag when set.
+	enabled := effectiveBool(cmd, f.GateFlag, seedEnabled)
+
+	// Prompt for the enable/disable choice only when it wasn't already decided
+	// on the CLI. Declining here skips the feature's content prompts entirely —
+	// there's nothing left to ask once the feature itself is turned off.
+	if prompt.ShouldPrompt(force) && !cmd.Flags().Changed(f.GateFlag) {
+		confirmed, err := prompt.RunConfirm(f.PromptTitle, f.PromptDesc, enabled)
+		if err != nil {
+			return false, err
+		}
+		enabled = confirmed
+	}
+
+	// Non-interactive callers that supply the feature's content flags without
+	// also passing its gate flag would otherwise have those flags silently
+	// ignored: with the opt-in default there's no confirm prompt to catch the
+	// mismatch, and the caller just skips configuring any of it.
+	if !enabled && !prompt.ShouldPrompt(force) {
+		for _, name := range f.ContentFlags {
+			if cmd.Flags().Changed(name) {
+				return false, errorx.IllegalArgument.New(
+					"--%s was supplied but %s is not enabled (--%s defaults to false)", name, f.Noun, f.GateFlag).
+					WithProperty(models.ErrPropertyResolution, []string{
+						"Pass --" + f.GateFlag + "=true to actually apply these settings",
+						"Or drop --" + name + " if you did not intend to configure " + f.Noun,
+					})
+			}
+		}
+	}
+
+	return enabled, nil
+}
+
+// effectiveBool returns the effective value for a bool flag: the flag when
+// explicitly set, else cfgVal (the caller-supplied "unset" default). Used by
+// resolveFeatureGate to resolve each feature's enable/disable gate.
+func effectiveBool(cmd *cobra.Command, name string, cfgVal bool) bool {
+	if cmd.Flags().Changed(name) {
+		v, _ := cmd.Flags().GetBool(name)
+		return v
+	}
+	return cfgVal
+}

--- a/cmd/cli/commands/common/gated_feature_test.go
+++ b/cmd/cli/commands/common/gated_feature_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// testFeature is a minimal gatedFeature used to exercise resolveFeatureGate in
+// isolation from the firewall/traffic-shaping specifics.
+func testFeature() gatedFeature {
+	return gatedFeature{
+		GateFlag:     "feature-enabled",
+		Noun:         "the test feature",
+		PromptTitle:  "Enable the test feature?",
+		PromptDesc:   "desc",
+		ContentFlags: []string{"feature-content"},
+	}
+}
+
+// newGateCmd builds a command with the gate flag, one content flag, and --force
+// registered. Tests pass --force so ShouldPrompt is always false: the confirm
+// prompt is skipped and the seed/flag/mismatch-guard logic runs deterministically
+// without a TTY.
+func newGateCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "x", RunE: func(*cobra.Command, []string) error { return nil }}
+	cmd.Flags().Bool("feature-enabled", false, "")
+	cmd.Flags().String("feature-content", "", "")
+	var force bool
+	FlagForce().SetVarP(cmd, &force, false)
+	return cmd
+}
+
+func TestResolveFeatureGate_SeedAndFlag(t *testing.T) {
+	cases := []struct {
+		name    string
+		setGate string // "" = leave unset, else the value to Set
+		seed    bool
+		want    bool
+	}{
+		{"unset seeds enabled", "", true, true},
+		{"unset seeds disabled", "", false, false},
+		{"flag true overrides seed false", "true", false, true},
+		{"flag false overrides seed true", "false", true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cmd := newGateCmd()
+			if c.setGate != "" {
+				if err := cmd.Flags().Set("feature-enabled", c.setGate); err != nil {
+					t.Fatalf("set gate: %v", err)
+				}
+			}
+			got, err := resolveFeatureGate(cmd, []string{"--force"}, testFeature(), c.seed)
+			if err != nil {
+				t.Fatalf("resolveFeatureGate: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("enabled = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestResolveFeatureGate_ContentFlagWithoutGateErrors(t *testing.T) {
+	cmd := newGateCmd()
+	if err := cmd.Flags().Set("feature-content", "x"); err != nil {
+		t.Fatalf("set content: %v", err)
+	}
+	// Gate left off (seed=false, flag unset): supplying a content flag must be a
+	// hard error rather than silently dropping the value.
+	_, err := resolveFeatureGate(cmd, []string{"--force"}, testFeature(), false)
+	if err == nil {
+		t.Fatal("expected an error when a content flag is set without the gate, got nil")
+	}
+}
+
+func TestResolveFeatureGate_ContentFlagAllowedWhenGated(t *testing.T) {
+	cmd := newGateCmd()
+	if err := cmd.Flags().Set("feature-enabled", "true"); err != nil {
+		t.Fatalf("set gate: %v", err)
+	}
+	if err := cmd.Flags().Set("feature-content", "x"); err != nil {
+		t.Fatalf("set content: %v", err)
+	}
+	got, err := resolveFeatureGate(cmd, []string{"--force"}, testFeature(), false)
+	if err != nil {
+		t.Fatalf("resolveFeatureGate: %v", err)
+	}
+	if !got {
+		t.Error("enabled = false, want true when gate flag is set")
+	}
+}

--- a/cmd/cli/commands/common/host_firewall.go
+++ b/cmd/cli/commands/common/host_firewall.go
@@ -99,6 +99,20 @@ func RegisterHostFirewallFlags(cmd *cobra.Command) {
 		"Host-service ports reachable from the pod CIDR by the node host firewall (comma-separated)")
 }
 
+// hostFirewallFeature describes the host firewall as a gated network feature for
+// resolveFeatureGate: the --firewall-enabled opt-in gate plus the content flags
+// that are meaningless without it.
+func hostFirewallFeature() gatedFeature {
+	return gatedFeature{
+		GateFlag:    FlagNameFirewallEnabled,
+		Noun:        "the host firewall",
+		PromptTitle: "Enable host firewall?",
+		PromptDesc: "Apply the node-level inet host firewall (SSH/mgmt allowlist, ICMP policy, in-cluster ports). " +
+			"Opt-in, default No — choose Yes to have this tool manage the host firewall.",
+		ContentFlags: []string{FlagNameMgmtCIDRs, FlagNameBlockedCIDRs, FlagNameSSHPort, FlagNamePodCIDR, FlagNameInClusterPorts},
+	}
+}
+
 // ResolveHostFirewallConfig determines the effective host firewall configuration
 // (enabled, management CIDR allowlist, SSH port, pod CIDR, in-cluster
 // host-service ports) and applies it to the global config so the
@@ -118,10 +132,11 @@ func RegisterHostFirewallFlags(cmd *cobra.Command) {
 // seedEnabled is the default the enable/disable choice falls back to when neither
 // the flag nor an interactive prompt decides it. `install` passes false (opt-in —
 // a fresh install without the flag installs no firewall), while `reconfigure`
-// passes whether the inet host table currently exists on the host, so a no-flag /
-// default-accept reconfigure keeps the current state rather than silently tearing
-// an established firewall down. It is intentionally NOT derived from cfg.Disabled:
-// config.yaml's zero value cannot distinguish "enabled" from "never configured".
+// passes the block node's persisted firewall decision (MachineState.Firewall), so
+// a no-flag / default-accept reconfigure keeps the last-chosen state rather than
+// silently tearing an established firewall down. It is intentionally NOT derived
+// from cfg.Disabled: config.yaml's zero value cannot distinguish "enabled" from
+// "never configured".
 //
 // It requires RegisterHostFirewallFlags to have been called on cmd.
 func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues, seedEnabled bool) error {
@@ -131,39 +146,13 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.Cho
 	}
 
 	cfg := config.Get().Host
-	firewallEnabled := effectiveBool(cmd, FlagNameFirewallEnabled, seedEnabled)
 
-	// Prompt for the enable/disable choice only when it wasn't already decided
-	// on the CLI. Declining here skips the allowlist/port prompts below entirely
-	// — there's nothing left to ask once the firewall itself is turned off.
-	if prompt.ShouldPrompt(force) && !cmd.Flags().Changed(FlagNameFirewallEnabled) {
-		enabled, err := prompt.RunConfirm(
-			"Enable host firewall?",
-			"Apply the node-level inet host firewall (SSH/mgmt allowlist, ICMP policy, in-cluster ports). "+
-				"Opt-in, default No — choose Yes to have this tool manage the host firewall.",
-			firewallEnabled,
-		)
-		if err != nil {
-			return err
-		}
-		firewallEnabled = enabled
-	}
-
-	// Non-interactive callers that supply host-firewall config flags without also
-	// passing --firewall-enabled=true would otherwise have those flags silently
-	// ignored: with the opt-in default there's no confirm prompt to catch the
-	// mismatch, and the early return below drops out without applying anything.
-	if !firewallEnabled && !prompt.ShouldPrompt(force) {
-		for _, name := range []string{FlagNameMgmtCIDRs, FlagNameBlockedCIDRs, FlagNameSSHPort, FlagNamePodCIDR, FlagNameInClusterPorts} {
-			if cmd.Flags().Changed(name) {
-				return errorx.IllegalArgument.New(
-					"--%s was supplied but the host firewall is not enabled (--firewall-enabled defaults to false)", name).
-					WithProperty(models.ErrPropertyResolution, []string{
-						"Pass --firewall-enabled=true to actually apply the host firewall settings",
-						"Or drop --" + name + " if you did not intend to configure the host firewall",
-					})
-			}
-		}
+	// Resolve the enable/disable gate through the shared gated-feature resolver
+	// (flag > confirm-prompt > seed, plus the content-flag-without-gate guard),
+	// identical to how traffic shaping is gated.
+	firewallEnabled, err := resolveFeatureGate(cmd, args, hostFirewallFeature(), seedEnabled)
+	if err != nil {
+		return err
 	}
 
 	// An explicit opt-out skips resolving/prompting for the allowlist/port
@@ -239,17 +228,6 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.Cho
 	return nil
 }
 
-// effectiveBool returns the effective value for a bool flag: the flag when
-// explicitly set, else cfgVal (which already carries the correct "unset"
-// default via HostConfig.Disabled's negative polarity).
-func effectiveBool(cmd *cobra.Command, name string, cfgVal bool) bool {
-	if cmd.Flags().Changed(name) {
-		v, _ := cmd.Flags().GetBool(name)
-		return v
-	}
-	return cfgVal
-}
-
 // effectiveCSV returns the effective comma-joined value for a StringSlice flag:
 // the flag when explicitly set, else the config value.
 func effectiveCSV(cmd *cobra.Command, name string, cfgVal []string) string {
@@ -313,8 +291,8 @@ func joinInts(in []int) string {
 // It is the "state" tier of the flag > config > state > default precedence for the
 // firewall allowlist: the returned config seeds the effective* helpers, where a
 // CLI flag still takes priority. Only the allowlist content is merged — the
-// enable/disable decision is resolved separately (flag / prompt / live probe), so
-// the persisted Firewall.Disabled is intentionally ignored here. Returns cfg
+// enable/disable decision is resolved separately (flag / prompt / persisted
+// state), so the persisted Firewall.Disabled is intentionally ignored here. Returns cfg
 // unchanged when no firewall was ever persisted or the state read fails.
 func mergeHostFirewallFromState(cfg models.HostConfig) models.HostConfig {
 	defaults, err := state.ReadPromptDefaultsFromDisk()

--- a/cmd/cli/commands/common/traffic_shaping.go
+++ b/cmd/cli/commands/common/traffic_shaping.go
@@ -4,8 +4,6 @@ package common
 
 import (
 	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
-	"github.com/hashgraph/solo-weaver/pkg/models"
-	"github.com/joomcode/errorx"
 	"github.com/spf13/cobra"
 )
 
@@ -39,58 +37,34 @@ func RegisterTrafficShapingFlags(cmd *cobra.Command) {
 // seedEnabled is the default the choice falls back to when neither the flag nor
 // an interactive prompt decides it: `install` passes false (opt-in — a fresh
 // install without the flag stays unshaped), while `reconfigure` passes the block
-// node's CURRENT traffic-shaping state (from BlockNodeState.TrafficShapingDisabled)
+// node's persisted traffic-shaping decision (BlockNodeState.TrafficShapingDisabled)
 // so a no-flag / default-accept reconfigure keeps the existing decision rather than
 // silently tearing an established plane down.
 //
 // It requires RegisterTrafficShapingFlags to have been called on cmd.
 func ResolveTrafficShapingConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues, seedEnabled bool) (bool, error) {
-	force, err := FlagForce().Value(cmd, args)
-	if err != nil {
-		return false, errorx.IllegalArgument.Wrap(err, "failed to get %s flag", FlagForce().Name)
-	}
+	// Traffic shaping and the host firewall are gated identically (flag >
+	// confirm-prompt > seed, plus the content-flag-without-gate guard); the only
+	// difference is the flag/noun/prompt wording and the content-flag set, which
+	// trafficShapingFeature supplies as data.
+	return resolveFeatureGate(cmd, args, trafficShapingFeature(), seedEnabled)
+}
 
-	// Seeded from the caller-supplied default (opt-in false for install; the
-	// current persisted state for reconfigure), overridden by the flag when set.
-	enabled := effectiveBool(cmd, FlagNameTrafficShapingEnabled, seedEnabled)
-
-	// Prompt for the enable/disable choice only when it wasn't already decided
-	// on the CLI. Declining here skips the egress prompts below entirely —
-	// there's nothing left to ask once the plane itself is turned off.
-	if prompt.ShouldPrompt(force) && !cmd.Flags().Changed(FlagNameTrafficShapingEnabled) {
-		confirmed, err := prompt.RunConfirm(
-			"Enable traffic shaping?",
-			"Create the BN workload network-policy plane (inet weaver classification) and tc HTB "+
-				"traffic shaping, and install the traffic-shaper daemon. Opt-in, default No — choose Yes "+
-				"to get all three.",
-			enabled,
-		)
-		if err != nil {
-			return false, err
-		}
-		enabled = confirmed
-	}
-
-	// Non-interactive callers that supply traffic-shaping-only flags (egress
-	// NIC/link-rate, --shape overrides, daemon binary source) without also
-	// passing --traffic-shaping-enabled=true would otherwise have those flags
-	// silently ignored: with the opt-in default there's no confirm prompt to
-	// catch the mismatch, and the caller just skips configuring any of it.
-	if !enabled && !prompt.ShouldPrompt(force) {
-		for _, name := range []string{
+// trafficShapingFeature describes traffic shaping as a gated network feature for
+// resolveFeatureGate: the --traffic-shaping-enabled opt-in gate plus the
+// traffic-shaping-only flags (egress NIC/link-rate, --shape overrides, daemon
+// binary source) that are meaningless without it.
+func trafficShapingFeature() gatedFeature {
+	return gatedFeature{
+		GateFlag:    FlagNameTrafficShapingEnabled,
+		Noun:        "traffic shaping",
+		PromptTitle: "Enable traffic shaping?",
+		PromptDesc: "Create the BN workload network-policy plane (inet weaver classification) and tc HTB " +
+			"traffic shaping, and install the traffic-shaper daemon. Opt-in, default No — choose Yes " +
+			"to get all three.",
+		ContentFlags: []string{
 			FlagNameEgressInterface, FlagNameLinkRate, FlagNameShape,
 			FlagDaemonBin().Name, FlagDaemonVersion().Name,
-		} {
-			if cmd.Flags().Changed(name) {
-				return false, errorx.IllegalArgument.New(
-					"--%s was supplied but traffic shaping is not enabled (--traffic-shaping-enabled defaults to false)", name).
-					WithProperty(models.ErrPropertyResolution, []string{
-						"Pass --traffic-shaping-enabled=true to actually apply these settings",
-						"Or drop --" + name + " if you did not intend to configure traffic shaping",
-					})
-			}
-		}
+		},
 	}
-
-	return enabled, nil
 }

--- a/cmd/cli/commands/network/firewall/create.go
+++ b/cmd/cli/commands/network/firewall/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/kube"
 	fw "github.com/hashgraph/solo-weaver/internal/network/firewall"
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
 	"github.com/spf13/cobra"
 )
 
@@ -49,14 +50,25 @@ var createCmd = &cobra.Command{
 			t.SSHPort = flagSSHPort
 		}
 
-		// --pod-cidr defaults to auto-detection: when the operator does not
-		// pass it, resolve the local node's .spec.podCIDR from the cluster.
-		// Detection is best-effort — `network firewall create` is node-agnostic
-		// and may run before a cluster exists, so if no cluster is reachable we
-		// fall back to omitting the in-cluster-ports rule and tell the operator
-		// how to set it explicitly.
-		t.PodCIDR = flagPodCIDR
-		if t.PodCIDR == "" {
+		// --pod-cidr accepts a mixed v4/v6 list; route each entry to the matching
+		// family slot so a dual-stack node can admit in-cluster traffic over both.
+		// A value that fails family classification is slotted as v4 so Table.Validate
+		// surfaces a clear --pod-cidr error rather than dropping it silently.
+		//
+		// When the operator passes nothing, auto-detection resolves the local
+		// node's .spec.podCIDR (a single, v4 value today). Detection is
+		// best-effort — `network firewall create` is node-agnostic and may run
+		// before a cluster exists, so if no cluster is reachable we fall back to
+		// omitting the in-cluster-ports rule and tell the operator how to set it.
+		if len(flagPodCIDR) > 0 {
+			for _, c := range flagPodCIDR {
+				if isV6, err := sanity.CIDRIsIPv6(c); err == nil && isV6 {
+					t.PodCIDR6 = c
+				} else {
+					t.PodCIDR = c
+				}
+			}
+		} else {
 			if cidr, err := detectPodCIDR(cmd.Context()); err != nil {
 				logx.As().Warn().Err(err).Msg(
 					"could not auto-detect pod CIDR; the in-cluster host-service ports rule will be omitted — pass --pod-cidr to set it explicitly")
@@ -93,5 +105,5 @@ func init() {
 	createCmd.Flags().StringSliceVar(&flagBlockedCIDRs, "blocked-cidrs", nil, "Operator-curated block list CIDRs, dropped before any other rule (comma-separated or repeated)")
 	createCmd.Flags().IntSliceVar(&flagInClusterPorts, "in-cluster-ports", fw.DefaultInClusterPorts, "Host-service ports reachable from the pod CIDR")
 	createCmd.Flags().IntVar(&flagSSHPort, "ssh-port", fw.DefaultSSHPort, "SSH/management TCP port accepted from the allowlist")
-	createCmd.Flags().StringVar(&flagPodCIDR, "pod-cidr", "", "Pod CIDR allowed to reach the in-cluster host-service ports (default: auto-detected from the local node's .spec.podCIDR; the rule is omitted if no cluster is reachable)")
+	createCmd.Flags().StringSliceVar(&flagPodCIDR, "pod-cidr", nil, "Pod CIDR(s) allowed to reach the in-cluster host-service ports; may be IPv4 and/or IPv6 (comma-separated or repeated). Default: auto-detected from the local node's .spec.podCIDR; the rule is omitted if no cluster is reachable")
 }

--- a/cmd/cli/commands/network/firewall/firewall.go
+++ b/cmd/cli/commands/network/firewall/firewall.go
@@ -28,7 +28,7 @@ var (
 	flagInClusterPorts []int
 	flagInClusterPort  int
 	flagSSHPort        int
-	flagPodCIDR        string
+	flagPodCIDR        []string
 )
 
 var firewallCmd = &cobra.Command{

--- a/cmd/cli/commands/network/policy/create.go
+++ b/cmd/cli/commands/network/policy/create.go
@@ -46,26 +46,28 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		podCIDR := flagPodCIDR
-		if podCIDR == "" && p.Action != pol.ActionDeny {
+		podCIDRs := flagPodCIDR
+		if len(podCIDRs) == 0 && p.Action != pol.ActionDeny {
 			// A --deny rule never references POD_CIDR (see Render), so skip
 			// resolving it entirely for --deny -- no point requiring a
 			// reachable cluster (or --pod-cidr) for a quarantine-only policy.
 			// If a sibling --stamp policy in the registry still needs it,
 			// Manager.Create's Render call below surfaces that clearly.
 			//
-			// An explicit --pod-cidr works offline; only auto-detection needs a
-			// reachable cluster. Unlike `network firewall create` (best-effort,
-			// node-agnostic), `network policy create` is expected to run against a
-			// live cluster, so a detection failure with no
-			// --pod-cidr is a hard error rather than a warning.
+			// An explicit --pod-cidr works offline (and may carry both an IPv4 and
+			// an IPv6 pod CIDR for dual-stack classification); only auto-detection
+			// needs a reachable cluster. Unlike `network firewall create`
+			// (best-effort, node-agnostic), `network policy create` is expected to
+			// run against a live cluster, so a detection failure with no --pod-cidr
+			// is a hard error rather than a warning. Auto-detection resolves a
+			// single (v4) pod CIDR today; pass --pod-cidr for the v6 companion.
 			detected, derr := detectPodCIDR(cmd.Context())
 			if derr != nil {
 				return errorx.IllegalState.Wrap(derr,
 					"could not auto-detect the pod CIDR; pass --pod-cidr explicitly")
 			}
-			podCIDR = detected
-			logx.As().Info().Str("pod_cidr", podCIDR).Msg("auto-detected pod CIDR from the local node")
+			podCIDRs = []string{detected}
+			logx.As().Info().Str("pod_cidr", detected).Msg("auto-detected pod CIDR from the local node")
 		}
 
 		force, err := common.FlagForce().Value(cmd, args)
@@ -73,7 +75,7 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		changed, err := newManager().Create(cmd.Context(), p, cidrs, podCIDR, force)
+		changed, err := newManager().Create(cmd.Context(), p, cidrs, podCIDRs, force)
 		if err != nil {
 			return err
 		}
@@ -160,6 +162,6 @@ func init() {
 	createCmd.Flags().StringSliceVar(&flagPorts, "ports", nil, "Workload listener ports for the match key (comma-separated or repeated)")
 	createCmd.Flags().StringSliceVar(&flagCIDRs, "cidrs", nil, "Initial set membership (comma-separated or repeated); ip:port entries for --reply-stamp")
 	createCmd.Flags().StringVar(&flagCIDRsFile, "cidrs-file", "", "Alternative to --cidrs: a file of CIDRs (one per line or comma-separated)")
-	createCmd.Flags().StringVar(&flagPodCIDR, "pod-cidr", "", "Pod CIDR to scope classification to (default: auto-detected from the local node's .spec.podCIDR)")
+	createCmd.Flags().StringSliceVar(&flagPodCIDR, "pod-cidr", nil, "Pod CIDR(s) to scope classification to; may be IPv4 and/or IPv6 for dual-stack (comma-separated or repeated). Default: auto-detected (v4) from the local node's .spec.podCIDR")
 	_ = createCmd.MarkFlagRequired("name")
 }

--- a/cmd/cli/commands/network/policy/policy.go
+++ b/cmd/cli/commands/network/policy/policy.go
@@ -26,7 +26,7 @@ var (
 	flagPorts      []string
 	flagCIDRs      []string
 	flagCIDRsFile  string
-	flagPodCIDR    string
+	flagPodCIDR    []string
 	// flagCIDR is used by add/remove (singular --cidr, repeatable) to match
 	// the element-verb flag name the issue specifies, distinct from create/set's
 	// --cidrs (which take a full list in one shot).

--- a/cmd/cli/commands/network/policy/policy_test.go
+++ b/cmd/cli/commands/network/policy/policy_test.go
@@ -155,8 +155,8 @@ func resetFlags() {
 	flagName, flagStamp = "", ""
 	flagDeny = false
 	flagReplyStamp, flagFromEntity = "", ""
-	flagPorts, flagCIDRs, flagCIDR = nil, nil, nil
-	flagCIDRsFile, flagPodCIDR = "", ""
+	flagPorts, flagCIDRs, flagCIDR, flagPodCIDR = nil, nil, nil, nil
+	flagCIDRsFile = ""
 	// Command singletons share cobra flag state across Execute() calls; clear
 	// Changed so prior-test values don't trip mutual-exclusion guards.
 	for _, cmd := range []*cobra.Command{createCmd, addCmd, removeCmd, setCmd, showCmd, deleteCmd} {

--- a/cmd/cli/commands/network/policy/policy_test.go
+++ b/cmd/cli/commands/network/policy/policy_test.go
@@ -376,7 +376,10 @@ func TestSetCmd_CIDRsAndFileMutuallyExclusive(t *testing.T) {
 // --- show verb ---
 
 func TestShowCmd_Flags(t *testing.T) {
-	require.NotNil(t, showCmd.Flags().Lookup("name"), "show is missing --name")
+	f := showCmd.Flags().Lookup("name")
+	require.NotNil(t, f, "show is missing --name")
+	require.NotContains(t, f.Annotations, cobra.BashCompOneRequiredFlag,
+		"--name must not be required: a bare `show` lists all policies (parity with `shape show`)")
 }
 
 func TestShowCmd_PrintsOutput(t *testing.T) {
@@ -396,6 +399,31 @@ func TestShowCmd_PolicyNotFound(t *testing.T) {
 	env := newTestEnv(t)
 	_, err := env.runShow(t, "--name", "bn-nonexistent")
 	require.ErrorContains(t, err, "not found")
+}
+
+func TestShowCmd_NoName_ListsAllPolicies(t *testing.T) {
+	env := newTestEnv(t)
+	_, err := env.runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "40840",
+		"--cidrs", "10.1.0.1/32")
+	require.NoError(t, err)
+	_, err = env.runCreate(t, "--name", "bn-partner-out", "--stamp", "partner", "--ports", "40841",
+		"--cidrs", "10.2.0.1/32")
+	require.NoError(t, err)
+
+	// Bare `show` (no --name) lists every configured policy.
+	out, err := env.runShow(t)
+	require.NoError(t, err)
+	require.Contains(t, out, "policy: bn-publisher")
+	require.Contains(t, out, "policy: bn-partner-out")
+}
+
+func TestShowCmd_NoName_EmptyRegistry(t *testing.T) {
+	env := newTestEnv(t)
+	// With no policies configured, a bare `show` is not an error — it reports
+	// the empty state, mirroring `network shape show`.
+	out, err := env.runShow(t)
+	require.NoError(t, err)
+	require.Contains(t, out, "no policies configured")
 }
 
 // --- delete verb ---

--- a/cmd/cli/commands/network/policy/show.go
+++ b/cmd/cli/commands/network/policy/show.go
@@ -8,12 +8,21 @@ import (
 
 var showCmd = &cobra.Command{
 	Use:   "show",
-	Short: "Show a policy's config and live set membership",
-	Long: "Print the named policy's registry config (action, class, ports, created_at) followed by " +
-		"its current live CIDR set membership from the kernel (`nft list set inet weaver <name>`). " +
-		"No lock is taken — show is a read-only operation.",
+	Short: "Show policy config and live set membership (all policies, or one with --name)",
+	Long: "Without --name, list every configured policy. With --name, print just that policy's " +
+		"registry config (action, class, ports, created_at) followed by its current live CIDR set " +
+		"membership from the kernel (`nft list set inet weaver <name>`). No lock is taken — show is a " +
+		"read-only operation. This mirrors `network shape show`, where a bare `show` lists everything " +
+		"and flags narrow the scope.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		out, err := newManager().Show(cmd.Context(), flagName)
+		m := newManager()
+		var out string
+		var err error
+		if flagName == "" {
+			out, err = m.ShowAll(cmd.Context())
+		} else {
+			out, err = m.Show(cmd.Context(), flagName)
+		}
 		if err != nil {
 			return err
 		}
@@ -23,6 +32,5 @@ var showCmd = &cobra.Command{
 }
 
 func init() {
-	showCmd.Flags().StringVar(&flagName, "name", "", "Policy name (required)")
-	_ = showCmd.MarkFlagRequired("name")
+	showCmd.Flags().StringVar(&flagName, "name", "", "Policy name (omit to list all policies)")
 }

--- a/cmd/cli/commands/network/shape/shape.go
+++ b/cmd/cli/commands/network/shape/shape.go
@@ -43,6 +43,7 @@ func init() {
 	shapeCmd.AddCommand(createCmd)
 	shapeCmd.AddCommand(setCmd)
 	shapeCmd.AddCommand(showCmd)
+	shapeCmd.AddCommand(watchCmd)
 	shapeCmd.AddCommand(deleteCmd)
 }
 

--- a/cmd/cli/commands/network/shape/shape_test.go
+++ b/cmd/cli/commands/network/shape/shape_test.go
@@ -22,7 +22,10 @@ func resetFlags() {
 	flagCeil = ""
 	flagPrio = 0
 	flagDefault = ""
-	for _, cmd := range []*cobra.Command{createCmd, setCmd, showCmd, deleteCmd} {
+	flagWatchIface = ""
+	flagWatchInterval = 2 * time.Second // watch's registered default
+	flagWatchCount = 0
+	for _, cmd := range []*cobra.Command{createCmd, setCmd, showCmd, watchCmd, deleteCmd} {
 		cmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
 	}
 }
@@ -34,7 +37,7 @@ func TestShapeCmd_HasExpectedSubcommands(t *testing.T) {
 	for _, c := range shapeCmd.Commands() {
 		subs[c.Name()] = true
 	}
-	for _, want := range []string{"create", "set", "show", "delete"} {
+	for _, want := range []string{"create", "set", "show", "watch", "delete"} {
 		require.True(t, subs[want], "missing subcommand %q", want)
 	}
 }
@@ -165,6 +168,50 @@ func TestShowCmd_BothClassAndDevice_Error(t *testing.T) {
 
 	err := showCmd.RunE(showCmd, nil)
 	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+// --- watch: flag registration + early validation (fires before newManager) ---
+
+func TestWatchCmd_FlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"class", "device", "iface", "interval", "count"} {
+		require.NotNil(t, watchCmd.Flags().Lookup(flag), "watch: missing --%s", flag)
+	}
+}
+
+func TestWatchCmd_RequiresDevice(t *testing.T) {
+	defer resetFlags()
+	flagWatchIface = "enp0s1" // device left empty
+
+	err := watchCmd.RunE(watchCmd, nil)
+	require.ErrorContains(t, err, "--device is required")
+}
+
+func TestWatchCmd_RequiresIface(t *testing.T) {
+	defer resetFlags()
+	flagDevice = "egress" // iface left empty
+
+	err := watchCmd.RunE(watchCmd, nil)
+	require.ErrorContains(t, err, "--iface is required")
+}
+
+func TestWatchCmd_NonPositiveInterval_Error(t *testing.T) {
+	defer resetFlags()
+	flagDevice = "egress"
+	flagWatchIface = "enp0s1"
+	flagWatchInterval = 0
+
+	err := watchCmd.RunE(watchCmd, nil)
+	require.ErrorContains(t, err, "--interval must be positive")
+}
+
+func TestWatchCmd_NegativeCount_Error(t *testing.T) {
+	defer resetFlags()
+	flagDevice = "egress"
+	flagWatchIface = "enp0s1"
+	flagWatchCount = -1
+
+	err := watchCmd.RunE(watchCmd, nil)
+	require.ErrorContains(t, err, "--count")
 }
 
 // --- delete: mutual exclusion and required-one-of validation ---

--- a/cmd/cli/commands/network/shape/watch.go
+++ b/cmd/cli/commands/network/shape/watch.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"os/signal"
+	"syscall"
+	"time"
+
+	shp "github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+// watch-only flag binding targets (interval/count/iface are unique to `watch`;
+// --class/--device are the shared vars declared in shape.go).
+var (
+	flagWatchIface    string
+	flagWatchInterval time.Duration
+	flagWatchCount    int
+)
+
+var watchCmd = &cobra.Command{
+	Use:   "watch",
+	Short: "Sample live tc class counters over time (read-only)",
+	Long: "Sample the live tc HTB class counters (`tc -s class show`) at a fixed interval and print " +
+		"per-class rate-over-time — throughput, plus the change in overlimits and drops — each tick. " +
+		"Use it to confirm traffic is actually being classified and shaped (e.g. partner traffic landing " +
+		"in 1:40 with a non-zero rate and climbing overlimits).\n\n" +
+		"Read-only: it never mutates tc or the shape registry. Both --device (egress or ingress) and " +
+		"--iface (the interface to sample) are required — the command does no environment probing (no NIC " +
+		"or veth auto-detection), so it stays independent of any running block node. For egress, --iface " +
+		"is the physical NIC (e.g. enp0s1); for ingress, the per-pod host veth (e.g. lxc1a2b3c). --class " +
+		"narrows the output to a single class within --device. Runs until interrupted (Ctrl-C) unless " +
+		"--count is given.",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if flagDevice == "" {
+			return errorx.IllegalArgument.New("--device is required (egress or ingress)")
+		}
+		if flagWatchIface == "" {
+			return errorx.IllegalArgument.New("--iface is required (the interface to sample)")
+		}
+		if flagWatchInterval <= 0 {
+			return errorx.IllegalArgument.New("--interval must be positive")
+		}
+		if flagWatchCount < 0 {
+			return errorx.IllegalArgument.New("--count must be zero or positive (0 = run until interrupted)")
+		}
+
+		// Ctrl-C (and SIGTERM) cancels the sampling loop cleanly rather than
+		// aborting mid-write; WatchClasses returns nil on ctx cancellation.
+		ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
+
+		spec := shp.WatchSpec{
+			Device:   flagDevice,
+			Iface:    flagWatchIface,
+			Class:    flagClass,
+			Interval: flagWatchInterval,
+			Count:    flagWatchCount,
+		}
+		return newManager().WatchClasses(ctx, spec, cmd.OutOrStdout())
+	},
+}
+
+func init() {
+	watchCmd.Flags().StringVar(&flagClass, "class", "", "Narrow output to a single class within --device (optional)")
+	watchCmd.Flags().StringVar(&flagDevice, "device", "", "Traffic direction to watch: egress ($NIC) or ingress ($VETH) (required)")
+	watchCmd.Flags().StringVar(&flagWatchIface, "iface", "", "Interface to sample, e.g. enp0s1 (egress) or lxc1a2b3c (ingress veth) (required)")
+	watchCmd.Flags().DurationVar(&flagWatchInterval, "interval", 2*time.Second, "Sampling interval (e.g. 1s, 500ms)")
+	watchCmd.Flags().IntVar(&flagWatchCount, "count", 0, "Number of samples to print then exit (0 = run until interrupted)")
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -198,10 +198,10 @@ sudo solo-provisioner block node install \
 | `--recent-retention`      | Recent block retention threshold (default: `96000`)                                                                                   |
 | `--load-balancer-enabled` | Inject MetalLB address-pool annotation into the block node service; set to `false` for environments without MetalLB (default: `true`). See [Block-node service exposure](./block-node-service-exposure.md) for how this interacts with `service.type` and the chart's split topology. |
 | `--firewall-enabled`      | Apply the node-level host firewall (`inet host` table: SSH/mgmt allowlist, ICMP policy, in-cluster ports). Opt-in (default: `false`); set to `true` to have this tool manage the host firewall |
-| `--mgmt-cidrs`            | Host firewall SSH/management allowlist CIDRs. Empty skips the host firewall.                                                          |
-| `--blocked-cidrs`         | Host firewall operator-curated block list CIDRs, dropped before any other rule including established connections. Distinct from the BN workload plane's `bn-restricted` set, which the traffic-shaper daemon manages automatically. |
+| `--mgmt-cidrs`            | Host firewall SSH/management allowlist CIDRs (IPv4 and/or IPv6 — each entry is routed to the matching `ipv4_addr`/`ipv6_addr` set). Empty skips the host firewall. |
+| `--blocked-cidrs`         | Host firewall operator-curated block list CIDRs (IPv4 and/or IPv6), dropped before any other rule including established connections. Distinct from the BN workload plane's `bn-restricted` set, which the traffic-shaper daemon manages automatically. |
 | `--ssh-port`              | Host firewall SSH/management TCP port (default `22`)                                                                                  |
-| `--pod-cidr`              | Host firewall pod CIDR for the in-cluster host-service ports rule (defaults to the cluster pod subnet)                                |
+| `--pod-cidr`              | Host firewall pod CIDR for the in-cluster host-service ports rule (defaults to the cluster pod subnet). May be IPv4 and/or IPv6 (repeat or comma-separate for dual-stack). |
 | `--in-cluster-ports`      | Host firewall in-cluster host-service ports (defaults to `6443,4244,7472,10250`)                                                     |
 | `--traffic-shaping-enabled` | Create the BN workload network-policy plane (`inet weaver` classification) and tc HTB traffic shaping, and install the traffic-shaper daemon. Opt-in (default: `false`); set to `true` to get all three |
 | `--egress-interface`      | Physical NIC for the `$EGRESS` HTB traffic-shaper hierarchy (e.g. `eth0`). Auto-detected from the default route when omitted; use this flag to override on multi-NIC hosts. Renders `/usr/local/sbin/solo-provisioner-tc-egress.sh` and installs `solo-provisioner-tc-egress.service` so the HTB hierarchy survives reboot. |
@@ -226,6 +226,18 @@ sudo solo-provisioner block node install \
 > list, dropped before every other rule (including established connections),
 > and is purely operator-managed for its whole lifecycle, unlike the
 > daemon-owned `bn-restricted` set on the BN workload plane.
+
+> **IPv6 / dual-stack**: both the host firewall (`inet host`) and the BN workload
+> plane (`inet weaver`, which drives traffic-shaping classification) are
+> dual-stack. The v4 and v6 sets are always rendered; `--mgmt-cidrs`,
+> `--blocked-cidrs`, `--pod-cidr` (and `network policy --cidrs`) accept mixed
+> IPv4/IPv6 lists and route each entry to the matching family's set. The host
+> firewall's default-drop input chain explicitly admits ICMPv6 Neighbor Discovery
+> (NS/NA/RS/RA, hop-limit-255 guarded), MLD, and `packet-too-big` (the IPv6 PMTUD
+> signal) — without these IPv6 would be non-functional under the drop policy.
+> IPv6 workload classification is active once a v6 `--pod-cidr` is supplied
+> (auto-detection resolves only the v4 pod CIDR today; pass the v6 companion
+> explicitly).
 
 > **Traffic shaping gate**: daemon activation is not a separate decision from
 > traffic shaping — `block node install` automatically installs and provisions

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -753,29 +753,34 @@ For `--reply-stamp` policies the CIDR entries must be `ip:port` pairs for all th
 
 #### Inspect a Policy (show)
 
-Print a policy's registry config and current live set membership:
+Print a policy's registry config and current live set membership. Without `--name`, `show` lists **all** configured policies (sorted by name); with `--name`, it prints just that one. This mirrors `network shape show`, where a bare `show` lists everything and flags narrow the scope.
 
 ```bash
+# List every configured policy
+sudo solo-provisioner network policy show
+
+# Inspect a single policy
 sudo solo-provisioner network policy show --name bn-publisher
 ```
 
-Output example:
+Output example (single policy). `direction` leads, and the live set is nested under the policy:
 ```
 policy: bn-publisher
+  direction: ingress
   action:  stamp
   class:   publisher
-  direction: ingress
   ports:   40840
   created: 2026-01-01T00:00:00Z
-
-live set @bn-publisher:
-  10.1.0.1/32
-  10.1.0.2/32
+  live set @bn-publisher:
+    10.1.0.1/32
+    10.1.0.2/32
 ```
 
-| Flag     | Description     | Required |
-|----------|-----------------|----------|
-| `--name` | Policy name     | yes      |
+With no policies configured, a bare `show` prints `no policies configured` rather than failing.
+
+| Flag     | Description                              | Required |
+|----------|------------------------------------------|----------|
+| `--name` | Policy name (omit to list all policies)  | no       |
 
 #### Remove a Policy (delete)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -851,6 +851,24 @@ sudo solo-provisioner network shape show              # all devices and classes
 sudo solo-provisioner network shape show --class partner  # single class
 ```
 
+`show` reports the **stored** configuration (rate/ceil/prio). To see **live** traffic flowing through the classes, use `watch`.
+
+**Watch (live counters, read-only)**
+
+```bash
+# Watch the egress NIC every 2s — both --device and --iface are required.
+# Runs until Ctrl-C.
+sudo solo-provisioner network shape watch --device egress --iface enp0s1
+
+# Narrow to a single class, faster sampling, bounded to 5 samples then exit.
+sudo solo-provisioner network shape watch --device egress --iface enp0s1 --class partner --interval 1s --count 5
+
+# Watch a block node's ingress veth (find it with `ip link` or `tc qdisc show`).
+sudo solo-provisioner network shape watch --device ingress --iface lxc1a2b3c
+```
+
+`watch` samples `tc -s class show dev <iface>` at `--interval` and prints, per class, the throughput (from the byte delta) plus the change in overlimits and drops since the previous sample — "rate over time". It is read-only: it never mutates tc or the shape registry. Use it to confirm traffic is actually being classified and shaped — e.g. partner traffic landing in `1:40` with a non-zero rate and climbing overlimits. Both `--device` (egress or ingress — selects the class set) and `--iface` (the interface to sample) are **required**: the command does no environment probing — no NIC or veth auto-detection — so it stays independent of any running block node. For egress, `--iface` is the physical NIC (e.g. `enp0s1`); for ingress, the per-pod host veth (e.g. `lxc1a2b3c`), which you can find with `ip link` or `tc qdisc show`. `--class` narrows the output to one class within `--device`. This complements the Prometheus counters, which target dashboards rather than an operator at a terminal.
+
 **Delete**
 
 ```bash
@@ -867,6 +885,9 @@ sudo solo-provisioner network shape delete --class reserve-egress
 | `--prio`    | HTB scheduling priority `[0,7]`; 0 is highest                                   | no (default 0)        |
 | `--default` | Default class for unmatched traffic (`--device` form only)                      | yes (`--device`)      |
 | `--force`   | Replace an existing device or class config                                       | no                    |
+| `--iface`   | Interface to sample (`watch`); **required** — e.g. `enp0s1` (egress) or `lxc1a2b3c` (ingress veth). No auto-detection | `watch`               |
+| `--interval`| Sampling interval for `watch` (e.g. `1s`, `500ms`); default `2s`                 | no                    |
+| `--count`   | Number of `watch` samples to print then exit; `0` = run until interrupted        | no                    |
 
 ---
 

--- a/internal/bll/blocknode/network_plane.go
+++ b/internal/bll/blocknode/network_plane.go
@@ -4,8 +4,7 @@ package blocknode
 
 import (
 	"github.com/automa-saga/automa"
-	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
-	"github.com/hashgraph/solo-weaver/pkg/config"
+	"github.com/hashgraph/solo-weaver/internal/workflows"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 )
 
@@ -21,75 +20,24 @@ import (
 //     allowTeardown=false: it re-asserts (create-if-missing) whatever the install
 //     decision was, but never tears anything down from a routine version bump.
 //
-// Every step is idempotent, so the same list is safe to re-run: create steps are
-// create-if-missing and teardown steps are delete-if-present. The step ordering
-// mirrors NetworkSetupWorkflow — firewall first, then NetworkPolicyCreate before
-// NftWeaverPersist so the policy registry is populated when the weaver table is
-// rendered.
+// It is a thin adapter over workflows.NetworkPlaneSteps — the single assembler
+// also used by the install path (via NetworkSetupWorkflow) — that maps the
+// block-node inputs onto the shared options and always requests the inline daemon
+// reload (both reconfigure and upgrade may run against a live daemon whose
+// daemon.yaml changed). See workflows.NetworkPlaneSteps for the step semantics.
 //
 // trafficShapingEnabled is the resolved traffic-shaping target. force is the
-// operator's --force, threaded into NetworkPolicyCreate for the enable path.
-// healthPort is the resolved block-node health/statusz port (from
-// blocknode.ResolveHealthPort against the operator's effective values), threaded
-// into NetworkPolicyCreate so the bn-mgmt set tracks the port the BN actually
-// listens on — matching the install path.
+// operator's --force. healthPort is the resolved block-node health/statusz port.
 func networkPlaneSteps(ins models.BlockNodeInputs, force, trafficShapingEnabled, allowTeardown bool, healthPort string) []automa.Builder {
-	var out []automa.Builder
-
-	// Host firewall: desired-state convergence. NetworkFirewallCreate self-gates
-	// on config.Host.Disabled, so it is always safe to include; a delete only runs
-	// when teardown is permitted (reconfigure) AND the operator resolved the
-	// firewall to disabled.
-	if allowTeardown && config.Get().Host.Disabled {
-		out = append(out, steps.NetworkFirewallDelete())
-	} else {
-		// reconcile=allowTeardown: reconfigure (allowTeardown=true) force
-		// re-renders the host firewall so changed settings actually take effect;
-		// upgrade (allowTeardown=false) re-asserts create-if-missing only.
-		out = append(out, steps.NetworkFirewallCreate(allowTeardown))
-	}
-
-	switch {
-	case trafficShapingEnabled:
-		// Enable: create the BN policy plane, persist the weaver table, (re)provision
-		// tc egress/ingress shaping, enable the daemon's traffic-shaper monitor, and
-		// restart the daemon so that change takes effect. The daemon reads daemon.yaml
-		// only at startup (no hot-reload) and the post-workflow ensureBlockNodeDaemon
-		// is a no-op when the daemon is already running — so re-enabling on a host
-		// where the daemon is up (e.g. a prior disable left it running with the
-		// monitor off) would otherwise never start the monitor, and the ingress $VETH
-		// HTB would never be (re)installed. Restarting here reloads daemon.yaml; the
-		// monitor's initial pod list then shapes the current pod's veth immediately,
-		// and the subsequent rollout-restart's new veth via a watch event.
-		// RestartDaemonServiceStep self-skips when the daemon is not running (fresh
-		// enable), where post-workflow ensureBlockNodeDaemon installs and starts it.
-		shapeOverrides := toClassOverrides(ins.ShapeOverrides)
-		out = append(out,
-			steps.NetworkPolicyCreate(force, healthPort),
-			steps.NftWeaverPersist(),
-			steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate, shapeOverrides),
-			steps.TcIngressRecord(ins.EgressInterface, ins.LinkRate, shapeOverrides),
-			steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace, true),
-			steps.RestartDaemonServiceStep(),
-		)
-	case allowTeardown:
-		// Disable: remove every BN policy (the last delete tears the inet weaver
-		// table down, so no NftWeaverPersist is needed), drop the tc egress hierarchy,
-		// turn the daemon's block-node traffic-shaper monitor off, and restart the
-		// daemon so that change takes effect. The daemon reads daemon.yaml only at
-		// startup (no hot-reload), so without the restart the live monitor keeps
-		// running and re-applies the ingress $VETH HTB on the next BN pod create —
-		// which, on the default reconfigure path, is triggered by the rollout-restart
-		// that runs right after these network steps. Restarting here (before that pod
-		// churn) ensures the monitor is gone when the new veth appears, so it comes up
-		// unshaped. RestartDaemonServiceStep self-skips when the daemon is not running.
-		out = append(out,
-			steps.NetworkPolicyDeleteAll(),
-			steps.TcEgressTeardown(),
-			steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace, false),
-			steps.RestartDaemonServiceStep(),
-		)
-	}
-
-	return out
+	return workflows.NetworkPlaneSteps(workflows.NetworkPlaneOptions{
+		Force:                 force,
+		TrafficShapingEnabled: trafficShapingEnabled,
+		HealthPort:            healthPort,
+		Namespace:             ins.Namespace,
+		EgressInterface:       ins.EgressInterface,
+		LinkRate:              ins.LinkRate,
+		ShapeOverrides:        toClassOverrides(ins.ShapeOverrides),
+		AllowTeardown:         allowTeardown,
+		WithDaemonReload:      true,
+	})
 }

--- a/internal/blocknode/shaper/policy_map.go
+++ b/internal/blocknode/shaper/policy_map.go
@@ -193,11 +193,20 @@ func computePolicyDeltas(ctx context.Context, lister elementLister, ce categoryE
 		if err != nil {
 			return nil, err
 		}
+		// Read live membership from BOTH families' sets and merge before diffing:
+		// desired may carry v4 and v6 endpoints (routed to @<name> and @<name>6 on
+		// apply), so a diff against only the v4 set would report every v6 element
+		// as a perpetual add and re-apply the set every tick. DiffElements
+		// canonicalizes both families, so the merged live compares correctly.
 		live, err := lister.ListElements(ctx, b.policyName)
 		if err != nil {
 			return nil, errorx.Decorate(err, "read live membership for policy %s", b.policyName)
 		}
-		delta := policy.DiffElements(desired, live)
+		live6, err := lister.ListElements(ctx, policy.V6SetName(b.policyName))
+		if err != nil {
+			return nil, errorx.Decorate(err, "read live IPv6 membership for policy %s", b.policyName)
+		}
+		delta := policy.DiffElements(desired, append(live, live6...))
 		if delta.Empty() {
 			continue
 		}

--- a/internal/blocknode/shaper/policy_map_test.go
+++ b/internal/blocknode/shaper/policy_map_test.go
@@ -88,6 +88,29 @@ func TestComputePolicyDeltas_EmptyCategoryClearsSet(t *testing.T) {
 	}, deltas)
 }
 
+func TestComputePolicyDeltas_MergesBothFamilyLiveSets(t *testing.T) {
+	l := newFakeLister()
+	// A v4 member lives in @bn-publisher and a v6 member in @bn-publisher6; the
+	// desired set spans both families. Reading only the v4 set would report the
+	// v6 member as a perpetual add and re-apply every tick — merging both
+	// families' live sets yields no delta when live already matches desired.
+	l.elements["bn-publisher"] = []string{"10.1.0.1/32"}
+	l.elements[policy.V6SetName("bn-publisher")] = []string{"2001:db8::1/128"}
+
+	deltas, err := computePolicyDeltas(context.Background(), l,
+		categoryEndpoints{{Inbound, CategoryPublisher}: {"10.1.0.1/32", "2001:db8::1/128"}})
+	require.NoError(t, err)
+	require.Empty(t, deltas, "desired already live across both families → no delta")
+
+	// A new v6 member (absent from the live v6 set) surfaces as an add.
+	deltas, err = computePolicyDeltas(context.Background(), l,
+		categoryEndpoints{{Inbound, CategoryPublisher}: {"10.1.0.1/32", "2001:db8::1/128", "2001:db8::2/128"}})
+	require.NoError(t, err)
+	require.Equal(t, []PolicyDelta{
+		{Policy: "bn-publisher", SetDelta: setDelta([]string{"2001:db8::2"}, nil)},
+	}, deltas)
+}
+
 func TestComputePolicyDeltas_AbsentCategoryLeavesSetUntouched(t *testing.T) {
 	l := newFakeLister()
 	l.elements["bn-publisher"] = []string{"10.1.0.1/32"}

--- a/internal/blocknode/shaper/reconciler.go
+++ b/internal/blocknode/shaper/reconciler.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"net"
 	"net/netip"
 	"sort"
 	"strings"
@@ -234,7 +235,10 @@ func bucketize(ce categoryEndpoints, dir Direction, data NetworkData) {
 		if conn.Remote.Port == "" || conn.Remote.Port == "*" {
 			continue
 		}
-		ce[k] = append(ce[k], conn.Remote.Address+":"+conn.Remote.Port)
+		// net.JoinHostPort brackets an IPv6 host ("[2001:db8::1]:443") so the
+		// compound token parses unambiguously downstream; a v4 host is joined
+		// plainly ("1.2.3.4:443"), unchanged from before.
+		ce[k] = append(ce[k], net.JoinHostPort(conn.Remote.Address, conn.Remote.Port))
 	}
 }
 
@@ -243,19 +247,24 @@ func bucketize(ce categoryEndpoints, dir Direction, data NetworkData) {
 // as a bare host IP ("198.51.100.7"), but policy.Manager.ApplySets validates
 // every plain-set element as a CIDR and rejects a bare IP outright
 // (sanity.ValidateCIDR: callers must be explicit about the mask). A bare IPv4
-// host is therefore rendered as an explicit /32; a value that already carries a
-// prefix ("10.0.0.0/24"), or that does not parse as a bare IPv4 address (an
-// unexpected wildcard or IPv6 token), is returned unchanged so the downstream
-// validator surfaces a precise error rather than this stage silently mangling
-// it. The /32 is diff-stable: policy.CanonicalizeElements collapses it back to
-// the bare address nft prints, so digests and membership deltas are identical to
-// the pre-normalization form.
+// host is therefore rendered as an explicit /32, and a bare IPv6 host as an
+// explicit /128; a value that already carries a prefix ("10.0.0.0/24"), or that
+// does not parse as a bare IP address (an unexpected wildcard token), is
+// returned unchanged so the downstream validator surfaces a precise error rather
+// than this stage silently mangling it. The /32 (and /128) is diff-stable:
+// policy.CanonicalizeElements collapses it back to the bare address nft prints,
+// so digests and membership deltas are identical to the pre-normalization form.
 func hostCIDR(addr string) string {
 	if strings.Contains(addr, "/") {
 		return addr
 	}
-	if a, err := netip.ParseAddr(addr); err == nil && a.Is4() {
-		return addr + "/32"
+	if a, err := netip.ParseAddr(addr); err == nil {
+		if a.Is4() {
+			return addr + "/32"
+		}
+		if a.Is6() {
+			return addr + "/128"
+		}
 	}
 	return addr
 }

--- a/internal/blocknode/shaper/reconciler_test.go
+++ b/internal/blocknode/shaper/reconciler_test.go
@@ -174,6 +174,26 @@ func TestBucketizeEndpoints_NormalizesBareHostToSlash32(t *testing.T) {
 	assert.Equal(t, []string{"198.51.100.0/24"}, ce[bindingKey{Inbound, CategoryPartner}])
 }
 
+// TestBucketizeEndpoints_IPv6 mirrors the /32 normalization for IPv6: a bare v6
+// peer becomes an explicit /128 (the form the policy layer accepts), and a
+// compound (outbound partner) v6 endpoint is bracketed so its ip:port token
+// parses unambiguously downstream in CompoundElement.
+func TestBucketizeEndpoints_IPv6(t *testing.T) {
+	inbound := NetworkData{ActiveEndpoints: []NetworkConnection{
+		conn("publisher", "2001:db8::1", "*"),   // bare v6 host → /128
+		conn("partner", "2001:db8:a::/48", "*"), // already a CIDR → unchanged
+	}}
+	outbound := NetworkData{ActiveEndpoints: []NetworkConnection{
+		conn("partner", "2001:db8::2", "43473"), // compound v6 → bracketed ip:port
+	}}
+
+	ce := bucketizeEndpoints(inbound, outbound)
+
+	assert.Equal(t, []string{"2001:db8::1/128"}, ce[bindingKey{Inbound, CategoryPublisher}])
+	assert.Equal(t, []string{"2001:db8:a::/48"}, ce[bindingKey{Inbound, CategoryPartner}])
+	assert.Equal(t, []string{"[2001:db8::2]:43473"}, ce[bindingKey{Outbound, CategoryPartner}])
+}
+
 // TestReconciler_Apply_NormalizesBareHostMembership is the end-to-end guard: a
 // statusz snapshot carrying a bare host IP must reach ApplySets as an explicit
 // /32 CIDR (the form policy.Manager.ApplySets accepts), not the bare address

--- a/internal/network/firewall/firewall_test.go
+++ b/internal/network/firewall/firewall_test.go
@@ -4,6 +4,7 @@ package firewall
 
 import (
 	"context"
+	"flag"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+// update regenerates the golden .nft fixtures instead of comparing against
+// them: `go test ./internal/network/firewall/... -update`. Review the diff
+// before committing a regenerated golden.
+var update = flag.Bool("update", false, "regenerate golden testdata files")
 
 // fakeRunner is an in-memory Runner for tests: it tracks table existence
 // without touching the kernel. Apply is intentionally absent — live rule
@@ -32,6 +38,19 @@ func sampleTable() *Table {
 		InClusterPorts: []int{4244, 6443, 7472, 10250},
 		SSHPort:        22,
 		PodCIDR:        "10.4.0.0/24",
+	}
+}
+
+// dualStackTable is sampleTable with IPv6 members mixed into every dimension,
+// exercising the ipv6_addr sets, the `ip6` rules, and the v6 in-cluster rule.
+func dualStackTable() *Table {
+	return &Table{
+		MgmtCIDRs:      []string{"10.0.0.0/8", "2001:db8:a11::/48"},
+		BlockedCIDRs:   []string{"203.0.113.0/24", "2001:db8:bad::/48"},
+		InClusterPorts: []int{4244, 6443, 7472, 10250},
+		SSHPort:        22,
+		PodCIDR:        "10.4.0.0/24",
+		PodCIDR6:       "2001:db8:c0de::/64",
 	}
 }
 
@@ -105,18 +124,55 @@ func TestRender_NoMgmtNoPod(t *testing.T) {
 	require.NoError(t, err)
 
 	// Empty mgmt set renders without an elements clause; no pod CIDR means no
-	// in-cluster rule line.
+	// in-cluster rule line. Both families' sets are always declared (dual-stack).
 	require.Contains(t, doc, "set mgmt_addrs { type ipv4_addr; flags interval; }")
+	require.Contains(t, doc, "set mgmt_addrs6 { type ipv6_addr; flags interval; }")
 	require.Contains(t, doc, "set blocked_addrs { type ipv4_addr; flags interval; }")
+	require.Contains(t, doc, "set blocked_addrs6 { type ipv6_addr; flags interval; }")
 	require.NotContains(t, doc, "tcp dport @in_cluster_ports accept")
+}
+
+func TestRender_DualStack(t *testing.T) {
+	doc, err := dualStackTable().Render()
+	require.NoError(t, err)
+
+	// Each family's members land in its own set; mixed --mgmt/--blocked lists
+	// are split by family, not smuggled into the wrong-typed set.
+	require.Contains(t, doc, "set mgmt_addrs { type ipv4_addr; flags interval; elements = { 10.0.0.0/8 }; }")
+	require.Contains(t, doc, "set mgmt_addrs6 { type ipv6_addr; flags interval; elements = { 2001:db8:a11::/48 }; }")
+	require.Contains(t, doc, "set blocked_addrs { type ipv4_addr; flags interval; elements = { 203.0.113.0/24 }; }")
+	require.Contains(t, doc, "set blocked_addrs6 { type ipv6_addr; flags interval; elements = { 2001:db8:bad::/48 }; }")
+
+	// Parallel v6 match rules.
+	require.Contains(t, doc, "ip6 saddr @blocked_addrs6 drop")
+	require.Contains(t, doc, "ip6 saddr @mgmt_addrs6 tcp dport 22 accept")
+	require.Contains(t, doc, "ip saddr 10.4.0.0/24 tcp dport @in_cluster_ports accept")
+	require.Contains(t, doc, "ip6 saddr 2001:db8:c0de::/64 tcp dport @in_cluster_ports accept")
+
+	// ICMPv6 Neighbor Discovery + MLD are mandatory under the default-drop policy
+	// or IPv6 is dead; packet-too-big is the v6 PMTUD signal. nd-redirect must NOT
+	// be accepted (on-link MITM). Hop-limit 255 guards the NDP accept.
+	require.Contains(t, doc, "icmpv6 type { nd-neighbor-solicit, nd-neighbor-advert, nd-router-solicit, nd-router-advert } ip6 hoplimit 255 accept")
+	require.Contains(t, doc, "icmpv6 type { mld-listener-query, mld-listener-report, mld-listener-done } accept")
+	require.Contains(t, doc, "icmpv6 type packet-too-big accept")
+	require.NotContains(t, doc, "nd-redirect")
+
+	// NDP must precede the established/related fast-path, same reasoning as the
+	// v4 ICMP ordering.
+	ndpIdx := strings.Index(doc, "nd-neighbor-solicit")
+	estIdx := strings.LastIndex(doc, "ct state established,related accept")
+	require.Greater(t, ndpIdx, 0)
+	require.Less(t, ndpIdx, estIdx, "NDP accepts must precede established,related accept")
 }
 
 func TestRoundTrip_RenderParseRender(t *testing.T) {
 	cases := map[string]*Table{
-		"full":      sampleTable(),
-		"defaults":  NewTable(),
-		"mgmt-only": {MgmtCIDRs: []string{"10.1.0.0/16"}, SSHPort: 2222},
-		"no-mgmt":   {SSHPort: 22},
+		"full":       sampleTable(),
+		"dual-stack": dualStackTable(),
+		"defaults":   NewTable(),
+		"mgmt-only":  {MgmtCIDRs: []string{"10.1.0.0/16"}, SSHPort: 2222},
+		"v6-only":    {MgmtCIDRs: []string{"2001:db8:a11::/48"}, BlockedCIDRs: []string{"2001:db8:bad::/48"}, SSHPort: 22, PodCIDR6: "2001:db8:c0de::/64", InClusterPorts: []int{6443}},
+		"no-mgmt":    {SSHPort: 22},
 	}
 	for name, tbl := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -223,23 +279,45 @@ func TestManager_AddRejectsBadInput(t *testing.T) {
 
 	require.Error(t, m.AddMgmtCIDR(ctx, "not-a-cidr"))
 	require.Error(t, m.AddPort(ctx, 70000))
-	require.Error(t, m.AddMgmtCIDR(ctx, "2001:db8::/32")) // IPv6 not supported by ipv4_addr sets
 	require.Error(t, m.AddBlockedCIDR(ctx, "not-a-cidr"))
-	require.Error(t, m.AddBlockedCIDR(ctx, "2001:db8::/32")) // IPv6 not supported by ipv4_addr sets
+	// A bare IP without a prefix length is still rejected (both families).
+	require.Error(t, m.AddMgmtCIDR(ctx, "2001:db8::1"))
 }
 
-func TestTable_Validate_RejectsIPv6(t *testing.T) {
+func TestManager_AddAcceptsIPv6(t *testing.T) {
+	r := &fakeRunner{}
+	applyCount := 0
+	m, nftPath := newTestManager(t, r, &applyCount)
+	ctx := context.Background()
+	_, err := m.Create(ctx, NewTable(), false)
+	require.NoError(t, err)
+
+	// IPv6 CIDRs are now accepted and land in the ipv6_addr sets.
+	require.NoError(t, m.AddMgmtCIDR(ctx, "2001:db8:a11::/48"))
+	require.NoError(t, m.AddBlockedCIDR(ctx, "2001:db8:bad::/48"))
+	data, err := os.ReadFile(nftPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "set mgmt_addrs6 { type ipv6_addr; flags interval; elements = { 2001:db8:a11::/48 }; }")
+	require.Contains(t, string(data), "set blocked_addrs6 { type ipv6_addr; flags interval; elements = { 2001:db8:bad::/48 }; }")
+}
+
+func TestTable_Validate_AcceptsIPv6(t *testing.T) {
 	mgmt := sampleTable()
 	mgmt.MgmtCIDRs = []string{"2001:db8::/32"}
-	require.ErrorContains(t, mgmt.Validate(), "IPv6 CIDRs are not yet supported")
+	require.NoError(t, mgmt.Validate())
 
 	pod := sampleTable()
-	pod.PodCIDR = "2001:db8::/32"
-	require.ErrorContains(t, pod.Validate(), "IPv6 CIDRs are not yet supported")
+	pod.PodCIDR6 = "2001:db8::/32"
+	require.NoError(t, pod.Validate())
 
 	blocked := sampleTable()
 	blocked.BlockedCIDRs = []string{"2001:db8::/32"}
-	require.ErrorContains(t, blocked.Validate(), "IPv6 CIDRs are not yet supported")
+	require.NoError(t, blocked.Validate())
+
+	// A bare IPv6 address without a prefix length is still rejected.
+	bare := sampleTable()
+	bare.MgmtCIDRs = []string{"2001:db8::1"}
+	require.Error(t, bare.Validate())
 }
 
 func TestManager_MutateBeforeCreateFails(t *testing.T) {
@@ -286,10 +364,15 @@ func TestRender_GoldenStable(t *testing.T) {
 	// Guards against accidental rule reordering/whitespace drift. If the
 	// ruleset legitimately changes, regenerate testdata/network-host.golden.nft
 	// deliberately and review the diff.
-	want, err := os.ReadFile(filepath.Join("testdata", "network-host.golden.nft"))
+	goldenPath := filepath.Join("testdata", "network-host.golden.nft")
+	doc, err := sampleTable().Render()
 	require.NoError(t, err)
 
-	doc, err := sampleTable().Render()
+	if *update {
+		require.NoError(t, os.WriteFile(goldenPath, []byte(doc), 0o644))
+	}
+
+	want, err := os.ReadFile(goldenPath)
 	require.NoError(t, err)
 	require.Equal(t, strings.TrimSpace(string(want)), strings.TrimSpace(doc))
 }

--- a/internal/network/firewall/parse.go
+++ b/internal/network/firewall/parse.go
@@ -22,11 +22,20 @@ func Parse(content string) (*Table, error) {
 		return nil, errorx.IllegalFormat.New("not a recognised inet host ruleset")
 	}
 
+	// Merge each family's set back into the single mixed list the Table holds.
+	// Render re-splits by family, so a render→parse→render round-trip is the
+	// identity regardless of the mixed-list order (pinned by TestRoundTrip).
 	if cidrs, ok := parseElements(content, reMgmtSet); ok {
-		t.MgmtCIDRs = splitElements(cidrs)
+		t.MgmtCIDRs = append(t.MgmtCIDRs, splitElements(cidrs)...)
+	}
+	if cidrs, ok := parseElements(content, reMgmtSet6); ok {
+		t.MgmtCIDRs = append(t.MgmtCIDRs, splitElements(cidrs)...)
 	}
 	if cidrs, ok := parseElements(content, reBlockedSet); ok {
-		t.BlockedCIDRs = splitElements(cidrs)
+		t.BlockedCIDRs = append(t.BlockedCIDRs, splitElements(cidrs)...)
+	}
+	if cidrs, ok := parseElements(content, reBlockedSet6); ok {
+		t.BlockedCIDRs = append(t.BlockedCIDRs, splitElements(cidrs)...)
 	}
 	if ports, ok := parseElements(content, rePortSet); ok {
 		for _, p := range splitElements(ports) {
@@ -48,16 +57,22 @@ func Parse(content string) (*Table, error) {
 	if m := rePodCIDR.FindStringSubmatch(content); m != nil {
 		t.PodCIDR = m[1]
 	}
+	if m := rePodCIDR6.FindStringSubmatch(content); m != nil {
+		t.PodCIDR6 = m[1]
+	}
 
 	return t, nil
 }
 
 var (
-	reMgmtSet    = regexp.MustCompile(`set mgmt_addrs \{[^}]*elements = \{ ([^}]*) \}`)
-	reBlockedSet = regexp.MustCompile(`set blocked_addrs \{[^}]*elements = \{ ([^}]*) \}`)
-	rePortSet    = regexp.MustCompile(`set in_cluster_ports \{[^}]*elements = \{ ([^}]*) \}`)
-	reSSHPort    = regexp.MustCompile(`ip saddr @mgmt_addrs tcp dport (\d+) accept`)
-	rePodCIDR    = regexp.MustCompile(`ip saddr (\S+) tcp dport @in_cluster_ports accept`)
+	reMgmtSet     = regexp.MustCompile(`set mgmt_addrs \{[^}]*elements = \{ ([^}]*) \}`)
+	reMgmtSet6    = regexp.MustCompile(`set mgmt_addrs6 \{[^}]*elements = \{ ([^}]*) \}`)
+	reBlockedSet  = regexp.MustCompile(`set blocked_addrs \{[^}]*elements = \{ ([^}]*) \}`)
+	reBlockedSet6 = regexp.MustCompile(`set blocked_addrs6 \{[^}]*elements = \{ ([^}]*) \}`)
+	rePortSet     = regexp.MustCompile(`set in_cluster_ports \{[^}]*elements = \{ ([^}]*) \}`)
+	reSSHPort     = regexp.MustCompile(`ip saddr @mgmt_addrs tcp dport (\d+) accept`)
+	rePodCIDR     = regexp.MustCompile(`ip saddr (\S+) tcp dport @in_cluster_ports accept`)
+	rePodCIDR6    = regexp.MustCompile(`ip6 saddr (\S+) tcp dport @in_cluster_ports accept`)
 )
 
 func parseElements(content string, re *regexp.Regexp) (string, bool) {

--- a/internal/network/firewall/render.go
+++ b/internal/network/firewall/render.go
@@ -9,18 +9,23 @@ import (
 	"strings"
 
 	"github.com/hashgraph/solo-weaver/internal/templates"
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
 	"github.com/joomcode/errorx"
 )
 
 // renderData is the flattened view of a Table passed to the nft template.
 // Strings are pre-joined here because templates.Render parses without a FuncMap,
-// so the template itself cannot call join.
+// so the template itself cannot call join. The `*6` fields carry the IPv6-family
+// members so the template can declare parallel ipv6_addr sets and `ip6` rules.
 type renderData struct {
-	MgmtElements    string
-	BlockedElements string
-	PortElements    string
-	SSHPort         int
-	PodCIDR         string
+	MgmtElements     string
+	MgmtElements6    string
+	BlockedElements  string
+	BlockedElements6 string
+	PortElements     string
+	SSHPort          int
+	PodCIDR          string
+	PodCIDR6         string
 }
 
 // Render produces the full `inet host` nft document for this table. The same
@@ -36,12 +41,19 @@ func (t *Table) Render() (string, error) {
 		ports[i] = strconv.Itoa(p)
 	}
 
+	mgmtV4, mgmtV6 := splitCIDRsByFamily(t.MgmtCIDRs)
+	blockedV4, blockedV6 := splitCIDRsByFamily(t.BlockedCIDRs)
+	podV4, podV6 := routePodCIDRs(t.PodCIDR, t.PodCIDR6)
+
 	data := renderData{
-		MgmtElements:    strings.Join(t.MgmtCIDRs, ", "),
-		BlockedElements: strings.Join(t.BlockedCIDRs, ", "),
-		PortElements:    strings.Join(ports, ", "),
-		SSHPort:         t.SSHPort,
-		PodCIDR:         t.PodCIDR,
+		MgmtElements:     strings.Join(mgmtV4, ", "),
+		MgmtElements6:    strings.Join(mgmtV6, ", "),
+		BlockedElements:  strings.Join(blockedV4, ", "),
+		BlockedElements6: strings.Join(blockedV6, ", "),
+		PortElements:     strings.Join(ports, ", "),
+		SSHPort:          t.SSHPort,
+		PodCIDR:          podV4,
+		PodCIDR6:         podV6,
 	}
 
 	rendered, err := templates.Render(hostNftTemplate, data)
@@ -50,6 +62,44 @@ func (t *Table) Render() (string, error) {
 	}
 
 	return rendered, nil
+}
+
+// splitCIDRsByFamily partitions a validated mixed CIDR list into its IPv4 and
+// IPv6 members, preserving order. Table.Validate has already run, so a
+// classification error is not expected here; a value that somehow fails to
+// classify is dropped from both lists rather than smuggled into the wrong-family
+// nft set (which nft would reject at apply time anyway).
+func splitCIDRsByFamily(cidrs []string) (v4, v6 []string) {
+	for _, c := range cidrs {
+		isV6, err := sanity.CIDRIsIPv6(c)
+		if err != nil {
+			continue
+		}
+		if isV6 {
+			v6 = append(v6, c)
+		} else {
+			v4 = append(v4, c)
+		}
+	}
+	return v4, v6
+}
+
+// routePodCIDRs assigns the two pod-CIDR fields to the v4/v6 render slots by
+// their actual family, so a value placed in either Table field renders into the
+// correct `ip`/`ip6` in-cluster rule even if a caller slotted it by the wrong
+// field. When both fields carry the same family the later one wins that slot.
+func routePodCIDRs(pod, pod6 string) (v4, v6 string) {
+	for _, c := range []string{pod, pod6} {
+		if c == "" {
+			continue
+		}
+		if isV6, err := sanity.CIDRIsIPv6(c); err == nil && isV6 {
+			v6 = c
+		} else {
+			v4 = c
+		}
+	}
+	return v4, v6
 }
 
 // atomicWriteFile writes content to path via a temp file in the same directory

--- a/internal/network/firewall/table.go
+++ b/internal/network/firewall/table.go
@@ -43,8 +43,16 @@ type Table struct {
 	// SSHPort is the TCP port accepted from @mgmt_addrs for management access.
 	SSHPort int
 	// PodCIDR is the source range allowed to reach @in_cluster_ports. Empty
-	// means no in-cluster port rule is rendered.
+	// means no in-cluster port rule is rendered. It may hold either an IPv4 or
+	// IPv6 CIDR; Render routes it to the matching (`ip`/`ip6`) rule by family.
 	PodCIDR string
+	// PodCIDR6 is the optional IPv6 companion to PodCIDR so a dual-stack node can
+	// admit in-cluster traffic over both families. It is a separate field (rather
+	// than folding PodCIDR into a slice) to keep the existing single-value callers
+	// — the block-node install/reconfigure wiring — untouched. Render family-routes
+	// whichever of PodCIDR/PodCIDR6 is set, so mis-slotting a value by family still
+	// renders correctly.
+	PodCIDR6 string
 }
 
 // NewTable returns a Table populated with the design defaults. Callers override
@@ -65,20 +73,26 @@ func NewTable() *Table {
 // break the atomic transaction or smuggle in nft syntax.
 func (t *Table) Validate() error {
 	for _, c := range t.MgmtCIDRs {
-		if err := sanity.ValidateIPv4CIDR(c); err != nil {
+		if err := sanity.ValidateCIDR(c); err != nil {
 			return errorx.IllegalArgument.Wrap(err, "invalid --mgmt-cidr %q", c)
 		}
 	}
 
 	for _, c := range t.BlockedCIDRs {
-		if err := sanity.ValidateIPv4CIDR(c); err != nil {
+		if err := sanity.ValidateCIDR(c); err != nil {
 			return errorx.IllegalArgument.Wrap(err, "invalid --blocked-cidr %q", c)
 		}
 	}
 
 	if t.PodCIDR != "" {
-		if err := sanity.ValidateIPv4CIDR(t.PodCIDR); err != nil {
+		if err := sanity.ValidateCIDR(t.PodCIDR); err != nil {
 			return errorx.IllegalArgument.Wrap(err, "invalid --pod-cidr %q", t.PodCIDR)
+		}
+	}
+
+	if t.PodCIDR6 != "" {
+		if err := sanity.ValidateCIDR(t.PodCIDR6); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --pod-cidr %q", t.PodCIDR6)
 		}
 	}
 
@@ -97,7 +111,7 @@ func (t *Table) Validate() error {
 
 // AddMgmtCIDR adds a single CIDR to the management allowlist (idempotent).
 func (t *Table) AddMgmtCIDR(cidr string) error {
-	if err := sanity.ValidateIPv4CIDR(cidr); err != nil {
+	if err := sanity.ValidateCIDR(cidr); err != nil {
 		return errorx.IllegalArgument.Wrap(err, "invalid --mgmt-cidr %q", cidr)
 	}
 	if sanity.Contains(cidr, t.MgmtCIDRs) {
@@ -123,7 +137,7 @@ func (t *Table) RemoveMgmtCIDR(cidr string) {
 // SetMgmtCIDRs atomically replaces the full management allowlist.
 func (t *Table) SetMgmtCIDRs(cidrs []string) error {
 	for _, c := range cidrs {
-		if err := sanity.ValidateIPv4CIDR(c); err != nil {
+		if err := sanity.ValidateCIDR(c); err != nil {
 			return errorx.IllegalArgument.Wrap(err, "invalid --mgmt-cidr %q", c)
 		}
 	}
@@ -135,7 +149,7 @@ func (t *Table) SetMgmtCIDRs(cidrs []string) error {
 
 // AddBlockedCIDR adds a single CIDR to the operator block list (idempotent).
 func (t *Table) AddBlockedCIDR(cidr string) error {
-	if err := sanity.ValidateIPv4CIDR(cidr); err != nil {
+	if err := sanity.ValidateCIDR(cidr); err != nil {
 		return errorx.IllegalArgument.Wrap(err, "invalid --blocked-cidr %q", cidr)
 	}
 	if sanity.Contains(cidr, t.BlockedCIDRs) {
@@ -161,7 +175,7 @@ func (t *Table) RemoveBlockedCIDR(cidr string) {
 // SetBlockedCIDRs atomically replaces the full operator block list.
 func (t *Table) SetBlockedCIDRs(cidrs []string) error {
 	for _, c := range cidrs {
-		if err := sanity.ValidateIPv4CIDR(c); err != nil {
+		if err := sanity.ValidateCIDR(c); err != nil {
 			return errorx.IllegalArgument.Wrap(err, "invalid --blocked-cidr %q", c)
 		}
 	}

--- a/internal/network/firewall/testdata/network-host.golden.nft
+++ b/internal/network/firewall/testdata/network-host.golden.nft
@@ -3,22 +3,38 @@ delete table inet host
 add table inet host
 table inet host {
 	set mgmt_addrs { type ipv4_addr; flags interval; elements = { 10.0.0.0/8, 192.168.0.0/16 }; }
+	set mgmt_addrs6 { type ipv6_addr; flags interval; }
 	set blocked_addrs { type ipv4_addr; flags interval; elements = { 203.0.113.0/24 }; }
+	set blocked_addrs6 { type ipv6_addr; flags interval; }
 	set in_cluster_ports { type inet_service; elements = { 4244, 6443, 7472, 10250 }; }
 
 	chain input {
 		type filter hook input priority 0; policy drop;
 
-		# Drop invalid; admit loopback.
+		# Drop invalid; admit loopback. `iif "lo"` covers both 127.0.0.0/8 and
+		# ::1 since this is an `inet` (dual-family) table.
 		ct state invalid drop
 
 		# Operator-curated block list (`network firewall --blocked-cidrs`). Runs
 		# before every other rule, including established/related, so an entry
 		# added here drops already-open connections too. Purely operator-managed:
-		# nothing else ever writes to this set.
+		# nothing else ever writes to these sets. One rule per family.
 		ip saddr @blocked_addrs drop
+		ip6 saddr @blocked_addrs6 drop
 
 		iif "lo" accept
+
+		# --- IPv6 Neighbor Discovery + MLD (REQUIRED under policy drop) ---
+		# IPv6 is non-functional without Neighbor Discovery: address resolution
+		# (neighbor solicit/advert) and router discovery (router solicit/advert)
+		# ride on ICMPv6 and would otherwise be dropped, breaking all IPv6. NDP
+		# packets use a hop limit of 255 (RFC 4861 §11.2); enforce it so an
+		# off-link (routed) forgery cannot satisfy the accept. ICMPv6 Redirect is
+		# deliberately excluded here (accepting it enables on-link MITM).
+		icmpv6 type { nd-neighbor-solicit, nd-neighbor-advert, nd-router-solicit, nd-router-advert } ip6 hoplimit 255 accept
+		# Multicast Listener Discovery — the switch needs these reports to forward
+		# the solicited-node multicast that NDP relies on.
+		icmpv6 type { mld-listener-query, mld-listener-report, mld-listener-done } accept
 
 		# ICMP is evaluated BEFORE the established/related fast-path. netfilter
 		# conntrack DOES track ICMP echo as a flow (keyed on the echo id), so a
@@ -31,6 +47,7 @@ table inet host {
 
 		# Full ICMP from management sources (ping, traceroute, diagnostics) — no rate limit.
 		ip saddr @mgmt_addrs icmp type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem } accept
+		ip6 saddr @mgmt_addrs6 icmpv6 type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem, packet-too-big } accept
 
 		# From everyone else: always allow the path-health subset (Path MTU
 		# Discovery + traceroute), and rate-limit echo-request to prevent floods.
@@ -42,11 +59,22 @@ table inet host {
 		icmp type echo-request limit rate 10/second accept
 		icmp type echo-request drop
 
+		# IPv6 path health for everyone. packet-too-big is the IPv6 PMTUD signal —
+		# IPv6 routers never fragment, so dropping it silently blackholes any flow
+		# whose path MTU is smaller than the sender's.
+		icmpv6 type packet-too-big accept
+		icmpv6 type destination-unreachable accept
+		icmpv6 type time-exceeded accept
+		icmpv6 type parameter-problem accept
+		icmpv6 type echo-request limit rate 10/second accept
+		icmpv6 type echo-request drop
+
 		# Conntrack fast-path for TCP/UDP (and solicited ICMP replies).
 		ct state established,related accept
 
-		# SSH / management access from the allowlist only.
+		# SSH / management access from the allowlist only (both families).
 		ip saddr @mgmt_addrs tcp dport 22 accept
+		ip6 saddr @mgmt_addrs6 tcp dport 22 accept
 
 		# In-cluster host-service ports, reachable from the pod CIDR only.
 		ip saddr 10.4.0.0/24 tcp dport @in_cluster_ports accept

--- a/internal/network/policy/diff.go
+++ b/internal/network/policy/diff.go
@@ -27,9 +27,10 @@ const maxPort = 65535
 // token "<ip> . <port>" used by --reply-stamp policies' sets (e.g. bn-backfill).
 // It is the single conversion the apply path (`network policy set`) and the
 // daemon poll loop's diff both call, so desired membership is built byte for
-// byte identical to what gets written to the kernel. The set is
-// `ipv4_addr . inet_service`, so the host must be IPv4 and the port in range;
-// the returned token is canonical (host normalized, port stripped of any leading
+// byte identical to what gets written to the kernel. Both address families are
+// accepted (IPv6 hosts must be bracketed, e.g. "[2001:db8::1]:443"); the caller
+// routes the element to the ipv4_addr or ipv6_addr compound set by family. The
+// returned token is canonical (host normalized, port stripped of any leading
 // zeros) and a malformed pair is rejected here rather than poisoning a later
 // batch apply.
 func CompoundElement(ipPort string) (string, error) {
@@ -38,8 +39,8 @@ func CompoundElement(ipPort string) (string, error) {
 		return "", errorx.IllegalArgument.Wrap(err, "invalid ip:port %q: compound-set entries require an ip:port pair", ipPort)
 	}
 	addr, err := netip.ParseAddr(host)
-	if err != nil || !addr.Is4() {
-		return "", errorx.IllegalArgument.New("invalid ip:port %q: %q is not an IPv4 address", ipPort, host)
+	if err != nil {
+		return "", errorx.IllegalArgument.New("invalid ip:port %q: %q is not an IP address", ipPort, host)
 	}
 	if err := sanity.ValidatePort(port); err != nil {
 		return "", errorx.IllegalArgument.Wrap(err, "invalid ip:port %q", ipPort)
@@ -137,12 +138,13 @@ type elemKey struct {
 func parseElement(tok string) elemKey {
 	tok = strings.TrimSpace(tok)
 
-	// These are ipv4_addr(. inet_service) sets, so only IPv4 hosts and in-range
-	// ports count as parsed/authoritative; anything else falls through to the
-	// unparseable path (preserved as-is, sorted last) rather than being ordered
-	// among valid elements.
+	// These are ipv4_addr / ipv6_addr(. inet_service) sets, so any valid host of
+	// either family plus an in-range port counts as parsed/authoritative;
+	// anything else falls through to the unparseable path (preserved as-is,
+	// sorted last) rather than being ordered among valid elements. Family is
+	// carried in elemKey.addr and orders v4 before v6 (netip.Addr.Compare).
 	if host, port, ok := splitCompound(tok); ok {
-		if addr, err := netip.ParseAddr(host); err == nil && addr.Is4() {
+		if addr, err := netip.ParseAddr(host); err == nil {
 			if p, err := strconv.Atoi(port); err == nil && p >= 1 && p <= maxPort {
 				return elemKey{
 					canon:  addr.String() + compoundSep + strconv.Itoa(p),
@@ -157,10 +159,12 @@ func parseElement(tok string) elemKey {
 	}
 
 	if strings.Contains(tok, "/") {
-		if pfx, err := netip.ParsePrefix(tok); err == nil && pfx.Addr().Is4() {
+		if pfx, err := netip.ParsePrefix(tok); err == nil {
 			pfx = pfx.Masked()
 			// A full-length prefix is a single host; nft prints an interval
-			// set's /32 as the bare address, so collapse it to match.
+			// set's /32 (v4) or /128 (v6) as the bare address, so collapse it to
+			// match. Addr.BitLen() is 32 for v4 and 128 for v6, so this handles
+			// both families with the same check.
 			if pfx.Bits() == pfx.Addr().BitLen() {
 				return elemKey{canon: pfx.Addr().String(), addr: pfx.Addr(), bits: pfx.Bits(), port: -1, parsed: true}
 			}
@@ -169,7 +173,7 @@ func parseElement(tok string) elemKey {
 		return elemKey{canon: tok, bits: -1, port: -1}
 	}
 
-	if addr, err := netip.ParseAddr(tok); err == nil && addr.Is4() {
+	if addr, err := netip.ParseAddr(tok); err == nil {
 		return elemKey{canon: addr.String(), addr: addr, bits: addr.BitLen(), port: -1, parsed: true}
 	}
 	return elemKey{canon: tok, bits: -1, port: -1}

--- a/internal/network/policy/diff_test.go
+++ b/internal/network/policy/diff_test.go
@@ -19,18 +19,24 @@ func TestCompoundElement(t *testing.T) {
 	require.Equal(t, "10.30.5.7 . 80", tok)
 
 	for _, bad := range []string{
-		"not-an-ip-port",   // no port
-		"10.30.5.7",        // missing port
-		"10.30.5.7:-1",     // negative port
-		"10.30.5.7:0",      // port below range
-		"10.30.5.7:99999",  // port above range
-		"10.30.5.7:http",   // non-numeric port
-		"::1:80",           // IPv6 host
-		"[2001:db8::1]:80", // IPv6 host
+		"not-an-ip-port",  // no port
+		"10.30.5.7",       // missing port
+		"10.30.5.7:-1",    // negative port
+		"10.30.5.7:0",     // port below range
+		"10.30.5.7:99999", // port above range
+		"10.30.5.7:http",  // non-numeric port
+		"::1:80",          // unbracketed IPv6 host (ambiguous colons)
+		"2001:db8::1:443", // unbracketed IPv6 host
 	} {
 		_, err := CompoundElement(bad)
 		require.Error(t, err, "expected %q to be rejected", bad)
 	}
+
+	// Bracketed IPv6 hosts are accepted (dual-stack) and canonicalized to the
+	// compact "<ip> . <port>" token nft prints for an ipv6_addr . inet_service set.
+	tok, err = CompoundElement("[2001:db8::1]:80")
+	require.NoError(t, err)
+	require.Equal(t, "2001:db8::1 . 80", tok)
 }
 
 func TestCanonicalizeElements(t *testing.T) {

--- a/internal/network/policy/manager.go
+++ b/internal/network/policy/manager.go
@@ -556,18 +556,51 @@ func (m *Manager) Show(ctx context.Context, name string) (string, error) {
 	if p == nil {
 		return "", errorx.IllegalState.New("policy %q not found", name)
 	}
+	return m.showOne(ctx, p)
+}
 
+// ShowAll returns a summary of every configured policy, sorted by name, in the
+// same format Show produces for a single policy. With no policies configured it
+// returns a friendly message rather than an error, mirroring `network shape
+// show`. No lock is taken — it is read-only.
+func (m *Manager) ShowAll(ctx context.Context) (string, error) {
+	policies, err := loadAll(m.registryDir)
+	if err != nil {
+		return "", err
+	}
+	if len(policies) == 0 {
+		return "no policies configured\n", nil
+	}
+	var b strings.Builder
+	for i, p := range policies {
+		out, err := m.showOne(ctx, p)
+		if err != nil {
+			return "", err
+		}
+		if i > 0 {
+			b.WriteString("\n") // blank line between policies
+		}
+		b.WriteString(out)
+	}
+	return b.String(), nil
+}
+
+// showOne renders a single policy's registry config (action, class, ports,
+// created_at) followed by its live set membership from the kernel. No lock is
+// taken — it is read-only.
+func (m *Manager) showOne(ctx context.Context, p *Policy) (string, error) {
 	var b strings.Builder
 	fmt.Fprintf(&b, "policy: %s\n", p.Name)
+	// Direction is the most operationally significant attribute, so it leads.
+	if p.Direction != "" {
+		fmt.Fprintf(&b, "  direction: %s\n", p.Direction)
+	}
 	fmt.Fprintf(&b, "  action:  %s\n", p.Action)
 	if p.Stamp != "" {
 		fmt.Fprintf(&b, "  class:   %s\n", p.Stamp)
 	}
 	if p.ReplyStamp != "" {
 		fmt.Fprintf(&b, "  reply-class: %s\n", p.ReplyStamp)
-	}
-	if p.Direction != "" {
-		fmt.Fprintf(&b, "  direction: %s\n", p.Direction)
 	}
 	if len(p.Ports) > 0 {
 		fmt.Fprintf(&b, "  ports:   %s\n", strings.Join(p.Ports, ", "))
@@ -589,20 +622,20 @@ func (m *Manager) Show(ctx context.Context, name string) (string, error) {
 	fmt.Fprintf(&b, "  created: %s\n", p.CreatedAt.Format(time.RFC3339))
 
 	if !p.hasCIDRSet() {
-		b.WriteString("\nlive set: none (--from-entity world policy; any source/dest matches, no IP-set)\n")
+		b.WriteString("  live set: none (--from-entity world policy; any source/dest matches, no IP-set)\n")
 		return b.String(), nil
 	}
 
-	elements, err := m.runner.ListElements(ctx, name)
+	elements, err := m.runner.ListElements(ctx, p.Name)
 	if err != nil {
 		return "", err
 	}
-	fmt.Fprintf(&b, "\nlive set @%s:\n", name)
+	fmt.Fprintf(&b, "  live set @%s:\n", p.Name)
 	if len(elements) == 0 {
-		b.WriteString("  (empty)\n")
+		b.WriteString("    (empty)\n")
 	} else {
 		for _, e := range elements {
-			fmt.Fprintf(&b, "  %s\n", e)
+			fmt.Fprintf(&b, "    %s\n", e)
 		}
 	}
 	return b.String(), nil

--- a/internal/network/policy/manager.go
+++ b/internal/network/policy/manager.go
@@ -90,20 +90,25 @@ func NewManagerWithConfig(cfg Config) *Manager {
 // true, in which case its config and membership are replaced (not merged)
 // from p and cidrs. cidrs is set membership, applied to the live kernel
 // only — never persisted.
-func (m *Manager) Create(ctx context.Context, p *Policy, cidrs []string, podCIDR string, force bool) (bool, error) {
+func (m *Manager) Create(ctx context.Context, p *Policy, cidrs []string, podCIDRs []string, force bool) (bool, error) {
 	if err := p.Validate(cidrs); err != nil {
 		return false, err
 	}
 	// No blanket podCIDR requirement here: Render (below) only requires it
 	// when the merged policy set actually contains a --stamp policy -- a
 	// --deny-only chain never references POD_CIDR. When the caller doesn't
-	// supply one (as --deny never does), recover the value last used to
+	// supply one (as --deny never does), recover the value(s) last used to
 	// render network-weaver.nft -- it's a deployment-wide constant, not a
 	// per-call argument, so an unrelated --deny create shouldn't need it
 	// re-supplied just to correctly re-render an unchanged --stamp sibling.
-	if podCIDR == "" {
+	//
+	// Drop empty entries first (e.g. a Cobra StringSlice from `--pod-cidr ""`)
+	// so recovery still fires instead of treating "" as one explicit-but-empty
+	// pod CIDR — same normalization as RenderWeaverNft.
+	podCIDRs = nonEmptyStrings(podCIDRs)
+	if len(podCIDRs) == 0 {
 		if existing, err := os.ReadFile(m.weaverNftPath); err == nil {
-			podCIDR = ExtractPodCIDR(string(existing))
+			podCIDRs = ExtractPodCIDRs(string(existing))
 		}
 	}
 
@@ -190,7 +195,7 @@ func (m *Manager) Create(ctx context.Context, p *Policy, cidrs []string, podCIDR
 		// Render the prospective full chain BEFORE touching disk so a render or
 		// kernel-apply failure leaves the registry untouched.
 		merged := upsert(policies, target)
-		doc, err := Render(merged, podCIDR)
+		doc, err := Render(merged, podCIDRs...)
 		if err != nil {
 			return err
 		}
@@ -198,25 +203,27 @@ func (m *Manager) Create(ctx context.Context, p *Policy, cidrs []string, podCIDR
 			return err
 		}
 		// The table is now live in the kernel, emptied of all membership.
-		// Restore every sibling's snapshot as-is; target's membership is
-		// replaced with exactly newCIDRs, not merged with what was live
-		// before (force means "this is the new desired state"). Any failure
-		// from here leaves the kernel ahead of disk; decorate so the caller
-		// reads it as "re-run to reconcile" (create is idempotent) rather
-		// than "nothing happened".
+		// Restore every sibling's snapshot as-is, per family; target's
+		// membership is replaced with exactly newCIDRs (split by family into its
+		// v4/v6 sets), not merged with what was live before (force means "this
+		// is the new desired state"). Any failure from here leaves the kernel
+		// ahead of disk; decorate so the caller reads it as "re-run to
+		// reconcile" (create is idempotent) rather than "nothing happened".
+		targetV4, targetV6 := setElementsByFamily(target, newCIDRs)
 		for _, lp := range merged {
 			if !lp.hasCIDRSet() {
 				continue
 			}
-			elements := snapshot[lp.Name]
+			v4Set, v6Set := lp.Name, V6SetName(lp.Name)
+			v4Elems, v6Elems := snapshot[v4Set], snapshot[v6Set]
 			if lp.Name == target.Name {
-				elements = setElements(target, newCIDRs)
+				v4Elems, v6Elems = targetV4, targetV6
 			}
-			if len(elements) == 0 {
-				continue
+			if err := m.restoreSet(ctx, v4Set, v4Elems); err != nil {
+				return err
 			}
-			if err := m.runner.AddElements(ctx, lp.Name, elements); err != nil {
-				return errorx.Decorate(err, "inet weaver chain applied to the kernel but restoring %q membership failed; re-run to reconcile", lp.Name)
+			if err := m.restoreSet(ctx, v6Set, v6Elems); err != nil {
+				return err
 			}
 		}
 		if err := writeEntry(m.registryDir, target); err != nil {
@@ -236,24 +243,48 @@ func (m *Manager) Create(ctx context.Context, p *Policy, cidrs []string, podCIDR
 
 // snapshotMembership captures the live membership of every policy that
 // carries a CIDR set, before the caller runs a destructive Apply() that would
-// otherwise wipe it. A ListElements failure aborts immediately (returned to
-// the caller) rather than silently proceeding with a partial snapshot into a
-// destructive apply.
+// otherwise wipe it. Both the IPv4 (@<name>) and IPv6 (@<name>6) sets are
+// snapshotted, keyed by set name. A ListElements failure aborts immediately
+// (returned to the caller) rather than silently proceeding with a partial
+// snapshot into a destructive apply.
 func (m *Manager) snapshotMembership(ctx context.Context, policies []*Policy) (map[string][]string, error) {
 	snapshot := make(map[string][]string, len(policies))
 	for _, lp := range policies {
-		if !lp.hasCIDRSet() {
-			continue
-		}
-		elements, err := m.runner.ListElements(ctx, lp.Name)
-		if err != nil {
-			return nil, errorx.Decorate(err, "failed to snapshot live membership for policy %q before re-render", lp.Name)
-		}
-		if len(elements) > 0 {
-			snapshot[lp.Name] = elements
+		for _, setName := range cidrSetNames(lp) {
+			elements, err := m.runner.ListElements(ctx, setName)
+			if err != nil {
+				return nil, errorx.Decorate(err, "failed to snapshot live membership for set %q before re-render", setName)
+			}
+			if len(elements) > 0 {
+				snapshot[setName] = elements
+			}
 		}
 	}
 	return snapshot, nil
+}
+
+// cidrSetNames returns the nft set names that hold a policy's CIDR membership:
+// the IPv4 set (the bare policy name) and its IPv6 companion (@<name>6). A
+// --from-entity world policy has no membership set and returns nil.
+func cidrSetNames(p *Policy) []string {
+	if !p.hasCIDRSet() {
+		return nil
+	}
+	return []string{p.Name, V6SetName(p.Name)}
+}
+
+// restoreSet re-adds a set's snapshotted membership after a destructive
+// re-render emptied it. An empty slice is a no-op (the freshly recreated set is
+// already empty). A failure is decorated as "re-run to reconcile" since the
+// kernel is now ahead of disk.
+func (m *Manager) restoreSet(ctx context.Context, setName string, elements []string) error {
+	if len(elements) == 0 {
+		return nil
+	}
+	if err := m.runner.AddElements(ctx, setName, elements); err != nil {
+		return errorx.Decorate(err, "inet weaver chain applied to the kernel but restoring %q membership failed; re-run to reconcile", setName)
+	}
+	return nil
 }
 
 // findByName returns the policy with the given name, or nil.
@@ -300,7 +331,11 @@ func (m *Manager) Add(ctx context.Context, name string, cidrs []string) error {
 		if err := m.requireTableExists(ctx, name); err != nil {
 			return err
 		}
-		return m.runner.AddElements(ctx, name, setElements(p, cidrs))
+		v4, v6 := setElementsByFamily(p, cidrs)
+		if err := m.runner.AddElements(ctx, name, v4); err != nil {
+			return err
+		}
+		return m.runner.AddElements(ctx, V6SetName(name), v6)
 	})
 }
 
@@ -321,7 +356,11 @@ func (m *Manager) Remove(ctx context.Context, name string, cidrs []string) error
 		if err := m.requireTableExists(ctx, name); err != nil {
 			return err
 		}
-		return m.runner.DeleteElements(ctx, name, setElements(p, cidrs))
+		v4, v6 := setElementsByFamily(p, cidrs)
+		if err := m.runner.DeleteElements(ctx, name, v4); err != nil {
+			return err
+		}
+		return m.runner.DeleteElements(ctx, V6SetName(name), v6)
 	})
 }
 
@@ -351,7 +390,14 @@ func (m *Manager) applySet(ctx context.Context, name string, cidrs []string) err
 	if err := m.requireTableExists(ctx, name); err != nil {
 		return err
 	}
-	return m.runner.SetElements(ctx, name, setElements(p, cidrs))
+	// Full-replace each family's set. SetElements flushes then adds, so a family
+	// with no members in cidrs is cleared (not left stale) — required for the
+	// daemon's present/absent reconcile semantics to hold per family.
+	v4, v6 := setElementsByFamily(p, cidrs)
+	if err := m.runner.SetElements(ctx, name, v4); err != nil {
+		return err
+	}
+	return m.runner.SetElements(ctx, V6SetName(name), v6)
 }
 
 // ApplyMembership pushes desired CIDR membership into one or more policies'
@@ -626,16 +672,19 @@ func (m *Manager) showOne(ctx context.Context, p *Policy) (string, error) {
 		return b.String(), nil
 	}
 
-	elements, err := m.runner.ListElements(ctx, p.Name)
-	if err != nil {
-		return "", err
-	}
-	fmt.Fprintf(&b, "  live set @%s:\n", p.Name)
-	if len(elements) == 0 {
-		b.WriteString("    (empty)\n")
-	} else {
-		for _, e := range elements {
-			fmt.Fprintf(&b, "    %s\n", e)
+	// Show both families' live sets (@<name> and @<name>6).
+	for _, setName := range cidrSetNames(p) {
+		elements, err := m.runner.ListElements(ctx, setName)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(&b, "  live set @%s:\n", setName)
+		if len(elements) == 0 {
+			b.WriteString("    (empty)\n")
+		} else {
+			for _, e := range elements {
+				fmt.Fprintf(&b, "    %s\n", e)
+			}
 		}
 	}
 	return b.String(), nil
@@ -698,12 +747,12 @@ func (m *Manager) Delete(ctx context.Context, name string) error {
 			return nil
 		}
 
-		// Recover the pod CIDR from the existing .nft if any remaining policy
+		// Recover the pod CIDR(s) from the existing .nft if any remaining policy
 		// is a --stamp (same pattern as Create).
-		podCIDR := ""
+		var podCIDRs []string
 		if needsPodCIDR(remaining) {
 			if existing, err := os.ReadFile(m.weaverNftPath); err == nil {
-				podCIDR = ExtractPodCIDR(string(existing))
+				podCIDRs = ExtractPodCIDRs(string(existing))
 			}
 		}
 
@@ -715,7 +764,7 @@ func (m *Manager) Delete(ctx context.Context, name string) error {
 			return err
 		}
 
-		doc, err := Render(remaining, podCIDR)
+		doc, err := Render(remaining, podCIDRs...)
 		if err != nil {
 			return err
 		}
@@ -723,18 +772,12 @@ func (m *Manager) Delete(ctx context.Context, name string) error {
 			return err
 		}
 
-		// Restore remaining policies' membership.
+		// Restore remaining policies' membership, both families.
 		for _, lp := range remaining {
-			if !lp.hasCIDRSet() {
-				continue
-			}
-			elements := snapshot[lp.Name]
-			if len(elements) == 0 {
-				continue
-			}
-			if err := m.runner.AddElements(ctx, lp.Name, elements); err != nil {
-				return errorx.Decorate(err,
-					"inet weaver chain re-rendered but restoring %q membership failed; re-run to reconcile", lp.Name)
+			for _, setName := range cidrSetNames(lp) {
+				if err := m.restoreSet(ctx, setName, snapshot[setName]); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/internal/network/policy/manager_apply_membership_test.go
+++ b/internal/network/policy/manager_apply_membership_test.go
@@ -49,8 +49,16 @@ func TestApplyMembership_OnePolicyPerTransactionInSortedOrder(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, applied)
-	// One SetElements transaction per policy, in deterministic sorted name order.
-	require.Equal(t, []string{"bn-partner", "bn-publisher", "bn-restricted"}, r.setElemOrder)
+	// One SetElements transaction per policy PER FAMILY, in deterministic sorted
+	// name order: each policy's IPv4 set (@<name>) then its IPv6 set (@<name>6).
+	// The v6 sets receive an empty (flush-only) transaction here since every
+	// input CIDR is IPv4, which is how the full-replace reconcile clears a stale
+	// v6 member.
+	require.Equal(t, []string{
+		"bn-partner", "bn-partner6",
+		"bn-publisher", "bn-publisher6",
+		"bn-restricted", "bn-restricted6",
+	}, r.setElemOrder)
 }
 
 func TestApplyMembership_FullListReplace(t *testing.T) {
@@ -178,7 +186,7 @@ func TestApplyMembership_IdenticalKernelStateToLoopedSet(t *testing.T) {
 		seedDenyPolicy(t, m, "bn-restricted", nil)
 		_, err := m.Create(context.Background(),
 			&Policy{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
-			nil, "10.4.0.0/24", false)
+			nil, []string{"10.4.0.0/24"}, false)
 		require.NoError(t, err)
 	}
 

--- a/internal/network/policy/manager_apply_ports_test.go
+++ b/internal/network/policy/manager_apply_ports_test.go
@@ -17,7 +17,7 @@ func seedManagedPortsPolicy(t *testing.T, m *Manager, name, stamp string) {
 	t.Helper()
 	_, err := m.Create(context.Background(),
 		&Policy{Name: name, Action: ActionStamp, Stamp: stamp, ManagedPorts: true},
-		nil, "10.4.0.0/24", false)
+		nil, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 }
 

--- a/internal/network/policy/manager_ops_test.go
+++ b/internal/network/policy/manager_ops_test.go
@@ -12,12 +12,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// podCIDRArg wraps a single pod CIDR for Manager.Create's []string parameter,
+// mapping "" to nil so the empty case still triggers .nft pod-CIDR recovery
+// rather than passing a stray empty element.
+func podCIDRArg(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return []string{s}
+}
+
+func TestManager_MembershipRoutesByFamily(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"}, nil, "10.4.0.0/24")
+
+	ctx := context.Background()
+
+	// A mixed v4/v6 Add routes each family to its own set (@name and @name6).
+	require.NoError(t, m.Add(ctx, "bn-publisher", []string{"10.1.0.1/32", "2001:db8::1/128"}))
+	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"])
+	require.Equal(t, []string{"2001:db8::1/128"}, r.elements["bn-publisher6"])
+
+	// Set full-replaces each family independently: a v6-only Set clears the v4
+	// set (present/absent reconcile semantics per family).
+	require.NoError(t, m.Set(ctx, "bn-publisher", []string{"2001:db8::2/128"}))
+	require.Empty(t, r.elements["bn-publisher"])
+	require.Equal(t, []string{"2001:db8::2/128"}, r.elements["bn-publisher6"])
+
+	// Show surfaces both families' live sets.
+	out, err := m.Show(ctx, "bn-publisher")
+	require.NoError(t, err)
+	require.Contains(t, out, "live set @bn-publisher:")
+	require.Contains(t, out, "live set @bn-publisher6:")
+}
+
 // seedPolicy creates a policy via Create and verifies no error.
 func seedPolicy(t *testing.T, m *Manager, name, stamp string, ports []string, cidrs []string, podCIDR string) {
 	t.Helper()
 	_, err := m.Create(context.Background(),
 		&Policy{Name: name, Action: ActionStamp, Stamp: stamp, Ports: ports},
-		cidrs, podCIDR, false)
+		cidrs, podCIDRArg(podCIDR), false)
 	require.NoError(t, err)
 }
 
@@ -25,7 +60,7 @@ func seedDenyPolicy(t *testing.T, m *Manager, name string, cidrs []string) {
 	t.Helper()
 	_, err := m.Create(context.Background(),
 		&Policy{Name: name, Action: ActionDeny},
-		cidrs, "", false)
+		cidrs, nil, false)
 	require.NoError(t, err)
 }
 
@@ -63,7 +98,7 @@ func TestAdd_FromEntityWorldPolicyRejected(t *testing.T) {
 	m, _, _ := newTestManager(t, r)
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-public-out", Action: ActionStamp, Stamp: "public", FromEntityWorld: true, Ports: []string{"40980"}},
-		nil, "10.4.0.0/24", false)
+		nil, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 
 	err = m.Add(context.Background(), "bn-public-out", []string{"10.0.0.1/32"})
@@ -220,7 +255,7 @@ func TestShow_FromEntityWorldPolicy(t *testing.T) {
 	m, _, _ := newTestManager(t, r)
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-public-out", Action: ActionStamp, Stamp: "public", FromEntityWorld: true, Ports: []string{"40980"}},
-		nil, "10.4.0.0/24", false)
+		nil, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 
 	out, err := m.Show(context.Background(), "bn-public-out")
@@ -337,7 +372,7 @@ func TestDelete_CompoundSetPolicy(t *testing.T) {
 	m, _, regDir := newTestManager(t, r)
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
-		[]string{"10.30.5.7:43473"}, "10.4.0.0/24", false)
+		[]string{"10.30.5.7:43473"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 
 	require.NoError(t, m.Delete(context.Background(), "bn-backfill"))
@@ -352,7 +387,7 @@ func TestAdd_CompoundSetPolicy(t *testing.T) {
 	m, _, _ := newTestManager(t, r)
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
-		nil, "10.4.0.0/24", false)
+		nil, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 
 	require.NoError(t, m.Add(context.Background(), "bn-backfill", []string{"10.30.5.7:43473"}))
@@ -365,7 +400,7 @@ func TestSet_CompoundSetPolicy(t *testing.T) {
 	m, _, _ := newTestManager(t, r)
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
-		[]string{"10.30.5.7:43473"}, "10.4.0.0/24", false)
+		[]string{"10.30.5.7:43473"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 
 	require.NoError(t, m.Set(context.Background(), "bn-backfill", []string{"10.30.5.8:43473"}))
@@ -377,7 +412,7 @@ func TestShow_ReplyStampPolicy(t *testing.T) {
 	m, _, _ := newTestManager(t, r)
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-backfill", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
-		[]string{"10.30.5.7:43473"}, "10.4.0.0/24", false)
+		[]string{"10.30.5.7:43473"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 
 	out, err := m.Show(context.Background(), "bn-backfill")

--- a/internal/network/policy/manager_ops_test.go
+++ b/internal/network/policy/manager_ops_test.go
@@ -182,6 +182,27 @@ func TestShow_StampPolicy(t *testing.T) {
 	require.Contains(t, out, "10.1.0.1/32")
 }
 
+func TestShow_Layout_DirectionLeadsAndLiveSetNested(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"},
+		[]string{"10.1.0.1/32"}, "10.4.0.0/24")
+
+	out, err := m.Show(context.Background(), "bn-publisher")
+	require.NoError(t, err)
+
+	// direction is the first field under the policy header (before action).
+	require.Less(t, strings.Index(out, "direction:"), strings.Index(out, "action:"),
+		"direction must be listed before action")
+
+	// The live set is nested inside the policy block: its header is indented two
+	// spaces (same level as action/class/created) and its members four spaces —
+	// not flush-left as a separate top-level section.
+	require.Contains(t, out, "  live set @bn-publisher:\n")
+	require.Contains(t, out, "    10.1.0.1/32\n")
+	require.NotContains(t, out, "\nlive set @", "live set must not be a flush-left top-level section")
+}
+
 func TestShow_DenyPolicy(t *testing.T) {
 	r := newFakeRunner()
 	m, _, _ := newTestManager(t, r)

--- a/internal/network/policy/parse.go
+++ b/internal/network/policy/parse.go
@@ -4,24 +4,32 @@ package policy
 
 import "regexp"
 
-// rePodCIDR matches the literal CIDR every rendered --stamp rule starts with
-// (`ip daddr <PODCIDR> ...` ingress, `ip saddr <PODCIDR> ...` egress/reply-stamp
-// forward -- see renderStampRule). A `\d+\.\d+\.\d+\.\d+/\d+` literal never
-// matches a deny rule's `ip saddr/daddr @<name> drop`, which references a set
-// by name, not an inline CIDR.
-var rePodCIDR = regexp.MustCompile(`ip (?:daddr|saddr) (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{1,2})\b`)
+// rePodCIDR / rePodCIDR6 match the literal CIDR every rendered --stamp rule
+// starts with (`ip daddr <PODCIDR> ...` ingress, `ip saddr <PODCIDR> ...`
+// egress/reply-stamp forward, and the `ip6` variants -- see renderStampRule). An
+// inline-CIDR literal never matches a deny rule's `ip saddr/daddr @<name> drop`,
+// which references a set by name, not an inline CIDR. The v6 pattern deliberately
+// excludes '@' so it never matches a `@<name>6` set reference.
+var (
+	rePodCIDR  = regexp.MustCompile(`ip (?:daddr|saddr) (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{1,2})\b`)
+	rePodCIDR6 = regexp.MustCompile(`ip6 (?:daddr|saddr) ([0-9A-Fa-f:]+/\d{1,3})\b`)
+)
 
-// ExtractPodCIDR recovers the pod CIDR last used to render network-weaver.nft.
-// Mirrors internal/network/firewall's Parse(): it understands only the exact
-// format Render produces, not a general nft parser, and exists so a caller
-// that doesn't supply --pod-cidr (as --deny never does) can still correctly
-// re-render unchanged --stamp siblings using the value they were already
-// rendered with, instead of requiring every call to re-supply or re-detect a
-// value that's effectively a deployment-wide constant. Returns "" if none is
-// found (e.g. a deny-only chain, or the file doesn't exist yet).
-func ExtractPodCIDR(content string) string {
+// ExtractPodCIDRs recovers the pod CIDR(s) last used to render network-weaver.nft
+// (IPv4 first, then IPv6 if present). Mirrors internal/network/firewall's Parse():
+// it understands only the exact format Render produces, not a general nft parser,
+// and exists so a caller that doesn't supply --pod-cidr (as --deny never does)
+// can still correctly re-render unchanged --stamp siblings using the value they
+// were already rendered with, instead of requiring every call to re-supply or
+// re-detect a value that's effectively a deployment-wide constant. Returns nil
+// if none is found (e.g. a deny-only chain, or the file doesn't exist yet).
+func ExtractPodCIDRs(content string) []string {
+	var out []string
 	if m := rePodCIDR.FindStringSubmatch(content); m != nil {
-		return m[1]
+		out = append(out, m[1])
 	}
-	return ""
+	if m := rePodCIDR6.FindStringSubmatch(content); m != nil {
+		out = append(out, m[1])
+	}
+	return out
 }

--- a/internal/network/policy/parse_test.go
+++ b/internal/network/policy/parse_test.go
@@ -8,49 +8,69 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExtractPodCIDR(t *testing.T) {
+func TestExtractPodCIDRs(t *testing.T) {
 	tests := []struct {
 		name string
 		doc  string
-		want string
+		want []string
 	}{
 		{
 			name: "ingress rule",
 			doc:  "ip daddr 10.4.0.0/24 ip saddr @bn-publisher tcp dport @bn-publisher_ports meta priority set 0x10010 accept",
-			want: "10.4.0.0/24",
+			want: []string{"10.4.0.0/24"},
 		},
 		{
 			name: "egress rule",
 			doc:  "ip saddr 10.4.0.0/24 ip daddr @bn-partner-out tcp sport @bn-partner-out_ports meta priority set 0x10040 accept",
-			want: "10.4.0.0/24",
+			want: []string{"10.4.0.0/24"},
 		},
 		{
 			name: "compound reply-stamp forward rule",
 			doc:  "ip saddr 10.4.0.0/24 ip daddr . tcp dport @bn-backfill ct mark set 0x20 meta priority set 0x10060 accept",
-			want: "10.4.0.0/24",
+			want: []string{"10.4.0.0/24"},
+		},
+		{
+			name: "dual-stack recovers both families",
+			doc:  "ip saddr 10.4.0.0/24 ip daddr @bn-partner-out meta priority set 0x10040 accept\nip6 saddr 2001:db8:c0de::/64 ip6 daddr @bn-partner-out6 meta priority set 0x10040 accept",
+			want: []string{"10.4.0.0/24", "2001:db8:c0de::/64"},
+		},
+		{
+			name: "v6-only egress rule",
+			doc:  "ip6 saddr 2001:db8:c0de::/64 ip6 daddr @bn-partner-out6 meta priority set 0x10040 accept",
+			want: []string{"2001:db8:c0de::/64"},
+		},
+		{
+			name: "v6 set reference must not be mistaken for a pod CIDR",
+			doc:  "ip6 saddr @bn-restricted6 drop\nip6 daddr @bn-restricted6 drop",
+			want: nil,
 		},
 		{
 			name: "deny-only chain has no literal CIDR to recover",
 			doc:  "ip saddr @bn-restricted drop\nip daddr @bn-restricted drop",
-			want: "",
+			want: nil,
 		},
 		{
 			name: "empty document",
 			doc:  "",
-			want: "",
+			want: nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, ExtractPodCIDR(tt.doc))
+			require.Equal(t, tt.want, ExtractPodCIDRs(tt.doc))
 		})
 	}
 }
 
-func TestExtractPodCIDR_FromGoldenFile(t *testing.T) {
+func TestExtractPodCIDRs_FromGoldenFile(t *testing.T) {
 	// The real render output must round-trip: whatever Render/renderStampRule
 	// wrote for the sample BN install set must be recoverable byte-for-byte.
 	doc, err := Render(sampleBNPolicies(), "10.4.0.0/24")
 	require.NoError(t, err)
-	require.Equal(t, "10.4.0.0/24", ExtractPodCIDR(doc))
+	require.Equal(t, []string{"10.4.0.0/24"}, ExtractPodCIDRs(doc))
+
+	// Dual-stack: both families round-trip out of the rendered chain.
+	dual, err := Render(sampleBNPolicies(), "10.4.0.0/24", "2001:db8:c0de::/64")
+	require.NoError(t, err)
+	require.Equal(t, []string{"10.4.0.0/24", "2001:db8:c0de::/64"}, ExtractPodCIDRs(dual))
 }

--- a/internal/network/policy/policy.go
+++ b/internal/network/policy/policy.go
@@ -4,6 +4,7 @@ package policy
 
 import (
 	"net"
+	"net/netip"
 	"sort"
 	"strings"
 	"time"
@@ -160,8 +161,10 @@ func (p *Policy) validateDeny() error {
 }
 
 // validateCIDRs checks the initial membership entries against the set type the
-// policy renders: compound ip:port keys for a --reply-stamp policy (matching a
-// `ipv4_addr . inet_service` set), plain IPv4 CIDRs otherwise.
+// policy renders: compound ip:port keys for a --reply-stamp policy (matching an
+// `ipv4_addr . inet_service` / `ipv6_addr . inet_service` set), plain CIDRs
+// otherwise. Both address families are accepted; each entry is routed to the
+// policy's v4 (@name) or v6 (@name6) set by family at render/apply time.
 func (p *Policy) validateCIDRs(cidrs []string) error {
 	for _, c := range cidrs {
 		if p.isCompoundSet() {
@@ -173,13 +176,18 @@ func (p *Policy) validateCIDRs(cidrs []string) error {
 		if err := sanity.ValidateCIDR(c); err != nil {
 			return errorx.IllegalArgument.Wrap(err, "invalid --cidrs entry %q", c)
 		}
-		if ip, _, _ := net.ParseCIDR(c); ip.To4() == nil {
-			return errorx.IllegalArgument.New(
-				"invalid --cidrs entry %q: IPv6 is not yet supported; the inet weaver sets use ipv4_addr", c)
-		}
 	}
 	return nil
 }
+
+// V6SetName returns the IPv6 companion set name for a policy (or its compound
+// set): the base policy name with a "6" suffix. The IPv4 set keeps the bare
+// policy name so the on-disk registry and existing element tooling are
+// unchanged; the v6 set is the parallel ipv6_addr(. inet_service) set the
+// dual-stack renderer declares. The renderer, the Manager's apply/snapshot
+// paths, and the traffic-shaper daemon all derive the v6 set name through this
+// one function so render, diff, and apply can never disagree on the spelling.
+func V6SetName(name string) string { return name + "6" }
 
 // isCompoundSet reports whether the policy's nft set is a compound
 // `ipv4_addr . inet_service` key set — true only for --reply-stamp policies,
@@ -205,10 +213,10 @@ func (p *Policy) hasPortsSet() bool {
 func validateIPPort(s string) error {
 	host, port, err := net.SplitHostPort(s)
 	if err != nil {
-		return errorx.IllegalArgument.New("invalid --cidrs entry %q: --reply-stamp policies require ip:port pairs", s)
+		return errorx.IllegalArgument.New("invalid --cidrs entry %q: --reply-stamp policies require ip:port pairs (bracket IPv6 hosts, e.g. [2001:db8::1]:443)", s)
 	}
-	if ip := net.ParseIP(host); ip == nil || ip.To4() == nil {
-		return errorx.IllegalArgument.New("invalid --cidrs entry %q: %q is not an IPv4 address", s, host)
+	if ip := net.ParseIP(host); ip == nil {
+		return errorx.IllegalArgument.New("invalid --cidrs entry %q: %q is not an IP address", s, host)
 	}
 	if err := sanity.ValidatePort(port); err != nil {
 		return errorx.IllegalArgument.Wrap(err, "invalid --cidrs entry %q", s)
@@ -216,22 +224,53 @@ func validateIPPort(s string) error {
 	return nil
 }
 
-// setElements converts initial --cidrs entries into nft element tokens for the
-// policy's set: `<ip> . <port>` compound keys for --reply-stamp policies, plain
-// CIDRs otherwise. The input is assumed already validated, so the compound
-// conversion's error (only possible on a malformed ip:port) cannot fire here;
-// it shares CompoundElement so the CLI apply path and the daemon poll loop's
-// diff render compound elements identically.
-func setElements(p *Policy, cidrs []string) []string {
-	if !p.isCompoundSet() {
-		return cidrs
+// elementToken renders one --cidrs entry into its nft set element token and
+// reports its address family, so the caller can route it to the policy's IPv4
+// (@name) or IPv6 (@name6) set. Compound (--reply-stamp) entries are ip:port
+// pairs converted through CompoundElement; plain entries are CIDRs passed
+// through as-is. Input is assumed already validated.
+func elementToken(p *Policy, cidr string) (token string, isV6 bool, err error) {
+	if p.isCompoundSet() {
+		tok, err := CompoundElement(cidr)
+		if err != nil {
+			return "", false, err
+		}
+		host, _, splitErr := net.SplitHostPort(cidr)
+		if splitErr != nil {
+			return "", false, errorx.IllegalArgument.Wrap(splitErr, "invalid ip:port %q", cidr)
+		}
+		addr, addrErr := netip.ParseAddr(host)
+		if addrErr != nil {
+			return "", false, errorx.IllegalArgument.New("invalid ip:port %q: %q is not an IP address", cidr, host)
+		}
+		return tok, addr.Is6() && !addr.Is4In6(), nil
 	}
-	out := make([]string, 0, len(cidrs))
+	isV6, err = sanity.CIDRIsIPv6(cidr)
+	if err != nil {
+		return "", false, err
+	}
+	return cidr, isV6, nil
+}
+
+// setElementsByFamily converts initial --cidrs entries into nft element tokens,
+// partitioned by address family so each lands in the policy's IPv4 (@name) or
+// IPv6 (@name6) set. The input is assumed already validated, so a token
+// conversion error (only possible on a malformed entry) cannot fire here; it
+// shares CompoundElement so the CLI apply path and the daemon poll loop's diff
+// render compound elements identically.
+func setElementsByFamily(p *Policy, cidrs []string) (v4, v6 []string) {
 	for _, c := range cidrs {
-		tok, _ := CompoundElement(c)
-		out = append(out, tok)
+		tok, isV6, err := elementToken(p, c)
+		if err != nil {
+			continue
+		}
+		if isV6 {
+			v6 = append(v6, tok)
+		} else {
+			v4 = append(v4, tok)
+		}
 	}
-	return out
+	return v4, v6
 }
 
 // portElements returns the --ports values joined for an nft `elements = { … }`

--- a/internal/network/policy/policy_test.go
+++ b/internal/network/policy/policy_test.go
@@ -5,6 +5,7 @@ package policy
 import (
 	"context"
 	"errors"
+	"flag"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+// update regenerates the golden .nft fixtures instead of comparing against
+// them: `go test ./internal/network/policy/... -update`. Review the diff before
+// committing a regenerated golden.
+var update = flag.Bool("update", false, "regenerate golden testdata files")
 
 // fakeRunner is an in-memory Runner for tests: it records the applied document
 // and the elements added per set without touching the kernel. Apply clears
@@ -135,9 +141,36 @@ func TestRender_GoldenMatchesBNInstallSet(t *testing.T) {
 	doc, err := Render(sampleBNPolicies(), "10.4.0.0/24")
 	require.NoError(t, err)
 
-	want, err := os.ReadFile("testdata/network-weaver.golden.nft")
+	goldenPath := "testdata/network-weaver.golden.nft"
+	if *update {
+		require.NoError(t, os.WriteFile(goldenPath, []byte(doc), 0o644))
+	}
+	want, err := os.ReadFile(goldenPath)
 	require.NoError(t, err)
-	require.Equal(t, string(want), doc, "render drifted from golden; if intentional, regenerate testdata/network-weaver.golden.nft")
+	require.Equal(t, string(want), doc, "render drifted from golden; if intentional, regenerate with -update")
+}
+
+// TestRender_DualStackGolden pins the dual-stack render: the same BN install set
+// with both an IPv4 and an IPv6 pod CIDR. It asserts the v6 sets and `ip6` rules
+// appear alongside their v4 counterparts.
+func TestRender_DualStackGolden(t *testing.T) {
+	doc, err := Render(sampleBNPolicies(), "10.4.0.0/24", "2001:db8:c0de::/64")
+	require.NoError(t, err)
+
+	goldenPath := "testdata/network-weaver-dualstack.golden.nft"
+	if *update {
+		require.NoError(t, os.WriteFile(goldenPath, []byte(doc), 0o644))
+	}
+	want, err := os.ReadFile(goldenPath)
+	require.NoError(t, err)
+	require.Equal(t, string(want), doc, "dual-stack render drifted from golden; if intentional, regenerate with -update")
+
+	// Spot-check the key v6 constructs are present.
+	require.Contains(t, doc, "set bn-publisher6 { type ipv6_addr; flags interval; }")
+	require.Contains(t, doc, "set bn-backfill6 { type ipv6_addr . inet_service; }")
+	require.Contains(t, doc, "ip6 saddr @bn-restricted6 drop")
+	require.Contains(t, doc, "ip6 daddr 2001:db8:c0de::/64 ip6 saddr @bn-publisher6")
+	require.Contains(t, doc, "ip6 saddr 2001:db8:c0de::/64 accept")
 }
 
 func TestRender_DeterministicRegardlessOfInputOrder(t *testing.T) {
@@ -232,7 +265,7 @@ func TestCreate_PersistsAndSeedsMembership(t *testing.T) {
 	m, nftPath, regDir := newTestManager(t, r)
 	p := &Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}}
 
-	changed, err := m.Create(context.Background(), p, []string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+	changed, err := m.Create(context.Background(), p, []string{"10.1.0.1/32"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 	require.True(t, changed)
 
@@ -253,7 +286,7 @@ func TestCreate_ExistingWithoutForceIsNoOp(t *testing.T) {
 
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
-		[]string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+		[]string{"10.1.0.1/32"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 	require.Equal(t, 1, r.applyCount)
 
@@ -261,7 +294,7 @@ func TestCreate_ExistingWithoutForceIsNoOp(t *testing.T) {
 	// matching internal/network/firewall's create-if-missing convention.
 	changed, err := m.Create(context.Background(),
 		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840", "50000"}},
-		[]string{"10.1.0.2/32"}, "10.4.0.0/24", false)
+		[]string{"10.1.0.2/32"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 	require.False(t, changed, "an existing policy without --force must not change")
 	require.Equal(t, 1, r.applyCount, "no --force on an existing policy must never re-render")
@@ -274,14 +307,14 @@ func TestCreate_ForceReplacesConfigAndMembership(t *testing.T) {
 
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-mgmt-in", Action: ActionStamp, Stamp: "reserve-ingress", Ports: []string{"40983"}, CreatedAt: fixedTime()},
-		[]string{"10.0.0.0/8"}, "10.4.0.0/24", false)
+		[]string{"10.0.0.0/8"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 
 	// --force with a changed port set and a different --cidrs: re-renders,
 	// replaces (not merges) membership, and keeps the original created_at.
 	changed, err := m.Create(context.Background(),
 		&Policy{Name: "bn-mgmt-in", Action: ActionStamp, Stamp: "reserve-ingress", Ports: []string{"40983", "40984"}},
-		[]string{"192.168.0.0/16"}, "10.4.0.0/24", true)
+		[]string{"192.168.0.0/16"}, []string{"10.4.0.0/24"}, true)
 	require.NoError(t, err)
 	require.True(t, changed)
 
@@ -303,12 +336,12 @@ func TestCreate_ForceWithoutCIDRsClearsMembership(t *testing.T) {
 
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
-		[]string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+		[]string{"10.1.0.1/32"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 
 	_, err = m.Create(context.Background(),
 		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
-		nil, "10.4.0.0/24", true)
+		nil, []string{"10.4.0.0/24"}, true)
 	require.NoError(t, err)
 	require.Empty(t, r.elements["bn-publisher"], "--force without --cidrs replaces membership with nothing")
 }
@@ -319,7 +352,7 @@ func TestCreate_PreservesSiblingMembershipAcrossRerender(t *testing.T) {
 
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
-		[]string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+		[]string{"10.1.0.1/32"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"])
 
@@ -329,7 +362,7 @@ func TestCreate_PreservesSiblingMembershipAcrossRerender(t *testing.T) {
 	// rendered rule.
 	_, err = m.Create(context.Background(),
 		&Policy{Name: "bn-partner-out", Action: ActionStamp, Stamp: "partner", Ports: []string{"40980"}},
-		[]string{"10.20.0.0/16"}, "10.4.0.0/24", false)
+		[]string{"10.20.0.0/16"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"10.1.0.1/32"}, r.elements["bn-publisher"],
@@ -343,7 +376,7 @@ func TestCreate_SelfHealsMissingTableWithoutForce(t *testing.T) {
 
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
-		[]string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+		[]string{"10.1.0.1/32"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 	require.Equal(t, 1, r.applyCount)
 
@@ -358,7 +391,7 @@ func TestCreate_SelfHealsMissingTableWithoutForce(t *testing.T) {
 	// persisted), so it comes back empty.
 	changed, err := m.Create(context.Background(),
 		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840", "50000"}},
-		[]string{"10.1.0.99/32"}, "10.4.0.0/24", false)
+		[]string{"10.1.0.99/32"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err, "a missing table must be restored, not error")
 	require.True(t, changed)
 	require.Equal(t, 2, r.applyCount, "the table must be re-rendered when the kernel table is missing")
@@ -376,14 +409,14 @@ func TestCreate_SnapshotFailureAbortsBeforeApply(t *testing.T) {
 
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
-		[]string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+		[]string{"10.1.0.1/32"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 	require.Equal(t, 1, r.applyCount)
 
 	r.listElemErr = errors.New("nft: permission denied")
 	_, err = m.Create(context.Background(),
 		&Policy{Name: "bn-partner-out", Action: ActionStamp, Stamp: "partner", Ports: []string{"40980"}},
-		nil, "10.4.0.0/24", false)
+		nil, []string{"10.4.0.0/24"}, false)
 	require.ErrorContains(t, err, "failed to snapshot live membership")
 	require.Equal(t, 1, r.applyCount, "a snapshot failure must abort before the kernel is touched")
 }
@@ -393,7 +426,7 @@ func TestCreate_DenyDoesNotRequirePodCIDR(t *testing.T) {
 	m, _, _ := newTestManager(t, r)
 
 	changed, err := m.Create(context.Background(),
-		&Policy{Name: "bn-restricted", Action: ActionDeny}, []string{"10.99.0.0/16"}, "", false)
+		&Policy{Name: "bn-restricted", Action: ActionDeny}, []string{"10.99.0.0/16"}, nil, false)
 	require.NoError(t, err, "a deny-only policy must not require a pod CIDR")
 	require.True(t, changed)
 	require.Equal(t, []string{"10.99.0.0/16"}, r.elements["bn-restricted"])
@@ -405,7 +438,7 @@ func TestCreate_DenyRecoversPodCIDRFromExistingNftFile(t *testing.T) {
 
 	_, err := m.Create(context.Background(),
 		&Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}},
-		nil, "10.4.0.0/24", false)
+		nil, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 
 	// bn-restricted's own --deny rule never needs a pod CIDR, but the merged
@@ -413,13 +446,20 @@ func TestCreate_DenyRecoversPodCIDRFromExistingNftFile(t *testing.T) {
 	// passed here: it must be recovered from network-weaver.nft instead of
 	// erroring, mirroring internal/network/firewall's Parse().
 	changed, err := m.Create(context.Background(),
-		&Policy{Name: "bn-restricted", Action: ActionDeny}, []string{"10.99.0.0/16"}, "", false)
+		&Policy{Name: "bn-restricted", Action: ActionDeny}, []string{"10.99.0.0/16"}, nil, false)
 	require.NoError(t, err, "must recover the pod CIDR from the existing network-weaver.nft artifact")
 	require.True(t, changed)
 
 	doc, err := os.ReadFile(nftPath)
 	require.NoError(t, err)
 	require.Contains(t, string(doc), "10.4.0.0/24", "bn-publisher's rule must still be rendered with the recovered pod CIDR")
+
+	// A slice carrying only an empty string (e.g. Cobra StringSlice from
+	// `--pod-cidr ""`) must be normalized away so recovery still fires, rather
+	// than being treated as one explicit-but-empty pod CIDR that fails Render.
+	_, err = m.Create(context.Background(),
+		&Policy{Name: "bn-partner-out", Action: ActionDeny}, []string{"10.88.0.0/16"}, []string{""}, false)
+	require.NoError(t, err, "an empty --pod-cidr entry must not defeat pod-CIDR recovery")
 }
 
 func TestCreate_StampSiblingStillRequiresPodCIDRWhenNftFileMissing(t *testing.T) {
@@ -434,14 +474,14 @@ func TestCreate_StampSiblingStillRequiresPodCIDRWhenNftFileMissing(t *testing.T)
 	}))
 
 	_, err := m.Create(context.Background(),
-		&Policy{Name: "bn-restricted", Action: ActionDeny}, []string{"10.99.0.0/16"}, "", false)
+		&Policy{Name: "bn-restricted", Action: ActionDeny}, []string{"10.99.0.0/16"}, nil, false)
 	require.ErrorContains(t, err, "pod CIDR is required")
 }
 
 func TestCreate_UnknownClassRejected(t *testing.T) {
 	r := newFakeRunner()
 	m, _, _ := newTestManager(t, r)
-	_, err := m.Create(context.Background(), &Policy{Name: "bad", Action: ActionStamp, Stamp: "nonexistent"}, nil, "10.4.0.0/24", false)
+	_, err := m.Create(context.Background(), &Policy{Name: "bad", Action: ActionStamp, Stamp: "nonexistent"}, nil, []string{"10.4.0.0/24"}, false)
 	require.ErrorContains(t, err, "unknown class")
 	require.Empty(t, r.applied, "invalid policy must never reach the kernel")
 }
@@ -456,7 +496,7 @@ func TestCreate_CorruptSiblingRegistryRejected(t *testing.T) {
 	bad := `{"name":"bn-bad","action":"stamp","stamp":"retired-class","direction":"","ports":null,"from_entity_world":false}`
 	require.NoError(t, os.WriteFile(filepath.Join(regDir, "bn-bad.json"), []byte(bad), 0o644))
 
-	_, err := m.Create(context.Background(), &Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}}, nil, "10.4.0.0/24", false)
+	_, err := m.Create(context.Background(), &Policy{Name: "bn-publisher", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}}, nil, []string{"10.4.0.0/24"}, false)
 	require.ErrorContains(t, err, "corrupt policy registry entry")
 	require.Empty(t, r.applied, "a corrupt sibling entry must fail before the kernel is touched")
 }
@@ -468,13 +508,13 @@ func TestCreate_OverlappingSpecificPoliciesRejected(t *testing.T) {
 	// publisher and reserve-ingress are both DirectionIngress; same --ports
 	// makes the two policies claim the same (Direction, Ports) group.
 	a := &Policy{Name: "bn-a", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}}
-	changed, err := m.Create(context.Background(), a, []string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+	changed, err := m.Create(context.Background(), a, []string{"10.1.0.1/32"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 	require.True(t, changed)
 	firstApplyCount := r.applyCount
 
 	b := &Policy{Name: "bn-b", Action: ActionStamp, Stamp: "reserve-ingress", Ports: []string{"40840"}}
-	_, err = m.Create(context.Background(), b, []string{"10.1.0.2/32"}, "10.4.0.0/24", false)
+	_, err = m.Create(context.Background(), b, []string{"10.1.0.2/32"}, []string{"10.4.0.0/24"}, false)
 	require.ErrorContains(t, err, "overlaps with existing policy")
 
 	require.Equal(t, firstApplyCount, r.applyCount, "a rejected overlap must never reach the kernel")
@@ -486,12 +526,12 @@ func TestCreate_OverlapCheckExcludesSelfOnForce(t *testing.T) {
 	m, _, _ := newTestManager(t, r)
 
 	a := &Policy{Name: "bn-a", Action: ActionStamp, Stamp: "publisher", Ports: []string{"40840"}}
-	_, err := m.Create(context.Background(), a, []string{"10.1.0.1/32"}, "10.4.0.0/24", false)
+	_, err := m.Create(context.Background(), a, []string{"10.1.0.1/32"}, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 
 	// Re-creating the SAME name with --force must not trip the overlap check
 	// against its own prior registry entry.
-	changed, err := m.Create(context.Background(), a, []string{"10.1.0.2/32"}, "10.4.0.0/24", true)
+	changed, err := m.Create(context.Background(), a, []string{"10.1.0.2/32"}, []string{"10.4.0.0/24"}, true)
 	require.NoError(t, err)
 	require.True(t, changed)
 }
@@ -501,11 +541,11 @@ func TestCreate_FromEntityWorldNotSubjectToOverlapCheck(t *testing.T) {
 	m, _, _ := newTestManager(t, r)
 
 	a := &Policy{Name: "bn-a", Action: ActionStamp, Stamp: "public", FromEntityWorld: true, Ports: []string{"9000"}}
-	_, err := m.Create(context.Background(), a, nil, "10.4.0.0/24", false)
+	_, err := m.Create(context.Background(), a, nil, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err)
 
 	b := &Policy{Name: "bn-b", Action: ActionStamp, Stamp: "reserve-egress", FromEntityWorld: true, Ports: []string{"9000"}}
-	changed, err := m.Create(context.Background(), b, nil, "10.4.0.0/24", false)
+	changed, err := m.Create(context.Background(), b, nil, []string{"10.4.0.0/24"}, false)
 	require.NoError(t, err, "fallthrough policies sharing direction+ports are not overlap-checked")
 	require.True(t, changed)
 

--- a/internal/network/policy/render.go
+++ b/internal/network/policy/render.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
 	"github.com/joomcode/errorx"
 )
 
@@ -31,8 +32,9 @@ import (
 //  5. unclassified pod egress                (structural; only when podCIDR is set)
 //  6. ct state established,related accept   (structural)
 //  7. drop                                   (structural)
-func Render(policies []*Policy, podCIDR string) (string, error) {
-	if podCIDR == "" && needsPodCIDR(policies) {
+func Render(policies []*Policy, podCIDRs ...string) (string, error) {
+	podV4, podV6 := partitionPodCIDRs(podCIDRs)
+	if podV4 == "" && podV6 == "" && needsPodCIDR(policies) {
 		return "", errorx.IllegalArgument.New("pod CIDR is required to render a --stamp policy in the inet weaver chain")
 	}
 
@@ -48,7 +50,7 @@ func Render(policies []*Policy, podCIDR string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	chainLines, err := renderChain(policies, podCIDR)
+	chainLines, err := renderChain(policies, podV4, podV6)
 	if err != nil {
 		return "", err
 	}
@@ -84,6 +86,39 @@ func needsPodCIDR(policies []*Policy) bool {
 	return false
 }
 
+// nonEmptyStrings returns in with empty entries removed, allocating a fresh
+// slice so the caller's argument is untouched.
+func nonEmptyStrings(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// partitionPodCIDRs splits the supplied pod CIDRs into one IPv4 and one IPv6
+// value by family (the last of each family wins), ignoring empties. A dual-stack
+// deployment supplies both, so the chain renders both `ip` and `ip6` stamp/egress
+// rules; a single-stack one supplies one and the other family's rules are simply
+// not rendered (its v6/v4 set stays declared but unreferenced). A value that
+// fails classification is treated as v4 so a stamp chain still renders rather
+// than silently dropping the pod scope.
+func partitionPodCIDRs(podCIDRs []string) (v4, v6 string) {
+	for _, c := range podCIDRs {
+		if c == "" {
+			continue
+		}
+		if isV6, err := sanity.CIDRIsIPv6(c); err == nil && isV6 {
+			v6 = c
+		} else {
+			v4 = c
+		}
+	}
+	return v4, v6
+}
+
 // sortedByName returns a name-sorted copy of policies, leaving the input
 // slice untouched.
 func sortedByName(policies []*Policy) []*Policy {
@@ -102,10 +137,15 @@ func renderSetDecls(policies []*Policy) ([]string, error) {
 	for _, p := range policies {
 		if p.hasCIDRSet() {
 			if p.isCompoundSet() {
-				// Compound ip:port key for --reply-stamp destinations.
-				lines = append(lines, fmt.Sprintf("\tset %s { type ipv4_addr . inet_service; }", p.Name))
+				// Compound ip:port key for --reply-stamp destinations, one set
+				// per family (the v6 set carries the "6"-suffixed name).
+				lines = append(lines,
+					fmt.Sprintf("\tset %s { type ipv4_addr . inet_service; }", p.Name),
+					fmt.Sprintf("\tset %s { type ipv6_addr . inet_service; }", V6SetName(p.Name)))
 			} else {
-				lines = append(lines, fmt.Sprintf("\tset %s { type ipv4_addr; flags interval; }", p.Name))
+				lines = append(lines,
+					fmt.Sprintf("\tset %s { type ipv4_addr; flags interval; }", p.Name),
+					fmt.Sprintf("\tset %s { type ipv6_addr; flags interval; }", V6SetName(p.Name)))
 			}
 		}
 		if len(p.Ports) > 0 {
@@ -126,19 +166,21 @@ func renderSetDecls(policies []*Policy) ([]string, error) {
 
 // renderChain builds the forward chain body lines (indented two tabs), grouped
 // into the seven tiers above.
-func renderChain(policies []*Policy, podCIDR string) ([]string, error) {
+func renderChain(policies []*Policy, podV4, podV6 string) ([]string, error) {
 	lines := []string{
 		"\t\ttype filter hook forward priority 0; policy drop;",
 		"\t\tct state invalid drop",
 	}
 
-	// Tier 1: quarantine drops.
+	// Tier 1: quarantine drops, both families.
 	var deny []string
 	for _, p := range policies {
 		if p.Action == ActionDeny {
 			deny = append(deny,
 				fmt.Sprintf("\t\tip saddr @%s drop", p.Name),
-				fmt.Sprintf("\t\tip daddr @%s drop", p.Name))
+				fmt.Sprintf("\t\tip daddr @%s drop", p.Name),
+				fmt.Sprintf("\t\tip6 saddr @%s drop", V6SetName(p.Name)),
+				fmt.Sprintf("\t\tip6 daddr @%s drop", V6SetName(p.Name)))
 		}
 	}
 	if len(deny) > 0 {
@@ -188,18 +230,18 @@ func renderChain(policies []*Policy, podCIDR string) ([]string, error) {
 
 	var specific, fallthr []string
 	for _, p := range specificPolicies {
-		rule, err := renderStampRule(p, podCIDR)
+		rules, err := renderStampRule(p, podV4, podV6)
 		if err != nil {
 			return nil, err
 		}
-		specific = append(specific, rule)
+		specific = append(specific, rules...)
 	}
 	for _, p := range fallthrPolicies {
-		rule, err := renderStampRule(p, podCIDR)
+		rules, err := renderStampRule(p, podV4, podV6)
 		if err != nil {
 			return nil, err
 		}
-		fallthr = append(fallthr, rule)
+		fallthr = append(fallthr, rules...)
 	}
 	if len(specific) > 0 {
 		lines = append(lines, "", "\t\t# Classification — specific matches.")
@@ -218,10 +260,15 @@ func renderChain(policies []*Policy, podCIDR string) ([]string, error) {
 	// doesn't otherwise classify (e.g. the chart's Maven-based plugin
 	// resolution), so it falls to the HTB default class instead of one of
 	// the classified priority bands.
-	if podCIDR != "" {
+	if podV4 != "" || podV6 != "" {
 		lines = append(lines, "",
-			"\t\t# Unclassified pod egress (no meta priority; HTB default class).",
-			fmt.Sprintf("\t\tip saddr %s accept", podCIDR))
+			"\t\t# Unclassified pod egress (no meta priority; HTB default class).")
+		if podV4 != "" {
+			lines = append(lines, fmt.Sprintf("\t\tip saddr %s accept", podV4))
+		}
+		if podV6 != "" {
+			lines = append(lines, fmt.Sprintf("\t\tip6 saddr %s accept", podV6))
+		}
 	}
 
 	lines = append(lines, "",
@@ -275,41 +322,76 @@ func renderReplyRestoreRule(p *Policy) (string, error) {
 		hex(reply.Mark), hex(reply.Priority)), nil
 }
 
-// renderStampRule renders a single stamp policy's classification rule for its
+// renderStampRule renders a stamp policy's classification rule(s) for its
 // direction, honoring --from-entity world (no IP-set clause) and --reply-stamp
-// (compound-key egress forward rule with a ct mark write).
-func renderStampRule(p *Policy, podCIDR string) (string, error) {
+// (compound-key egress forward rule with a ct mark write). It emits one rule per
+// pod-CIDR family supplied: an `ip` rule (against @<name>) when podV4 is set and
+// an `ip6` rule (against @<name>6) when podV6 is set, so a dual-stack deployment
+// classifies both families and a single-stack one renders only its family.
+func renderStampRule(p *Policy, podV4, podV6 string) ([]string, error) {
 	fwd, err := lookupClass(p.Stamp)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
+
+	var rules []string
 
 	if p.isCompoundSet() {
 		// --reply-stamp forward rule: egress, compound ip:port destination key,
-		// ct mark write for the reply restore to read back.
+		// ct mark write for the reply restore to read back. One per pod family.
 		reply, err := lookupClass(p.ReplyStamp)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		return fmt.Sprintf("\t\tip saddr %s ip daddr . tcp dport @%s ct mark set %s meta priority set %s accept",
-			podCIDR, p.Name, hex(reply.Mark), hex(fwd.Priority)), nil
+		if podV4 != "" {
+			rules = append(rules, fmt.Sprintf("\t\tip saddr %s ip daddr . tcp dport @%s ct mark set %s meta priority set %s accept",
+				podV4, p.Name, hex(reply.Mark), hex(fwd.Priority)))
+		}
+		if podV6 != "" {
+			rules = append(rules, fmt.Sprintf("\t\tip6 saddr %s ip6 daddr . tcp dport @%s ct mark set %s meta priority set %s accept",
+				podV6, V6SetName(p.Name), hex(reply.Mark), hex(fwd.Priority)))
+		}
+		return rules, nil
 	}
 
+	if podV4 != "" {
+		rule, err := renderPlainStampRule(p, podV4, "ip", p.Name, fwd)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, rule)
+	}
+	if podV6 != "" {
+		rule, err := renderPlainStampRule(p, podV6, "ip6", V6SetName(p.Name), fwd)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, rule)
+	}
+	return rules, nil
+}
+
+// renderPlainStampRule renders one address family's plain stamp classification
+// rule. proto is the nft L3 keyword ("ip" or "ip6"); setName is that family's
+// membership set (@<name> or @<name>6). The listener-ports set is a shared
+// family-agnostic inet_service set, so it is referenced by the same @<name>_ports
+// name in both families.
+func renderPlainStampRule(p *Policy, podCIDR, proto, setName string, fwd class) (string, error) {
 	var b strings.Builder
 	b.WriteString("\t\t")
 	switch p.Direction {
 	case DirectionIngress:
-		b.WriteString("ip daddr " + podCIDR)
+		b.WriteString(proto + " daddr " + podCIDR)
 		if p.hasCIDRSet() {
-			b.WriteString(" ip saddr @" + p.Name)
+			b.WriteString(" " + proto + " saddr @" + setName)
 		}
 		if p.hasPortsSet() {
 			b.WriteString(" tcp dport @" + PortsSetName(p.Name))
 		}
 	case DirectionEgress:
-		b.WriteString("ip saddr " + podCIDR)
+		b.WriteString(proto + " saddr " + podCIDR)
 		if p.hasCIDRSet() {
-			b.WriteString(" ip daddr @" + p.Name)
+			b.WriteString(" " + proto + " daddr @" + setName)
 		}
 		if p.hasPortsSet() {
 			b.WriteString(" tcp sport @" + PortsSetName(p.Name))

--- a/internal/network/policy/render_weaver.go
+++ b/internal/network/policy/render_weaver.go
@@ -14,12 +14,12 @@ import (
 // (mode 0644). If the on-disk content is already identical (SHA-256 match)
 // the write is skipped — making it safe to call from idempotent install flows.
 //
-// podCIDR is required only when at least one registered policy is a --stamp
-// policy. If the caller passes "" and the existing weaverNftPath is readable,
-// the pod CIDR is recovered from that file automatically — the same recovery
-// path Manager.Create uses. An error is returned only when a stamp policy is
-// present and no podCIDR can be resolved.
-func RenderWeaverNft(registryDir, weaverNftPath, podCIDR string) error {
+// podCIDRs (mixed IPv4/IPv6) are required only when at least one registered
+// policy is a --stamp policy. If the caller passes none and the existing
+// weaverNftPath is readable, the pod CIDRs are recovered from that file
+// automatically — the same recovery path Manager.Create uses. An error is
+// returned only when a stamp policy is present and no podCIDR can be resolved.
+func RenderWeaverNft(registryDir, weaverNftPath string, podCIDRs ...string) error {
 	policies, err := loadAll(registryDir)
 	if err != nil {
 		return err
@@ -47,13 +47,17 @@ func RenderWeaverNft(registryDir, weaverNftPath, podCIDR string) error {
 		}
 	}
 
-	if podCIDR == "" && needsPodCIDR(policies) {
+	// Drop empty entries so a caller passing a single "" (the common
+	// "recover from the existing file" invocation) still triggers recovery
+	// rather than being treated as one explicit-but-empty pod CIDR.
+	podCIDRs = nonEmptyStrings(podCIDRs)
+	if len(podCIDRs) == 0 && needsPodCIDR(policies) {
 		if existing, readErr := os.ReadFile(weaverNftPath); readErr == nil {
-			podCIDR = ExtractPodCIDR(string(existing))
+			podCIDRs = ExtractPodCIDRs(string(existing))
 		}
 	}
 
-	doc, err := Render(policies, podCIDR)
+	doc, err := Render(policies, podCIDRs...)
 	if err != nil {
 		return errorx.Decorate(err, "failed to render %s", weaverNftPath)
 	}

--- a/internal/network/policy/render_weaver_test.go
+++ b/internal/network/policy/render_weaver_test.go
@@ -122,7 +122,7 @@ func TestRenderWeaverNft_RecoversPodCIDRFromExistingFile(t *testing.T) {
 	out := filepath.Join(dir, "network-weaver.nft")
 
 	// Seed the output file with content that embeds the pod CIDR so
-	// ExtractPodCIDR can recover it when podCIDR="" is passed.
+	// ExtractPodCIDRs can recover it when no pod CIDR is passed.
 	const podCIDR = "10.244.0.0/16"
 	require.NoError(t, os.WriteFile(out, []byte("ip daddr "+podCIDR+" placeholder\n"), 0o644))
 

--- a/internal/network/policy/testdata/network-weaver-dualstack.golden.nft
+++ b/internal/network/policy/testdata/network-weaver-dualstack.golden.nft
@@ -32,15 +32,21 @@ table inet weaver {
 
 		# Classification — specific matches.
 		ip saddr 10.4.0.0/24 ip daddr . tcp dport @bn-backfill ct mark set 0x20 meta priority set 0x10060 accept
+		ip6 saddr 2001:db8:c0de::/64 ip6 daddr . tcp dport @bn-backfill6 ct mark set 0x20 meta priority set 0x10060 accept
 		ip saddr 10.4.0.0/24 ip daddr @bn-partner-out tcp sport @bn-partner-out_ports meta priority set 0x10040 accept
+		ip6 saddr 2001:db8:c0de::/64 ip6 daddr @bn-partner-out6 tcp sport @bn-partner-out_ports meta priority set 0x10040 accept
 		ip daddr 10.4.0.0/24 ip saddr @bn-publisher tcp dport @bn-publisher_ports meta priority set 0x10010 accept
+		ip6 daddr 2001:db8:c0de::/64 ip6 saddr @bn-publisher6 tcp dport @bn-publisher_ports meta priority set 0x10010 accept
 
 		# Classification — fallthrough (any source/dest).
 		ip saddr 10.4.0.0/24 tcp sport @bn-public-out_ports meta priority set 0x10050 accept
+		ip6 saddr 2001:db8:c0de::/64 tcp sport @bn-public-out_ports meta priority set 0x10050 accept
 		ip daddr 10.4.0.0/24 tcp dport @bn-subscriber-in_ports meta priority set 0x10030 accept
+		ip6 daddr 2001:db8:c0de::/64 tcp dport @bn-subscriber-in_ports meta priority set 0x10030 accept
 
 		# Unclassified pod egress (no meta priority; HTB default class).
 		ip saddr 10.4.0.0/24 accept
+		ip6 saddr 2001:db8:c0de::/64 accept
 
 		ct state established,related accept
 		drop

--- a/internal/network/policy/validate_test.go
+++ b/internal/network/policy/validate_test.go
@@ -97,10 +97,22 @@ func TestValidate(t *testing.T) {
 			wantErr: "invalid --cidrs entry",
 		},
 		{
-			name:    "ipv6 cidr rejected",
+			name:    "ipv6 cidr accepted (dual-stack)",
 			policy:  &Policy{Name: "x", Action: ActionStamp, Stamp: "publisher"},
 			cidrs:   []string{"2001:db8::/32"},
-			wantErr: "IPv6 is not yet supported",
+			wantErr: "",
+		},
+		{
+			name:    "mixed v4/v6 cidrs accepted",
+			policy:  &Policy{Name: "x", Action: ActionStamp, Stamp: "publisher"},
+			cidrs:   []string{"10.1.0.0/16", "2001:db8::/32"},
+			wantErr: "",
+		},
+		{
+			name:    "reply-stamp accepts bracketed ipv6 ip:port",
+			policy:  &Policy{Name: "x", Action: ActionStamp, Stamp: "reserve-egress", ReplyStamp: "backfill-response"},
+			cidrs:   []string{"[2001:db8::7]:443"},
+			wantErr: "",
 		},
 		{
 			name:    "reply-stamp cidr without port rejected",

--- a/internal/network/shape/defaults.go
+++ b/internal/network/shape/defaults.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/joomcode/errorx"
+)
+
+// defaultClassSpec describes one HTB class in a default shaping profile as
+// proportions of the device trunk rate. rate is always ratePct% of the trunk;
+// ceil is either ceilPct% of the trunk, or — when ceilFull is set — the trunk
+// rate verbatim (preserving the operator's original unit, e.g. "1gbit" rather
+// than "1000mbit").
+type defaultClassSpec struct {
+	name     string
+	ratePct  int
+	ceilPct  int
+	ceilFull bool
+	prio     int
+}
+
+// defaultProfile is the default device root + class set for one direction.
+type defaultProfile struct {
+	dir          string
+	defaultClass string
+	classes      []defaultClassSpec
+}
+
+// egressProfile: three egress classes at partner 40%/70%, public 30%/70%,
+// reserve-egress 30%/100%.
+var egressProfile = defaultProfile{
+	dir:          DirEgress,
+	defaultClass: "reserve-egress",
+	classes: []defaultClassSpec{
+		{name: "partner", ratePct: 40, ceilPct: 70, prio: 0},
+		{name: "public", ratePct: 30, ceilPct: 70, prio: 5},
+		{name: "reserve-egress", ratePct: 30, ceilFull: true, prio: 1},
+	},
+}
+
+// ingressProfile: three ingress classes at publisher 80%, backfill-response
+// 10%, reserve-ingress 10%; all ceil 100% of trunk.
+var ingressProfile = defaultProfile{
+	dir:          DirIngress,
+	defaultClass: "reserve-ingress",
+	classes: []defaultClassSpec{
+		{name: "publisher", ratePct: 80, ceilFull: true, prio: 0},
+		{name: "backfill-response", ratePct: 10, ceilFull: true, prio: 7},
+		{name: "reserve-ingress", ratePct: 10, ceilFull: true, prio: 1},
+	},
+}
+
+// buildDefaultConfig materialises a profile against a concrete trunkRate,
+// returning the device root and per-class configs with rates/ceils computed
+// from the trunk. All records share a single CreatedAt. Exposed as a
+// package-internal helper so tests can verify the computation without disk I/O.
+func buildDefaultConfig(p defaultProfile, trunkRate string) (*DeviceConfig, []*ClassConfig, error) {
+	bps, err := parseBandwidthBps(trunkRate)
+	if err != nil {
+		return nil, nil, errorx.IllegalArgument.Wrap(err, "invalid trunk rate %q", trunkRate)
+	}
+	mbps := bps / 1_000_000
+	now := time.Now().UTC()
+	dev := &DeviceConfig{
+		Dir:          p.dir,
+		Rate:         trunkRate,
+		DefaultClass: p.defaultClass,
+		CreatedAt:    now,
+	}
+	classes := make([]*ClassConfig, 0, len(p.classes))
+	for _, c := range p.classes {
+		ceil := trunkRate
+		if !c.ceilFull {
+			ceil = fmt.Sprintf("%dmbit", mbps*int64(c.ceilPct)/100)
+		}
+		classes = append(classes, &ClassConfig{
+			Name:      c.name,
+			Rate:      fmt.Sprintf("%dmbit", mbps*int64(c.ratePct)/100),
+			Ceil:      ceil,
+			Prio:      c.prio,
+			CreatedAt: now,
+		})
+	}
+	return dev, classes, nil
+}
+
+// defaultEgressConfig returns the egress device root and three default egress
+// classes at proportions derived from trunkRate (partner 40%/70%, public
+// 30%/70%, reserve-egress 30%/100%).
+func defaultEgressConfig(trunkRate string) (*DeviceConfig, []*ClassConfig, error) {
+	return buildDefaultConfig(egressProfile, trunkRate)
+}
+
+// defaultIngressConfig returns the ingress device root and three default
+// ingress classes at proportions derived from trunkRate (publisher 80%,
+// backfill-response 10%, reserve-ingress 10%; all ceil 100% of trunk).
+func defaultIngressConfig(trunkRate string) (*DeviceConfig, []*ClassConfig, error) {
+	return buildDefaultConfig(ingressProfile, trunkRate)
+}

--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -144,15 +144,7 @@ func (m *Manager) CreateClass(ctx context.Context, cls *ClassConfig, force bool)
 	if err != nil {
 		return false, err
 	}
-	if err := validateRate(cls.Rate); err != nil {
-		return false, err
-	}
-	if cls.Ceil != "" {
-		if err := validateCeilGeRate(cls.Ceil, cls.Rate); err != nil {
-			return false, err
-		}
-	}
-	if err := validatePrio(cls.Prio); err != nil {
+	if err := validateClassFields(cls.Rate, cls.Ceil, cls.Prio); err != nil {
 		return false, err
 	}
 
@@ -233,15 +225,7 @@ func (m *Manager) SetClass(ctx context.Context, name string, rate, ceil *string,
 		}
 
 		// Validate the updated state.
-		if err := validateRate(cls.Rate); err != nil {
-			return err
-		}
-		if cls.Ceil != "" {
-			if err := validateCeilGeRate(cls.Ceil, cls.Rate); err != nil {
-				return err
-			}
-		}
-		if err := validatePrio(cls.Prio); err != nil {
+		if err := validateClassFields(cls.Rate, cls.Ceil, cls.Prio); err != nil {
 			return err
 		}
 
@@ -663,41 +647,16 @@ func (m *Manager) persistEgressScript(nic string) error {
 	return m.writeEgressScript(rendered)
 }
 
-// defaultEgressConfig returns the device root and three default egress classes
-// at proportions derived from trunkRate (partner 40%/70%, public 30%/70%,
-// reserve-egress 30%/100%). Exposed as a package-internal helper so tests can
-// verify the computation without disk I/O.
-func defaultEgressConfig(trunkRate string) (*DeviceConfig, []*ClassConfig, error) {
-	bps, err := parseBandwidthBps(trunkRate)
-	if err != nil {
-		return nil, nil, errorx.IllegalArgument.Wrap(err, "invalid trunk rate %q", trunkRate)
-	}
-	mbps := bps / 1_000_000
-	now := time.Now().UTC()
-	dev := &DeviceConfig{
-		Dir:          DirEgress,
-		Rate:         trunkRate,
-		DefaultClass: "reserve-egress",
-		CreatedAt:    now,
-	}
-	classes := []*ClassConfig{
-		{Name: "partner", Rate: fmt.Sprintf("%dmbit", mbps*40/100), Ceil: fmt.Sprintf("%dmbit", mbps*70/100), Prio: 0, CreatedAt: now},
-		{Name: "public", Rate: fmt.Sprintf("%dmbit", mbps*30/100), Ceil: fmt.Sprintf("%dmbit", mbps*70/100), Prio: 5, CreatedAt: now},
-		{Name: "reserve-egress", Rate: fmt.Sprintf("%dmbit", mbps*30/100), Ceil: trunkRate, Prio: 1, CreatedAt: now},
-	}
-	return dev, classes, nil
-}
-
-// ProvisionDefaultEgress configures the egress device root and three default
-// HTB classes at proportions derived from trunkRate (partner 40%/70%, public
-// 30%/70%, reserve-egress 30%/100%), then renders and applies the boot script.
-// trunkRate may be "auto", which is resolved to the detected link speed at
-// create time (see resolveAutoRateString). Existing configs are always
-// replaced. Called by block node install so the shape registry is the single
-// source of truth from first install.
-func (m *Manager) ProvisionDefaultEgress(ctx context.Context, nicName, trunkRate string, overrides map[string]ClassOverride) error {
+// provisionDefaults resolves trunkRate (possibly "auto"), materialises the
+// profile's device + class set with any --shape overrides merged in, validates
+// the merged set against the trunk budget, and writes device + all classes
+// under a single lock. afterWrite, when non-nil, runs inside the same lock
+// after the writes (egress renders and applies the boot script; ingress writes
+// config only). Shared by ProvisionDefaultEgress and ProvisionDefaultIngress so
+// the two directions cannot drift.
+func (m *Manager) provisionDefaults(prof defaultProfile, trunkRate string, overrides map[string]ClassOverride, afterWrite func() error) error {
 	trunkRate = m.resolveAutoRateString(trunkRate)
-	dev, classes, err := defaultEgressConfig(trunkRate)
+	dev, classes, err := buildDefaultConfig(prof, trunkRate)
 	if err != nil {
 		return err
 	}
@@ -714,15 +673,24 @@ func (m *Manager) ProvisionDefaultEgress(ctx context.Context, nicName, trunkRate
 				return err
 			}
 		}
-		return m.renderAndApplyScript(ctx, nicName)
+		if afterWrite != nil {
+			return afterWrite()
+		}
+		return nil
 	})
 }
 
-// RenderAndApplyEgress renders the tc-egress boot script for nic from stored
-// shape config (if available) or the sysfs auto-detect default, then installs
-// and restarts tc-egress.service. Idempotent.
-func (m *Manager) RenderAndApplyEgress(ctx context.Context, nic string) error {
-	return m.renderAndApplyScript(ctx, nic)
+// ProvisionDefaultEgress configures the egress device root and three default
+// HTB classes at proportions derived from trunkRate (partner 40%/70%, public
+// 30%/70%, reserve-egress 30%/100%), then renders and applies the boot script.
+// trunkRate may be "auto", which is resolved to the detected link speed at
+// create time (see resolveAutoRateString). Existing configs are always
+// replaced. Called by block node install so the shape registry is the single
+// source of truth from first install.
+func (m *Manager) ProvisionDefaultEgress(ctx context.Context, nicName, trunkRate string, overrides map[string]ClassOverride) error {
+	return m.provisionDefaults(egressProfile, trunkRate, overrides, func() error {
+		return m.renderAndApplyScript(ctx, nicName)
+	})
 }
 
 // ProvisionDefaultEgressShape configures the egress shape registry with the
@@ -731,32 +699,6 @@ func (m *Manager) RenderAndApplyEgress(ctx context.Context, nic string) error {
 // script. Convenience wrapper over NewManager().ProvisionDefaultEgress.
 func ProvisionDefaultEgressShape(ctx context.Context, nicName, trunkRate string, overrides map[string]ClassOverride) error {
 	return NewManager().ProvisionDefaultEgress(ctx, nicName, trunkRate, overrides)
-}
-
-// defaultIngressConfig returns the ingress device root and three default ingress
-// classes at proportions derived from trunkRate (publisher 80%, backfill-response
-// 10%, reserve-ingress 10%; all ceil 100% of trunk). Mirrors defaultEgressConfig;
-// exposed as a package-internal helper so tests can verify the computation
-// without disk I/O.
-func defaultIngressConfig(trunkRate string) (*DeviceConfig, []*ClassConfig, error) {
-	bps, err := parseBandwidthBps(trunkRate)
-	if err != nil {
-		return nil, nil, errorx.IllegalArgument.Wrap(err, "invalid trunk rate %q", trunkRate)
-	}
-	mbps := bps / 1_000_000
-	now := time.Now().UTC()
-	dev := &DeviceConfig{
-		Dir:          DirIngress,
-		Rate:         trunkRate,
-		DefaultClass: "reserve-ingress",
-		CreatedAt:    now,
-	}
-	classes := []*ClassConfig{
-		{Name: "publisher", Rate: fmt.Sprintf("%dmbit", mbps*80/100), Ceil: trunkRate, Prio: 0, CreatedAt: now},
-		{Name: "backfill-response", Rate: fmt.Sprintf("%dmbit", mbps*10/100), Ceil: trunkRate, Prio: 7, CreatedAt: now},
-		{Name: "reserve-ingress", Rate: fmt.Sprintf("%dmbit", mbps*10/100), Ceil: trunkRate, Prio: 1, CreatedAt: now},
-	}
-	return dev, classes, nil
 }
 
 // ProvisionDefaultIngress records the ingress ($VETH) device root and three
@@ -770,26 +712,7 @@ func defaultIngressConfig(trunkRate string) (*DeviceConfig, []*ClassConfig, erro
 // finds concrete ingress config on the first pod create (the per-pod replay has
 // no sysfs fallback, so the recorded rates must always be concrete).
 func (m *Manager) ProvisionDefaultIngress(_ context.Context, trunkRate string, overrides map[string]ClassOverride) error {
-	trunkRate = m.resolveAutoRateString(trunkRate)
-	dev, classes, err := defaultIngressConfig(trunkRate)
-	if err != nil {
-		return err
-	}
-	applyClassOverrides(classes, overrides)
-	if err := validateProvisionedClasses(classes, dev.Rate); err != nil {
-		return err
-	}
-	return m.withLock(func() error {
-		if err := writeDevice(dev); err != nil {
-			return err
-		}
-		for _, cls := range classes {
-			if err := writeClass(cls); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
+	return m.provisionDefaults(ingressProfile, trunkRate, overrides, nil)
 }
 
 // ProvisionDefaultIngressShape records the ingress shape registry with the three
@@ -810,7 +733,7 @@ func ProvisionDefaultIngressShape(ctx context.Context, nicName, trunkRate string
 // Used when no trunk rate is supplied (e.g. block node reconfigure without
 // --link-rate).
 func RenderAndApplyDefaultEgress(ctx context.Context, nic string) error {
-	return NewManager().RenderAndApplyEgress(ctx, nic)
+	return NewManager().renderAndApplyScript(ctx, nic)
 }
 
 // withLock serialises a mutation behind a cross-command flock so concurrent

--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -122,7 +122,7 @@ func (m *Manager) CreateDevice(ctx context.Context, dev *DeviceConfig, force boo
 			return err
 		}
 		if dev.Dir == DirEgress {
-			if err := m.renderAndApplyEgress(ctx); err != nil {
+			if err := m.applyEgressScript(ctx, "", applyRestart); err != nil {
 				return err
 			}
 		}
@@ -186,7 +186,7 @@ func (m *Manager) CreateClass(ctx context.Context, cls *ClassConfig, force bool)
 			return err
 		}
 		if ci.Dir == DirEgress {
-			if err := m.renderAndApplyEgress(ctx); err != nil {
+			if err := m.applyEgressScript(ctx, "", applyRestart); err != nil {
 				return err
 			}
 		}
@@ -258,8 +258,9 @@ func (m *Manager) SetClass(ctx context.Context, name string, rate, ceil *string,
 			}
 			// Persist the boot script for reboot without restarting the service:
 			// the live tc class change above already updated the kernel, and a
-			// restart would tear down and rebuild the root qdisc.
-			if err := m.persistEgressScript(nic); err != nil {
+			// restart would tear down and rebuild the root qdisc. Reuse the NIC
+			// detected above rather than re-detecting.
+			if err := m.applyEgressScript(ctx, nic, applyPersistOnly); err != nil {
 				return errorx.Decorate(err,
 					"live tc class change applied but boot script re-render failed; reboot may revert the change")
 			}
@@ -405,7 +406,7 @@ func (m *Manager) DeleteClass(ctx context.Context, name string) error {
 			return err
 		}
 		if ci.Dir == DirEgress {
-			if err := m.renderAndApplyEgress(ctx); err != nil {
+			if err := m.applyEgressScript(ctx, "", applyRestart); err != nil {
 				return errorx.Decorate(err,
 					"class config deleted but boot script re-render failed; restart tc-egress.service to sync")
 			}
@@ -446,7 +447,7 @@ func (m *Manager) DeleteDevice(ctx context.Context, dir string) error {
 		}
 		if dir == DirEgress {
 			// Re-render with default (empty) egress config.
-			if err := m.renderAndApplyEgress(ctx); err != nil {
+			if err := m.applyEgressScript(ctx, "", applyRestart); err != nil {
 				return errorx.Decorate(err,
 					"device config deleted but boot script re-render failed; restart tc-egress.service to sync")
 			}
@@ -482,11 +483,11 @@ func (m *Manager) TeardownEgress(ctx context.Context) error {
 		}
 		// Re-render an unshape boot script (delete root qdisc, re-add nothing) and
 		// apply it so both the boot script and the live kernel hierarchy are reset
-		// to unshaped. This must NOT go through renderAndApplyEgress: with the
-		// device/class registry now empty, that path falls through to the default
-		// shaping render and would re-apply the stock HTB hierarchy instead of
-		// removing it.
-		if err := m.renderAndApplyUnshapeEgress(ctx); err != nil {
+		// to unshaped. applyUnshape (not applyRestart) is required: with the
+		// device/class registry now empty, the normal render falls through to the
+		// default shaping render and would re-apply the stock HTB hierarchy instead
+		// of removing it.
+		if err := m.applyEgressScript(ctx, "", applyUnshape); err != nil {
 			return errorx.Decorate(err,
 				"egress shape config removed but boot script re-render failed; restart tc-egress.service to sync")
 		}
@@ -536,45 +537,84 @@ func (m *Manager) resolveAutoRate(dev *DeviceConfig) {
 	dev.Rate = m.resolveAutoRateString(dev.Rate)
 }
 
-// renderAndApplyEgress detects the egress NIC, re-renders the boot script from
-// stored config (or the default if no device config exists), and applies via
-// service restart.
-func (m *Manager) renderAndApplyEgress(ctx context.Context) error {
-	nic, err := m.nicDetect()
-	if err != nil {
-		return errorx.Decorate(err, "cannot re-render tc-egress script: egress NIC detection failed")
-	}
-	return m.renderAndApplyScript(ctx, nic)
-}
+// egressApplyMode selects what applyEgressScript does after (re-)rendering the
+// tc-egress boot script. It turns the "restart vs no-restart vs direct
+// qdisc-del" reasoning — previously scattered across four near-synonymous
+// methods — into one explicit decision.
+type egressApplyMode int
 
-// renderAndApplyUnshapeEgress renders the teardown-only (unshape) boot script for
-// the detected egress NIC, persists it, drops the live HTB hierarchy directly,
-// and restarts the tc-egress oneshot so the on-disk state matches. Used
-// exclusively by TeardownEgress — the registry is already empty at that point, so
-// the normal render would re-apply default shaping instead of removing it.
+const (
+	// applyRestart writes the freshly rendered boot script and restarts the
+	// tc-egress oneshot so the kernel replays the full HTB hierarchy. Used by
+	// structural mutations (device/class create or delete), where a full
+	// re-apply is the correct way to reach the new state.
+	applyRestart egressApplyMode = iota
+
+	// applyPersistOnly writes the boot script for reboot persistence WITHOUT
+	// restarting the service. Used by `set`, whose live `tc class change` has
+	// already updated the running kernel: restarting the oneshot would run the
+	// boot script, which deletes and re-adds the root qdisc — reintroducing
+	// exactly the qdisc teardown a live update is meant to avoid.
+	applyPersistOnly
+
+	// applyUnshape writes a teardown-only boot script (delete the root qdisc,
+	// re-add nothing) and drops the live HTB hierarchy directly via the tc
+	// runner. Used by TeardownEgress: the registry is empty at that point, so a
+	// normal render would fall through to the default-shaping render and
+	// re-apply the stock hierarchy instead of removing it. The direct
+	// `tc qdisc del dev <nic> root` makes teardown immediate and deterministic
+	// rather than relying on the (now unshape) boot script re-running via a
+	// restart — the boot script's job is to ADD the hierarchy, so restarting to
+	// REMOVE it would be indirect. The unshape script keeps the NIC unshaped
+	// across reboots.
+	applyUnshape
+)
+
+// applyEgressScript (re-)renders the tc-egress boot script and reconciles it
+// with the live kernel according to mode. It is the single egress apply path,
+// replacing the former renderAndApplyEgress / renderAndApplyScript /
+// persistEgressScript / renderAndApplyUnshapeEgress tangle.
 //
-// The live root qdisc is deleted directly via the tc runner rather than relying
-// solely on the systemd oneshot re-running the (now unshape) boot script: the
-// boot script's job is to ADD the hierarchy, so using a service restart to REMOVE
-// it is indirect. A direct `tc qdisc del dev <nic> root` makes the teardown
-// immediate and deterministic; the unshape boot script written above keeps the
-// NIC unshaped across reboots.
-func (m *Manager) renderAndApplyUnshapeEgress(ctx context.Context) error {
-	nic, err := m.nicDetect()
-	if err != nil {
-		return errorx.Decorate(err, "cannot re-render tc-egress script: egress NIC detection failed")
+// nic is the target egress interface. When empty it is auto-detected (the
+// operator-verb path: create/delete). Callers that already hold the NIC pass it
+// explicitly to avoid a redundant detection — `block node install` passing the
+// operator-chosen --egress-interface, and `set` reusing the NIC it detected for
+// the live `tc class change`.
+func (m *Manager) applyEgressScript(ctx context.Context, nic string, mode egressApplyMode) error {
+	if nic == "" {
+		var err error
+		if nic, err = m.nicDetect(); err != nil {
+			return errorx.Decorate(err, "cannot re-render tc-egress script: egress NIC detection failed")
+		}
 	}
-	rendered, err := renderTcEgressUnshapeScript(nic)
+
+	// applyUnshape renders a teardown-only script; every other mode renders from
+	// the current registry (or the sysfs-detect default when no device exists).
+	var rendered string
+	var err error
+	if mode == applyUnshape {
+		rendered, err = renderTcEgressUnshapeScript(nic)
+	} else {
+		rendered, err = m.renderEgressScript(nic)
+	}
 	if err != nil {
 		return err
 	}
 	if err := m.writeEgressScript(rendered); err != nil {
 		return err
 	}
-	// Drop the live hierarchy now, independent of systemd. Best-effort: a NIC with
-	// no root qdisc is not an error (see TCRunner.QdiscDelRoot).
-	if err := m.tcRunner.QdiscDelRoot(ctx, nic); err != nil {
-		return errorx.Decorate(err, "failed to delete live tc-egress root qdisc on %s", nic)
+
+	switch mode {
+	case applyPersistOnly:
+		// Live `tc class change` already applied by the caller; the boot script is
+		// now persisted for reboot. A restart would churn the root qdisc, so skip it.
+		return nil
+	case applyUnshape:
+		// Drop the live hierarchy now, independent of systemd. Best-effort: a NIC
+		// with no root qdisc is not an error (see TCRunner.QdiscDelRoot).
+		if err := m.tcRunner.QdiscDelRoot(ctx, nic); err != nil {
+			return errorx.Decorate(err, "failed to delete live tc-egress root qdisc on %s", nic)
+		}
 	}
 	return m.applyEgress(ctx)
 }
@@ -619,34 +659,6 @@ func (m *Manager) writeEgressScript(rendered string) error {
 	return atomicWriteFile(m.scriptPath, rendered, 0o755)
 }
 
-// renderAndApplyScript renders the boot script, persists it, and restarts the
-// tc-egress oneshot so the kernel replays the full hierarchy. Used by mutations
-// that change the qdisc structure (create/delete of a device or class), where a
-// full re-apply is the correct way to reach the new state.
-func (m *Manager) renderAndApplyScript(ctx context.Context, nic string) error {
-	rendered, err := m.renderEgressScript(nic)
-	if err != nil {
-		return err
-	}
-	if err := m.writeEgressScript(rendered); err != nil {
-		return err
-	}
-	return m.applyEgress(ctx)
-}
-
-// persistEgressScript renders and writes the boot script for reboot persistence
-// WITHOUT restarting the service. Used by `set`, whose live `tc class change`
-// has already updated the running kernel: restarting the oneshot would run the
-// boot script, which deletes and re-adds the root qdisc — reintroducing exactly
-// the qdisc teardown a live update is meant to avoid.
-func (m *Manager) persistEgressScript(nic string) error {
-	rendered, err := m.renderEgressScript(nic)
-	if err != nil {
-		return err
-	}
-	return m.writeEgressScript(rendered)
-}
-
 // provisionDefaults resolves trunkRate (possibly "auto"), materialises the
 // profile's device + class set with any --shape overrides merged in, validates
 // the merged set against the trunk budget, and writes device + all classes
@@ -689,7 +701,7 @@ func (m *Manager) provisionDefaults(prof defaultProfile, trunkRate string, overr
 // source of truth from first install.
 func (m *Manager) ProvisionDefaultEgress(ctx context.Context, nicName, trunkRate string, overrides map[string]ClassOverride) error {
 	return m.provisionDefaults(egressProfile, trunkRate, overrides, func() error {
-		return m.renderAndApplyScript(ctx, nicName)
+		return m.applyEgressScript(ctx, nicName, applyRestart)
 	})
 }
 
@@ -733,7 +745,7 @@ func ProvisionDefaultIngressShape(ctx context.Context, nicName, trunkRate string
 // Used when no trunk rate is supplied (e.g. block node reconfigure without
 // --link-rate).
 func RenderAndApplyDefaultEgress(ctx context.Context, nic string) error {
-	return NewManager().renderAndApplyScript(ctx, nic)
+	return NewManager().applyEgressScript(ctx, nic, applyRestart)
 }
 
 // withLock serialises a mutation behind a cross-command flock so concurrent

--- a/internal/network/shape/override.go
+++ b/internal/network/shape/override.go
@@ -49,17 +49,6 @@ func ValidateClassOverride(name string, o ClassOverride) error {
 	return nil
 }
 
-// ClassDirection returns the tc device direction ("ingress" or "egress") a
-// class belongs to, so callers can route a --shape override to the device it
-// applies to. Unknown class names return an error naming the known classes.
-func ClassDirection(name string) (string, error) {
-	info, err := lookupClassInfo(name)
-	if err != nil {
-		return "", err
-	}
-	return info.Dir, nil
-}
-
 // applyClassOverrides merges overrides into the matching classes by name,
 // leaving unmatched classes and unset override fields at their profile
 // defaults. Overrides naming a class not in classes (e.g. an egress class when
@@ -91,15 +80,7 @@ func applyClassOverrides(classes []*ClassConfig, overrides map[string]ClassOverr
 // budget.
 func validateProvisionedClasses(classes []*ClassConfig, deviceRate string) error {
 	for _, c := range classes {
-		if err := validateRate(c.Rate); err != nil {
-			return errorx.Decorate(err, "invalid rate for class %q", c.Name)
-		}
-		if c.Ceil != "" {
-			if err := validateCeilGeRate(c.Ceil, c.Rate); err != nil {
-				return errorx.Decorate(err, "class %q", c.Name)
-			}
-		}
-		if err := validatePrio(c.Prio); err != nil {
+		if err := validateClassFields(c.Rate, c.Ceil, c.Prio); err != nil {
 			return errorx.Decorate(err, "class %q", c.Name)
 		}
 	}
@@ -107,15 +88,7 @@ func validateProvisionedClasses(classes []*ClassConfig, deviceRate string) error
 	if err != nil {
 		return nil // device rate unparseable (legacy expression): skip the sum check
 	}
-	var sum int64
-	for _, c := range classes {
-		bps, err := parseBandwidthBps(c.Rate)
-		if err != nil {
-			continue
-		}
-		sum += bps
-	}
-	if sum > deviceBps {
+	if sum := sumParseableRatesBps(classes); sum > deviceBps {
 		return errorx.IllegalArgument.New(
 			"total class rates (%d bit) exceed the device root rate %s (%d bit) after --shape overrides; lower a --shape rate or raise --link-rate",
 			sum, deviceRate, deviceBps)

--- a/internal/network/shape/registry.go
+++ b/internal/network/shape/registry.go
@@ -22,60 +22,51 @@ func classPath(name string) string {
 	return filepath.Join(ClassConfigDir, name+".json")
 }
 
-// writeDevice atomically writes the device config JSON.
-func writeDevice(dev *DeviceConfig) error {
-	if err := os.MkdirAll(DeviceConfigDir, 0o755); err != nil {
-		return errorx.ExternalError.Wrap(err, "failed to create device config dir %s", DeviceConfigDir)
+// writeConfigJSON atomically writes v as indented JSON to path, first creating
+// its parent directory. Shared by writeDevice/writeClass.
+func writeConfigJSON(path string, v any) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return errorx.ExternalError.Wrap(err, "failed to create config dir %s", dir)
 	}
-	data, err := json.MarshalIndent(dev, "", "  ")
+	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		return errorx.InternalError.Wrap(err, "failed to marshal device config %q", dev.Dir)
+		return errorx.InternalError.Wrap(err, "failed to marshal config %s", path)
 	}
-	return atomicWriteFile(devicePath(dev.Dir), string(data)+"\n", 0o644)
+	return atomicWriteFile(path, string(data)+"\n", 0o644)
 }
 
-// writeClass atomically writes the class config JSON.
-func writeClass(cls *ClassConfig) error {
-	if err := os.MkdirAll(ClassConfigDir, 0o755); err != nil {
-		return errorx.ExternalError.Wrap(err, "failed to create class config dir %s", ClassConfigDir)
-	}
-	data, err := json.MarshalIndent(cls, "", "  ")
-	if err != nil {
-		return errorx.InternalError.Wrap(err, "failed to marshal class config %q", cls.Name)
-	}
-	return atomicWriteFile(classPath(cls.Name), string(data)+"\n", 0o644)
-}
-
-// readDevice loads a device config by dir, returning nil if not found.
-func readDevice(dir string) (*DeviceConfig, error) {
-	data, err := os.ReadFile(devicePath(dir))
+// readConfigJSON loads a *T from path, returning (nil, nil) when the file does
+// not exist. Shared by readDevice/readClass.
+func readConfigJSON[T any](path string) (*T, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, errorx.ExternalError.Wrap(err, "failed to read device config %s", devicePath(dir))
+		return nil, errorx.ExternalError.Wrap(err, "failed to read config %s", path)
 	}
-	var dev DeviceConfig
-	if err := json.Unmarshal(data, &dev); err != nil {
-		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse device config %s", devicePath(dir))
+	var v T
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse config %s", path)
 	}
-	return &dev, nil
+	return &v, nil
+}
+
+// writeDevice atomically writes the device config JSON.
+func writeDevice(dev *DeviceConfig) error { return writeConfigJSON(devicePath(dev.Dir), dev) }
+
+// writeClass atomically writes the class config JSON.
+func writeClass(cls *ClassConfig) error { return writeConfigJSON(classPath(cls.Name), cls) }
+
+// readDevice loads a device config by dir, returning nil if not found.
+func readDevice(dir string) (*DeviceConfig, error) {
+	return readConfigJSON[DeviceConfig](devicePath(dir))
 }
 
 // readClass loads a class config by name, returning nil if not found.
 func readClass(name string) (*ClassConfig, error) {
-	data, err := os.ReadFile(classPath(name))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, errorx.ExternalError.Wrap(err, "failed to read class config %s", classPath(name))
-	}
-	var cls ClassConfig
-	if err := json.Unmarshal(data, &cls); err != nil {
-		return nil, errorx.IllegalFormat.Wrap(err, "failed to parse class config %s", classPath(name))
-	}
-	return &cls, nil
+	return readConfigJSON[ClassConfig](classPath(name))
 }
 
 // loadClassesForDir loads all class configs for the given direction, sorted by
@@ -115,23 +106,20 @@ func loadClassesForDir(dir string) ([]*ClassConfig, error) {
 	return classes, nil
 }
 
-// removeClass deletes a class config file, ignoring not-found.
-func removeClass(name string) error {
-	err := os.Remove(classPath(name))
-	if err != nil && !os.IsNotExist(err) {
-		return errorx.ExternalError.Wrap(err, "failed to remove class config %s", classPath(name))
+// removeConfigFile deletes path, ignoring not-found. Shared by
+// removeDevice/removeClass.
+func removeConfigFile(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return errorx.ExternalError.Wrap(err, "failed to remove config %s", path)
 	}
 	return nil
 }
 
+// removeClass deletes a class config file, ignoring not-found.
+func removeClass(name string) error { return removeConfigFile(classPath(name)) }
+
 // removeDevice deletes a device config file, ignoring not-found.
-func removeDevice(dir string) error {
-	err := os.Remove(devicePath(dir))
-	if err != nil && !os.IsNotExist(err) {
-		return errorx.ExternalError.Wrap(err, "failed to remove device config %s", devicePath(dir))
-	}
-	return nil
-}
+func removeDevice(dir string) error { return removeConfigFile(devicePath(dir)) }
 
 // policyStampRef is a minimal representation of a policy registry entry used
 // only to check stamp references when deleting a shape class. Avoids importing

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -120,7 +120,7 @@ func TestRenderTcEgressUnshapeScript(t *testing.T) {
 // systemd), writes the unshape boot script for reboot persistence, and triggers
 // the apply. This is the runtime half of the fix for TeardownEgress leaving the
 // NIC shaped.
-func TestRenderAndApplyUnshapeEgress_DeletesLiveRootAndPersists(t *testing.T) {
+func TestApplyEgressScript_Unshape_DeletesLiveRootAndPersists(t *testing.T) {
 	tc := &recordingTCRunner{}
 	scriptPath := filepath.Join(t.TempDir(), "tc-egress.sh")
 	applied := false
@@ -133,8 +133,8 @@ func TestRenderAndApplyUnshapeEgress_DeletesLiveRootAndPersists(t *testing.T) {
 		ApplyEgress: func(_ context.Context) error { applied = true; return nil },
 	})
 
-	if err := m.renderAndApplyUnshapeEgress(context.Background()); err != nil {
-		t.Fatalf("renderAndApplyUnshapeEgress: %v", err)
+	if err := m.applyEgressScript(context.Background(), "", applyUnshape); err != nil {
+		t.Fatalf("applyEgressScript(applyUnshape): %v", err)
 	}
 
 	// Live hierarchy dropped directly on the detected NIC.
@@ -770,7 +770,7 @@ func TestEffectiveCeil_DefaultsToRate(t *testing.T) {
 // --- Device-only rendering tests ---
 //
 // When a device root is configured but no class configs exist yet,
-// renderAndApplyScript branches on defaultEgressConfig(dev.Rate): an explicit
+// renderEgressScript branches on defaultEgressConfig(dev.Rate): an explicit
 // rate yields the three default egress classes at proportional explicit rates
 // (no SPEED variable); "auto" or any unparseable rate makes defaultEgressConfig
 // fail and the render falls back to sysfs auto-detect. These tests pin that
@@ -778,7 +778,7 @@ func TestEffectiveCeil_DefaultsToRate(t *testing.T) {
 
 func TestDefaultEgressConfig_AutoRateFallsBack(t *testing.T) {
 	// "auto" is not a parseable bandwidth, so defaultEgressConfig returns an
-	// error — the signal renderAndApplyScript uses to fall back to sysfs detect.
+	// error — the signal renderEgressScript uses to fall back to sysfs detect.
 	if _, _, err := defaultEgressConfig("auto"); err == nil {
 		t.Error("expected defaultEgressConfig(\"auto\") to error, got nil")
 	}
@@ -789,7 +789,7 @@ func TestDefaultEgressConfig_AutoRateFallsBack(t *testing.T) {
 }
 
 func TestDeviceOnly_ExplicitRate_NoSpeed(t *testing.T) {
-	// Device-only explicit render reuses the same path as renderAndApplyScript:
+	// Device-only explicit render reuses the same path as renderEgressScript:
 	// defaultEgressConfig(rate) → renderTcEgressScriptFromConfig(dev, classes).
 	dev := &DeviceConfig{Dir: DirEgress, Rate: "500mbit", DefaultClass: "reserve-egress"}
 	_, classes, err := defaultEgressConfig(dev.Rate)
@@ -863,11 +863,11 @@ func TestResolveAutoRate_ExplicitRateUntouched(t *testing.T) {
 	}
 }
 
-func TestPersistEgressScript_NoServiceRestart(t *testing.T) {
+func TestApplyEgressScript_PersistOnly_NoServiceRestart(t *testing.T) {
 	// `set` persists the boot script for reboot but must NOT restart the service:
 	// its live `tc class change` already updated the kernel, and a restart would
-	// tear down and rebuild the root qdisc. persistEgressScript writes; only
-	// renderAndApplyScript restarts.
+	// tear down and rebuild the root qdisc. applyPersistOnly writes; only
+	// applyRestart restarts.
 	scriptPath := filepath.Join(t.TempDir(), "tc-egress.sh")
 	applied := false
 	m := NewManagerWithConfig(Config{
@@ -876,23 +876,23 @@ func TestPersistEgressScript_NoServiceRestart(t *testing.T) {
 		ApplyEgress: func(context.Context) error { applied = true; return nil },
 	})
 
-	if err := m.persistEgressScript("eth0"); err != nil {
-		t.Fatalf("persistEgressScript: %v", err)
+	if err := m.applyEgressScript(context.Background(), "eth0", applyPersistOnly); err != nil {
+		t.Fatalf("applyEgressScript(applyPersistOnly): %v", err)
 	}
 	if applied {
-		t.Error("persistEgressScript must not restart the service (no qdisc churn)")
+		t.Error("applyPersistOnly must not restart the service (no qdisc churn)")
 	}
 	if _, err := os.Stat(scriptPath); err != nil {
 		t.Errorf("expected boot script persisted to disk: %v", err)
 	}
 
-	// Contrast: renderAndApplyScript does restart the service.
+	// Contrast: applyRestart does restart the service.
 	applied = false
-	if err := m.renderAndApplyScript(context.Background(), "eth0"); err != nil {
-		t.Fatalf("renderAndApplyScript: %v", err)
+	if err := m.applyEgressScript(context.Background(), "eth0", applyRestart); err != nil {
+		t.Fatalf("applyEgressScript(applyRestart): %v", err)
 	}
 	if !applied {
-		t.Error("renderAndApplyScript must restart the service")
+		t.Error("applyRestart must restart the service")
 	}
 }
 

--- a/internal/network/shape/stats.go
+++ b/internal/network/shape/stats.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/joomcode/errorx"
+)
+
+// ClassStat is a point-in-time snapshot of one tc HTB class's cumulative
+// counters, as read from `tc -s class show dev <device>`. The byte/packet/drop/
+// overlimit counters are monotonic since the class (qdisc) was installed, so a
+// throughput reading is the delta between two snapshots over the elapsed time.
+type ClassStat struct {
+	ClassID    string // tc handle, e.g. "1:40"
+	Bytes      uint64
+	Packets    uint64
+	Drops      uint64
+	Overlimits uint64
+}
+
+// ClassDelta is the change in one class's counters between two samples, plus the
+// throughput implied by the byte delta over the sampling interval. It is what
+// `network shape watch` prints per tick: rate-over-time, not the cumulative
+// totals (which `network shape show` does not expose and dashboards cover via
+// the Prometheus counters).
+type ClassDelta struct {
+	Name            string  // class name ("partner") when the classid is known, else the raw classid
+	ClassID         string  // tc handle, e.g. "1:40"
+	RateBitsPerSec  float64 // byte delta * 8 / interval seconds
+	BytesDelta      uint64
+	OverlimitsDelta uint64
+	DropsDelta      uint64
+}
+
+// WatchSpec parameterises Manager.WatchClasses. Both Device (the traffic
+// direction, which selects the class set) and Iface (the interface to sample)
+// are required and operator-supplied: `network shape watch` performs no
+// environment probing — no NIC or veth auto-detection — so it never depends on a
+// block node running or on Kubernetes. Class optionally narrows the watch to one
+// class, which must belong to Device's direction.
+type WatchSpec struct {
+	Device   string        // "egress" or "ingress" — required; selects the class set
+	Iface    string        // interface to sample — required
+	Class    string        // optional: narrow to one class in Device's direction
+	Interval time.Duration // sampling interval
+	Count    int           // number of delta samples to print then stop; 0 = until ctx is cancelled
+}
+
+// WatchClasses samples the live tc class counters on the resolved interface every
+// spec.Interval and writes a per-class delta row (rate, bytes sent, Δoverlimits,
+// Δdrops) each tick to w. It is read-only: no locks, no mutations. It returns
+// when ctx is cancelled (e.g. the operator hits Ctrl-C) or, when spec.Count > 0,
+// after that many delta rows have been printed.
+func (m *Manager) WatchClasses(ctx context.Context, spec WatchSpec, w io.Writer) error {
+	if spec.Interval <= 0 {
+		return errorx.IllegalArgument.New("--interval must be positive")
+	}
+	if spec.Count < 0 {
+		return errorx.IllegalArgument.New("--count must be zero or positive (0 = run until interrupted)")
+	}
+	if spec.Iface == "" {
+		return errorx.IllegalArgument.New("--iface is required (the interface to sample)")
+	}
+
+	dir, classes, err := resolveWatchClasses(spec)
+	if err != nil {
+		return err
+	}
+	iface := spec.Iface
+
+	fmt.Fprintf(w, "watching tc classes on %s (%s device), interval %s — Ctrl-C to stop\n",
+		iface, dir, spec.Interval)
+	writeWatchHeader(w)
+
+	// Establish the baseline sample; deltas are printed from the second sample on.
+	prev, prevAt, stopped, err := m.sampleStats(ctx, iface)
+	if stopped {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(spec.Interval)
+	defer ticker.Stop()
+
+	printed := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+
+		cur, curAt, stopped, err := m.sampleStats(ctx, iface)
+		if stopped {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		// Rate over the ACTUAL elapsed time between the two reads (the interval
+		// plus the time spent running tc), not the nominal interval — dividing by
+		// spec.Interval over-reports throughput, most visibly on the first tick.
+		writeWatchRows(w, classDeltas(prev, cur, classes, curAt.Sub(prevAt)))
+		prev, prevAt = cur, curAt
+
+		printed++
+		if spec.Count > 0 && printed >= spec.Count {
+			return nil
+		}
+	}
+}
+
+// sampleStats reads the live class counters and stamps the read time. A failure
+// caused by context cancellation (the operator hit Ctrl-C mid-sample) is reported
+// as a clean stop (stopped=true, err=nil), so WatchClasses honors its "returns nil
+// on cancellation" contract even when the cancellation lands during a tc exec
+// rather than while waiting on the ticker.
+func (m *Manager) sampleStats(ctx context.Context, iface string) (stats map[string]ClassStat, at time.Time, stopped bool, err error) {
+	stats, err = m.tcRunner.ClassStats(ctx, iface)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, time.Time{}, true, nil
+		}
+		return nil, time.Time{}, false, err
+	}
+	return stats, time.Now(), false, nil
+}
+
+// resolveWatchClasses validates the spec's device/class selection and returns the
+// direction plus the class names to display. --device (required) selects the
+// class set; --class optionally narrows it to a single class, which must belong
+// to that direction. There is no defaulting or auto-detection: the operator
+// states intent explicitly, keeping the command independent of the running block
+// node.
+func resolveWatchClasses(spec WatchSpec) (dir string, classes []string, err error) {
+	if spec.Device == "" {
+		return "", nil, errorx.IllegalArgument.New("--device is required (egress or ingress)")
+	}
+	if err := validateDir(spec.Device); err != nil {
+		return "", nil, err
+	}
+	if spec.Class != "" {
+		ci, err := lookupClassInfo(spec.Class)
+		if err != nil {
+			return "", nil, err
+		}
+		if ci.Dir != spec.Device {
+			return "", nil, errorx.IllegalArgument.New(
+				"--class %q is a %s class but --device %s was given", spec.Class, ci.Dir, spec.Device)
+		}
+		return spec.Device, []string{spec.Class}, nil
+	}
+	return spec.Device, knownClassNamesForDir(spec.Device), nil
+}
+
+// classDeltas computes the per-class delta between two samples for the named
+// classes, in classid order. A class absent from the current sample (not
+// installed on the live device) is skipped; a counter that went backwards (the
+// qdisc was reinstalled between samples) yields a zero delta for that tick rather
+// than a spurious huge number.
+func classDeltas(prev, cur map[string]ClassStat, classes []string, elapsed time.Duration) []ClassDelta {
+	secs := elapsed.Seconds()
+	out := make([]ClassDelta, 0, len(classes))
+	for _, name := range classes {
+		ci, err := lookupClassInfo(name)
+		if err != nil {
+			continue
+		}
+		classid := "1:" + ci.Minor
+		c, ok := cur[classid]
+		if !ok {
+			continue
+		}
+		p := prev[classid] // zero value when the class is new this tick
+		bytesDelta := monotonicDelta(p.Bytes, c.Bytes)
+		var rate float64
+		if secs > 0 {
+			rate = float64(bytesDelta) * 8 / secs
+		}
+		out = append(out, ClassDelta{
+			Name:            name,
+			ClassID:         classid,
+			RateBitsPerSec:  rate,
+			BytesDelta:      bytesDelta,
+			OverlimitsDelta: monotonicDelta(p.Overlimits, c.Overlimits),
+			DropsDelta:      monotonicDelta(p.Drops, c.Drops),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ClassID < out[j].ClassID })
+	return out
+}
+
+// monotonicDelta returns cur-prev for a monotonic counter, clamping to 0 when the
+// counter appears to have reset (cur < prev) so a qdisc reinstall between samples
+// does not report a bogus multi-exabyte delta.
+func monotonicDelta(prev, cur uint64) uint64 {
+	if cur < prev {
+		return 0
+	}
+	return cur - prev
+}
+
+func writeWatchHeader(w io.Writer) {
+	fmt.Fprintf(w, "%-18s %-8s %15s %12s %11s %8s\n",
+		"CLASS", "CLASSID", "RATE", "SENT", "OVERLIMITS", "DROPPED")
+}
+
+func writeWatchRows(w io.Writer, deltas []ClassDelta) {
+	for _, d := range deltas {
+		fmt.Fprintf(w, "%-18s %-8s %15s %12s %11s %8s\n",
+			d.Name, d.ClassID, humanRate(d.RateBitsPerSec), humanBytes(d.BytesDelta),
+			"+"+strconv.FormatUint(d.OverlimitsDelta, 10),
+			"+"+strconv.FormatUint(d.DropsDelta, 10))
+	}
+	fmt.Fprintln(w) // blank line separates ticks
+}
+
+// humanRate renders a bit/s throughput with a decimal (SI) magnitude suffix,
+// matching how tc bandwidth values are expressed (Mbit/Gbit, powers of 1000).
+func humanRate(bitsPerSec float64) string {
+	const k = 1000.0
+	switch {
+	case bitsPerSec >= k*k*k:
+		return fmt.Sprintf("%.2f Gbit/s", bitsPerSec/(k*k*k))
+	case bitsPerSec >= k*k:
+		return fmt.Sprintf("%.2f Mbit/s", bitsPerSec/(k*k))
+	case bitsPerSec >= k:
+		return fmt.Sprintf("%.2f Kbit/s", bitsPerSec/k)
+	default:
+		return fmt.Sprintf("%.0f bit/s", bitsPerSec)
+	}
+}
+
+// humanBytes renders a byte count with a binary (IEC) magnitude suffix.
+func humanBytes(b uint64) string {
+	const k = 1024.0
+	f := float64(b)
+	switch {
+	case f >= k*k*k:
+		return fmt.Sprintf("%.2f GB", f/(k*k*k))
+	case f >= k*k:
+		return fmt.Sprintf("%.2f MB", f/(k*k))
+	case f >= k:
+		return fmt.Sprintf("%.2f KB", f/k)
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/internal/network/shape/stats_test.go
+++ b/internal/network/shape/stats_test.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonotonicDelta(t *testing.T) {
+	require.Equal(t, uint64(0), monotonicDelta(0, 0))
+	require.Equal(t, uint64(5), monotonicDelta(10, 15))
+	require.Equal(t, uint64(15), monotonicDelta(0, 15))
+	// Counter reset (qdisc reinstalled between samples): clamp to 0, never wrap.
+	require.Equal(t, uint64(0), monotonicDelta(100, 3))
+}
+
+func TestClassDeltas(t *testing.T) {
+	prev := map[string]ClassStat{
+		"1:40": {ClassID: "1:40", Bytes: 1_000, Overlimits: 2, Drops: 0},
+		"1:50": {ClassID: "1:50", Bytes: 500, Overlimits: 0, Drops: 1},
+	}
+	cur := map[string]ClassStat{
+		"1:40": {ClassID: "1:40", Bytes: 126_000, Overlimits: 7, Drops: 0}, // +125000 B over 1s → 1_000_000 bit/s
+		"1:50": {ClassID: "1:50", Bytes: 400, Overlimits: 3, Drops: 4},     // bytes went backwards → 0
+		// reserve-egress (1:60) absent from cur → skipped
+	}
+
+	got := classDeltas(prev, cur, []string{"partner", "public", "reserve-egress"}, time.Second)
+	require.Len(t, got, 2, "reserve-egress absent from the live device must be skipped")
+
+	// Ordered by classid: partner (1:40) before public (1:50).
+	require.Equal(t, "partner", got[0].Name)
+	require.Equal(t, "1:40", got[0].ClassID)
+	require.Equal(t, uint64(125_000), got[0].BytesDelta)
+	require.InDelta(t, 1_000_000.0, got[0].RateBitsPerSec, 0.001)
+	require.Equal(t, uint64(5), got[0].OverlimitsDelta)
+	require.Equal(t, uint64(0), got[0].DropsDelta)
+
+	require.Equal(t, "public", got[1].Name)
+	require.Equal(t, uint64(0), got[1].BytesDelta, "backwards byte counter clamps to 0")
+	require.Equal(t, uint64(3), got[1].OverlimitsDelta)
+	require.Equal(t, uint64(3), got[1].DropsDelta)
+}
+
+func TestClassDeltas_FirstSampleFromZeroBaseline(t *testing.T) {
+	// prev empty (a class just appeared): full current value is the delta.
+	cur := map[string]ClassStat{"1:40": {ClassID: "1:40", Bytes: 2_000}}
+	got := classDeltas(map[string]ClassStat{}, cur, []string{"partner"}, time.Second)
+	require.Len(t, got, 1)
+	require.Equal(t, uint64(2_000), got[0].BytesDelta)
+}
+
+func TestHumanRate(t *testing.T) {
+	require.Equal(t, "0 bit/s", humanRate(0))
+	require.Equal(t, "1.00 Kbit/s", humanRate(1_000))
+	require.Equal(t, "1.00 Mbit/s", humanRate(1_000_000))
+	require.Equal(t, "2.50 Gbit/s", humanRate(2_500_000_000))
+}
+
+func TestHumanBytes(t *testing.T) {
+	require.Equal(t, "512 B", humanBytes(512))
+	require.Equal(t, "1.00 KB", humanBytes(1024))
+	require.Equal(t, "1.00 MB", humanBytes(1024*1024))
+}
+
+// scriptedStatsRunner returns a fixed sequence of samples from ClassStats,
+// repeating the last one once exhausted. Write verbs are inherited (unused).
+type scriptedStatsRunner struct {
+	recordingTCRunner
+	samples []map[string]ClassStat
+	idx     int
+	calls   int
+}
+
+func (r *scriptedStatsRunner) ClassStats(ctx context.Context, _ string) (map[string]ClassStat, error) {
+	// Mirror the real runner: a cancelled context surfaces as an error, which
+	// WatchClasses must treat as a clean stop.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	i := r.idx
+	if i >= len(r.samples) {
+		i = len(r.samples) - 1
+	}
+	r.idx++
+	r.calls++
+	return r.samples[i], nil
+}
+
+func newWatchManager(tc TCRunner) *Manager {
+	// NICDetect is intentionally unset: the watch path must never probe the NIC.
+	return NewManagerWithConfig(Config{TCRunner: tc})
+}
+
+func TestWatchClasses_CountBoundedLoop(t *testing.T) {
+	tc := &scriptedStatsRunner{samples: []map[string]ClassStat{
+		{"1:40": {ClassID: "1:40", Bytes: 0}},
+		{"1:40": {ClassID: "1:40", Bytes: 125_000, Overlimits: 1}},
+		{"1:40": {ClassID: "1:40", Bytes: 250_000, Overlimits: 3}},
+	}}
+	m := newWatchManager(tc)
+
+	var buf bytes.Buffer
+	spec := WatchSpec{Device: "egress", Iface: "enp0s1", Class: "partner", Interval: time.Millisecond, Count: 2}
+	require.NoError(t, m.WatchClasses(context.Background(), spec, &buf))
+
+	// Baseline + 2 delta samples = 3 ClassStats calls.
+	require.Equal(t, 3, tc.calls)
+	out := buf.String()
+	require.Contains(t, out, "watching tc classes on enp0s1 (egress device)")
+	require.Contains(t, out, "CLASS")
+	require.Contains(t, out, "partner")
+	require.Contains(t, out, "1:40")
+}
+
+func TestWatchClasses_IngressWithIface(t *testing.T) {
+	tc := &scriptedStatsRunner{samples: []map[string]ClassStat{
+		{"1:10": {ClassID: "1:10", Bytes: 0}},
+		{"1:10": {ClassID: "1:10", Bytes: 125_000}},
+	}}
+	m := newWatchManager(tc)
+
+	var buf bytes.Buffer
+	spec := WatchSpec{Device: "ingress", Iface: "lxc1a2b3c", Interval: time.Millisecond, Count: 1}
+	require.NoError(t, m.WatchClasses(context.Background(), spec, &buf))
+	out := buf.String()
+	require.Contains(t, out, "watching tc classes on lxc1a2b3c (ingress device)")
+	require.Contains(t, out, "publisher")
+}
+
+func TestWatchClasses_CtxCancelStops(t *testing.T) {
+	tc := &scriptedStatsRunner{samples: []map[string]ClassStat{
+		{"1:40": {ClassID: "1:40", Bytes: 0}},
+	}}
+	m := newWatchManager(tc)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled: the baseline sample errors on the cancelled ctx
+
+	var buf bytes.Buffer
+	// A cancelled context during the (baseline) tc sample is a clean stop, not an
+	// error — WatchClasses must return nil rather than bubbling up the ctx error.
+	err := m.WatchClasses(ctx, WatchSpec{Device: "egress", Iface: "enp0s1", Interval: time.Hour}, &buf)
+	require.NoError(t, err)
+}
+
+func TestWatchClasses_RequiresIface(t *testing.T) {
+	m := newWatchManager(&scriptedStatsRunner{samples: []map[string]ClassStat{{}}})
+	err := m.WatchClasses(context.Background(), WatchSpec{Device: "egress", Interval: time.Second}, &bytes.Buffer{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--iface")
+}
+
+func TestWatchClasses_RequiresDevice(t *testing.T) {
+	m := newWatchManager(&scriptedStatsRunner{samples: []map[string]ClassStat{{}}})
+	err := m.WatchClasses(context.Background(), WatchSpec{Iface: "enp0s1", Interval: time.Second}, &bytes.Buffer{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--device")
+}
+
+func TestWatchClasses_ClassDeviceMismatch(t *testing.T) {
+	m := newWatchManager(&scriptedStatsRunner{samples: []map[string]ClassStat{{}}})
+	// partner is an egress class; watching it under --device ingress must fail.
+	err := m.WatchClasses(context.Background(),
+		WatchSpec{Device: "ingress", Iface: "lxc1a2b3c", Class: "partner", Interval: time.Second}, &bytes.Buffer{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "egress class")
+}
+
+func TestWatchClasses_BadInterval(t *testing.T) {
+	m := newWatchManager(&scriptedStatsRunner{samples: []map[string]ClassStat{{}}})
+	err := m.WatchClasses(context.Background(),
+		WatchSpec{Device: "egress", Iface: "enp0s1", Interval: 0}, &bytes.Buffer{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--interval")
+}
+
+func TestResolveWatchClasses_RequiresDevice(t *testing.T) {
+	_, _, err := resolveWatchClasses(WatchSpec{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--device")
+}
+
+func TestResolveWatchClasses_EgressDevice(t *testing.T) {
+	dir, classes, err := resolveWatchClasses(WatchSpec{Device: "egress"})
+	require.NoError(t, err)
+	require.Equal(t, DirEgress, dir)
+	require.ElementsMatch(t, []string{"partner", "public", "reserve-egress"}, classes)
+}
+
+func TestResolveWatchClasses_IngressDevice(t *testing.T) {
+	dir, classes, err := resolveWatchClasses(WatchSpec{Device: "ingress"})
+	require.NoError(t, err)
+	require.Equal(t, DirIngress, dir)
+	require.ElementsMatch(t, []string{"publisher", "backfill-response", "reserve-ingress"}, classes)
+}
+
+func TestResolveWatchClasses_ClassNarrowsWithinDevice(t *testing.T) {
+	dir, classes, err := resolveWatchClasses(WatchSpec{Device: "egress", Class: "partner"})
+	require.NoError(t, err)
+	require.Equal(t, DirEgress, dir)
+	require.Equal(t, []string{"partner"}, classes)
+}
+
+func TestResolveWatchClasses_ClassDeviceMismatch(t *testing.T) {
+	_, _, err := resolveWatchClasses(WatchSpec{Device: "ingress", Class: "partner"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "egress class")
+}
+
+func TestResolveWatchClasses_UnknownClass(t *testing.T) {
+	_, _, err := resolveWatchClasses(WatchSpec{Device: "egress", Class: "nope"})
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "unknown class"))
+}

--- a/internal/network/shape/tc.go
+++ b/internal/network/shape/tc.go
@@ -39,4 +39,9 @@ type TCRunner interface {
 	// QdiscAddFqCodel runs `tc qdisc add dev <nic> parent 1:<minor> handle
 	// <handle>: fq_codel`, the leaf qdisc for a class.
 	QdiscAddFqCodel(ctx context.Context, nic, minor, handle string) error
+
+	// ClassStats runs `tc -s -j class show dev <dev>` and returns each class's
+	// cumulative counters keyed by tc handle (e.g. "1:40"). It is the read
+	// counterpart to the write verbs above, backing `network shape watch`.
+	ClassStats(ctx context.Context, dev string) (map[string]ClassStat, error)
 }

--- a/internal/network/shape/tc.go
+++ b/internal/network/shape/tc.go
@@ -2,7 +2,10 @@
 
 package shape
 
-import "context"
+import (
+	"context"
+	"strconv"
+)
 
 // TCRunner abstracts live kernel tc qdisc/class operations for testability. The
 // egress path drives ClassChange (live tuning of an already-installed
@@ -44,4 +47,49 @@ type TCRunner interface {
 	// cumulative counters keyed by tc handle (e.g. "1:40"). It is the read
 	// counterpart to the write verbs above, backing `network shape watch`.
 	ClassStats(ctx context.Context, dev string) (map[string]ClassStat, error)
+}
+
+// The tc*Args helpers are the single source of the tc command argument
+// encoding: HTB argument order and the field set for each qdisc/class verb.
+// The live path (execTCRunner, tc_linux.go) executes these arg slices, and the
+// tc-egress boot-script template renders the same commands as shell text; a
+// lockstep test (tc_encoding_test.go) asserts the two encodings match token for
+// token so a change to one side cannot silently drift from the other. They are
+// build-tag-free (this file) so the live path, the render path, and that test
+// all reference one definition. nic is a literal interface name on the live
+// path; the boot script passes the shell variable "$NIC".
+
+// tcQdiscDelRootArgs builds `qdisc del dev <nic> root`.
+func tcQdiscDelRootArgs(nic string) []string {
+	return []string{"qdisc", "del", "dev", nic, "root"}
+}
+
+// tcQdiscAddRootArgs builds `qdisc add dev <nic> root handle 1: htb default
+// <defaultMinor>`.
+func tcQdiscAddRootArgs(nic, defaultMinor string) []string {
+	return []string{"qdisc", "add", "dev", nic, "root", "handle", "1:", "htb", "default", defaultMinor}
+}
+
+// tcClassAddRootArgs builds `class add dev <nic> parent 1: classid 1:1 htb rate
+// <rate> ceil <ceil>` — the trunk class.
+func tcClassAddRootArgs(nic, rate, ceil string) []string {
+	return []string{"class", "add", "dev", nic, "parent", "1:", "classid", "1:1", "htb", "rate", rate, "ceil", ceil}
+}
+
+// tcClassAddArgs builds `class add dev <nic> parent 1:1 classid 1:<minor> htb
+// rate <rate> ceil <ceil> prio <prio>` — a per-class leaf under the trunk.
+func tcClassAddArgs(nic, minor, rate, ceil string, prio int) []string {
+	return []string{"class", "add", "dev", nic, "parent", "1:1", "classid", "1:" + minor, "htb", "rate", rate, "ceil", ceil, "prio", strconv.Itoa(prio)}
+}
+
+// tcClassChangeArgs builds `class change dev <nic> parent 1:1 classid 1:<minor>
+// htb rate <rate> ceil <ceil> prio <prio>` — live tuning of an existing leaf.
+func tcClassChangeArgs(nic, minor, rate, ceil string, prio int) []string {
+	return []string{"class", "change", "dev", nic, "parent", "1:1", "classid", "1:" + minor, "htb", "rate", rate, "ceil", ceil, "prio", strconv.Itoa(prio)}
+}
+
+// tcQdiscAddFqCodelArgs builds `qdisc add dev <nic> parent 1:<minor> handle
+// <handle>: fq_codel` — the leaf qdisc for a class.
+func tcQdiscAddFqCodelArgs(nic, minor, handle string) []string {
+	return []string{"qdisc", "add", "dev", nic, "parent", "1:" + minor, "handle", handle + ":", "fq_codel"}
 }

--- a/internal/network/shape/tc.go
+++ b/internal/network/shape/tc.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import "context"
+
+// TCRunner abstracts live kernel tc qdisc/class operations for testability. The
+// egress path drives ClassChange (live tuning of an already-installed
+// hierarchy); the ingress path drives the qdisc/class add verbs to install the
+// per-veth HTB hierarchy from scratch on each BN pod create.
+//
+// The interface lives in this build-tag-free file so both the Linux
+// (execTCRunner) and non-Linux (noopTCRunner) implementations, and the
+// platform-agnostic Manager that consumes it, share a single declaration.
+type TCRunner interface {
+	// ClassChange runs `tc class change dev <nic> parent 1:1 classid 1:<minor>
+	// htb rate <rate> ceil <ceil> prio <prio>` on the live kernel.
+	ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error
+
+	// QdiscDelRoot runs `tc qdisc del dev <nic> root`, tearing down any existing
+	// hierarchy (cascading to all classes and leaf qdiscs). It is best-effort: a
+	// missing root qdisc (a fresh veth) is not an error, so the caller can
+	// unconditionally rebuild — matching the tc-egress boot script's `|| true`.
+	QdiscDelRoot(ctx context.Context, nic string) error
+
+	// QdiscAddRoot runs `tc qdisc add dev <nic> root handle 1: htb default
+	// <defaultMinor>`, installing the root HTB qdisc whose unmatched traffic
+	// falls to class 1:<defaultMinor>.
+	QdiscAddRoot(ctx context.Context, nic, defaultMinor string) error
+
+	// ClassAddRoot runs `tc class add dev <nic> parent 1: classid 1:1 htb rate
+	// <rate> ceil <ceil>`, the trunk class every per-class leaf attaches to.
+	ClassAddRoot(ctx context.Context, nic, rate, ceil string) error
+
+	// ClassAdd runs `tc class add dev <nic> parent 1:1 classid 1:<minor> htb
+	// rate <rate> ceil <ceil> prio <prio>`, a per-class leaf under the trunk.
+	ClassAdd(ctx context.Context, nic, minor, rate, ceil string, prio int) error
+
+	// QdiscAddFqCodel runs `tc qdisc add dev <nic> parent 1:<minor> handle
+	// <handle>: fq_codel`, the leaf qdisc for a class.
+	QdiscAddFqCodel(ctx context.Context, nic, minor, handle string) error
+}

--- a/internal/network/shape/tc_encoding_test.go
+++ b/internal/network/shape/tc_encoding_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// normalizeTcLine turns a rendered boot-script `tc ...` line into the token
+// slice the tc*Args builders produce: drop the leading "tc", strip the
+// best-effort redirection suffix (`2>/dev/null || true`) and the shell quotes
+// the template wraps rates/device in, and collapse the template's cosmetic
+// column-alignment whitespace. The device stays as the shell variable "$NIC".
+func normalizeTcLine(line string) []string {
+	line = strings.TrimSpace(line)
+	if i := strings.Index(line, " 2>/dev/null"); i >= 0 {
+		line = line[:i]
+	}
+	line = strings.ReplaceAll(line, "\"", "")
+	line = strings.TrimPrefix(line, "tc ")
+	return strings.Fields(line) // Fields collapses any run of whitespace
+}
+
+// TestBootScriptTcEncodingMatchesArgBuilders is the lockstep guard for #946
+// AC#2: the tc command encoding must live in one place. The live path
+// (execTCRunner) executes the tc*Args slices; the tc-egress boot script renders
+// the same commands as shell text. This renders the explicit-rate boot script
+// for a concrete egress config and asserts every `tc ...` line equals the
+// arg-builder encoding token for token (whitespace- and quote-insensitive), so
+// a change to HTB argument order or the field set on either side fails here.
+func TestBootScriptTcEncodingMatchesArgBuilders(t *testing.T) {
+	dev := &DeviceConfig{Dir: DirEgress, Rate: "500mbit", DefaultClass: "reserve-egress"}
+	classes := []*ClassConfig{
+		{Name: "partner", Rate: "200mbit", Ceil: "350mbit", Prio: 0},
+		{Name: "public", Rate: "150mbit", Ceil: "350mbit", Prio: 5},
+		{Name: "reserve-egress", Rate: "150mbit", Prio: 1}, // ceil defaults to rate
+	}
+
+	// The rendered tc lines reference the shell variable "$NIC" regardless of the
+	// nicName passed here (which only fills the NIC="..." assignment), so the
+	// expected builder encoding uses "$NIC" as the device.
+	const nic = "$NIC"
+	rendered, err := renderTcEgressScriptFromConfig("enp0s1", dev, classes)
+	if err != nil {
+		t.Fatalf("renderTcEgressScriptFromConfig: %v", err)
+	}
+
+	def, err := lookupClassInfo(dev.DefaultClass)
+	if err != nil {
+		t.Fatalf("lookupClassInfo(%q): %v", dev.DefaultClass, err)
+	}
+	expected := [][]string{
+		tcQdiscDelRootArgs(nic),
+		tcQdiscAddRootArgs(nic, def.Minor),
+		tcClassAddRootArgs(nic, dev.Rate, dev.Rate),
+	}
+	for _, c := range classes {
+		ci, err := lookupClassInfo(c.Name)
+		if err != nil {
+			t.Fatalf("lookupClassInfo(%q): %v", c.Name, err)
+		}
+		expected = append(expected,
+			tcClassAddArgs(nic, ci.Minor, c.Rate, c.effectiveCeil(), c.Prio),
+			tcQdiscAddFqCodelArgs(nic, ci.Minor, ci.Handle),
+		)
+	}
+
+	var actual [][]string
+	for _, ln := range strings.Split(rendered, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(ln), "tc ") {
+			actual = append(actual, normalizeTcLine(ln))
+		}
+	}
+
+	if len(actual) != len(expected) {
+		t.Fatalf("boot script has %d tc lines, arg-builders produce %d\nscript:\n%s",
+			len(actual), len(expected), rendered)
+	}
+	for i := range expected {
+		if !reflect.DeepEqual(actual[i], expected[i]) {
+			t.Errorf("tc line %d encoding drift:\n  boot script:  %v\n  arg-builders: %v",
+				i, actual[i], expected[i])
+		}
+	}
+}

--- a/internal/network/shape/tc_linux.go
+++ b/internal/network/shape/tc_linux.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/joomcode/errorx"
@@ -51,37 +50,30 @@ func (r *execTCRunner) run(ctx context.Context, args ...string) error {
 }
 
 func (r *execTCRunner) ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error {
-	return r.run(ctx, "class", "change",
-		"dev", nic, "parent", "1:1", "classid", "1:"+minor,
-		"htb", "rate", rate, "ceil", ceil, "prio", strconv.Itoa(prio))
+	return r.run(ctx, tcClassChangeArgs(nic, minor, rate, ceil, prio)...)
 }
 
 func (r *execTCRunner) QdiscDelRoot(ctx context.Context, nic string) error {
 	// Best-effort: swallow the error so a fresh veth (no root qdisc yet) or a
 	// recycled veth name both start from a clean rebuild.
-	_ = exec.CommandContext(ctx, tcBin, "qdisc", "del", "dev", nic, "root").Run()
+	_ = exec.CommandContext(ctx, tcBin, tcQdiscDelRootArgs(nic)...).Run()
 	return nil
 }
 
 func (r *execTCRunner) QdiscAddRoot(ctx context.Context, nic, defaultMinor string) error {
-	return r.run(ctx, "qdisc", "add",
-		"dev", nic, "root", "handle", "1:", "htb", "default", defaultMinor)
+	return r.run(ctx, tcQdiscAddRootArgs(nic, defaultMinor)...)
 }
 
 func (r *execTCRunner) ClassAddRoot(ctx context.Context, nic, rate, ceil string) error {
-	return r.run(ctx, "class", "add",
-		"dev", nic, "parent", "1:", "classid", "1:1", "htb", "rate", rate, "ceil", ceil)
+	return r.run(ctx, tcClassAddRootArgs(nic, rate, ceil)...)
 }
 
 func (r *execTCRunner) ClassAdd(ctx context.Context, nic, minor, rate, ceil string, prio int) error {
-	return r.run(ctx, "class", "add",
-		"dev", nic, "parent", "1:1", "classid", "1:"+minor,
-		"htb", "rate", rate, "ceil", ceil, "prio", strconv.Itoa(prio))
+	return r.run(ctx, tcClassAddArgs(nic, minor, rate, ceil, prio)...)
 }
 
 func (r *execTCRunner) QdiscAddFqCodel(ctx context.Context, nic, minor, handle string) error {
-	return r.run(ctx, "qdisc", "add",
-		"dev", nic, "parent", "1:"+minor, "handle", handle+":", "fq_codel")
+	return r.run(ctx, tcQdiscAddFqCodelArgs(nic, minor, handle)...)
 }
 
 func (r *execTCRunner) ClassStats(ctx context.Context, dev string) (map[string]ClassStat, error) {

--- a/internal/network/shape/tc_linux.go
+++ b/internal/network/shape/tc_linux.go
@@ -18,39 +18,6 @@ import (
 // attacker-controlled directory (see docs/dev/security-model.md).
 const tcBin = "/sbin/tc"
 
-// TCRunner abstracts live kernel tc qdisc/class operations for testability. The
-// egress path drives ClassChange (live tuning of an already-installed
-// hierarchy); the ingress path drives the qdisc/class add verbs to install the
-// per-veth HTB hierarchy from scratch on each BN pod create.
-type TCRunner interface {
-	// ClassChange runs `tc class change dev <nic> parent 1:1 classid 1:<minor>
-	// htb rate <rate> ceil <ceil> prio <prio>` on the live kernel.
-	ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error
-
-	// QdiscDelRoot runs `tc qdisc del dev <nic> root`, tearing down any existing
-	// hierarchy (cascading to all classes and leaf qdiscs). It is best-effort: a
-	// missing root qdisc (a fresh veth) is not an error, so the caller can
-	// unconditionally rebuild — matching the tc-egress boot script's `|| true`.
-	QdiscDelRoot(ctx context.Context, nic string) error
-
-	// QdiscAddRoot runs `tc qdisc add dev <nic> root handle 1: htb default
-	// <defaultMinor>`, installing the root HTB qdisc whose unmatched traffic
-	// falls to class 1:<defaultMinor>.
-	QdiscAddRoot(ctx context.Context, nic, defaultMinor string) error
-
-	// ClassAddRoot runs `tc class add dev <nic> parent 1: classid 1:1 htb rate
-	// <rate> ceil <ceil>`, the trunk class every per-class leaf attaches to.
-	ClassAddRoot(ctx context.Context, nic, rate, ceil string) error
-
-	// ClassAdd runs `tc class add dev <nic> parent 1:1 classid 1:<minor> htb
-	// rate <rate> ceil <ceil> prio <prio>`, a per-class leaf under the trunk.
-	ClassAdd(ctx context.Context, nic, minor, rate, ceil string, prio int) error
-
-	// QdiscAddFqCodel runs `tc qdisc add dev <nic> parent 1:<minor> handle
-	// <handle>: fq_codel`, the leaf qdisc for a class.
-	QdiscAddFqCodel(ctx context.Context, nic, minor, handle string) error
-}
-
 type execTCRunner struct{}
 
 // run execs `tc <args...>` and wraps any non-zero exit with the combined output.

--- a/internal/network/shape/tc_linux.go
+++ b/internal/network/shape/tc_linux.go
@@ -5,7 +5,9 @@
 package shape
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -17,6 +19,24 @@ import (
 // PATH) so a caller cannot hijack the privileged invocation via an
 // attacker-controlled directory (see docs/dev/security-model.md).
 const tcBin = "/sbin/tc"
+
+// tcClassJSON is the subset of one element of `tc -s -j class show` output we
+// consume. iproute2 emits the counters at the top level of each class object;
+// the optional nested "stats" object is decoded too as a defensive fallback for
+// versions that nest them, preferring whichever is populated.
+type tcClassJSON struct {
+	Handle     string `json:"handle"`
+	Bytes      uint64 `json:"bytes"`
+	Packets    uint64 `json:"packets"`
+	Drops      uint64 `json:"drops"`
+	Overlimits uint64 `json:"overlimits"`
+	Stats      *struct {
+		Bytes      uint64 `json:"bytes"`
+		Packets    uint64 `json:"packets"`
+		Drops      uint64 `json:"drops"`
+		Overlimits uint64 `json:"overlimits"`
+	} `json:"stats"`
+}
 
 type execTCRunner struct{}
 
@@ -62,6 +82,48 @@ func (r *execTCRunner) ClassAdd(ctx context.Context, nic, minor, rate, ceil stri
 func (r *execTCRunner) QdiscAddFqCodel(ctx context.Context, nic, minor, handle string) error {
 	return r.run(ctx, "qdisc", "add",
 		"dev", nic, "parent", "1:"+minor, "handle", handle+":", "fq_codel")
+}
+
+func (r *execTCRunner) ClassStats(ctx context.Context, dev string) (map[string]ClassStat, error) {
+	cmd := exec.CommandContext(ctx, tcBin, "-s", "-j", "class", "show", "dev", dev)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, errorx.ExternalError.Wrap(err,
+			"tc -s -j class show dev %s failed: %s", dev, strings.TrimSpace(stderr.String()))
+	}
+
+	var raw []tcClassJSON
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, errorx.ExternalError.Wrap(err,
+			"failed to parse tc class stats JSON for dev %s", dev)
+	}
+
+	stats := make(map[string]ClassStat, len(raw))
+	for _, c := range raw {
+		if c.Handle == "" {
+			continue // qdisc-only or malformed entry
+		}
+		s := ClassStat{
+			ClassID:    c.Handle,
+			Bytes:      c.Bytes,
+			Packets:    c.Packets,
+			Drops:      c.Drops,
+			Overlimits: c.Overlimits,
+		}
+		// Fallback only when the flat form carried nothing: some iproute2 builds
+		// nest the counters under "stats" instead. Never overwrite populated
+		// top-level values with a (possibly empty) nested object.
+		if c.Stats != nil && s.Bytes == 0 && s.Packets == 0 && s.Drops == 0 && s.Overlimits == 0 {
+			s.Bytes = c.Stats.Bytes
+			s.Packets = c.Stats.Packets
+			s.Drops = c.Stats.Drops
+			s.Overlimits = c.Stats.Overlimits
+		}
+		stats[c.Handle] = s
+	}
+	return stats, nil
 }
 
 // newExecTCRunner returns the production TC runner that shells out to /sbin/tc.

--- a/internal/network/shape/tc_other.go
+++ b/internal/network/shape/tc_other.go
@@ -36,6 +36,10 @@ func (r *noopTCRunner) QdiscAddFqCodel(_ context.Context, _, _, _ string) error 
 	return errUnsupported()
 }
 
+func (r *noopTCRunner) ClassStats(_ context.Context, _ string) (map[string]ClassStat, error) {
+	return nil, errUnsupported()
+}
+
 // newExecTCRunner returns a no-op runner on non-Linux platforms.
 func newExecTCRunner() TCRunner {
 	return &noopTCRunner{}

--- a/internal/network/shape/tc_other.go
+++ b/internal/network/shape/tc_other.go
@@ -10,16 +10,6 @@ import (
 	"github.com/joomcode/errorx"
 )
 
-// TCRunner abstracts live kernel tc qdisc/class operations for testability.
-type TCRunner interface {
-	ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error
-	QdiscDelRoot(ctx context.Context, nic string) error
-	QdiscAddRoot(ctx context.Context, nic, defaultMinor string) error
-	ClassAddRoot(ctx context.Context, nic, rate, ceil string) error
-	ClassAdd(ctx context.Context, nic, minor, rate, ceil string, prio int) error
-	QdiscAddFqCodel(ctx context.Context, nic, minor, handle string) error
-}
-
 type noopTCRunner struct{}
 
 func errUnsupported() error {

--- a/internal/network/shape/validate.go
+++ b/internal/network/shape/validate.go
@@ -74,6 +74,34 @@ func parseBandwidthBps(s string) (int64, error) {
 	return n * multiplier, nil
 }
 
+// validateClassFields checks one class's bandwidth fields together: rate is a
+// non-empty parseable bandwidth, ceil (when set) is >= rate, and prio is in
+// [0,7]. Shared by the create/set verbs and the provision-time re-check so all
+// three enforce identical per-class rules.
+func validateClassFields(rate, ceil string, prio int) error {
+	if err := validateRate(rate); err != nil {
+		return err
+	}
+	if ceil != "" {
+		if err := validateCeilGeRate(ceil, rate); err != nil {
+			return err
+		}
+	}
+	return validatePrio(prio)
+}
+
+// sumParseableRatesBps sums the bits-per-second of every class whose rate
+// parses, silently skipping any unparseable rate (a legacy shell expression).
+func sumParseableRatesBps(classes []*ClassConfig) int64 {
+	var sum int64
+	for _, c := range classes {
+		if bps, err := parseBandwidthBps(c.Rate); err == nil {
+			sum += bps
+		}
+	}
+	return sum
+}
+
 // validateRate checks that rate is a non-empty, parseable tc bandwidth string.
 func validateRate(rate string) error {
 	if strings.TrimSpace(rate) == "" {
@@ -109,22 +137,18 @@ func validateSumRates(existing []*ClassConfig, cfg *ClassConfig, deviceRate stri
 	if err != nil {
 		return nil // device rate unparseable (legacy expression): skip
 	}
-	var sum int64
-	for _, c := range existing {
-		if c.Name == cfg.Name {
-			continue // will be replaced by cfg in the sum
-		}
-		bps, err := parseBandwidthBps(c.Rate)
-		if err != nil {
-			continue // unparseable sibling: skip its contribution
-		}
-		sum += bps
-	}
 	newBps, err := parseBandwidthBps(cfg.Rate)
 	if err != nil {
 		return nil // new rate unparseable: skip
 	}
-	sum += newBps
+	siblings := make([]*ClassConfig, 0, len(existing))
+	for _, c := range existing {
+		if c.Name == cfg.Name {
+			continue // will be replaced by cfg in the sum
+		}
+		siblings = append(siblings, c)
+	}
+	sum := sumParseableRatesBps(siblings) + newBps
 	if sum > deviceBps {
 		return errorx.IllegalArgument.New(
 			"total class rates (%d bit) would exceed device root rate %s (%d bit); reduce --rate or raise the device rate",

--- a/internal/network/shape/veth_test.go
+++ b/internal/network/shape/veth_test.go
@@ -48,6 +48,12 @@ func (r *recordingTCRunner) QdiscAddFqCodel(_ context.Context, nic, minor, handl
 	return r.record(fmt.Sprintf("qdisc-fqcodel %s 1:%s handle=%s", nic, minor, handle))
 }
 
+// ClassStats is unused by the write-path tests; the watch tests use a dedicated
+// scripted fake (see stats_test.go).
+func (r *recordingTCRunner) ClassStats(_ context.Context, _ string) (map[string]ClassStat, error) {
+	return nil, nil
+}
+
 func newRecordingManager(t *testing.T, tc TCRunner) *Manager {
 	t.Helper()
 	return NewManagerWithConfig(Config{

--- a/internal/templates/files/network/network-host.nft.tmpl
+++ b/internal/templates/files/network/network-host.nft.tmpl
@@ -3,22 +3,38 @@ delete table inet host
 add table inet host
 table inet host {
 	set mgmt_addrs { type ipv4_addr; flags interval;{{if .MgmtElements}} elements = { {{.MgmtElements}} };{{end}} }
+	set mgmt_addrs6 { type ipv6_addr; flags interval;{{if .MgmtElements6}} elements = { {{.MgmtElements6}} };{{end}} }
 	set blocked_addrs { type ipv4_addr; flags interval;{{if .BlockedElements}} elements = { {{.BlockedElements}} };{{end}} }
+	set blocked_addrs6 { type ipv6_addr; flags interval;{{if .BlockedElements6}} elements = { {{.BlockedElements6}} };{{end}} }
 	set in_cluster_ports { type inet_service;{{if .PortElements}} elements = { {{.PortElements}} };{{end}} }
 
 	chain input {
 		type filter hook input priority 0; policy drop;
 
-		# Drop invalid; admit loopback.
+		# Drop invalid; admit loopback. `iif "lo"` covers both 127.0.0.0/8 and
+		# ::1 since this is an `inet` (dual-family) table.
 		ct state invalid drop
 
 		# Operator-curated block list (`network firewall --blocked-cidrs`). Runs
 		# before every other rule, including established/related, so an entry
 		# added here drops already-open connections too. Purely operator-managed:
-		# nothing else ever writes to this set.
+		# nothing else ever writes to these sets. One rule per family.
 		ip saddr @blocked_addrs drop
+		ip6 saddr @blocked_addrs6 drop
 
 		iif "lo" accept
+
+		# --- IPv6 Neighbor Discovery + MLD (REQUIRED under policy drop) ---
+		# IPv6 is non-functional without Neighbor Discovery: address resolution
+		# (neighbor solicit/advert) and router discovery (router solicit/advert)
+		# ride on ICMPv6 and would otherwise be dropped, breaking all IPv6. NDP
+		# packets use a hop limit of 255 (RFC 4861 §11.2); enforce it so an
+		# off-link (routed) forgery cannot satisfy the accept. ICMPv6 Redirect is
+		# deliberately excluded here (accepting it enables on-link MITM).
+		icmpv6 type { nd-neighbor-solicit, nd-neighbor-advert, nd-router-solicit, nd-router-advert } ip6 hoplimit 255 accept
+		# Multicast Listener Discovery — the switch needs these reports to forward
+		# the solicited-node multicast that NDP relies on.
+		icmpv6 type { mld-listener-query, mld-listener-report, mld-listener-done } accept
 
 		# ICMP is evaluated BEFORE the established/related fast-path. netfilter
 		# conntrack DOES track ICMP echo as a flow (keyed on the echo id), so a
@@ -31,6 +47,7 @@ table inet host {
 
 		# Full ICMP from management sources (ping, traceroute, diagnostics) — no rate limit.
 		ip saddr @mgmt_addrs icmp type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem } accept
+		ip6 saddr @mgmt_addrs6 icmpv6 type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem, packet-too-big } accept
 
 		# From everyone else: always allow the path-health subset (Path MTU
 		# Discovery + traceroute), and rate-limit echo-request to prevent floods.
@@ -42,15 +59,29 @@ table inet host {
 		icmp type echo-request limit rate 10/second accept
 		icmp type echo-request drop
 
+		# IPv6 path health for everyone. packet-too-big is the IPv6 PMTUD signal —
+		# IPv6 routers never fragment, so dropping it silently blackholes any flow
+		# whose path MTU is smaller than the sender's.
+		icmpv6 type packet-too-big accept
+		icmpv6 type destination-unreachable accept
+		icmpv6 type time-exceeded accept
+		icmpv6 type parameter-problem accept
+		icmpv6 type echo-request limit rate 10/second accept
+		icmpv6 type echo-request drop
+
 		# Conntrack fast-path for TCP/UDP (and solicited ICMP replies).
 		ct state established,related accept
 
-		# SSH / management access from the allowlist only.
+		# SSH / management access from the allowlist only (both families).
 		ip saddr @mgmt_addrs tcp dport {{.SSHPort}} accept
+		ip6 saddr @mgmt_addrs6 tcp dport {{.SSHPort}} accept
 {{- if .PodCIDR}}
 
 		# In-cluster host-service ports, reachable from the pod CIDR only.
 		ip saddr {{.PodCIDR}} tcp dport @in_cluster_ports accept
+{{- end}}
+{{- if .PodCIDR6}}
+		ip6 saddr {{.PodCIDR6}} tcp dport @in_cluster_ports accept
 {{- end}}
 	}
 }

--- a/internal/ui/prompt/daemon.go
+++ b/internal/ui/prompt/daemon.go
@@ -261,14 +261,33 @@ func RunDaemonInstallPrompts(
 		}
 	}
 
-	// Step 4: wire up block-node component if selected.
-	// Orbit and Kubeconfig are omitted while the traffic-shaper is stubbed.
+	// Step 4: wire up block-node component if selected. The traffic-shaper
+	// monitor needs its scoped kubeconfig and the orbit namespace it watches, so
+	// this mirrors the consensus-node wiring above (kubeconfig set here, orbit
+	// prompted in Step 5) rather than leaving them empty.
 	if cs.Has(ComponentBlockNode) && cfg.Components.BlockNode == nil {
 		c := daemon.BlockNodeComponentConfig{
-			Enabled:  true,
-			Monitors: daemon.BlockNodeMonitors{TrafficShaper: true},
+			Enabled:    true,
+			Kubeconfig: paths.DaemonBNKubeconfigPath,
+			Monitors:   daemon.BlockNodeMonitors{TrafficShaper: true},
 		}
 		cfg.Components.BlockNode = &c
+		targets.BNOrbit = &cfg.Components.BlockNode.Orbit
+	}
+
+	// Step 5: prompt for block-node fields.
+	if cs.Has(ComponentBlockNode) && cfg.Components.BlockNode != nil {
+		bn := cfg.Components.BlockNode
+		orbitTarget := targets.BNOrbit
+		if orbitTarget == nil {
+			orbitTarget = &bn.Orbit
+		}
+		bnPrompts := []InputPrompt{
+			daemonBNOrbitInputPrompt(*orbitTarget, orbitTarget),
+		}
+		if err := RunInputPrompts(cmd, bnPrompts, cv); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/workflows/network_setup.go
+++ b/internal/workflows/network_setup.go
@@ -9,8 +9,124 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/network/shape"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
 	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
+	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 )
+
+// NetworkPlaneOptions parameterizes NetworkPlaneSteps for the three block-node
+// commands that converge the static network plane (install, reconfigure,
+// upgrade). All three share the same host-firewall + traffic-shaping step
+// bundle; they differ only in the fields below (issue #947).
+type NetworkPlaneOptions struct {
+	// Force is the operator's --force, threaded into NetworkPolicyCreate.
+	Force bool
+	// TrafficShapingEnabled is the resolved traffic-shaping target: the BN
+	// workload policy plane + tc HTB shaping + daemon monitor as one bundle.
+	TrafficShapingEnabled bool
+	// HealthPort is the resolved block-node health/statusz port, threaded into
+	// NetworkPolicyCreate so the bn-mgmt set tracks the port the BN listens on.
+	HealthPort string
+	// Namespace is the block-node namespace, used by the daemon-config step when
+	// WithDaemonReload is set.
+	Namespace string
+	// EgressInterface / LinkRate / ShapeOverrides feed the tc egress/ingress steps.
+	EgressInterface string
+	LinkRate        string
+	ShapeOverrides  map[string]shape.ClassOverride
+
+	// AllowTeardown permits deleting a feature resolved to off. reconfigure sets
+	// it (turning a feature off deletes it); install/upgrade leave it false and
+	// re-assert create-if-missing only, so a routine run never tears anything down.
+	AllowTeardown bool
+	// WithDaemonReload appends the daemon-config write + service restart inline
+	// after the shaping steps so a live daemon reloads the changed daemon.yaml
+	// (it reads the file only at startup — no hot-reload). reconfigure/upgrade set
+	// this; install leaves it false and instead writes the daemon config as a
+	// separate later phase (BlockNodeDaemonConfigWorkflow) and starts the service
+	// post-workflow, once the deployment the daemon watches exists.
+	WithDaemonReload bool
+}
+
+// NetworkPlaneSteps builds the static network-plane step list — host firewall
+// (inet host) convergence plus, when enabled, the BN traffic-shaping bundle
+// (policy plane + weaver table + $EGRESS/$VETH tc HTB shaping + daemon monitor)
+// — shared by `block node install`, `reconfigure`, and `upgrade`. Every step is
+// idempotent, so the same list is safe to re-run: create steps are
+// create-if-missing and teardown steps are delete-if-present.
+//
+// The three commands drive it through NetworkPlaneOptions:
+//   - install: AllowTeardown=false, WithDaemonReload=false (wrapped in the
+//     "Network Setup" phase by NetworkSetupWorkflow; daemon handled separately).
+//   - reconfigure: AllowTeardown=true, WithDaemonReload=true (operator-resolved
+//     target, allowed to tear a feature down).
+//   - upgrade: AllowTeardown=false, WithDaemonReload=true (persisted-state target,
+//     re-assert create-if-missing only).
+//
+// Ordering: firewall first, then NetworkPolicyCreate before NftWeaverPersist so
+// the policy registry is populated when the weaver table is rendered (an empty
+// registry would persist a policy-drop chain).
+func NetworkPlaneSteps(opts NetworkPlaneOptions) []automa.Builder {
+	var out []automa.Builder
+
+	// Host firewall: desired-state convergence. NetworkFirewallCreate self-gates
+	// on config.Host.Disabled, so it is always safe to include; a delete only runs
+	// when teardown is permitted (reconfigure) AND the operator resolved the
+	// firewall to disabled. reconcile=AllowTeardown: reconfigure force re-renders
+	// the host firewall so changed settings take effect; install/upgrade re-assert
+	// create-if-missing only.
+	if opts.AllowTeardown && config.Get().Host.Disabled {
+		out = append(out, steps.NetworkFirewallDelete())
+	} else {
+		out = append(out, steps.NetworkFirewallCreate(opts.AllowTeardown))
+	}
+
+	switch {
+	case opts.TrafficShapingEnabled:
+		// Enable: create the BN policy plane, persist the weaver table, (re)provision
+		// tc egress/ingress shaping, then — for the reload callers — enable the
+		// daemon's traffic-shaper monitor and restart the daemon so the change takes
+		// effect. The daemon reads daemon.yaml only at startup (no hot-reload) and the
+		// post-workflow ensureBlockNodeDaemon is a no-op when the daemon is already
+		// running, so re-enabling on a host where the daemon is up would otherwise
+		// never start the monitor and the ingress $VETH HTB would never be
+		// (re)installed. RestartDaemonServiceStep self-skips when the daemon is not
+		// running (fresh enable), where post-workflow ensureBlockNodeDaemon installs it.
+		out = append(out,
+			steps.NetworkPolicyCreate(opts.Force, opts.HealthPort),
+			steps.NftWeaverPersist(),
+			steps.TcEgressPersist(opts.EgressInterface, opts.LinkRate, opts.ShapeOverrides),
+			steps.TcIngressRecord(opts.EgressInterface, opts.LinkRate, opts.ShapeOverrides),
+		)
+		if opts.WithDaemonReload {
+			out = append(out,
+				steps.WriteBlockNodeDaemonConfigStep(models.Paths(), opts.Namespace, true),
+				steps.RestartDaemonServiceStep(),
+			)
+		}
+	case opts.AllowTeardown:
+		// Disable (reconfigure only): remove every BN policy (the last delete tears
+		// the inet weaver table down, so no NftWeaverPersist is needed), drop the tc
+		// egress hierarchy, then turn the daemon's monitor off and restart the daemon.
+		// The restart matters because the daemon reads daemon.yaml only at startup:
+		// without it the live monitor keeps re-applying the ingress $VETH HTB on the
+		// next BN pod create (triggered by the rollout-restart that runs right after
+		// these steps). Restarting here — before that pod churn — ensures the monitor
+		// is gone when the new veth appears, so it comes up unshaped.
+		// RestartDaemonServiceStep self-skips when the daemon is not running.
+		out = append(out,
+			steps.NetworkPolicyDeleteAll(),
+			steps.TcEgressTeardown(),
+		)
+		if opts.WithDaemonReload {
+			out = append(out,
+				steps.WriteBlockNodeDaemonConfigStep(models.Paths(), opts.Namespace, false),
+				steps.RestartDaemonServiceStep(),
+			)
+		}
+	}
+
+	return out
+}
 
 // NetworkSetupWorkflow lays down the block node's static network plane: the
 // node-level host firewall (inet host), the weaver policy-table persistence
@@ -31,15 +147,20 @@ import (
 // When false, none of the four steps are added: there is no inet weaver table
 // to persist and no tc config to shape traffic with.
 func NetworkSetupWorkflow(egressInterface, linkRate string, shapeOverrides map[string]shape.ClassOverride, force bool, trafficShapingEnabled bool, healthPort string) *automa.WorkflowBuilder {
-	stepList := []automa.Builder{steps.NetworkFirewallCreate(false)}
-	if trafficShapingEnabled {
-		stepList = append(stepList,
-			steps.NetworkPolicyCreate(force, healthPort),
-			steps.NftWeaverPersist(),
-			steps.TcEgressPersist(egressInterface, linkRate, shapeOverrides),
-			steps.TcIngressRecord(egressInterface, linkRate, shapeOverrides),
-		)
-	}
+	// Install shares the network-plane bundle with reconfigure/upgrade via
+	// NetworkPlaneSteps but never tears down (AllowTeardown=false) and defers the
+	// daemon monitor to the separate BlockNodeDaemonConfigWorkflow phase, which
+	// runs after the deployment it watches is in place (WithDaemonReload=false).
+	stepList := NetworkPlaneSteps(NetworkPlaneOptions{
+		Force:                 force,
+		TrafficShapingEnabled: trafficShapingEnabled,
+		HealthPort:            healthPort,
+		EgressInterface:       egressInterface,
+		LinkRate:              linkRate,
+		ShapeOverrides:        shapeOverrides,
+		AllowTeardown:         false,
+		WithDaemonReload:      false,
+	})
 
 	return automa.NewWorkflowBuilder().
 		WithId("block-node-network-setup").

--- a/internal/workflows/steps/step_network_policy.go
+++ b/internal/workflows/steps/step_network_policy.go
@@ -204,7 +204,10 @@ func NetworkPolicyCreate(force bool, healthPort string) *automa.StepBuilder {
 				}
 
 				cidrs := initialCIDRs(c, mgmtCIDRs)
-				changed, err := mgr.Create(ctx, c.toPolicy(healthPort), cidrs, podCIDR, force)
+				// Install-time wiring auto-detects a single (v4) pod CIDR; dual-stack
+				// v6 classification is opt-in via the `network policy create --pod-cidr`
+				// CLI (Manager.Create accepts a mixed v4/v6 list).
+				changed, err := mgr.Create(ctx, c.toPolicy(healthPort), cidrs, []string{podCIDR}, force)
 				if err != nil {
 					stp.State().Local().Set(policyCreatedNamesKey, created)
 					return automa.FailureReport(stp, automa.WithError(

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -749,6 +749,23 @@ func ValidateIPv4CIDR(s string) error {
 	return nil
 }
 
+// CIDRIsIPv6 reports whether s is an IPv6 CIDR (as opposed to IPv4). It is the
+// family classifier that lets the dual-stack `inet host` / `inet weaver`
+// renderers route each entry of a mixed --mgmt-cidrs / --blocked-cidrs / --cidrs
+// list into the matching nft set (ipv4_addr vs ipv6_addr). s should already have
+// passed ValidateCIDR; an unparseable value returns an error rather than a
+// misleading family verdict. Classification is by net.IP.To4(): it returns
+// non-nil for an IPv4-mapped IPv6 address (e.g. "::ffff:10.0.0.1"), so such an
+// address classifies as IPv4 — the family nft would place it in — even though
+// net.ParseCIDR keeps the address in 16-byte form.
+func CIDRIsIPv6(s string) (bool, error) {
+	ip, _, err := net.ParseCIDR(s)
+	if err != nil {
+		return false, errorx.IllegalArgument.New("invalid CIDR: %s", s)
+	}
+	return ip.To4() == nil, nil
+}
+
 // ValidatePort rejects any string that is not a valid TCP/UDP port number in
 // the range 1–65535. It is the boundary check for `--in-cluster-port` values
 // before they are rendered into the `inet host` nftables ruleset.

--- a/pkg/sanity/sanity_cidr_test.go
+++ b/pkg/sanity/sanity_cidr_test.go
@@ -46,6 +46,35 @@ func TestSanity_ValidateCIDR(t *testing.T) {
 	}
 }
 
+func TestSanity_CIDRIsIPv6(t *testing.T) {
+	testCases := []struct {
+		name    string
+		cidr    string
+		wantV6  bool
+		wantErr bool
+	}{
+		{name: "ipv4", cidr: "10.0.0.0/8", wantV6: false},
+		{name: "ipv4 host", cidr: "192.168.68.117/32", wantV6: false},
+		{name: "ipv6", cidr: "2001:db8::/32", wantV6: true},
+		{name: "ipv6 host", cidr: "2001:db8::1/128", wantV6: true},
+		{name: "ipv4-mapped ipv6 classifies as ipv4", cidr: "::ffff:10.0.0.1/128", wantV6: false},
+		{name: "not a cidr", cidr: "not-a-cidr", wantErr: true},
+		{name: "bare ip", cidr: "10.0.0.1", wantErr: true},
+		{name: "empty", cidr: "", wantErr: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			isV6, err := CIDRIsIPv6(tc.cidr)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantV6, isV6)
+		})
+	}
+}
+
 func TestSanity_ValidatePort(t *testing.T) {
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
## Description

Behavior-preserving cleanup of the traffic-shaper engine (`internal/network/shape`), which accumulated duplication and dead code as the feature landed across ~10 PRs, plus a fix for a real bug in the interactive daemon installer. Net **−116 lines**; no functional change to the shaping engine.

The daemon fix addresses a latent bug: the interactive `daemon service install` path built the block-node component **without** its kubeconfig or orbit namespace, guarded by a stale `"traffic-shaper is stubbed"` comment. The monitor is fully wired now, so that path produced an incomplete config versus `block node install` and `daemon_offer.go`, which both set these fields. The `bn-orbit` prompt and `BNOrbit` target already existed but were never hooked up.

### Files changed

| File | Change |
|---|---|
| `internal/network/shape/defaults.go` (new) | Data-driven egress/ingress default profiles + shared `buildDefaultConfig` |
| `internal/network/shape/tc.go` (new) | Single build-tag-free `TCRunner` interface declaration |
| `internal/network/shape/manager.go` | Share one `provisionDefaults`; drop twin `default*Config` + redundant exported `RenderAndApplyEgress`; use `validateClassFields` |
| `internal/network/shape/validate.go` | Add `validateClassFields` + `sumParseableRatesBps` |
| `internal/network/shape/override.go` | Use the shared validators; remove dead `ClassDirection` |
| `internal/network/shape/registry.go` | Generic `writeConfigJSON`/`readConfigJSON`/`removeConfigFile` behind the device/class wrappers |
| `internal/network/shape/tc_linux.go`, `tc_other.go` | Remove the now-shared `TCRunner` interface declaration |
| `internal/ui/prompt/daemon.go` | Wire block-node kubeconfig + orbit prompt (bug fix) |

### Review guide

Checklist:
- `defaults.go:64` `buildDefaultConfig` — verify `ceilFull` classes emit the trunk rate verbatim (e.g. `1gbit`, not `1000mbit`) and percentage classes match the previous `mbps*pct/100` maths (egress partner 40/70, public 30/70, reserve 30/trunk; ingress 80/10/10 all ceil=trunk).
- `manager.go` `provisionDefaults` — egress passes an `afterWrite` that renders+applies the boot script; ingress passes `nil` (config only, no boot script). Both still run under `withLock`.
- `validate.go` `validateSumRates` — the "device rate unparseable" and "new rate unparseable" early-return skips are preserved (guards the legacy SPEED path, intentionally untouched here).
- `registry.go` — error-message wording changed (no test asserts it); behavior identical, mkdir target unchanged.
- `daemon.go` — Step 4/5 mirror the consensus-node wiring; `bn-orbit` is prompted only when the block-node component is selected.

Tests:
```bash
go test ./internal/network/shape/... ./internal/blocknode/shaper/... ./internal/ui/prompt/...
task lint
```
All pass; `golangci-lint` reports 0 issues; `go vet` clean.

### Not in scope

The legacy "SPEED" sysfs-fallback render path is deliberately left untouched — it is still reachable via `network shape delete --device egress` and legacy on-disk registries, and retiring it needs a `DeleteDevice(egress)` redesign first (tracked in #946). Two follow-up structural refactors are filed separately: #946 (collapse the render/apply pipeline + single-source tc encoding) and #947 (unify the firewall/traffic-shaping gated-feature wiring).

### Related Issues

* Closes #948
