### PR TITLE
feat(network/shape): add read-only `network shape watch` operator verify

### DIFF
--- a/cmd/cli/commands/network/shape/shape.go
+++ b/cmd/cli/commands/network/shape/shape.go
@@ -43,6 +43,7 @@ func init() {
 	shapeCmd.AddCommand(createCmd)
 	shapeCmd.AddCommand(setCmd)
 	shapeCmd.AddCommand(showCmd)
+	shapeCmd.AddCommand(watchCmd)
 	shapeCmd.AddCommand(deleteCmd)
 }
 

--- a/cmd/cli/commands/network/shape/shape_test.go
+++ b/cmd/cli/commands/network/shape/shape_test.go
@@ -22,7 +22,10 @@ func resetFlags() {
 	flagCeil = ""
 	flagPrio = 0
 	flagDefault = ""
-	for _, cmd := range []*cobra.Command{createCmd, setCmd, showCmd, deleteCmd} {
+	flagWatchIface = ""
+	flagWatchInterval = 2 * time.Second // watch's registered default
+	flagWatchCount = 0
+	for _, cmd := range []*cobra.Command{createCmd, setCmd, showCmd, watchCmd, deleteCmd} {
 		cmd.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
 	}
 }
@@ -34,7 +37,7 @@ func TestShapeCmd_HasExpectedSubcommands(t *testing.T) {
 	for _, c := range shapeCmd.Commands() {
 		subs[c.Name()] = true
 	}
-	for _, want := range []string{"create", "set", "show", "delete"} {
+	for _, want := range []string{"create", "set", "show", "watch", "delete"} {
 		require.True(t, subs[want], "missing subcommand %q", want)
 	}
 }
@@ -165,6 +168,39 @@ func TestShowCmd_BothClassAndDevice_Error(t *testing.T) {
 
 	err := showCmd.RunE(showCmd, nil)
 	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+// --- watch: flag registration + early validation (fires before newManager) ---
+
+func TestWatchCmd_FlagsRegistered(t *testing.T) {
+	for _, flag := range []string{"class", "device", "iface", "interval", "count"} {
+		require.NotNil(t, watchCmd.Flags().Lookup(flag), "watch: missing --%s", flag)
+	}
+}
+
+func TestWatchCmd_BothClassAndDevice_Error(t *testing.T) {
+	defer resetFlags()
+	flagClass = "partner"
+	flagDevice = "egress"
+
+	err := watchCmd.RunE(watchCmd, nil)
+	require.ErrorContains(t, err, "mutually exclusive")
+}
+
+func TestWatchCmd_NonPositiveInterval_Error(t *testing.T) {
+	defer resetFlags()
+	flagWatchInterval = 0
+
+	err := watchCmd.RunE(watchCmd, nil)
+	require.ErrorContains(t, err, "--interval must be positive")
+}
+
+func TestWatchCmd_NegativeCount_Error(t *testing.T) {
+	defer resetFlags()
+	flagWatchCount = -1
+
+	err := watchCmd.RunE(watchCmd, nil)
+	require.ErrorContains(t, err, "--count")
 }
 
 // --- delete: mutual exclusion and required-one-of validation ---

--- a/cmd/cli/commands/network/shape/shape_test.go
+++ b/cmd/cli/commands/network/shape/shape_test.go
@@ -178,17 +178,26 @@ func TestWatchCmd_FlagsRegistered(t *testing.T) {
 	}
 }
 
-func TestWatchCmd_BothClassAndDevice_Error(t *testing.T) {
+func TestWatchCmd_RequiresDevice(t *testing.T) {
 	defer resetFlags()
-	flagClass = "partner"
-	flagDevice = "egress"
+	flagWatchIface = "enp0s1" // device left empty
 
 	err := watchCmd.RunE(watchCmd, nil)
-	require.ErrorContains(t, err, "mutually exclusive")
+	require.ErrorContains(t, err, "--device is required")
+}
+
+func TestWatchCmd_RequiresIface(t *testing.T) {
+	defer resetFlags()
+	flagDevice = "egress" // iface left empty
+
+	err := watchCmd.RunE(watchCmd, nil)
+	require.ErrorContains(t, err, "--iface is required")
 }
 
 func TestWatchCmd_NonPositiveInterval_Error(t *testing.T) {
 	defer resetFlags()
+	flagDevice = "egress"
+	flagWatchIface = "enp0s1"
 	flagWatchInterval = 0
 
 	err := watchCmd.RunE(watchCmd, nil)
@@ -197,6 +206,8 @@ func TestWatchCmd_NonPositiveInterval_Error(t *testing.T) {
 
 func TestWatchCmd_NegativeCount_Error(t *testing.T) {
 	defer resetFlags()
+	flagDevice = "egress"
+	flagWatchIface = "enp0s1"
 	flagWatchCount = -1
 
 	err := watchCmd.RunE(watchCmd, nil)

--- a/cmd/cli/commands/network/shape/watch.go
+++ b/cmd/cli/commands/network/shape/watch.go
@@ -28,8 +28,10 @@ var watchCmd = &cobra.Command{
 		"Use it to confirm traffic is actually being classified and shaped (e.g. partner traffic landing " +
 		"in 1:40 with a non-zero rate and climbing overlimits).\n\n" +
 		"Read-only: it never mutates tc or the shape registry. Without flags it watches the egress NIC " +
-		"(auto-detected). --device ingress watches a per-pod $VETH and requires --iface. --class narrows " +
-		"the output to a single class. Runs until interrupted (Ctrl-C) unless --count is given.",
+		"(auto-detected from the default route). --device ingress auto-detects the shaped per-pod $VETH " +
+		"(the interface carrying an HTB qdisc); pass --iface only to override or to pick one when several " +
+		"ingress veths are shaped. --class narrows the output to a single class. Runs until interrupted " +
+		"(Ctrl-C) unless --count is given.",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		if flagClass != "" && flagDevice != "" {
 			return errorx.IllegalArgument.New("--class and --device are mutually exclusive")
@@ -60,7 +62,7 @@ var watchCmd = &cobra.Command{
 func init() {
 	watchCmd.Flags().StringVar(&flagClass, "class", "", "Watch a single class (device is derived from the class name)")
 	watchCmd.Flags().StringVar(&flagDevice, "device", "", "Traffic direction to watch: egress ($NIC, default) or ingress ($VETH)")
-	watchCmd.Flags().StringVar(&flagWatchIface, "iface", "", "Interface to sample; required for ingress (a per-pod $VETH), optional override for egress")
+	watchCmd.Flags().StringVar(&flagWatchIface, "iface", "", "Interface to sample; optional — egress auto-detects the NIC, ingress auto-detects the shaped $VETH. Pass to override, or to pick one when several ingress veths are shaped")
 	watchCmd.Flags().DurationVar(&flagWatchInterval, "interval", 2*time.Second, "Sampling interval (e.g. 1s, 500ms)")
 	watchCmd.Flags().IntVar(&flagWatchCount, "count", 0, "Number of samples to print then exit (0 = run until interrupted)")
 }

--- a/cmd/cli/commands/network/shape/watch.go
+++ b/cmd/cli/commands/network/shape/watch.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"os/signal"
+	"syscall"
+	"time"
+
+	shp "github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+// watch-only flag binding targets (interval/count/iface are unique to `watch`;
+// --class/--device are the shared vars declared in shape.go).
+var (
+	flagWatchIface    string
+	flagWatchInterval time.Duration
+	flagWatchCount    int
+)
+
+var watchCmd = &cobra.Command{
+	Use:   "watch",
+	Short: "Sample live tc class counters over time (read-only)",
+	Long: "Sample the live tc HTB class counters (`tc -s class show`) at a fixed interval and print " +
+		"per-class rate-over-time — throughput, plus the change in overlimits and drops — each tick. " +
+		"Use it to confirm traffic is actually being classified and shaped (e.g. partner traffic landing " +
+		"in 1:40 with a non-zero rate and climbing overlimits).\n\n" +
+		"Read-only: it never mutates tc or the shape registry. Without flags it watches the egress NIC " +
+		"(auto-detected). --device ingress watches a per-pod $VETH and requires --iface. --class narrows " +
+		"the output to a single class. Runs until interrupted (Ctrl-C) unless --count is given.",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if flagClass != "" && flagDevice != "" {
+			return errorx.IllegalArgument.New("--class and --device are mutually exclusive")
+		}
+		if flagWatchInterval <= 0 {
+			return errorx.IllegalArgument.New("--interval must be positive")
+		}
+		if flagWatchCount < 0 {
+			return errorx.IllegalArgument.New("--count must be zero or positive (0 = run until interrupted)")
+		}
+
+		// Ctrl-C (and SIGTERM) cancels the sampling loop cleanly rather than
+		// aborting mid-write; WatchClasses returns nil on ctx cancellation.
+		ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
+
+		spec := shp.WatchSpec{
+			Device:   flagDevice,
+			Iface:    flagWatchIface,
+			Class:    flagClass,
+			Interval: flagWatchInterval,
+			Count:    flagWatchCount,
+		}
+		return newManager().WatchClasses(ctx, spec, cmd.OutOrStdout())
+	},
+}
+
+func init() {
+	watchCmd.Flags().StringVar(&flagClass, "class", "", "Watch a single class (device is derived from the class name)")
+	watchCmd.Flags().StringVar(&flagDevice, "device", "", "Traffic direction to watch: egress ($NIC, default) or ingress ($VETH)")
+	watchCmd.Flags().StringVar(&flagWatchIface, "iface", "", "Interface to sample; required for ingress (a per-pod $VETH), optional override for egress")
+	watchCmd.Flags().DurationVar(&flagWatchInterval, "interval", 2*time.Second, "Sampling interval (e.g. 1s, 500ms)")
+	watchCmd.Flags().IntVar(&flagWatchCount, "count", 0, "Number of samples to print then exit (0 = run until interrupted)")
+}

--- a/cmd/cli/commands/network/shape/watch.go
+++ b/cmd/cli/commands/network/shape/watch.go
@@ -27,14 +27,18 @@ var watchCmd = &cobra.Command{
 		"per-class rate-over-time — throughput, plus the change in overlimits and drops — each tick. " +
 		"Use it to confirm traffic is actually being classified and shaped (e.g. partner traffic landing " +
 		"in 1:40 with a non-zero rate and climbing overlimits).\n\n" +
-		"Read-only: it never mutates tc or the shape registry. Without flags it watches the egress NIC " +
-		"(auto-detected from the default route). --device ingress auto-detects the shaped per-pod $VETH " +
-		"(the interface carrying an HTB qdisc); pass --iface only to override or to pick one when several " +
-		"ingress veths are shaped. --class narrows the output to a single class. Runs until interrupted " +
-		"(Ctrl-C) unless --count is given.",
+		"Read-only: it never mutates tc or the shape registry. Both --device (egress or ingress) and " +
+		"--iface (the interface to sample) are required — the command does no environment probing (no NIC " +
+		"or veth auto-detection), so it stays independent of any running block node. For egress, --iface " +
+		"is the physical NIC (e.g. enp0s1); for ingress, the per-pod host veth (e.g. lxc1a2b3c). --class " +
+		"narrows the output to a single class within --device. Runs until interrupted (Ctrl-C) unless " +
+		"--count is given.",
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		if flagClass != "" && flagDevice != "" {
-			return errorx.IllegalArgument.New("--class and --device are mutually exclusive")
+		if flagDevice == "" {
+			return errorx.IllegalArgument.New("--device is required (egress or ingress)")
+		}
+		if flagWatchIface == "" {
+			return errorx.IllegalArgument.New("--iface is required (the interface to sample)")
 		}
 		if flagWatchInterval <= 0 {
 			return errorx.IllegalArgument.New("--interval must be positive")
@@ -60,9 +64,9 @@ var watchCmd = &cobra.Command{
 }
 
 func init() {
-	watchCmd.Flags().StringVar(&flagClass, "class", "", "Watch a single class (device is derived from the class name)")
-	watchCmd.Flags().StringVar(&flagDevice, "device", "", "Traffic direction to watch: egress ($NIC, default) or ingress ($VETH)")
-	watchCmd.Flags().StringVar(&flagWatchIface, "iface", "", "Interface to sample; optional — egress auto-detects the NIC, ingress auto-detects the shaped $VETH. Pass to override, or to pick one when several ingress veths are shaped")
+	watchCmd.Flags().StringVar(&flagClass, "class", "", "Narrow output to a single class within --device (optional)")
+	watchCmd.Flags().StringVar(&flagDevice, "device", "", "Traffic direction to watch: egress ($NIC) or ingress ($VETH) (required)")
+	watchCmd.Flags().StringVar(&flagWatchIface, "iface", "", "Interface to sample, e.g. enp0s1 (egress) or lxc1a2b3c (ingress veth) (required)")
 	watchCmd.Flags().DurationVar(&flagWatchInterval, "interval", 2*time.Second, "Sampling interval (e.g. 1s, 500ms)")
 	watchCmd.Flags().IntVar(&flagWatchCount, "count", 0, "Number of samples to print then exit (0 = run until interrupted)")
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -846,6 +846,24 @@ sudo solo-provisioner network shape show              # all devices and classes
 sudo solo-provisioner network shape show --class partner  # single class
 ```
 
+`show` reports the **stored** configuration (rate/ceil/prio). To see **live** traffic flowing through the classes, use `watch`.
+
+**Watch (live counters, read-only)**
+
+```bash
+# Sample the egress NIC every 2s and print per-class rate + Δoverlimits/Δdrops.
+# Runs until Ctrl-C.
+sudo solo-provisioner network shape watch
+
+# Faster sampling of a single class, bounded to 5 samples then exit.
+sudo solo-provisioner network shape watch --class partner --interval 1s --count 5
+
+# Ingress classes live on per-pod $VETH interfaces, so name the interface:
+sudo solo-provisioner network shape watch --device ingress --iface veth1234
+```
+
+`watch` samples `tc -s class show dev <device>` at `--interval` and prints, per class, the throughput (from the byte delta) plus the change in overlimits and drops since the previous sample — "rate over time". It is read-only: it never mutates tc or the shape registry. Use it to confirm traffic is actually being classified and shaped — e.g. partner traffic landing in `1:40` with a non-zero rate and climbing overlimits. Without flags it watches the auto-detected egress NIC; `--device ingress` requires `--iface` (there is no single ingress device — the HTB lives on ephemeral per-pod veths). This complements the Prometheus counters, which target dashboards rather than an operator at a terminal.
+
 **Delete**
 
 ```bash
@@ -862,6 +880,9 @@ sudo solo-provisioner network shape delete --class reserve-egress
 | `--prio`    | HTB scheduling priority `[0,7]`; 0 is highest                                   | no (default 0)        |
 | `--default` | Default class for unmatched traffic (`--device` form only)                      | yes (`--device`)      |
 | `--force`   | Replace an existing device or class config                                       | no                    |
+| `--iface`   | Interface to sample (`watch`); required for `--device ingress` (a per-pod `$VETH`) | `watch` ingress       |
+| `--interval`| Sampling interval for `watch` (e.g. `1s`, `500ms`); default `2s`                 | no                    |
+| `--count`   | Number of `watch` samples to print then exit; `0` = run until interrupted        | no                    |
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -851,21 +851,18 @@ sudo solo-provisioner network shape show --class partner  # single class
 **Watch (live counters, read-only)**
 
 ```bash
-# Sample the egress NIC every 2s and print per-class rate + Δoverlimits/Δdrops.
+# Watch the egress NIC every 2s — both --device and --iface are required.
 # Runs until Ctrl-C.
-sudo solo-provisioner network shape watch
+sudo solo-provisioner network shape watch --device egress --iface enp0s1
 
-# Faster sampling of a single class, bounded to 5 samples then exit.
-sudo solo-provisioner network shape watch --class partner --interval 1s --count 5
+# Narrow to a single class, faster sampling, bounded to 5 samples then exit.
+sudo solo-provisioner network shape watch --device egress --iface enp0s1 --class partner --interval 1s --count 5
 
-# Ingress: the shaped per-pod $VETH is auto-detected — no --iface needed.
-sudo solo-provisioner network shape watch --device ingress
-
-# Only when several veths are shaped (multiple block-node pods) name one:
+# Watch a block node's ingress veth (find it with `ip link` or `tc qdisc show`).
 sudo solo-provisioner network shape watch --device ingress --iface lxc1a2b3c
 ```
 
-`watch` samples `tc -s class show dev <device>` at `--interval` and prints, per class, the throughput (from the byte delta) plus the change in overlimits and drops since the previous sample — "rate over time". It is read-only: it never mutates tc or the shape registry. Use it to confirm traffic is actually being classified and shaped — e.g. partner traffic landing in `1:40` with a non-zero rate and climbing overlimits. Without flags it watches the auto-detected egress NIC (the default-route interface); `--device ingress` auto-detects the shaped per-pod `$VETH` (the interface carrying an HTB qdisc, found via `tc qdisc show` — no Kubernetes needed). `--iface` is only needed to override the detected interface or to pick one when several ingress veths are shaped. This complements the Prometheus counters, which target dashboards rather than an operator at a terminal.
+`watch` samples `tc -s class show dev <iface>` at `--interval` and prints, per class, the throughput (from the byte delta) plus the change in overlimits and drops since the previous sample — "rate over time". It is read-only: it never mutates tc or the shape registry. Use it to confirm traffic is actually being classified and shaped — e.g. partner traffic landing in `1:40` with a non-zero rate and climbing overlimits. Both `--device` (egress or ingress — selects the class set) and `--iface` (the interface to sample) are **required**: the command does no environment probing — no NIC or veth auto-detection — so it stays independent of any running block node. For egress, `--iface` is the physical NIC (e.g. `enp0s1`); for ingress, the per-pod host veth (e.g. `lxc1a2b3c`), which you can find with `ip link` or `tc qdisc show`. `--class` narrows the output to one class within `--device`. This complements the Prometheus counters, which target dashboards rather than an operator at a terminal.
 
 **Delete**
 
@@ -883,7 +880,7 @@ sudo solo-provisioner network shape delete --class reserve-egress
 | `--prio`    | HTB scheduling priority `[0,7]`; 0 is highest                                   | no (default 0)        |
 | `--default` | Default class for unmatched traffic (`--device` form only)                      | yes (`--device`)      |
 | `--force`   | Replace an existing device or class config                                       | no                    |
-| `--iface`   | Interface to sample (`watch`); optional — egress auto-detects the NIC, ingress auto-detects the shaped `$VETH`. Pass to override, or to pick one when several ingress veths are shaped | no |
+| `--iface`   | Interface to sample (`watch`); **required** — e.g. `enp0s1` (egress) or `lxc1a2b3c` (ingress veth). No auto-detection | `watch`               |
 | `--interval`| Sampling interval for `watch` (e.g. `1s`, `500ms`); default `2s`                 | no                    |
 | `--count`   | Number of `watch` samples to print then exit; `0` = run until interrupted        | no                    |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -858,11 +858,14 @@ sudo solo-provisioner network shape watch
 # Faster sampling of a single class, bounded to 5 samples then exit.
 sudo solo-provisioner network shape watch --class partner --interval 1s --count 5
 
-# Ingress classes live on per-pod $VETH interfaces, so name the interface:
-sudo solo-provisioner network shape watch --device ingress --iface veth1234
+# Ingress: the shaped per-pod $VETH is auto-detected — no --iface needed.
+sudo solo-provisioner network shape watch --device ingress
+
+# Only when several veths are shaped (multiple block-node pods) name one:
+sudo solo-provisioner network shape watch --device ingress --iface lxc1a2b3c
 ```
 
-`watch` samples `tc -s class show dev <device>` at `--interval` and prints, per class, the throughput (from the byte delta) plus the change in overlimits and drops since the previous sample — "rate over time". It is read-only: it never mutates tc or the shape registry. Use it to confirm traffic is actually being classified and shaped — e.g. partner traffic landing in `1:40` with a non-zero rate and climbing overlimits. Without flags it watches the auto-detected egress NIC; `--device ingress` requires `--iface` (there is no single ingress device — the HTB lives on ephemeral per-pod veths). This complements the Prometheus counters, which target dashboards rather than an operator at a terminal.
+`watch` samples `tc -s class show dev <device>` at `--interval` and prints, per class, the throughput (from the byte delta) plus the change in overlimits and drops since the previous sample — "rate over time". It is read-only: it never mutates tc or the shape registry. Use it to confirm traffic is actually being classified and shaped — e.g. partner traffic landing in `1:40` with a non-zero rate and climbing overlimits. Without flags it watches the auto-detected egress NIC (the default-route interface); `--device ingress` auto-detects the shaped per-pod `$VETH` (the interface carrying an HTB qdisc, found via `tc qdisc show` — no Kubernetes needed). `--iface` is only needed to override the detected interface or to pick one when several ingress veths are shaped. This complements the Prometheus counters, which target dashboards rather than an operator at a terminal.
 
 **Delete**
 
@@ -880,7 +883,7 @@ sudo solo-provisioner network shape delete --class reserve-egress
 | `--prio`    | HTB scheduling priority `[0,7]`; 0 is highest                                   | no (default 0)        |
 | `--default` | Default class for unmatched traffic (`--device` form only)                      | yes (`--device`)      |
 | `--force`   | Replace an existing device or class config                                       | no                    |
-| `--iface`   | Interface to sample (`watch`); required for `--device ingress` (a per-pod `$VETH`) | `watch` ingress       |
+| `--iface`   | Interface to sample (`watch`); optional — egress auto-detects the NIC, ingress auto-detects the shaped `$VETH`. Pass to override, or to pick one when several ingress veths are shaped | no |
 | `--interval`| Sampling interval for `watch` (e.g. `1s`, `500ms`); default `2s`                 | no                    |
 | `--count`   | Number of `watch` samples to print then exit; `0` = run until interrupted        | no                    |
 

--- a/internal/network/shape/stats.go
+++ b/internal/network/shape/stats.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/joomcode/errorx"
@@ -40,13 +41,15 @@ type ClassDelta struct {
 }
 
 // WatchSpec parameterises Manager.WatchClasses. Device is the traffic direction
-// (egress/ingress); Iface names the concrete interface to sample and is required
-// for ingress (whose HTB lives on per-pod $VETH interfaces, so there is no single
-// device to auto-detect). Class, when set, narrows the watch to one class and
-// implies its direction.
+// (egress/ingress); Iface optionally names the concrete interface to sample —
+// when empty, egress auto-detects the NIC (default route) and ingress
+// auto-detects the shaped per-pod $VETH (the interface carrying an HTB qdisc).
+// Iface is only needed to override the egress NIC or to disambiguate when more
+// than one ingress veth is shaped. Class, when set, narrows the watch to one
+// class and implies its direction.
 type WatchSpec struct {
 	Device   string        // "egress" (default) or "ingress"
-	Iface    string        // explicit interface to sample; required for ingress
+	Iface    string        // explicit interface to sample; empty = auto-detect for the direction
 	Class    string        // single class to watch; "" watches all classes for the direction
 	Interval time.Duration // sampling interval
 	Count    int           // number of delta samples to print then stop; 0 = until ctx is cancelled
@@ -69,7 +72,7 @@ func (m *Manager) WatchClasses(ctx context.Context, spec WatchSpec, w io.Writer)
 	if err != nil {
 		return err
 	}
-	iface, err := m.resolveWatchIface(dir, spec.Iface)
+	iface, err := m.resolveWatchIface(ctx, dir, spec.Iface)
 	if err != nil {
 		return err
 	}
@@ -159,21 +162,64 @@ func resolveWatchClasses(spec WatchSpec) (dir string, classes []string, err erro
 }
 
 // resolveWatchIface resolves the concrete interface to sample. An explicit
-// --iface always wins. Otherwise egress auto-detects the NIC; ingress cannot be
-// auto-resolved (its HTB is per-pod $VETH) and requires --iface.
-func (m *Manager) resolveWatchIface(dir, iface string) (string, error) {
+// --iface always wins. Otherwise egress auto-detects the NIC (default route) and
+// ingress auto-detects the shaped per-pod $VETH from the live HTB qdisc (see
+// detectIngressVeths). Ingress auto-detection resolves cleanly only when exactly
+// one veth is shaped; with none or several it returns an actionable error asking
+// for --iface.
+func (m *Manager) resolveWatchIface(ctx context.Context, dir, iface string) (string, error) {
 	if iface != "" {
 		return iface, nil
 	}
 	if dir == DirIngress {
-		return "", errorx.IllegalArgument.New(
-			"ingress classes live on per-pod $VETH interfaces; pass --iface <veth> to name the interface to watch")
+		veths, err := m.detectIngressVeths(ctx)
+		if err != nil {
+			return "", errorx.Decorate(err, "cannot watch ingress shape: veth auto-detection failed")
+		}
+		switch len(veths) {
+		case 0:
+			return "", errorx.IllegalState.New(
+				"no ingress-shaped veth found (no per-pod interface carries an HTB qdisc); " +
+					"is a block node running and shaped? pass --iface <veth> to watch a specific interface")
+		case 1:
+			return veths[0], nil
+		default:
+			return "", errorx.IllegalArgument.New(
+				"multiple ingress-shaped veths found (%s); pass --iface <veth> to select one",
+				strings.Join(veths, ", "))
+		}
 	}
 	nic, err := m.nicDetect()
 	if err != nil {
 		return "", errorx.Decorate(err, "cannot watch egress shape: egress NIC detection failed")
 	}
 	return nic, nil
+}
+
+// detectIngressVeths returns the host-side veth interfaces carrying an ingress
+// HTB hierarchy: every device with an HTB qdisc (from `tc -j qdisc show`), minus
+// the egress NIC (which is also HTB-rooted). Keying on the live qdisc — rather
+// than on a pod's eth0 iflink, the way the daemon's k8s-dependent VethResolver
+// does — lets the host-only CLI find the shaped veth with no pod or kubeconfig.
+//
+// Excluding the egress NIC is best-effort: if egress detection fails (e.g. an
+// ingress-only host with no default route), nothing is excluded — the HTB
+// devices are all veths in that case anyway.
+func (m *Manager) detectIngressVeths(ctx context.Context) ([]string, error) {
+	devs, err := m.tcRunner.HTBDevices(ctx)
+	if err != nil {
+		return nil, err
+	}
+	egress, _ := m.nicDetect()
+	out := make([]string, 0, len(devs))
+	for _, d := range devs {
+		if d == egress {
+			continue
+		}
+		out = append(out, d)
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 // classDeltas computes the per-class delta between two samples for the named

--- a/internal/network/shape/stats.go
+++ b/internal/network/shape/stats.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/joomcode/errorx"
@@ -40,17 +39,16 @@ type ClassDelta struct {
 	DropsDelta      uint64
 }
 
-// WatchSpec parameterises Manager.WatchClasses. Device is the traffic direction
-// (egress/ingress); Iface optionally names the concrete interface to sample —
-// when empty, egress auto-detects the NIC (default route) and ingress
-// auto-detects the shaped per-pod $VETH (the interface carrying an HTB qdisc).
-// Iface is only needed to override the egress NIC or to disambiguate when more
-// than one ingress veth is shaped. Class, when set, narrows the watch to one
-// class and implies its direction.
+// WatchSpec parameterises Manager.WatchClasses. Both Device (the traffic
+// direction, which selects the class set) and Iface (the interface to sample)
+// are required and operator-supplied: `network shape watch` performs no
+// environment probing — no NIC or veth auto-detection — so it never depends on a
+// block node running or on Kubernetes. Class optionally narrows the watch to one
+// class, which must belong to Device's direction.
 type WatchSpec struct {
-	Device   string        // "egress" (default) or "ingress"
-	Iface    string        // explicit interface to sample; empty = auto-detect for the direction
-	Class    string        // single class to watch; "" watches all classes for the direction
+	Device   string        // "egress" or "ingress" — required; selects the class set
+	Iface    string        // interface to sample — required
+	Class    string        // optional: narrow to one class in Device's direction
 	Interval time.Duration // sampling interval
 	Count    int           // number of delta samples to print then stop; 0 = until ctx is cancelled
 }
@@ -67,15 +65,15 @@ func (m *Manager) WatchClasses(ctx context.Context, spec WatchSpec, w io.Writer)
 	if spec.Count < 0 {
 		return errorx.IllegalArgument.New("--count must be zero or positive (0 = run until interrupted)")
 	}
+	if spec.Iface == "" {
+		return errorx.IllegalArgument.New("--iface is required (the interface to sample)")
+	}
 
 	dir, classes, err := resolveWatchClasses(spec)
 	if err != nil {
 		return err
 	}
-	iface, err := m.resolveWatchIface(ctx, dir, spec.Iface)
-	if err != nil {
-		return err
-	}
+	iface := spec.Iface
 
 	fmt.Fprintf(w, "watching tc classes on %s (%s device), interval %s — Ctrl-C to stop\n",
 		iface, dir, spec.Interval)
@@ -137,89 +135,31 @@ func (m *Manager) sampleStats(ctx context.Context, iface string) (stats map[stri
 	return stats, time.Now(), false, nil
 }
 
-// resolveWatchClasses resolves the spec's device/class selection to a direction
-// plus the class names to display. --class selects a single class and derives its
-// direction; --device shows every class for that direction; the default (neither)
-// watches egress — the physical NIC is the common operator-verify target. --class
-// and --device are mutually exclusive at the CLI (see watch.go RunE), matching the
-// other `network shape` verbs, so both are never set here.
+// resolveWatchClasses validates the spec's device/class selection and returns the
+// direction plus the class names to display. --device (required) selects the
+// class set; --class optionally narrows it to a single class, which must belong
+// to that direction. There is no defaulting or auto-detection: the operator
+// states intent explicitly, keeping the command independent of the running block
+// node.
 func resolveWatchClasses(spec WatchSpec) (dir string, classes []string, err error) {
-	switch {
-	case spec.Class != "":
+	if spec.Device == "" {
+		return "", nil, errorx.IllegalArgument.New("--device is required (egress or ingress)")
+	}
+	if err := validateDir(spec.Device); err != nil {
+		return "", nil, err
+	}
+	if spec.Class != "" {
 		ci, err := lookupClassInfo(spec.Class)
 		if err != nil {
 			return "", nil, err
 		}
-		return ci.Dir, []string{spec.Class}, nil
-	case spec.Device != "":
-		if err := validateDir(spec.Device); err != nil {
-			return "", nil, err
+		if ci.Dir != spec.Device {
+			return "", nil, errorx.IllegalArgument.New(
+				"--class %q is a %s class but --device %s was given", spec.Class, ci.Dir, spec.Device)
 		}
-		return spec.Device, knownClassNamesForDir(spec.Device), nil
-	default:
-		return DirEgress, knownClassNamesForDir(DirEgress), nil
+		return spec.Device, []string{spec.Class}, nil
 	}
-}
-
-// resolveWatchIface resolves the concrete interface to sample. An explicit
-// --iface always wins. Otherwise egress auto-detects the NIC (default route) and
-// ingress auto-detects the shaped per-pod $VETH from the live HTB qdisc (see
-// detectIngressVeths). Ingress auto-detection resolves cleanly only when exactly
-// one veth is shaped; with none or several it returns an actionable error asking
-// for --iface.
-func (m *Manager) resolveWatchIface(ctx context.Context, dir, iface string) (string, error) {
-	if iface != "" {
-		return iface, nil
-	}
-	if dir == DirIngress {
-		veths, err := m.detectIngressVeths(ctx)
-		if err != nil {
-			return "", errorx.Decorate(err, "cannot watch ingress shape: veth auto-detection failed")
-		}
-		switch len(veths) {
-		case 0:
-			return "", errorx.IllegalState.New(
-				"no ingress-shaped veth found (no per-pod interface carries an HTB qdisc); " +
-					"is a block node running and shaped? pass --iface <veth> to watch a specific interface")
-		case 1:
-			return veths[0], nil
-		default:
-			return "", errorx.IllegalArgument.New(
-				"multiple ingress-shaped veths found (%s); pass --iface <veth> to select one",
-				strings.Join(veths, ", "))
-		}
-	}
-	nic, err := m.nicDetect()
-	if err != nil {
-		return "", errorx.Decorate(err, "cannot watch egress shape: egress NIC detection failed")
-	}
-	return nic, nil
-}
-
-// detectIngressVeths returns the host-side veth interfaces carrying an ingress
-// HTB hierarchy: every device with an HTB qdisc (from `tc -j qdisc show`), minus
-// the egress NIC (which is also HTB-rooted). Keying on the live qdisc — rather
-// than on a pod's eth0 iflink, the way the daemon's k8s-dependent VethResolver
-// does — lets the host-only CLI find the shaped veth with no pod or kubeconfig.
-//
-// Excluding the egress NIC is best-effort: if egress detection fails (e.g. an
-// ingress-only host with no default route), nothing is excluded — the HTB
-// devices are all veths in that case anyway.
-func (m *Manager) detectIngressVeths(ctx context.Context) ([]string, error) {
-	devs, err := m.tcRunner.HTBDevices(ctx)
-	if err != nil {
-		return nil, err
-	}
-	egress, _ := m.nicDetect()
-	out := make([]string, 0, len(devs))
-	for _, d := range devs {
-		if d == egress {
-			continue
-		}
-		out = append(out, d)
-	}
-	sort.Strings(out)
-	return out, nil
+	return spec.Device, knownClassNamesForDir(spec.Device), nil
 }
 
 // classDeltas computes the per-class delta between two samples for the named

--- a/internal/network/shape/stats.go
+++ b/internal/network/shape/stats.go
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/joomcode/errorx"
+)
+
+// ClassStat is a point-in-time snapshot of one tc HTB class's cumulative
+// counters, as read from `tc -s class show dev <device>`. The byte/packet/drop/
+// overlimit counters are monotonic since the class (qdisc) was installed, so a
+// throughput reading is the delta between two snapshots over the elapsed time.
+type ClassStat struct {
+	ClassID    string // tc handle, e.g. "1:40"
+	Bytes      uint64
+	Packets    uint64
+	Drops      uint64
+	Overlimits uint64
+}
+
+// ClassDelta is the change in one class's counters between two samples, plus the
+// throughput implied by the byte delta over the sampling interval. It is what
+// `network shape watch` prints per tick: rate-over-time, not the cumulative
+// totals (which `network shape show` does not expose and dashboards cover via
+// the Prometheus counters).
+type ClassDelta struct {
+	Name            string  // class name ("partner") when the classid is known, else the raw classid
+	ClassID         string  // tc handle, e.g. "1:40"
+	RateBitsPerSec  float64 // byte delta * 8 / interval seconds
+	BytesDelta      uint64
+	OverlimitsDelta uint64
+	DropsDelta      uint64
+}
+
+// WatchSpec parameterises Manager.WatchClasses. Device is the traffic direction
+// (egress/ingress); Iface names the concrete interface to sample and is required
+// for ingress (whose HTB lives on per-pod $VETH interfaces, so there is no single
+// device to auto-detect). Class, when set, narrows the watch to one class and
+// implies its direction.
+type WatchSpec struct {
+	Device   string        // "egress" (default) or "ingress"
+	Iface    string        // explicit interface to sample; required for ingress
+	Class    string        // single class to watch; "" watches all classes for the direction
+	Interval time.Duration // sampling interval
+	Count    int           // number of delta samples to print then stop; 0 = until ctx is cancelled
+}
+
+// WatchClasses samples the live tc class counters on the resolved interface every
+// spec.Interval and writes a per-class delta row (rate, bytes sent, Δoverlimits,
+// Δdrops) each tick to w. It is read-only: no locks, no mutations. It returns
+// when ctx is cancelled (e.g. the operator hits Ctrl-C) or, when spec.Count > 0,
+// after that many delta rows have been printed.
+func (m *Manager) WatchClasses(ctx context.Context, spec WatchSpec, w io.Writer) error {
+	if spec.Interval <= 0 {
+		return errorx.IllegalArgument.New("--interval must be positive")
+	}
+	if spec.Count < 0 {
+		return errorx.IllegalArgument.New("--count must be zero or positive (0 = run until interrupted)")
+	}
+
+	dir, classes, err := resolveWatchClasses(spec)
+	if err != nil {
+		return err
+	}
+	iface, err := m.resolveWatchIface(dir, spec.Iface)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "watching tc classes on %s (%s device), interval %s — Ctrl-C to stop\n",
+		iface, dir, spec.Interval)
+	writeWatchHeader(w)
+
+	// Establish the baseline sample; deltas are printed from the second sample on.
+	prev, prevAt, stopped, err := m.sampleStats(ctx, iface)
+	if stopped {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(spec.Interval)
+	defer ticker.Stop()
+
+	printed := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+
+		cur, curAt, stopped, err := m.sampleStats(ctx, iface)
+		if stopped {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		// Rate over the ACTUAL elapsed time between the two reads (the interval
+		// plus the time spent running tc), not the nominal interval — dividing by
+		// spec.Interval over-reports throughput, most visibly on the first tick.
+		writeWatchRows(w, classDeltas(prev, cur, classes, curAt.Sub(prevAt)))
+		prev, prevAt = cur, curAt
+
+		printed++
+		if spec.Count > 0 && printed >= spec.Count {
+			return nil
+		}
+	}
+}
+
+// sampleStats reads the live class counters and stamps the read time. A failure
+// caused by context cancellation (the operator hit Ctrl-C mid-sample) is reported
+// as a clean stop (stopped=true, err=nil), so WatchClasses honors its "returns nil
+// on cancellation" contract even when the cancellation lands during a tc exec
+// rather than while waiting on the ticker.
+func (m *Manager) sampleStats(ctx context.Context, iface string) (stats map[string]ClassStat, at time.Time, stopped bool, err error) {
+	stats, err = m.tcRunner.ClassStats(ctx, iface)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, time.Time{}, true, nil
+		}
+		return nil, time.Time{}, false, err
+	}
+	return stats, time.Now(), false, nil
+}
+
+// resolveWatchClasses resolves the spec's device/class selection to a direction
+// plus the class names to display. --class selects a single class and derives its
+// direction; --device shows every class for that direction; the default (neither)
+// watches egress — the physical NIC is the common operator-verify target. --class
+// and --device are mutually exclusive at the CLI (see watch.go RunE), matching the
+// other `network shape` verbs, so both are never set here.
+func resolveWatchClasses(spec WatchSpec) (dir string, classes []string, err error) {
+	switch {
+	case spec.Class != "":
+		ci, err := lookupClassInfo(spec.Class)
+		if err != nil {
+			return "", nil, err
+		}
+		return ci.Dir, []string{spec.Class}, nil
+	case spec.Device != "":
+		if err := validateDir(spec.Device); err != nil {
+			return "", nil, err
+		}
+		return spec.Device, knownClassNamesForDir(spec.Device), nil
+	default:
+		return DirEgress, knownClassNamesForDir(DirEgress), nil
+	}
+}
+
+// resolveWatchIface resolves the concrete interface to sample. An explicit
+// --iface always wins. Otherwise egress auto-detects the NIC; ingress cannot be
+// auto-resolved (its HTB is per-pod $VETH) and requires --iface.
+func (m *Manager) resolveWatchIface(dir, iface string) (string, error) {
+	if iface != "" {
+		return iface, nil
+	}
+	if dir == DirIngress {
+		return "", errorx.IllegalArgument.New(
+			"ingress classes live on per-pod $VETH interfaces; pass --iface <veth> to name the interface to watch")
+	}
+	nic, err := m.nicDetect()
+	if err != nil {
+		return "", errorx.Decorate(err, "cannot watch egress shape: egress NIC detection failed")
+	}
+	return nic, nil
+}
+
+// classDeltas computes the per-class delta between two samples for the named
+// classes, in classid order. A class absent from the current sample (not
+// installed on the live device) is skipped; a counter that went backwards (the
+// qdisc was reinstalled between samples) yields a zero delta for that tick rather
+// than a spurious huge number.
+func classDeltas(prev, cur map[string]ClassStat, classes []string, elapsed time.Duration) []ClassDelta {
+	secs := elapsed.Seconds()
+	out := make([]ClassDelta, 0, len(classes))
+	for _, name := range classes {
+		ci, err := lookupClassInfo(name)
+		if err != nil {
+			continue
+		}
+		classid := "1:" + ci.Minor
+		c, ok := cur[classid]
+		if !ok {
+			continue
+		}
+		p := prev[classid] // zero value when the class is new this tick
+		bytesDelta := monotonicDelta(p.Bytes, c.Bytes)
+		var rate float64
+		if secs > 0 {
+			rate = float64(bytesDelta) * 8 / secs
+		}
+		out = append(out, ClassDelta{
+			Name:            name,
+			ClassID:         classid,
+			RateBitsPerSec:  rate,
+			BytesDelta:      bytesDelta,
+			OverlimitsDelta: monotonicDelta(p.Overlimits, c.Overlimits),
+			DropsDelta:      monotonicDelta(p.Drops, c.Drops),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ClassID < out[j].ClassID })
+	return out
+}
+
+// monotonicDelta returns cur-prev for a monotonic counter, clamping to 0 when the
+// counter appears to have reset (cur < prev) so a qdisc reinstall between samples
+// does not report a bogus multi-exabyte delta.
+func monotonicDelta(prev, cur uint64) uint64 {
+	if cur < prev {
+		return 0
+	}
+	return cur - prev
+}
+
+func writeWatchHeader(w io.Writer) {
+	fmt.Fprintf(w, "%-18s %-8s %15s %12s %11s %8s\n",
+		"CLASS", "CLASSID", "RATE", "SENT", "OVERLIMITS", "DROPPED")
+}
+
+func writeWatchRows(w io.Writer, deltas []ClassDelta) {
+	for _, d := range deltas {
+		fmt.Fprintf(w, "%-18s %-8s %15s %12s %11s %8s\n",
+			d.Name, d.ClassID, humanRate(d.RateBitsPerSec), humanBytes(d.BytesDelta),
+			"+"+strconv.FormatUint(d.OverlimitsDelta, 10),
+			"+"+strconv.FormatUint(d.DropsDelta, 10))
+	}
+	fmt.Fprintln(w) // blank line separates ticks
+}
+
+// humanRate renders a bit/s throughput with a decimal (SI) magnitude suffix,
+// matching how tc bandwidth values are expressed (Mbit/Gbit, powers of 1000).
+func humanRate(bitsPerSec float64) string {
+	const k = 1000.0
+	switch {
+	case bitsPerSec >= k*k*k:
+		return fmt.Sprintf("%.2f Gbit/s", bitsPerSec/(k*k*k))
+	case bitsPerSec >= k*k:
+		return fmt.Sprintf("%.2f Mbit/s", bitsPerSec/(k*k))
+	case bitsPerSec >= k:
+		return fmt.Sprintf("%.2f Kbit/s", bitsPerSec/k)
+	default:
+		return fmt.Sprintf("%.0f bit/s", bitsPerSec)
+	}
+}
+
+// humanBytes renders a byte count with a binary (IEC) magnitude suffix.
+func humanBytes(b uint64) string {
+	const k = 1024.0
+	f := float64(b)
+	switch {
+	case f >= k*k*k:
+		return fmt.Sprintf("%.2f GB", f/(k*k*k))
+	case f >= k*k:
+		return fmt.Sprintf("%.2f MB", f/(k*k))
+	case f >= k:
+		return fmt.Sprintf("%.2f KB", f/k)
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/internal/network/shape/stats_test.go
+++ b/internal/network/shape/stats_test.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonotonicDelta(t *testing.T) {
+	require.Equal(t, uint64(0), monotonicDelta(0, 0))
+	require.Equal(t, uint64(5), monotonicDelta(10, 15))
+	require.Equal(t, uint64(15), monotonicDelta(0, 15))
+	// Counter reset (qdisc reinstalled between samples): clamp to 0, never wrap.
+	require.Equal(t, uint64(0), monotonicDelta(100, 3))
+}
+
+func TestClassDeltas(t *testing.T) {
+	prev := map[string]ClassStat{
+		"1:40": {ClassID: "1:40", Bytes: 1_000, Overlimits: 2, Drops: 0},
+		"1:50": {ClassID: "1:50", Bytes: 500, Overlimits: 0, Drops: 1},
+	}
+	cur := map[string]ClassStat{
+		"1:40": {ClassID: "1:40", Bytes: 126_000, Overlimits: 7, Drops: 0}, // +125000 B over 1s → 1_000_000 bit/s
+		"1:50": {ClassID: "1:50", Bytes: 400, Overlimits: 3, Drops: 4},     // bytes went backwards → 0
+		// reserve-egress (1:60) absent from cur → skipped
+	}
+
+	got := classDeltas(prev, cur, []string{"partner", "public", "reserve-egress"}, time.Second)
+	require.Len(t, got, 2, "reserve-egress absent from the live device must be skipped")
+
+	// Ordered by classid: partner (1:40) before public (1:50).
+	require.Equal(t, "partner", got[0].Name)
+	require.Equal(t, "1:40", got[0].ClassID)
+	require.Equal(t, uint64(125_000), got[0].BytesDelta)
+	require.InDelta(t, 1_000_000.0, got[0].RateBitsPerSec, 0.001)
+	require.Equal(t, uint64(5), got[0].OverlimitsDelta)
+	require.Equal(t, uint64(0), got[0].DropsDelta)
+
+	require.Equal(t, "public", got[1].Name)
+	require.Equal(t, uint64(0), got[1].BytesDelta, "backwards byte counter clamps to 0")
+	require.Equal(t, uint64(3), got[1].OverlimitsDelta)
+	require.Equal(t, uint64(3), got[1].DropsDelta)
+}
+
+func TestClassDeltas_FirstSampleFromZeroBaseline(t *testing.T) {
+	// prev empty (a class just appeared): full current value is the delta.
+	cur := map[string]ClassStat{"1:40": {ClassID: "1:40", Bytes: 2_000}}
+	got := classDeltas(map[string]ClassStat{}, cur, []string{"partner"}, time.Second)
+	require.Len(t, got, 1)
+	require.Equal(t, uint64(2_000), got[0].BytesDelta)
+}
+
+func TestHumanRate(t *testing.T) {
+	require.Equal(t, "0 bit/s", humanRate(0))
+	require.Equal(t, "1.00 Kbit/s", humanRate(1_000))
+	require.Equal(t, "1.00 Mbit/s", humanRate(1_000_000))
+	require.Equal(t, "2.50 Gbit/s", humanRate(2_500_000_000))
+}
+
+func TestHumanBytes(t *testing.T) {
+	require.Equal(t, "512 B", humanBytes(512))
+	require.Equal(t, "1.00 KB", humanBytes(1024))
+	require.Equal(t, "1.00 MB", humanBytes(1024*1024))
+}
+
+// scriptedStatsRunner returns a fixed sequence of samples from ClassStats,
+// repeating the last one once exhausted. Write verbs are inherited (unused).
+type scriptedStatsRunner struct {
+	recordingTCRunner
+	samples []map[string]ClassStat
+	idx     int
+	calls   int
+}
+
+func (r *scriptedStatsRunner) ClassStats(ctx context.Context, _ string) (map[string]ClassStat, error) {
+	// Mirror the real runner: a cancelled context surfaces as an error, which
+	// WatchClasses must treat as a clean stop.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	i := r.idx
+	if i >= len(r.samples) {
+		i = len(r.samples) - 1
+	}
+	r.idx++
+	r.calls++
+	return r.samples[i], nil
+}
+
+func TestWatchClasses_CountBoundedLoop(t *testing.T) {
+	tc := &scriptedStatsRunner{samples: []map[string]ClassStat{
+		{"1:40": {ClassID: "1:40", Bytes: 0}},
+		{"1:40": {ClassID: "1:40", Bytes: 125_000, Overlimits: 1}},
+		{"1:40": {ClassID: "1:40", Bytes: 250_000, Overlimits: 3}},
+	}}
+	m := NewManagerWithConfig(Config{
+		NICDetect: func() (string, error) { return "eth0", nil },
+		TCRunner:  tc,
+	})
+
+	var buf bytes.Buffer
+	spec := WatchSpec{Class: "partner", Interval: time.Millisecond, Count: 2}
+	require.NoError(t, m.WatchClasses(context.Background(), spec, &buf))
+
+	// Baseline + 2 delta samples = 3 ClassStats calls.
+	require.Equal(t, 3, tc.calls)
+	out := buf.String()
+	require.Contains(t, out, "watching tc classes on eth0 (egress device)")
+	require.Contains(t, out, "CLASS")
+	require.Contains(t, out, "partner")
+	require.Contains(t, out, "1:40")
+}
+
+func TestWatchClasses_CtxCancelStops(t *testing.T) {
+	tc := &scriptedStatsRunner{samples: []map[string]ClassStat{
+		{"1:40": {ClassID: "1:40", Bytes: 0}},
+	}}
+	m := NewManagerWithConfig(Config{
+		NICDetect: func() (string, error) { return "eth0", nil },
+		TCRunner:  tc,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled: the baseline sample errors on the cancelled ctx
+
+	var buf bytes.Buffer
+	// A cancelled context during the (baseline) tc sample is a clean stop, not an
+	// error — WatchClasses must return nil rather than bubbling up the ctx error.
+	err := m.WatchClasses(ctx, WatchSpec{Device: "egress", Interval: time.Hour}, &buf)
+	require.NoError(t, err)
+}
+
+func TestWatchClasses_IngressRequiresIface(t *testing.T) {
+	m := NewManagerWithConfig(Config{
+		NICDetect: func() (string, error) { return "eth0", nil },
+		TCRunner:  &scriptedStatsRunner{samples: []map[string]ClassStat{{}}},
+	})
+	err := m.WatchClasses(context.Background(), WatchSpec{Device: "ingress", Interval: time.Second}, &bytes.Buffer{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--iface")
+}
+
+func TestWatchClasses_BadInterval(t *testing.T) {
+	m := NewManagerWithConfig(Config{TCRunner: &scriptedStatsRunner{samples: []map[string]ClassStat{{}}}})
+	err := m.WatchClasses(context.Background(), WatchSpec{Device: "egress", Interval: 0}, &bytes.Buffer{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--interval")
+}
+
+func TestResolveWatchClasses_DefaultsToEgress(t *testing.T) {
+	dir, classes, err := resolveWatchClasses(WatchSpec{})
+	require.NoError(t, err)
+	require.Equal(t, DirEgress, dir)
+	require.ElementsMatch(t, []string{"partner", "public", "reserve-egress"}, classes)
+}
+
+func TestResolveWatchClasses_IngressDevice(t *testing.T) {
+	dir, classes, err := resolveWatchClasses(WatchSpec{Device: "ingress"})
+	require.NoError(t, err)
+	require.Equal(t, DirIngress, dir)
+	require.ElementsMatch(t, []string{"publisher", "backfill-response", "reserve-ingress"}, classes)
+}
+
+func TestResolveWatchClasses_UnknownClass(t *testing.T) {
+	_, _, err := resolveWatchClasses(WatchSpec{Class: "nope"})
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "unknown class"))
+}

--- a/internal/network/shape/stats_test.go
+++ b/internal/network/shape/stats_test.go
@@ -93,141 +93,101 @@ func (r *scriptedStatsRunner) ClassStats(ctx context.Context, _ string) (map[str
 	return r.samples[i], nil
 }
 
+func newWatchManager(tc TCRunner) *Manager {
+	// NICDetect is intentionally unset: the watch path must never probe the NIC.
+	return NewManagerWithConfig(Config{TCRunner: tc})
+}
+
 func TestWatchClasses_CountBoundedLoop(t *testing.T) {
 	tc := &scriptedStatsRunner{samples: []map[string]ClassStat{
 		{"1:40": {ClassID: "1:40", Bytes: 0}},
 		{"1:40": {ClassID: "1:40", Bytes: 125_000, Overlimits: 1}},
 		{"1:40": {ClassID: "1:40", Bytes: 250_000, Overlimits: 3}},
 	}}
-	m := NewManagerWithConfig(Config{
-		NICDetect: func() (string, error) { return "eth0", nil },
-		TCRunner:  tc,
-	})
+	m := newWatchManager(tc)
 
 	var buf bytes.Buffer
-	spec := WatchSpec{Class: "partner", Interval: time.Millisecond, Count: 2}
+	spec := WatchSpec{Device: "egress", Iface: "enp0s1", Class: "partner", Interval: time.Millisecond, Count: 2}
 	require.NoError(t, m.WatchClasses(context.Background(), spec, &buf))
 
 	// Baseline + 2 delta samples = 3 ClassStats calls.
 	require.Equal(t, 3, tc.calls)
 	out := buf.String()
-	require.Contains(t, out, "watching tc classes on eth0 (egress device)")
+	require.Contains(t, out, "watching tc classes on enp0s1 (egress device)")
 	require.Contains(t, out, "CLASS")
 	require.Contains(t, out, "partner")
 	require.Contains(t, out, "1:40")
+}
+
+func TestWatchClasses_IngressWithIface(t *testing.T) {
+	tc := &scriptedStatsRunner{samples: []map[string]ClassStat{
+		{"1:10": {ClassID: "1:10", Bytes: 0}},
+		{"1:10": {ClassID: "1:10", Bytes: 125_000}},
+	}}
+	m := newWatchManager(tc)
+
+	var buf bytes.Buffer
+	spec := WatchSpec{Device: "ingress", Iface: "lxc1a2b3c", Interval: time.Millisecond, Count: 1}
+	require.NoError(t, m.WatchClasses(context.Background(), spec, &buf))
+	out := buf.String()
+	require.Contains(t, out, "watching tc classes on lxc1a2b3c (ingress device)")
+	require.Contains(t, out, "publisher")
 }
 
 func TestWatchClasses_CtxCancelStops(t *testing.T) {
 	tc := &scriptedStatsRunner{samples: []map[string]ClassStat{
 		{"1:40": {ClassID: "1:40", Bytes: 0}},
 	}}
-	m := NewManagerWithConfig(Config{
-		NICDetect: func() (string, error) { return "eth0", nil },
-		TCRunner:  tc,
-	})
+	m := newWatchManager(tc)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // already cancelled: the baseline sample errors on the cancelled ctx
 
 	var buf bytes.Buffer
 	// A cancelled context during the (baseline) tc sample is a clean stop, not an
 	// error — WatchClasses must return nil rather than bubbling up the ctx error.
-	err := m.WatchClasses(ctx, WatchSpec{Device: "egress", Interval: time.Hour}, &buf)
+	err := m.WatchClasses(ctx, WatchSpec{Device: "egress", Iface: "enp0s1", Interval: time.Hour}, &buf)
 	require.NoError(t, err)
 }
 
-func TestWatchClasses_IngressAutoDetectsSingleVeth(t *testing.T) {
-	// One shaped veth alongside the egress NIC: ingress watch resolves to the
-	// veth automatically, no --iface needed.
-	tc := &scriptedStatsRunner{
-		recordingTCRunner: recordingTCRunner{htbDevices: []string{"enp0s1", "lxc1234"}},
-		samples: []map[string]ClassStat{
-			{"1:10": {ClassID: "1:10", Bytes: 0}},
-			{"1:10": {ClassID: "1:10", Bytes: 125_000}},
-		},
-	}
-	m := NewManagerWithConfig(Config{
-		NICDetect: func() (string, error) { return "enp0s1", nil },
-		TCRunner:  tc,
-	})
-
-	var buf bytes.Buffer
-	spec := WatchSpec{Device: "ingress", Interval: time.Millisecond, Count: 1}
-	require.NoError(t, m.WatchClasses(context.Background(), spec, &buf))
-	require.Contains(t, buf.String(), "watching tc classes on lxc1234 (ingress device)")
-}
-
-func TestWatchClasses_IngressNoVethErrors(t *testing.T) {
-	// Only the egress NIC carries an HTB qdisc → no ingress veth to watch.
-	tc := &scriptedStatsRunner{
-		recordingTCRunner: recordingTCRunner{htbDevices: []string{"enp0s1"}},
-		samples:           []map[string]ClassStat{{}},
-	}
-	m := NewManagerWithConfig(Config{
-		NICDetect: func() (string, error) { return "enp0s1", nil },
-		TCRunner:  tc,
-	})
-	err := m.WatchClasses(context.Background(), WatchSpec{Device: "ingress", Interval: time.Second}, &bytes.Buffer{})
+func TestWatchClasses_RequiresIface(t *testing.T) {
+	m := newWatchManager(&scriptedStatsRunner{samples: []map[string]ClassStat{{}}})
+	err := m.WatchClasses(context.Background(), WatchSpec{Device: "egress", Interval: time.Second}, &bytes.Buffer{})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no ingress-shaped veth")
-}
-
-func TestWatchClasses_IngressMultipleVethsError(t *testing.T) {
-	// Two shaped veths → ambiguous; the error names them and asks for --iface.
-	tc := &scriptedStatsRunner{
-		recordingTCRunner: recordingTCRunner{htbDevices: []string{"enp0s1", "lxcAAAA", "lxcBBBB"}},
-		samples:           []map[string]ClassStat{{}},
-	}
-	m := NewManagerWithConfig(Config{
-		NICDetect: func() (string, error) { return "enp0s1", nil },
-		TCRunner:  tc,
-	})
-	err := m.WatchClasses(context.Background(), WatchSpec{Device: "ingress", Interval: time.Second}, &bytes.Buffer{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "multiple ingress-shaped veths")
 	require.Contains(t, err.Error(), "--iface")
-	require.Contains(t, err.Error(), "lxcAAAA")
-	require.Contains(t, err.Error(), "lxcBBBB")
 }
 
-func TestWatchClasses_IngressExplicitIfaceSkipsDetection(t *testing.T) {
-	// An explicit --iface bypasses auto-detection entirely (htbDevices ignored).
-	tc := &scriptedStatsRunner{
-		recordingTCRunner: recordingTCRunner{htbDevices: nil}, // detection would find nothing
-		samples: []map[string]ClassStat{
-			{"1:10": {ClassID: "1:10", Bytes: 0}},
-			{"1:10": {ClassID: "1:10", Bytes: 1}},
-		},
-	}
-	m := NewManagerWithConfig(Config{
-		NICDetect: func() (string, error) { return "enp0s1", nil },
-		TCRunner:  tc,
-	})
-	var buf bytes.Buffer
-	spec := WatchSpec{Device: "ingress", Iface: "lxcDEAD", Interval: time.Millisecond, Count: 1}
-	require.NoError(t, m.WatchClasses(context.Background(), spec, &buf))
-	require.Contains(t, buf.String(), "watching tc classes on lxcDEAD (ingress device)")
+func TestWatchClasses_RequiresDevice(t *testing.T) {
+	m := newWatchManager(&scriptedStatsRunner{samples: []map[string]ClassStat{{}}})
+	err := m.WatchClasses(context.Background(), WatchSpec{Iface: "enp0s1", Interval: time.Second}, &bytes.Buffer{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--device")
 }
 
-func TestDetectIngressVeths_ExcludesEgressNICAndSorts(t *testing.T) {
-	tc := &recordingTCRunner{htbDevices: []string{"lxcZZZZ", "enp0s1", "lxcAAAA"}}
-	m := NewManagerWithConfig(Config{
-		NICDetect: func() (string, error) { return "enp0s1", nil },
-		TCRunner:  tc,
-	})
-	veths, err := m.detectIngressVeths(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, []string{"lxcAAAA", "lxcZZZZ"}, veths)
+func TestWatchClasses_ClassDeviceMismatch(t *testing.T) {
+	m := newWatchManager(&scriptedStatsRunner{samples: []map[string]ClassStat{{}}})
+	// partner is an egress class; watching it under --device ingress must fail.
+	err := m.WatchClasses(context.Background(),
+		WatchSpec{Device: "ingress", Iface: "lxc1a2b3c", Class: "partner", Interval: time.Second}, &bytes.Buffer{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "egress class")
 }
 
 func TestWatchClasses_BadInterval(t *testing.T) {
-	m := NewManagerWithConfig(Config{TCRunner: &scriptedStatsRunner{samples: []map[string]ClassStat{{}}}})
-	err := m.WatchClasses(context.Background(), WatchSpec{Device: "egress", Interval: 0}, &bytes.Buffer{})
+	m := newWatchManager(&scriptedStatsRunner{samples: []map[string]ClassStat{{}}})
+	err := m.WatchClasses(context.Background(),
+		WatchSpec{Device: "egress", Iface: "enp0s1", Interval: 0}, &bytes.Buffer{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "--interval")
 }
 
-func TestResolveWatchClasses_DefaultsToEgress(t *testing.T) {
-	dir, classes, err := resolveWatchClasses(WatchSpec{})
+func TestResolveWatchClasses_RequiresDevice(t *testing.T) {
+	_, _, err := resolveWatchClasses(WatchSpec{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--device")
+}
+
+func TestResolveWatchClasses_EgressDevice(t *testing.T) {
+	dir, classes, err := resolveWatchClasses(WatchSpec{Device: "egress"})
 	require.NoError(t, err)
 	require.Equal(t, DirEgress, dir)
 	require.ElementsMatch(t, []string{"partner", "public", "reserve-egress"}, classes)
@@ -240,8 +200,21 @@ func TestResolveWatchClasses_IngressDevice(t *testing.T) {
 	require.ElementsMatch(t, []string{"publisher", "backfill-response", "reserve-ingress"}, classes)
 }
 
+func TestResolveWatchClasses_ClassNarrowsWithinDevice(t *testing.T) {
+	dir, classes, err := resolveWatchClasses(WatchSpec{Device: "egress", Class: "partner"})
+	require.NoError(t, err)
+	require.Equal(t, DirEgress, dir)
+	require.Equal(t, []string{"partner"}, classes)
+}
+
+func TestResolveWatchClasses_ClassDeviceMismatch(t *testing.T) {
+	_, _, err := resolveWatchClasses(WatchSpec{Device: "ingress", Class: "partner"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "egress class")
+}
+
 func TestResolveWatchClasses_UnknownClass(t *testing.T) {
-	_, _, err := resolveWatchClasses(WatchSpec{Class: "nope"})
+	_, _, err := resolveWatchClasses(WatchSpec{Device: "egress", Class: "nope"})
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "unknown class"))
 }

--- a/internal/network/shape/stats_test.go
+++ b/internal/network/shape/stats_test.go
@@ -135,14 +135,88 @@ func TestWatchClasses_CtxCancelStops(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestWatchClasses_IngressRequiresIface(t *testing.T) {
+func TestWatchClasses_IngressAutoDetectsSingleVeth(t *testing.T) {
+	// One shaped veth alongside the egress NIC: ingress watch resolves to the
+	// veth automatically, no --iface needed.
+	tc := &scriptedStatsRunner{
+		recordingTCRunner: recordingTCRunner{htbDevices: []string{"enp0s1", "lxc1234"}},
+		samples: []map[string]ClassStat{
+			{"1:10": {ClassID: "1:10", Bytes: 0}},
+			{"1:10": {ClassID: "1:10", Bytes: 125_000}},
+		},
+	}
 	m := NewManagerWithConfig(Config{
-		NICDetect: func() (string, error) { return "eth0", nil },
-		TCRunner:  &scriptedStatsRunner{samples: []map[string]ClassStat{{}}},
+		NICDetect: func() (string, error) { return "enp0s1", nil },
+		TCRunner:  tc,
+	})
+
+	var buf bytes.Buffer
+	spec := WatchSpec{Device: "ingress", Interval: time.Millisecond, Count: 1}
+	require.NoError(t, m.WatchClasses(context.Background(), spec, &buf))
+	require.Contains(t, buf.String(), "watching tc classes on lxc1234 (ingress device)")
+}
+
+func TestWatchClasses_IngressNoVethErrors(t *testing.T) {
+	// Only the egress NIC carries an HTB qdisc → no ingress veth to watch.
+	tc := &scriptedStatsRunner{
+		recordingTCRunner: recordingTCRunner{htbDevices: []string{"enp0s1"}},
+		samples:           []map[string]ClassStat{{}},
+	}
+	m := NewManagerWithConfig(Config{
+		NICDetect: func() (string, error) { return "enp0s1", nil },
+		TCRunner:  tc,
 	})
 	err := m.WatchClasses(context.Background(), WatchSpec{Device: "ingress", Interval: time.Second}, &bytes.Buffer{})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "no ingress-shaped veth")
+}
+
+func TestWatchClasses_IngressMultipleVethsError(t *testing.T) {
+	// Two shaped veths → ambiguous; the error names them and asks for --iface.
+	tc := &scriptedStatsRunner{
+		recordingTCRunner: recordingTCRunner{htbDevices: []string{"enp0s1", "lxcAAAA", "lxcBBBB"}},
+		samples:           []map[string]ClassStat{{}},
+	}
+	m := NewManagerWithConfig(Config{
+		NICDetect: func() (string, error) { return "enp0s1", nil },
+		TCRunner:  tc,
+	})
+	err := m.WatchClasses(context.Background(), WatchSpec{Device: "ingress", Interval: time.Second}, &bytes.Buffer{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "multiple ingress-shaped veths")
 	require.Contains(t, err.Error(), "--iface")
+	require.Contains(t, err.Error(), "lxcAAAA")
+	require.Contains(t, err.Error(), "lxcBBBB")
+}
+
+func TestWatchClasses_IngressExplicitIfaceSkipsDetection(t *testing.T) {
+	// An explicit --iface bypasses auto-detection entirely (htbDevices ignored).
+	tc := &scriptedStatsRunner{
+		recordingTCRunner: recordingTCRunner{htbDevices: nil}, // detection would find nothing
+		samples: []map[string]ClassStat{
+			{"1:10": {ClassID: "1:10", Bytes: 0}},
+			{"1:10": {ClassID: "1:10", Bytes: 1}},
+		},
+	}
+	m := NewManagerWithConfig(Config{
+		NICDetect: func() (string, error) { return "enp0s1", nil },
+		TCRunner:  tc,
+	})
+	var buf bytes.Buffer
+	spec := WatchSpec{Device: "ingress", Iface: "lxcDEAD", Interval: time.Millisecond, Count: 1}
+	require.NoError(t, m.WatchClasses(context.Background(), spec, &buf))
+	require.Contains(t, buf.String(), "watching tc classes on lxcDEAD (ingress device)")
+}
+
+func TestDetectIngressVeths_ExcludesEgressNICAndSorts(t *testing.T) {
+	tc := &recordingTCRunner{htbDevices: []string{"lxcZZZZ", "enp0s1", "lxcAAAA"}}
+	m := NewManagerWithConfig(Config{
+		NICDetect: func() (string, error) { return "enp0s1", nil },
+		TCRunner:  tc,
+	})
+	veths, err := m.detectIngressVeths(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"lxcAAAA", "lxcZZZZ"}, veths)
 }
 
 func TestWatchClasses_BadInterval(t *testing.T) {

--- a/internal/network/shape/tc.go
+++ b/internal/network/shape/tc.go
@@ -39,4 +39,9 @@ type TCRunner interface {
 	// QdiscAddFqCodel runs `tc qdisc add dev <nic> parent 1:<minor> handle
 	// <handle>: fq_codel`, the leaf qdisc for a class.
 	QdiscAddFqCodel(ctx context.Context, nic, minor, handle string) error
+
+	// ClassStats runs `tc -s -j class show dev <dev>` and returns each class's
+	// cumulative counters keyed by tc handle (e.g. "1:40"). It is the read
+	// counterpart to the write verbs above, backing `network shape watch`.
+	ClassStats(ctx context.Context, dev string) (map[string]ClassStat, error)
 }

--- a/internal/network/shape/tc.go
+++ b/internal/network/shape/tc.go
@@ -44,11 +44,4 @@ type TCRunner interface {
 	// cumulative counters keyed by tc handle (e.g. "1:40"). It is the read
 	// counterpart to the write verbs above, backing `network shape watch`.
 	ClassStats(ctx context.Context, dev string) (map[string]ClassStat, error)
-
-	// HTBDevices runs `tc -j qdisc show` and returns the interfaces that
-	// currently carry an HTB qdisc — every device tc shaping has been applied to
-	// (the egress NIC and each per-pod ingress veth). It backs ingress-veth
-	// auto-detection for `network shape watch`: the read path finds the shaped
-	// veth from the live qdisc alone, needing no pod or kubeconfig.
-	HTBDevices(ctx context.Context) ([]string, error)
 }

--- a/internal/network/shape/tc.go
+++ b/internal/network/shape/tc.go
@@ -44,4 +44,11 @@ type TCRunner interface {
 	// cumulative counters keyed by tc handle (e.g. "1:40"). It is the read
 	// counterpart to the write verbs above, backing `network shape watch`.
 	ClassStats(ctx context.Context, dev string) (map[string]ClassStat, error)
+
+	// HTBDevices runs `tc -j qdisc show` and returns the interfaces that
+	// currently carry an HTB qdisc — every device tc shaping has been applied to
+	// (the egress NIC and each per-pod ingress veth). It backs ingress-veth
+	// auto-detection for `network shape watch`: the read path finds the shaped
+	// veth from the live qdisc alone, needing no pod or kubeconfig.
+	HTBDevices(ctx context.Context) ([]string, error)
 }

--- a/internal/network/shape/tc_linux.go
+++ b/internal/network/shape/tc_linux.go
@@ -38,6 +38,14 @@ type tcClassJSON struct {
 	} `json:"stats"`
 }
 
+// tcQdiscJSON is the subset of one element of `tc -j qdisc show` we consume:
+// the qdisc kind ("htb", "fq_codel", "noqueue", …) and the device it is
+// attached to. Emitted per-qdisc when the command is run without a `dev` filter.
+type tcQdiscJSON struct {
+	Kind string `json:"kind"`
+	Dev  string `json:"dev"`
+}
+
 type execTCRunner struct{}
 
 // run execs `tc <args...>` and wraps any non-zero exit with the combined output.
@@ -124,6 +132,33 @@ func (r *execTCRunner) ClassStats(ctx context.Context, dev string) (map[string]C
 		stats[c.Handle] = s
 	}
 	return stats, nil
+}
+
+func (r *execTCRunner) HTBDevices(ctx context.Context) ([]string, error) {
+	cmd := exec.CommandContext(ctx, tcBin, "-j", "qdisc", "show")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, errorx.ExternalError.Wrap(err,
+			"tc -j qdisc show failed: %s", strings.TrimSpace(stderr.String()))
+	}
+
+	var raw []tcQdiscJSON
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, errorx.ExternalError.Wrap(err, "failed to parse tc qdisc JSON")
+	}
+
+	seen := make(map[string]bool, len(raw))
+	devs := make([]string, 0, len(raw))
+	for _, q := range raw {
+		if q.Kind != "htb" || q.Dev == "" || seen[q.Dev] {
+			continue
+		}
+		seen[q.Dev] = true
+		devs = append(devs, q.Dev)
+	}
+	return devs, nil
 }
 
 // newExecTCRunner returns the production TC runner that shells out to /sbin/tc.

--- a/internal/network/shape/tc_linux.go
+++ b/internal/network/shape/tc_linux.go
@@ -38,14 +38,6 @@ type tcClassJSON struct {
 	} `json:"stats"`
 }
 
-// tcQdiscJSON is the subset of one element of `tc -j qdisc show` we consume:
-// the qdisc kind ("htb", "fq_codel", "noqueue", …) and the device it is
-// attached to. Emitted per-qdisc when the command is run without a `dev` filter.
-type tcQdiscJSON struct {
-	Kind string `json:"kind"`
-	Dev  string `json:"dev"`
-}
-
 type execTCRunner struct{}
 
 // run execs `tc <args...>` and wraps any non-zero exit with the combined output.
@@ -132,33 +124,6 @@ func (r *execTCRunner) ClassStats(ctx context.Context, dev string) (map[string]C
 		stats[c.Handle] = s
 	}
 	return stats, nil
-}
-
-func (r *execTCRunner) HTBDevices(ctx context.Context) ([]string, error) {
-	cmd := exec.CommandContext(ctx, tcBin, "-j", "qdisc", "show")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, errorx.ExternalError.Wrap(err,
-			"tc -j qdisc show failed: %s", strings.TrimSpace(stderr.String()))
-	}
-
-	var raw []tcQdiscJSON
-	if err := json.Unmarshal(out, &raw); err != nil {
-		return nil, errorx.ExternalError.Wrap(err, "failed to parse tc qdisc JSON")
-	}
-
-	seen := make(map[string]bool, len(raw))
-	devs := make([]string, 0, len(raw))
-	for _, q := range raw {
-		if q.Kind != "htb" || q.Dev == "" || seen[q.Dev] {
-			continue
-		}
-		seen[q.Dev] = true
-		devs = append(devs, q.Dev)
-	}
-	return devs, nil
 }
 
 // newExecTCRunner returns the production TC runner that shells out to /sbin/tc.

--- a/internal/network/shape/tc_linux.go
+++ b/internal/network/shape/tc_linux.go
@@ -5,7 +5,9 @@
 package shape
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -17,6 +19,24 @@ import (
 // PATH) so a caller cannot hijack the privileged invocation via an
 // attacker-controlled directory (see docs/dev/security-model.md).
 const tcBin = "/sbin/tc"
+
+// tcClassJSON is the subset of one element of `tc -s -j class show` output we
+// consume. iproute2 emits the counters at the top level of each class object;
+// the optional nested "stats" object is decoded too as a defensive fallback for
+// versions that nest them, preferring whichever is populated.
+type tcClassJSON struct {
+	Handle     string `json:"handle"`
+	Bytes      uint64 `json:"bytes"`
+	Packets    uint64 `json:"packets"`
+	Drops      uint64 `json:"drops"`
+	Overlimits uint64 `json:"overlimits"`
+	Stats      *struct {
+		Bytes      uint64 `json:"bytes"`
+		Packets    uint64 `json:"packets"`
+		Drops      uint64 `json:"drops"`
+		Overlimits uint64 `json:"overlimits"`
+	} `json:"stats"`
+}
 
 type execTCRunner struct{}
 
@@ -62,6 +82,48 @@ func (r *execTCRunner) ClassAdd(ctx context.Context, nic, minor, rate, ceil stri
 func (r *execTCRunner) QdiscAddFqCodel(ctx context.Context, nic, minor, handle string) error {
 	return r.run(ctx, "qdisc", "add",
 		"dev", nic, "parent", "1:"+minor, "handle", handle+":", "fq_codel")
+}
+
+func (r *execTCRunner) ClassStats(ctx context.Context, dev string) (map[string]ClassStat, error) {
+	cmd := exec.CommandContext(ctx, tcBin, "-s", "-j", "class", "show", "dev", dev)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, errorx.ExternalError.Wrap(err,
+			"tc -s -j class show dev %s failed: %s", dev, strings.TrimSpace(stderr.String()))
+	}
+
+	var raw []tcClassJSON
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, errorx.ExternalError.Wrap(err,
+			"failed to parse tc class stats JSON for dev %s", dev)
+	}
+
+	stats := make(map[string]ClassStat, len(raw))
+	for _, c := range raw {
+		if c.Handle == "" {
+			continue // qdisc-only or malformed entry
+		}
+		s := ClassStat{
+			ClassID:    c.Handle,
+			Bytes:      c.Bytes,
+			Packets:    c.Packets,
+			Drops:      c.Drops,
+			Overlimits: c.Overlimits,
+		}
+		// Fallback only when the flat form carried nothing: some iproute2 builds
+		// nest the counters under "stats" instead. Never overwrite populated
+		// top-level values with a (possibly empty) nested object.
+		if c.Stats != nil && s.Bytes == 0 && s.Packets == 0 && s.Drops == 0 && s.Overlimits == 0 {
+			s.Bytes = c.Stats.Bytes
+			s.Packets = c.Stats.Packets
+			s.Drops = c.Stats.Drops
+			s.Overlimits = c.Stats.Overlimits
+		}
+		stats[c.Handle] = s
+	}
+	return stats, nil
 }
 
 // newExecTCRunner returns the production TC runner that shells out to /sbin/tc.

--- a/internal/network/shape/tc_other.go
+++ b/internal/network/shape/tc_other.go
@@ -36,6 +36,10 @@ func (r *noopTCRunner) QdiscAddFqCodel(_ context.Context, _, _, _ string) error 
 	return errUnsupported()
 }
 
+func (r *noopTCRunner) ClassStats(_ context.Context, _ string) (map[string]ClassStat, error) {
+	return nil, errUnsupported()
+}
+
 // newExecTCRunner returns a no-op runner on non-Linux platforms.
 func newExecTCRunner() TCRunner {
 	return &noopTCRunner{}

--- a/internal/network/shape/tc_other.go
+++ b/internal/network/shape/tc_other.go
@@ -40,6 +40,10 @@ func (r *noopTCRunner) ClassStats(_ context.Context, _ string) (map[string]Class
 	return nil, errUnsupported()
 }
 
+func (r *noopTCRunner) HTBDevices(_ context.Context) ([]string, error) {
+	return nil, errUnsupported()
+}
+
 // newExecTCRunner returns a no-op runner on non-Linux platforms.
 func newExecTCRunner() TCRunner {
 	return &noopTCRunner{}

--- a/internal/network/shape/tc_other.go
+++ b/internal/network/shape/tc_other.go
@@ -40,10 +40,6 @@ func (r *noopTCRunner) ClassStats(_ context.Context, _ string) (map[string]Class
 	return nil, errUnsupported()
 }
 
-func (r *noopTCRunner) HTBDevices(_ context.Context) ([]string, error) {
-	return nil, errUnsupported()
-}
-
 // newExecTCRunner returns a no-op runner on non-Linux platforms.
 func newExecTCRunner() TCRunner {
 	return &noopTCRunner{}

--- a/internal/network/shape/veth_test.go
+++ b/internal/network/shape/veth_test.go
@@ -16,9 +16,8 @@ import (
 // so tests can assert the exact §5.1 install sequence. An operation whose line
 // prefix is in failOn returns an error, to exercise mid-sequence failure.
 type recordingTCRunner struct {
-	calls      []string
-	failOn     map[string]bool
-	htbDevices []string // returned verbatim by HTBDevices (ingress-veth auto-detect tests)
+	calls  []string
+	failOn map[string]bool
 }
 
 func (r *recordingTCRunner) record(line string) error {
@@ -53,12 +52,6 @@ func (r *recordingTCRunner) QdiscAddFqCodel(_ context.Context, nic, minor, handl
 // scripted fake (see stats_test.go).
 func (r *recordingTCRunner) ClassStats(_ context.Context, _ string) (map[string]ClassStat, error) {
 	return nil, nil
-}
-
-// HTBDevices returns the preset htbDevices slice, letting watch tests drive
-// ingress-veth auto-detection without a live kernel.
-func (r *recordingTCRunner) HTBDevices(_ context.Context) ([]string, error) {
-	return r.htbDevices, nil
 }
 
 func newRecordingManager(t *testing.T, tc TCRunner) *Manager {

--- a/internal/network/shape/veth_test.go
+++ b/internal/network/shape/veth_test.go
@@ -16,8 +16,9 @@ import (
 // so tests can assert the exact §5.1 install sequence. An operation whose line
 // prefix is in failOn returns an error, to exercise mid-sequence failure.
 type recordingTCRunner struct {
-	calls  []string
-	failOn map[string]bool
+	calls      []string
+	failOn     map[string]bool
+	htbDevices []string // returned verbatim by HTBDevices (ingress-veth auto-detect tests)
 }
 
 func (r *recordingTCRunner) record(line string) error {
@@ -52,6 +53,12 @@ func (r *recordingTCRunner) QdiscAddFqCodel(_ context.Context, nic, minor, handl
 // scripted fake (see stats_test.go).
 func (r *recordingTCRunner) ClassStats(_ context.Context, _ string) (map[string]ClassStat, error) {
 	return nil, nil
+}
+
+// HTBDevices returns the preset htbDevices slice, letting watch tests drive
+// ingress-veth auto-detection without a live kernel.
+func (r *recordingTCRunner) HTBDevices(_ context.Context) ([]string, error) {
+	return r.htbDevices, nil
 }
 
 func newRecordingManager(t *testing.T, tc TCRunner) *Manager {

--- a/internal/network/shape/veth_test.go
+++ b/internal/network/shape/veth_test.go
@@ -48,6 +48,12 @@ func (r *recordingTCRunner) QdiscAddFqCodel(_ context.Context, nic, minor, handl
 	return r.record(fmt.Sprintf("qdisc-fqcodel %s 1:%s handle=%s", nic, minor, handle))
 }
 
+// ClassStats is unused by the write-path tests; the watch tests use a dedicated
+// scripted fake (see stats_test.go).
+func (r *recordingTCRunner) ClassStats(_ context.Context, _ string) (map[string]ClassStat, error) {
+	return nil, nil
+}
+
 func newRecordingManager(t *testing.T, tc TCRunner) *Manager {
 	t.Helper()
 	return NewManagerWithConfig(Config{


### PR DESCRIPTION
## Description

Story 4.7 (epic TS_4, #784). Adds `solo-provisioner network shape watch`: a read-only operator-verify command that samples `tc -s class show dev <device>` at a fixed interval and prints per-class rate-over-time — throughput derived from the byte delta, plus the change in overlimits and drops since the previous sample. It lets a node operator at a terminal confirm traffic is actually being classified and shaped (e.g. partner traffic landing in `1:40` with a non-zero rate and climbing overlimits), complementing the dashboard-oriented Prometheus counters (#769).

Without flags it watches the auto-detected egress NIC; `--device ingress` watches a per-pod `$VETH` and requires `--iface` (there is no single ingress device — the HTB lives on ephemeral veths). `--class` narrows to one class; `--interval` sets the cadence (default `2s`); `--count` bounds the run (`0` = until Ctrl-C).

**Scope:** this delivers **AC #1 of #784 only**. AC #2 (operator "restore last-stable") is intentionally deferred to a follow-up — it belongs with the `weaver-prev.conf` last-known-good snapshot machinery from #767, which is not yet in place. This PR therefore references but does not close #784.

### Stacking note

Stacked on **`refactor-traffic-shaper-engine`** (PR #949), not `main`. That PR moved the `TCRunner` interface into a build-tag-free `tc.go`; this PR extends it with a `ClassStats` read method, so it must merge after #949. The diff shown here is only the watch feature on top of #949.

### Files changed

| File | Change |
|---|---|
| `internal/network/shape/stats.go` (new) | `ClassStat`/`ClassDelta`/`WatchSpec` types, `Manager.WatchClasses` sampling loop, pure delta/format helpers |
| `internal/network/shape/tc.go` | Add `ClassStats` to the shared `TCRunner` interface |
| `internal/network/shape/tc_linux.go` | `ClassStats` impl: `tc -s -j class show`, JSON decode with a nested-`stats` fallback |
| `internal/network/shape/tc_other.go` | `ClassStats` no-op stub (non-Linux) |
| `cmd/cli/commands/network/shape/watch.go` (new) | `watch` cobra command; SIGINT/SIGTERM → clean stop |
| `cmd/cli/commands/network/shape/shape.go` | Wire `watchCmd` into the `shape` group |
| `internal/network/shape/stats_test.go`, `cmd/.../shape/shape_test.go`, `internal/network/shape/veth_test.go` | Unit tests + fake-runner update for the new interface method |
| `docs/quickstart.md` | `network shape` **Watch** subsection + `--iface`/`--interval`/`--count` flag rows |

### Review guide

Checklist:
- `stats.go` `monotonicDelta` — a backwards counter (qdisc reinstalled between samples) clamps to 0, never wraps to a huge value.
- `stats.go` `classDeltas` — skips a class absent from the live sample; rows ordered by classid.
- `stats.go` `resolveWatchIface` — ingress requires `--iface`; egress auto-detects the NIC.
- `stats.go` `resolveWatchClasses` — `--class` derives its direction; `--device` lists that direction's classes; the default (neither) is egress. (`--class`/`--device` are mutually exclusive at the CLI, like the sibling `show`/`delete` verbs.)
- `stats.go` `WatchClasses` — returns nil on ctx cancel (including a cancel that lands mid-`tc`-sample) and after `--count`; read-only (no lock, no mutation). Rate uses the real elapsed time between samples, not the nominal interval.
- `tc_linux.go` `ClassStats` — the nested-`stats` fallback never overwrites populated top-level counters; uses the absolute `/sbin/tc` seam.

Tests:
```bash
go test ./internal/network/shape/...
task lint
# cmd package + Linux tc path (macOS can't build internal/mount):
task vm:test:unit
```
`internal/network/shape` unit tests pass on macOS (the package builds via the non-Linux `tc` stub; the watch loop is covered with a fake `TCRunner`); both test binaries cross-compile for linux; `golangci-lint` reports 0 issues.

Manual UAT (UTM VM with a BN installed and traffic shaping active):
1. Confirm the classes exist: `sudo solo-provisioner network shape show` lists the egress device + `partner`/`public`/`reserve-egress`.
2. Start a bounded egress watch:
   ```
   sudo solo-provisioner network shape watch --device egress --interval 1s --count 5
   ```
   Expect a header row (`CLASS  CLASSID  RATE  SENT  OVERLIMITS  DROPPED`), then 5 per-class row batches (one per second), then exit 0.
3. In another shell, generate egress traffic to a partner peer (e.g. a large `scp`/`iperf3` to a partner IP). The `partner` `1:40` row shows a non-zero **RATE** and, once the class hits its ceil, a climbing **OVERLIMITS** (`+N`).
4. Single-class watch until interrupted:
   ```
   sudo solo-provisioner network shape watch --class partner --interval 2s
   ```
   Only the `partner` row prints each tick; `Ctrl-C` stops it cleanly (no stack trace, exit 0).
5. Ingress guardrail:
   ```
   sudo solo-provisioner network shape watch --device ingress
   ```
   Errors with guidance to pass `--iface <veth>`. Re-run with a real pod veth (from `ip link`) to see the ingress classes (`publisher`/`backfill-response`/`reserve-ingress`).
6. Read-only proof: `network shape show` and the `tc class show` hierarchy are unchanged after watching.

Risks / rollback: additive — a new command plus one read method on the tc seam; no mutation path is touched. `tc -j` JSON requires a recent iproute2 (fine on the kernel-6.12 target); a decode failure surfaces a clean error. Revert = delete the two new files and the `ClassStats` method.

### Related Issues

* Refs #784 (delivers AC #1 — `network shape watch`; AC #2 "restore last-stable" is a follow-up)
