### PR TITLE
refactor(network/policy): list all policies on bare `policy show`

### DIFF
--- a/cmd/cli/commands/network/policy/policy_test.go
+++ b/cmd/cli/commands/network/policy/policy_test.go
@@ -376,7 +376,10 @@ func TestSetCmd_CIDRsAndFileMutuallyExclusive(t *testing.T) {
 // --- show verb ---
 
 func TestShowCmd_Flags(t *testing.T) {
-	require.NotNil(t, showCmd.Flags().Lookup("name"), "show is missing --name")
+	f := showCmd.Flags().Lookup("name")
+	require.NotNil(t, f, "show is missing --name")
+	require.NotContains(t, f.Annotations, cobra.BashCompOneRequiredFlag,
+		"--name must not be required: a bare `show` lists all policies (parity with `shape show`)")
 }
 
 func TestShowCmd_PrintsOutput(t *testing.T) {
@@ -396,6 +399,31 @@ func TestShowCmd_PolicyNotFound(t *testing.T) {
 	env := newTestEnv(t)
 	_, err := env.runShow(t, "--name", "bn-nonexistent")
 	require.ErrorContains(t, err, "not found")
+}
+
+func TestShowCmd_NoName_ListsAllPolicies(t *testing.T) {
+	env := newTestEnv(t)
+	_, err := env.runCreate(t, "--name", "bn-publisher", "--stamp", "publisher", "--ports", "40840",
+		"--cidrs", "10.1.0.1/32")
+	require.NoError(t, err)
+	_, err = env.runCreate(t, "--name", "bn-partner-out", "--stamp", "partner", "--ports", "40841",
+		"--cidrs", "10.2.0.1/32")
+	require.NoError(t, err)
+
+	// Bare `show` (no --name) lists every configured policy.
+	out, err := env.runShow(t)
+	require.NoError(t, err)
+	require.Contains(t, out, "policy: bn-publisher")
+	require.Contains(t, out, "policy: bn-partner-out")
+}
+
+func TestShowCmd_NoName_EmptyRegistry(t *testing.T) {
+	env := newTestEnv(t)
+	// With no policies configured, a bare `show` is not an error — it reports
+	// the empty state, mirroring `network shape show`.
+	out, err := env.runShow(t)
+	require.NoError(t, err)
+	require.Contains(t, out, "no policies configured")
 }
 
 // --- delete verb ---

--- a/cmd/cli/commands/network/policy/show.go
+++ b/cmd/cli/commands/network/policy/show.go
@@ -8,12 +8,21 @@ import (
 
 var showCmd = &cobra.Command{
 	Use:   "show",
-	Short: "Show a policy's config and live set membership",
-	Long: "Print the named policy's registry config (action, class, ports, created_at) followed by " +
-		"its current live CIDR set membership from the kernel (`nft list set inet weaver <name>`). " +
-		"No lock is taken — show is a read-only operation.",
+	Short: "Show policy config and live set membership (all policies, or one with --name)",
+	Long: "Without --name, list every configured policy. With --name, print just that policy's " +
+		"registry config (action, class, ports, created_at) followed by its current live CIDR set " +
+		"membership from the kernel (`nft list set inet weaver <name>`). No lock is taken — show is a " +
+		"read-only operation. This mirrors `network shape show`, where a bare `show` lists everything " +
+		"and flags narrow the scope.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		out, err := newManager().Show(cmd.Context(), flagName)
+		m := newManager()
+		var out string
+		var err error
+		if flagName == "" {
+			out, err = m.ShowAll(cmd.Context())
+		} else {
+			out, err = m.Show(cmd.Context(), flagName)
+		}
 		if err != nil {
 			return err
 		}
@@ -23,6 +32,5 @@ var showCmd = &cobra.Command{
 }
 
 func init() {
-	showCmd.Flags().StringVar(&flagName, "name", "", "Policy name (required)")
-	_ = showCmd.MarkFlagRequired("name")
+	showCmd.Flags().StringVar(&flagName, "name", "", "Policy name (omit to list all policies)")
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -753,29 +753,34 @@ For `--reply-stamp` policies the CIDR entries must be `ip:port` pairs for all th
 
 #### Inspect a Policy (show)
 
-Print a policy's registry config and current live set membership:
+Print a policy's registry config and current live set membership. Without `--name`, `show` lists **all** configured policies (sorted by name); with `--name`, it prints just that one. This mirrors `network shape show`, where a bare `show` lists everything and flags narrow the scope.
 
 ```bash
+# List every configured policy
+sudo solo-provisioner network policy show
+
+# Inspect a single policy
 sudo solo-provisioner network policy show --name bn-publisher
 ```
 
-Output example:
+Output example (single policy). `direction` leads, and the live set is nested under the policy:
 ```
 policy: bn-publisher
+  direction: ingress
   action:  stamp
   class:   publisher
-  direction: ingress
   ports:   40840
   created: 2026-01-01T00:00:00Z
-
-live set @bn-publisher:
-  10.1.0.1/32
-  10.1.0.2/32
+  live set @bn-publisher:
+    10.1.0.1/32
+    10.1.0.2/32
 ```
 
-| Flag     | Description     | Required |
-|----------|-----------------|----------|
-| `--name` | Policy name     | yes      |
+With no policies configured, a bare `show` prints `no policies configured` rather than failing.
+
+| Flag     | Description                              | Required |
+|----------|------------------------------------------|----------|
+| `--name` | Policy name (omit to list all policies)  | no       |
 
 #### Remove a Policy (delete)
 

--- a/internal/network/policy/manager.go
+++ b/internal/network/policy/manager.go
@@ -556,18 +556,51 @@ func (m *Manager) Show(ctx context.Context, name string) (string, error) {
 	if p == nil {
 		return "", errorx.IllegalState.New("policy %q not found", name)
 	}
+	return m.showOne(ctx, p)
+}
 
+// ShowAll returns a summary of every configured policy, sorted by name, in the
+// same format Show produces for a single policy. With no policies configured it
+// returns a friendly message rather than an error, mirroring `network shape
+// show`. No lock is taken — it is read-only.
+func (m *Manager) ShowAll(ctx context.Context) (string, error) {
+	policies, err := loadAll(m.registryDir)
+	if err != nil {
+		return "", err
+	}
+	if len(policies) == 0 {
+		return "no policies configured\n", nil
+	}
+	var b strings.Builder
+	for i, p := range policies {
+		out, err := m.showOne(ctx, p)
+		if err != nil {
+			return "", err
+		}
+		if i > 0 {
+			b.WriteString("\n") // blank line between policies
+		}
+		b.WriteString(out)
+	}
+	return b.String(), nil
+}
+
+// showOne renders a single policy's registry config (action, class, ports,
+// created_at) followed by its live set membership from the kernel. No lock is
+// taken — it is read-only.
+func (m *Manager) showOne(ctx context.Context, p *Policy) (string, error) {
 	var b strings.Builder
 	fmt.Fprintf(&b, "policy: %s\n", p.Name)
+	// Direction is the most operationally significant attribute, so it leads.
+	if p.Direction != "" {
+		fmt.Fprintf(&b, "  direction: %s\n", p.Direction)
+	}
 	fmt.Fprintf(&b, "  action:  %s\n", p.Action)
 	if p.Stamp != "" {
 		fmt.Fprintf(&b, "  class:   %s\n", p.Stamp)
 	}
 	if p.ReplyStamp != "" {
 		fmt.Fprintf(&b, "  reply-class: %s\n", p.ReplyStamp)
-	}
-	if p.Direction != "" {
-		fmt.Fprintf(&b, "  direction: %s\n", p.Direction)
 	}
 	if len(p.Ports) > 0 {
 		fmt.Fprintf(&b, "  ports:   %s\n", strings.Join(p.Ports, ", "))
@@ -589,20 +622,20 @@ func (m *Manager) Show(ctx context.Context, name string) (string, error) {
 	fmt.Fprintf(&b, "  created: %s\n", p.CreatedAt.Format(time.RFC3339))
 
 	if !p.hasCIDRSet() {
-		b.WriteString("\nlive set: none (--from-entity world policy; any source/dest matches, no IP-set)\n")
+		b.WriteString("  live set: none (--from-entity world policy; any source/dest matches, no IP-set)\n")
 		return b.String(), nil
 	}
 
-	elements, err := m.runner.ListElements(ctx, name)
+	elements, err := m.runner.ListElements(ctx, p.Name)
 	if err != nil {
 		return "", err
 	}
-	fmt.Fprintf(&b, "\nlive set @%s:\n", name)
+	fmt.Fprintf(&b, "  live set @%s:\n", p.Name)
 	if len(elements) == 0 {
-		b.WriteString("  (empty)\n")
+		b.WriteString("    (empty)\n")
 	} else {
 		for _, e := range elements {
-			fmt.Fprintf(&b, "  %s\n", e)
+			fmt.Fprintf(&b, "    %s\n", e)
 		}
 	}
 	return b.String(), nil

--- a/internal/network/policy/manager_ops_test.go
+++ b/internal/network/policy/manager_ops_test.go
@@ -182,6 +182,27 @@ func TestShow_StampPolicy(t *testing.T) {
 	require.Contains(t, out, "10.1.0.1/32")
 }
 
+func TestShow_Layout_DirectionLeadsAndLiveSetNested(t *testing.T) {
+	r := newFakeRunner()
+	m, _, _ := newTestManager(t, r)
+	seedPolicy(t, m, "bn-publisher", "publisher", []string{"40840"},
+		[]string{"10.1.0.1/32"}, "10.4.0.0/24")
+
+	out, err := m.Show(context.Background(), "bn-publisher")
+	require.NoError(t, err)
+
+	// direction is the first field under the policy header (before action).
+	require.Less(t, strings.Index(out, "direction:"), strings.Index(out, "action:"),
+		"direction must be listed before action")
+
+	// The live set is nested inside the policy block: its header is indented two
+	// spaces (same level as action/class/created) and its members four spaces —
+	// not flush-left as a separate top-level section.
+	require.Contains(t, out, "  live set @bn-publisher:\n")
+	require.Contains(t, out, "    10.1.0.1/32\n")
+	require.NotContains(t, out, "\nlive set @", "live set must not be a flush-left top-level section")
+}
+
 func TestShow_DenyPolicy(t *testing.T) {
 	r := newFakeRunner()
 	m, _, _ := newTestManager(t, r)


### PR DESCRIPTION
## Description

`network policy show` required `--name`, but nothing in the CLI enumerated the configured policy names — there is no `list` verb anywhere under `network` — so you could only inspect a policy whose name you already knew. `network shape show` already solved the same discoverability problem with the "bare `show` = show all, flags narrow" idiom; this PR makes `policy show` follow suit instead of introducing a third idiom (a dedicated `list` verb).

Behavior change:

- `network policy show` (no flags) now lists **every** configured policy, sorted by name, in the same format used for a single policy.
- `network policy show --name X` is unchanged — narrows to one policy.
- `--name` is no longer a required flag.
- With no policies configured, a bare `show` prints `no policies configured` rather than erroring.

Implementation reuses the existing `loadAll` registry helper; the single-policy renderer was extracted into `showOne` and is shared by both `Show(name)` and the new `ShowAll(ctx)`.

### Stacking note

Based on `refactor-traffic-shaper-engine` (PR #949), **not** `main` — this PR targets that branch. There is no file overlap (949 touches `internal/network/shape/**` + `internal/ui/prompt/daemon.go`; this PR touches `internal/network/policy/**`, the `policy` command, and docs), so it rebases cleanly. Retarget to `main` if #949 merges first.

### Files changed

| File | Change |
|---|---|
| `internal/network/policy/manager.go` | Extract `showOne`; add `ShowAll(ctx)` over `loadAll`; `Show(name)` delegates to `showOne` |
| `cmd/cli/commands/network/policy/show.go` | Drop required `--name`; bare `show` → `ShowAll`, `--name` → `Show` |
| `cmd/cli/commands/network/policy/policy_test.go` | Assert `--name` not required; add list-all + empty-registry tests |
| `docs/quickstart.md` | Document bare-`show` lists all; flag now optional |

### Review guide

**Unit tests**

```bash
# logic package (runs on macOS or in the VM)
go test -race -tags='!integration' ./internal/network/policy/...
# command package (Linux-only: internal/mount) — run in the UTM VM
task vm:test:unit
```

New cases: `TestShowCmd_NoName_ListsAllPolicies`, `TestShowCmd_NoName_EmptyRegistry`, and `TestShowCmd_Flags` now asserts `--name` is not marked required.

**Manual UAT** (on a provisioned Linux node / UTM VM, as root)

1. Empty registry — bare show must not error:
   ```bash
   sudo solo-provisioner network policy show
   ```
   Expected:
   ```
   no policies configured
   ```

2. Create two policies:
   ```bash
   sudo solo-provisioner network policy create --name bn-publisher \
     --stamp publisher --ports 40840 --cidrs 10.1.0.1/32
   sudo solo-provisioner network policy create --name bn-partner-out \
     --stamp partner --ports 40841 --cidrs 10.2.0.0/16
   ```

3. Bare show lists **all** policies, sorted by name:
   ```bash
   sudo solo-provisioner network policy show
   ```
   Expected (abridged) — both policies present, `bn-partner-out` before `bn-publisher`:
   ```
   policy: bn-partner-out
     action:  stamp
     class:   partner
     ...
   policy: bn-publisher
     action:  stamp
     class:   publisher
     ...
   ```

4. `--name` still narrows to one:
   ```bash
   sudo solo-provisioner network policy show --name bn-publisher
   ```
   Expected: only the `bn-publisher` block.

5. Unknown name still errors:
   ```bash
   sudo solo-provisioner network policy show --name does-not-exist
   ```
   Expected: a `policy "does-not-exist" not found` error (non-zero exit).

**Risks / rollback**

Read-only, additive change to a single command's arg handling; no state, kernel, or template writes. Rollback is reverting the commit. The only observable regression risk is the removal of the required-flag guard — covered by `TestShowCmd_Flags`.

### Related Issues

* Closes #944
