### PR TITLE
feat(taskfile): add multi-VM UTM network harness for traffic-shaper/firewall E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -369,6 +369,9 @@ docs/playbooks/production/dir-structure.txt
 
 ### SSH Keys for connecting to local development VM###
 .ssh/
+
+### Multi-VM network test harness scratch (taskfiles/network.yaml)###
+.network-uat/
 integration-test-report.md
 integration-test.json
 .aiassistant

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -70,6 +70,9 @@ includes:
   daemon:
     taskfile: ./taskfiles/daemon.yaml
     flatten: true
+  network:
+    taskfile: ./taskfiles/network.yaml
+    flatten: true
 
 tasks:
   clean:

--- a/scripts/network/gen-appstate.sh
+++ b/scripts/network/gen-appstate.sh
@@ -7,6 +7,12 @@
 # responses; authoring them is how the multi-VM network harness (taskfiles/network.yaml)
 # drives statusz deterministically. See docs/dev/traffic-shaper-test-plan.md (local).
 #
+# JSON casing: these files use snake_case ("active_endpoints") and carry scheme/protocol
+# fields — this is the BN's *input* format (per the real BN sample). It is deliberately
+# NOT the same surface as the statusz HTTP *response* the daemon decodes, which is
+# camelCase ("activeEndpoints", "tlsRequired") in internal/blocknode/shaper/statusz_client.go.
+# The BN reads snake_case files and emits camelCase statusz; do not "fix" this to camelCase.
+#
 # Usage:
 #   gen-appstate.sh <out-dir> <bn-ip> <publisher-ip> <partner-ip> \
 #                   <public-ip> <backfill-ip> <restricted-ip>

--- a/scripts/network/gen-appstate.sh
+++ b/scripts/network/gen-appstate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generate the three BN `application-state` JSON files from captured peer IPs.
+#
+# The block node reads these files to compose its statusz/inbound + statusz/outbound
+# responses; authoring them is how the multi-VM network harness (taskfiles/network.yaml)
+# drives statusz deterministically. See docs/dev/traffic-shaper-test-plan.md (local).
+#
+# Usage:
+#   gen-appstate.sh <out-dir> <bn-ip> <publisher-ip> <partner-ip> \
+#                   <public-ip> <backfill-ip> <restricted-ip>
+#
+# Ports are the current per-deployment BN listener assignments:
+#   publisher 40984 | subscriber 40980 | block-access 40981 | server-status 40982
+set -eu
+
+if [ "$#" -ne 7 ]; then
+  echo "usage: $0 <out-dir> <bn-ip> <publisher-ip> <partner-ip> <public-ip> <backfill-ip> <restricted-ip>" >&2
+  exit 2
+fi
+
+OUT_DIR=$1
+BN=$2
+PUBLISHER=$3
+PARTNER=$4
+PUBLIC=$5
+BACKFILL=$6
+RESTRICTED=$7
+
+PORT_PUBLISHER=40984
+PORT_SUBSCRIBER=40980
+PORT_BLOCKACCESS=40981
+PORT_STATUS=40982
+BACKFILL_PEER_PORT=50980  # the peer-BN API port for the outbound backfill entry
+
+mkdir -p "$OUT_DIR"
+
+# Emit one NetworkConnection object (matches network-data.proto shape).
+# Args: <laddr> <lport> <raddr> <rport> <category>
+conn() {
+  printf '    {\n'
+  printf '      "local": { "address": "%s", "port": "%s" },\n' "$1" "$2"
+  printf '      "remote": { "address": "%s", "port": "%s" },\n' "$3" "$4"
+  printf '      "category": "%s",\n' "$5"
+  printf '      "scheme": "grpc",\n'
+  printf '      "protocol": "TCP"\n'
+  printf '    }'
+}
+
+# known-publishers.json -> feeds statusz/inbound (publisher roster).
+{
+  printf '{\n  "active_endpoints": [\n'
+  conn "$BN" "$PORT_PUBLISHER" "$PUBLISHER" "*" "publisher"
+  printf '\n  ]\n}\n'
+} >"$OUT_DIR/known-publishers.json"
+
+# inbound-partners.json -> feeds statusz/inbound (full inbound roster).
+# public entries carry an empty remote.address (fallthrough, ports-only).
+{
+  printf '{\n  "active_endpoints": [\n'
+  conn "$BN" "$PORT_PUBLISHER" "$PUBLISHER" "*" "publisher"; printf ',\n'
+  conn "$BN" "$PORT_SUBSCRIBER" "$PARTNER" "*" "partner"; printf ',\n'
+  conn "$BN" "$PORT_SUBSCRIBER" "" "" "public"; printf ',\n'
+  conn "$BN" "$PORT_BLOCKACCESS" "" "" "public"; printf ',\n'
+  conn "$BN" "$PORT_STATUS" "" "" "public"; printf ',\n'
+  conn "$BN" "$PORT_SUBSCRIBER" "$RESTRICTED" "*" "restricted"
+  printf '\n  ]\n}\n'
+} >"$OUT_DIR/inbound-partners.json"
+
+# outbound-partners.json -> feeds statusz/outbound (peer-BN backfill, ip:port).
+{
+  printf '{\n  "active_endpoints": [\n'
+  conn "$BN" "*" "$BACKFILL" "$BACKFILL_PEER_PORT" "partner"
+  printf '\n  ]\n}\n'
+} >"$OUT_DIR/outbound-partners.json"
+
+echo "wrote known-publishers.json, inbound-partners.json, outbound-partners.json to $OUT_DIR"

--- a/scripts/network/peers-ip.sh
+++ b/scripts/network/peers-ip.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Print the bridged LAN IPv4 of a UTM VM, or nothing until DHCP assigns it.
+#
+# The golden image runs Docker, so the guest also carries a docker0 address
+# (172.17.0.1); `utmctl ip-address` lists every interface. We skip docker
+# (172.17-172.31), loopback (127.) and link-local (169.254.) so callers get the
+# bridged address they actually SSH to — and get an EMPTY result (not docker0)
+# while the real NIC is still waiting for its lease, so wait loops keep polling.
+#
+# Usage: peers-ip.sh <vm-name>
+set -euo pipefail
+
+VM="${1:?usage: peers-ip.sh <vm-name>}"
+
+utmctl ip-address "$VM" 2>/dev/null \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+  | grep -Ev '^(127\.|169\.254\.|172\.(1[7-9]|2[0-9]|3[01])\.)' \
+  | head -1 || true

--- a/scripts/network/provision-peers.sh
+++ b/scripts/network/provision-peers.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Provision a freshly cloned "peers" UTM VM's guest OS for the network harness:
+#   1. de-conflict its DHCP identity and stop the dhcpcd<->macvlan ARP churn,
+#   2. wait for a stable bridged LAN IP,
+#   3. install the SSH key and verify it with a real login.
+#
+# Prints the resolved peers LAN IP as the LAST line of STDOUT; all progress goes
+# to STDERR, so the caller can capture the IP with `$(... )`.
+#
+# This lives in a script (not the taskfile) because the guest-agent interaction is
+# finicky: `utmctl exec` returns 0 and does not forward guest stdout even when an
+# early write silently no-ops, so we cannot trust exit codes — we VERIFY by effect
+# (a stable IP, then a real SSH login). Running it in real bash also avoids the
+# `set -e` foot-guns of go-task's mvdan/sh interpreter.
+#
+# Usage:
+#   provision-peers.sh <vm-name> <ssh-priv-key> <ssh-pub-key> <vm-user> <roles> [ssh-opts]
+#     <roles>    space-separated macvlan role names (e.g. "publisher partner ...");
+#                each becomes a "<role>0" device that dhcpcd must ignore.
+#     [ssh-opts] extra ssh flags (word-split); e.g. "-o StrictHostKeyChecking=no ..."
+set -euo pipefail
+
+VM="${1:?vm-name}"; PRIV="${2:?ssh-priv-key}"; PUB="${3:?ssh-pub-key}"
+USER_="${4:?vm-user}"; ROLES="${5:?roles}"; SSH_OPTS="${6:-}"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+log() { echo "$@" >&2; }
+peers_ip() { "$HERE/peers-ip.sh" "$VM"; }
+
+# Retry a guest command over the UTM guest agent. qemu-guest-agent throws a
+# transient OSStatus -2700 for the first few seconds after boot; retry through it.
+gexec() {
+  local n=0
+  while [ "$n" -lt 8 ]; do
+    if utmctl exec "$VM" --cmd /bin/bash -c "$1" 2>/dev/null; then return 0; fi
+    n=$((n + 1)); sleep 2
+  done
+  return 1
+}
+
+# Wait until the guest agent answers at all (bounded). We do NOT trust it beyond
+# this single probe — the later steps verify by effect — but the DHCP step needs a
+# live agent to act on.
+log "Waiting for the UTM guest agent..."
+for _ in $(seq 1 60); do
+  if utmctl exec "$VM" --cmd /usr/bin/id >/dev/null 2>&1; then break; fi
+  sleep 2
+done
+
+# 1. De-conflict DHCP and stop the dhcpcd<->macvlan ARP churn (idempotent, guarded
+#    inside the guest shell). A clone inherits the golden's persistent dhcpcd DUID,
+#    so the peers and BN VMs present the SAME DHCP identity; and dhcpcd's ARP
+#    conflict-detection on the macvlan parent makes it decline and re-request leases
+#    endlessly (the IP "flips" through the pool). Fix: identify by the now-unique MAC
+#    via `clientid`, drop the inherited DUID, add `noarp`, and ignore the macvlan
+#    children (derived from the role names so it stays in sync with the caller).
+DENY=""
+for r in $ROLES; do DENY="$DENY ${r}0"; done
+DENY="${DENY# }"
+log "Applying DHCP de-confliction (idempotent; denyinterfaces: $DENY)..."
+DECONF='if ! grep -q "^clientid" /etc/dhcpcd.conf; then '
+DECONF+='sed -i "s/^duid$/clientid/" /etc/dhcpcd.conf; '
+DECONF+='grep -q "^noarp$" /etc/dhcpcd.conf || echo noarp >> /etc/dhcpcd.conf; '
+DECONF+="grep -q '^denyinterfaces ' /etc/dhcpcd.conf || echo 'denyinterfaces $DENY' >> /etc/dhcpcd.conf; "
+DECONF+='rm -f /var/lib/dhcpcd/duid; dhcpcd -k enp0s1 2>/dev/null; sleep 1; dhcpcd -b enp0s1 2>/dev/null; fi'
+gexec "$DECONF" || true
+
+# 2. Wait for a STABLE primary LAN IP: two consecutive equal reads, so we do not
+#    latch onto a lease that is still settling right after the dhcpcd restart.
+log "Waiting for a stable peers VM LAN IP..."
+PEERS_IP=""; last=""
+for _ in $(seq 1 30); do
+  cur="$(peers_ip)"
+  if [ -n "$cur" ] && [ "$cur" = "$last" ]; then PEERS_IP="$cur"; break; fi
+  last="$cur"; sleep 5
+done
+if [ -z "$PEERS_IP" ]; then
+  PEERS_IP="$(peers_ip)"
+  [ -n "$PEERS_IP" ] && log "⚠️  peers LAN IP did not stabilize; proceeding with $PEERS_IP (verify it is not flipping)"
+fi
+if [ -z "$PEERS_IP" ]; then log "❌ peers VM never got an IP"; exit 1; fi
+log "✓ peers VM at $PEERS_IP"
+
+# 3. Install the SSH key and VERIFY it by an actual login. The guest agent reports
+#    success even when an early write did not persist, so re-install and re-test in a
+#    loop until `ssh` truly connects. BatchMode=yes keeps a failed attempt from
+#    blocking on a password prompt.
+log "Installing SSH key and verifying login..."
+PUBKEY="$(cat "$PUB")"
+SSH_OK=""
+for _ in $(seq 1 15); do
+  gexec "mkdir -p /home/$USER_/.ssh && chmod 700 /home/$USER_/.ssh" || true
+  gexec "printf '%s\n' \"$PUBKEY\" > /home/$USER_/.ssh/authorized_keys && chmod 600 /home/$USER_/.ssh/authorized_keys && chown -R $USER_:$USER_ /home/$USER_/.ssh" || true
+  gexec "systemctl start ssh 2>/dev/null || systemctl start sshd 2>/dev/null || true" || true
+  if ssh -i "$PRIV" $SSH_OPTS -o BatchMode=yes -o ConnectTimeout=5 "$USER_@$PEERS_IP" true 2>/dev/null; then
+    SSH_OK=1; break
+  fi
+  sleep 5
+done
+if [ -z "$SSH_OK" ]; then log "❌ SSH key never took effect on the peers VM (login still failing)"; exit 1; fi
+log "✓ SSH key working on $PEERS_IP"
+
+# Emit the resolved IP as the last stdout line for the caller to capture.
+echo "$PEERS_IP"

--- a/scripts/network/strip-peers-vm.sh
+++ b/scripts/network/strip-peers-vm.sh
@@ -39,6 +39,22 @@ new_mac() {
   hexdump -vn5 -e '5/1 ":%02x"' /dev/urandom | sed 's/^:/02:/'
 }
 
+# Preflight: confirm this UTM version's config.plist exposes the keys we intend to edit
+# BEFORE we disturb any running VMs or quit UTM. Stopping every VM + quitting UTM is
+# disruptive (it also stops unrelated VMs, e.g. the BN working VM), so if the schema
+# differs — the right-sizing keys are not readable — no-op with a warning rather than
+# paying that cost for an edit we cannot apply. The caller (network:up) then starts the
+# peers VM at the golden's full CPU/RAM: larger than ideal, but functional.
+pf_cpu="$(plutil -extract System.CPUCount raw -o - "$PLIST" 2>/dev/null || echo "")"
+pf_mem="$(plutil -extract System.MemorySize raw -o - "$PLIST" 2>/dev/null || echo "")"
+if [ -z "$pf_cpu" ] || [ -z "$pf_mem" ]; then
+  echo "⚠️  config.plist does not expose System.CPUCount / System.MemorySize on this UTM version" >&2
+  echo "    (CPUCount='${pf_cpu:-<missing>}', MemorySize='${pf_mem:-<missing>}'). Skipping the" >&2
+  echo "    resource strip: no VMs stopped, UTM left running. Right-size the peers VM manually" >&2
+  echo "    in the UTM app, or update this script for your UTM config schema." >&2
+  exit 0
+fi
+
 # Gracefully stop every running VM BEFORE quitting UTM, then quit so it releases the
 # config files. Quitting the UTM app hard-stops (plug-pulls) any still-running VM,
 # which can corrupt guest files mid-write (e.g. NUL-padded /etc/passwd, a truncated

--- a/scripts/network/strip-peers-vm.sh
+++ b/scripts/network/strip-peers-vm.sh
@@ -39,7 +39,30 @@ new_mac() {
   hexdump -vn5 -e '5/1 ":%02x"' /dev/urandom | sed 's/^:/02:/'
 }
 
-# Quit UTM so it releases the config files, then reopen it afterwards.
+# Gracefully stop every running VM BEFORE quitting UTM, then quit so it releases the
+# config files. Quitting the UTM app hard-stops (plug-pulls) any still-running VM,
+# which can corrupt guest files mid-write (e.g. NUL-padded /etc/passwd, a truncated
+# just-installed binary) — including unrelated VMs such as the BN working VM.
+# IMPORTANT: `utmctl stop` defaults to --force (a hard power-off = same plug-pull), so
+# we must pass --request to ask the guest OS for a clean ACPI shutdown, then wait for
+# each VM to actually power down before quitting UTM.
+echo "Gracefully stopping any running VMs (ACPI) before quitting UTM..."
+running_vms() { utmctl list 2>/dev/null | awk 'NR>1 && tolower($2)=="started" {print $1}'; }
+for uuid in $(running_vms); do
+  echo "  requesting shutdown of $uuid"
+  utmctl stop --request "$uuid" >/dev/null 2>&1 || true
+done
+# Wait (bounded, ~2min) for the guest shutdowns to complete so nothing is running at quit.
+for _ in $(seq 1 60); do
+  [ -z "$(running_vms)" ] && break
+  sleep 2
+done
+if [ -n "$(running_vms)" ]; then
+  echo "  ⚠️  some VMs did not shut down gracefully in time; NOT force-quitting to avoid"
+  echo "      corrupting them. Stop them manually, then re-run. Aborting the strip."
+  exit 1
+fi
+
 echo "Quitting UTM to release VM config files..."
 osascript -e 'tell application "UTM" to quit' >/dev/null 2>&1 || true
 sleep 3

--- a/scripts/network/strip-peers-vm.sh
+++ b/scripts/network/strip-peers-vm.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Right-size and de-conflict the cloned "peers" UTM VM (taskfiles/network.yaml).
+#
+# A freshly `utmctl clone`d VM inherits the golden's exact config, including its MAC
+# address. On a bridged UTM network that means the peers VM and the BN VM present the
+# SAME MAC and fight over one DHCP lease — the peers VM either never gets an IP or
+# steals the BN's. This script gives the peers VM a distinct, locally-administered MAC
+# and trims its vCPU/RAM to the minimum needed to source traffic.
+#
+# UTM caches each VM's config in memory while the app is running and rewrites
+# config.plist on quit/state changes, clobbering external edits. So we QUIT UTM first
+# to release the files, edit with `plutil`, then reopen UTM so it reloads from disk.
+#
+# The MAC edit is idempotent: if the VM already has a locally-administered MAC (02:...)
+# we keep it, so re-running network:up on an existing peers VM does not churn its IP.
+#
+# Usage:
+#   strip-peers-vm.sh <config.plist-path> <cpu-count> <mem-mib>
+set -eu
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <config.plist-path> <cpu-count> <mem-mib>" >&2
+  exit 2
+fi
+
+PLIST=$1
+CPUS=$2
+MEM_MIB=$3
+
+if [ ! -f "$PLIST" ]; then
+  echo "❌ config.plist not found: $PLIST" >&2
+  exit 1
+fi
+
+# Locally-administered (02:...), unicast MAC generator.
+new_mac() {
+  hexdump -vn5 -e '5/1 ":%02x"' /dev/urandom | sed 's/^:/02:/'
+}
+
+# Quit UTM so it releases the config files, then reopen it afterwards.
+echo "Quitting UTM to release VM config files..."
+osascript -e 'tell application "UTM" to quit' >/dev/null 2>&1 || true
+sleep 3
+
+# MAC: only regenerate if the VM still carries a non-locally-administered address
+# (i.e. it is still the golden's cloned MAC and hasn't been de-conflicted yet).
+cur_mac="$(plutil -extract Network.0.MacAddress raw -o - "$PLIST" 2>/dev/null || echo "")"
+case "$cur_mac" in
+  [0][2]:*)
+    echo "  MAC already locally-administered ($cur_mac) — keeping it"
+    ;;
+  *)
+    mac="$(new_mac)"
+    plutil -replace Network.0.MacAddress -string "$mac" "$PLIST" \
+      && echo "  set MAC=$mac (was ${cur_mac:-<none>})" \
+      || echo "  ⚠️  could not set MacAddress — check UTM config schema"
+    ;;
+esac
+
+plutil -replace System.CPUCount -integer "$CPUS" "$PLIST" \
+  && echo "  set CPUCount=$CPUS" \
+  || echo "  ⚠️  could not set CPUCount — check UTM config schema"
+
+plutil -replace System.MemorySize -integer "$MEM_MIB" "$PLIST" \
+  && echo "  set MemorySize=${MEM_MIB}MiB" \
+  || echo "  ⚠️  could not set MemorySize — check UTM config schema"
+
+# Report the applied values so the caller can confirm.
+echo "peers VM config now: MAC=$(plutil -extract Network.0.MacAddress raw -o - "$PLIST" 2>/dev/null || echo '?')" \
+     "CPUs=$(plutil -extract System.CPUCount raw -o - "$PLIST" 2>/dev/null || echo '?')" \
+     "RAM=$(plutil -extract System.MemorySize raw -o - "$PLIST" 2>/dev/null || echo '?')MiB"
+
+# Reopen UTM so it picks up the new config and utmctl works again.
+echo "Reopening UTM..."
+open -a UTM
+sleep 5

--- a/taskfiles/network.yaml
+++ b/taskfiles/network.yaml
@@ -164,6 +164,7 @@ tasks:
 
   network:seed-statusz:
     desc: "Render the 3 statusz application-state JSON files from captured peer IPs and copy them into the BN VM"
+    aliases: [ network:seed ]
     deps:
       - vm:start   # the BN working VM's IP is the BN local address in the files
     cmds:
@@ -190,6 +191,7 @@ tasks:
 
   network:bn-deploy:
     desc: "Deploy the block node on the BN VM with firewall + traffic shaping (peers as the statusz roster)"
+    aliases: [ network:install ]
     deps:
       - vm:start
     cmds:

--- a/taskfiles/network.yaml
+++ b/taskfiles/network.yaml
@@ -1,0 +1,367 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Multi-VM UTM network test harness for the traffic-shaper / firewall plane (ENV-2).
+#
+# Topology: the existing single working VM (vm.yaml) runs the block node; ONE small
+# "peers" VM — a stripped clone of the golden — presents FIVE distinct, un-NAT'd
+# source IPs via macvlan sub-interfaces (publisher, partner, public, backfill,
+# restricted), each running a traffic generator. The BN classifies each peer by its
+# real source IP (requires the Service to use externalTrafficPolicy: Local).
+#
+# NOTE: several steps are UTM/host-specific and need on-hardware validation — search
+# this file for "ASSUMPTION". macvlan-over-UTM is the load-bearing unknown; if it
+# proves unreliable, the documented fallback is five tiny VMs.
+
+version: 3
+
+vars:
+  NET_PEERS_VM: "solo-weaver-{{.VM_OS_TYPE}}-peers"
+  NET_STATE_DIR: "{{.PWD}}/.network-uat"
+  NET_HOSTS_FILE: "{{.PWD}}/.network-uat/hosts.env"
+  # Peers VM resource strip (best-effort; see ASSUMPTION in network:up).
+  NET_PEERS_CPUS: '{{.NET_PEERS_CPUS | default "1"}}'
+  NET_PEERS_MEM_MIB: '{{.NET_PEERS_MEM_MIB | default "1024"}}'
+  # macvlan host-offsets within the peers VM's /24, high to dodge the DHCP range.
+  # Order matches NET_ROLES below.
+  NET_ROLES: "publisher partner public backfill restricted"
+  NET_PEER_OFFSETS: '{{.NET_PEER_OFFSETS | default "201 202 203 204 205"}}'
+  # BN application-state volume path inside the BN VM (matches --base-path/application-state).
+  NET_APPSTATE_DIR: '{{.NET_APPSTATE_DIR | default "/mnt/fast-storage/application-state"}}'
+  # BN egress NIC inside the VM. ASSUMPTION: validate with `ip route get 1.1.1.1` in the VM.
+  NET_EGRESS_IFACE: '{{.NET_EGRESS_IFACE | default "enp0s1"}}'
+  # Host arch selects the daemon binary the BN install consumes (built into bin/).
+  NET_DAEMON_ARCH: '{{.NET_DAEMON_ARCH | default "arm64"}}'
+
+tasks:
+  network:up:
+    desc: "Clone a stripped 'peers' VM, bring up 5 macvlan source IPs + iperf3, and capture the peer IPs"
+    deps:
+      - vm:setup   # ensures the golden image exists to clone from
+    cmds:
+      - |
+        set -eu
+        mkdir -p "{{.NET_STATE_DIR}}"
+        PEERS="{{.NET_PEERS_VM}}"
+        GOLDEN="{{.VM_GOLDEN_NAME}}"
+        # Resolve the peers VM's real LAN IP. The golden image runs Docker, so the guest
+        # also carries a docker0 address (172.17.0.1); utmctl ip-address lists every
+        # interface and the previous `head -1` could pick that (or a loopback/link-local)
+        # instead of the bridged NIC — the address we SSH to and derive macvlan IPs from.
+        # Return ONLY the bridged address (empty until DHCP assigns it) so the wait loop
+        # below keeps polling instead of latching onto docker0, which is up from boot.
+        # Excludes docker (172.17–172.31), loopback (127.) and link-local (169.254.).
+        peers_ip() {
+          utmctl ip-address "$PEERS" 2>/dev/null \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -Ev '^(127\.|169\.254\.|172\.(1[7-9]|2[0-9]|3[01])\.)' \
+            | head -1
+        }
+
+        # 1. Clone the golden -> peers VM (reuse if already present).
+        if ! utmctl status "$PEERS" >/dev/null 2>&1; then
+          echo "Cloning golden '$GOLDEN' -> peers VM '$PEERS'..."
+          # Remove any orphaned .utm directory left by a previous incomplete network:down.
+          # utmctl clone creates a numbered suffix (e.g. "…-peers 2.utm") when the target
+          # directory already exists, which causes the config.plist path assumed below to
+          # point at the old orphaned copy rather than the new clone — leaving the new VM
+          # with the golden's full CPU/RAM.
+          PEERS_UTM_DIR="{{.UTM_VMS_DIR}}/$PEERS.utm"
+          if [ -d "$PEERS_UTM_DIR" ]; then
+            echo "Removing orphaned VM directory: $PEERS_UTM_DIR"
+            rm -rf "$PEERS_UTM_DIR"
+          fi
+          utmctl stop "$GOLDEN" 2>/dev/null || true
+          sleep 2
+          utmctl clone "$GOLDEN" --name "$PEERS"
+          for _ in $(seq 1 15); do
+            [ "$(utmctl status "$PEERS" 2>/dev/null)" = "stopped" ] && break
+            sleep 1
+          done
+        else
+          echo "Peers VM '$PEERS' already exists; checking resource limits."
+        fi
+
+        # 2. Right-size the peers VM and give it a distinct MAC. A clone inherits the
+        #    golden's MAC, so on the bridged UTM network the peers VM and BN VM collide on
+        #    one DHCP lease; the helper assigns a locally-administered MAC and trims
+        #    vCPU/RAM. It quits and reopens UTM to make the config.plist edits stick, which
+        #    also stops any other running VMs — so we only run it when something actually
+        #    needs changing (fresh clone, or MAC/CPU/RAM not yet at target). A reused VM
+        #    that is already right-sized is left untouched (no UTM restart).
+        #    ASSUMPTION: UTM 4.x config.plist keys Network.0.MacAddress / System.CPUCount
+        #    / System.MemorySize (MiB). Non-fatal if the schema differs on your UTM.
+        CFG="{{.UTM_VMS_DIR}}/$PEERS.utm/config.plist"
+        if [ -f "$CFG" ]; then
+          CUR_MAC="$(plutil -extract Network.0.MacAddress raw -o - "$CFG" 2>/dev/null || echo "")"
+          CUR_CPU="$(plutil -extract System.CPUCount raw -o - "$CFG" 2>/dev/null || echo "")"
+          CUR_MEM="$(plutil -extract System.MemorySize raw -o - "$CFG" 2>/dev/null || echo "")"
+          if [ "${CUR_MAC#02:}" != "$CUR_MAC" ] && [ "$CUR_CPU" = "{{.NET_PEERS_CPUS}}" ] && [ "$CUR_MEM" = "{{.NET_PEERS_MEM_MIB}}" ]; then
+            echo "peers VM already right-sized (MAC=$CUR_MAC CPUs=$CUR_CPU RAM=${CUR_MEM}MiB); skipping strip"
+          else
+            bash scripts/network/strip-peers-vm.sh "$CFG" "{{.NET_PEERS_CPUS}}" "{{.NET_PEERS_MEM_MIB}}"
+          fi
+        else
+          echo "  ⚠️  config.plist not found at $CFG — skipping resource strip"
+        fi
+
+        # 3. Start it and wait until it is running. UTM was just reopened by the strip
+        #    helper, so retry start until it takes (utmctl can transiently fail while UTM
+        #    warms up).
+        for _ in $(seq 1 10); do
+          [ "$(utmctl status "$PEERS" 2>/dev/null)" = "started" ] && break
+          utmctl start --hide "$PEERS" 2>/dev/null || true
+          sleep 3
+        done
+
+        # 4. Wait for the UTM guest agent to come up. IMPORTANT: qemu-guest-agent answers
+        #    `id` probes early in boot but silently no-ops file writes until the guest is
+        #    fully up, AND utmctl exec does not forward guest stdout here — so its exit code
+        #    cannot be trusted. We therefore do not rely on exit codes: guest setup is
+        #    VERIFIED by its real effect (a working SSH login, step 7). gexec() still exists
+        #    to retry the transient OSStatus -2700 the agent throws right after boot.
+        gexec() {
+          _n=0
+          while [ "$_n" -lt 8 ]; do
+            if utmctl exec "$PEERS" --cmd /bin/bash -c "$1" 2>/dev/null; then return 0; fi
+            _n=$((_n + 1)); sleep 2
+          done
+          return 1
+        }
+        echo "Waiting for the UTM guest agent to stabilize..."
+        _hits=0
+        for _ in $(seq 1 60); do
+          if utmctl exec "$PEERS" --cmd /usr/bin/id >/dev/null 2>&1; then
+            _hits=$((_hits + 1))
+            if [ "$_hits" -ge 3 ]; then break; fi
+          else
+            _hits=0
+          fi
+          sleep 2
+        done
+
+        # 5. De-conflict DHCP and stop the dhcpcd<->macvlan ARP churn — done BEFORE the IP
+        #    wait because it restarts dhcpcd (the lease settles afterwards). A clone inherits
+        #    the golden's persistent dhcpcd DUID, so the peers and BN VMs present the SAME
+        #    DHCP identity; and dhcpcd's ARP conflict-detection on the macvlan parent makes
+        #    it decline and re-request leases endlessly (the IP "flips" through the pool).
+        #    Fix: identify by the now-unique MAC via `clientid`, drop the inherited DUID,
+        #    add `noarp`, and ignore the macvlan children. The guard runs INSIDE the guest
+        #    shell so it is reliable and idempotent; the denyinterfaces list must match the
+        #    macvlan devices created in step 8.
+        echo "Applying DHCP de-confliction (idempotent)..."
+        gexec 'if ! grep -q "^clientid" /etc/dhcpcd.conf; then sed -i "s/^duid$/clientid/" /etc/dhcpcd.conf; grep -q "^noarp$" /etc/dhcpcd.conf || echo noarp >> /etc/dhcpcd.conf; grep -q "^denyinterfaces " /etc/dhcpcd.conf || echo "denyinterfaces publisher0 partner0 public0 backfill0 restricted0" >> /etc/dhcpcd.conf; rm -f /var/lib/dhcpcd/duid; dhcpcd -k enp0s1 2>/dev/null; sleep 1; dhcpcd -b enp0s1 2>/dev/null; fi' || true
+
+        # 6. Wait for a STABLE primary LAN IP: two consecutive equal reads, so we do not
+        #    latch onto a lease that is still settling right after the dhcpcd restart.
+        #    (macvlan source IPs do not exist yet, so peers_ip only sees the primary NIC.)
+        echo "Waiting for a stable peers VM LAN IP..."
+        PEERS_IP=""; _last=""
+        for _ in $(seq 1 30); do
+          _cur="$(peers_ip)"
+          if [ -n "$_cur" ] && [ "$_cur" = "$_last" ]; then PEERS_IP="$_cur"; break; fi
+          _last="$_cur"; sleep 5
+        done
+        if [ -z "$PEERS_IP" ]; then
+          # Last resort: never stabilized. Take the current best LAN address so the run can
+          # proceed, but warn — a still-flipping IP means the de-confliction did not apply.
+          PEERS_IP="$(peers_ip)"
+          [ -n "$PEERS_IP" ] && echo "⚠️  peers LAN IP did not stabilize; proceeding with $PEERS_IP (verify it is not flipping)"
+        fi
+        [ -z "$PEERS_IP" ] && { echo "❌ peers VM never got an IP"; exit 1; }
+        echo "✓ peers VM at $PEERS_IP"
+
+        # 7. Install the SSH key and VERIFY it by an actual login. The guest agent reports
+        #    success even when an early write did not persist, so re-install and re-test in
+        #    a loop until `ssh` truly connects. BatchMode=yes keeps a failed attempt from
+        #    blocking on a password prompt.
+        echo "Installing SSH key and verifying login..."
+        PUBKEY="$(cat {{.SSH_PUBLIC_KEY}})"
+        SSH_OK=""
+        for _ in $(seq 1 15); do
+          gexec "mkdir -p /home/{{.VM_USER}}/.ssh && chmod 700 /home/{{.VM_USER}}/.ssh" || true
+          gexec "printf '%s\\n' \"$PUBKEY\" > /home/{{.VM_USER}}/.ssh/authorized_keys && chmod 600 /home/{{.VM_USER}}/.ssh/authorized_keys && chown -R {{.VM_USER}}:{{.VM_USER}} /home/{{.VM_USER}}/.ssh" || true
+          gexec "systemctl start ssh 2>/dev/null || systemctl start sshd 2>/dev/null || true" || true
+          if ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} -o BatchMode=yes -o ConnectTimeout=5 {{.VM_USER}}@$PEERS_IP true 2>/dev/null; then
+            SSH_OK=1; break
+          fi
+          sleep 5
+        done
+        [ -z "$SSH_OK" ] && { echo "❌ SSH key never took effect on the peers VM (login still failing)"; exit 1; }
+        echo "✓ SSH key working on $PEERS_IP"
+
+        # 8. Provision the five macvlan source IPs + iperf3.
+        #    macvlan (mode bridge) gives each peer a distinct MAC/IP on the peers NIC;
+        #    child<->external (the BN VM) works, which is all we need for source-IP
+        #    classification. ASSUMPTION: the UTM network forwards these child MACs
+        #    (true on a bridged segment; validate on 'shared' — this is the macvlan risk).
+        NIC="$(ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} {{.VM_USER}}@$PEERS_IP "ip route get 1.1.1.1 | sed -n 's/.* dev \([^ ]*\).*/\1/p' | head -1")"
+        echo "peers primary NIC: ${NIC:-<unknown>}"
+        PREFIX="$(echo "$PEERS_IP" | cut -d. -f1-3)"
+        : > "{{.NET_HOSTS_FILE}}"
+        echo "PEERS_VM_IP=$PEERS_IP" >> "{{.NET_HOSTS_FILE}}"
+        i=0
+        for role in {{.NET_ROLES}}; do
+          i=$((i + 1))
+          off="$(echo '{{.NET_PEER_OFFSETS}}' | cut -d' ' -f$i)"
+          ip="$PREFIX.$off"
+          ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} {{.VM_USER}}@$PEERS_IP "
+            sudo ip link add ${role}0 link $NIC type macvlan mode bridge 2>/dev/null || true
+            sudo ip addr replace $ip/24 dev ${role}0
+            sudo ip link set ${role}0 up
+            command -v iperf3 >/dev/null 2>&1 || (sudo apt-get update -qq && sudo apt-get install -y iperf3)
+          " 2>&1 || echo "  ⚠️  macvlan/iperf3 setup for $role may have failed (validate on-host)"
+          upper="$(echo "$role" | tr '[:lower:]' '[:upper:]')"
+          echo "${upper}_IP=$ip" >> "{{.NET_HOSTS_FILE}}"
+          echo "  $role -> $ip (${role}0)"
+        done
+        echo "✓ peer source IPs captured:"
+        cat "{{.NET_HOSTS_FILE}}"
+
+  network:seed:
+    desc: "Generate the 3 application-state JSON files from captured peer IPs and copy them into the BN VM"
+    deps:
+      - vm:start   # the BN working VM's IP is the BN local address in the files
+    cmds:
+      - |
+        set -eu
+        [ -f "{{.NET_HOSTS_FILE}}" ] || { echo "❌ run 'task network:up' first"; exit 1; }
+        . "{{.NET_HOSTS_FILE}}"
+        BN_IP="$({{.GET_VM_IP}} get_vm_ip)"
+        [ -z "$BN_IP" ] && { echo "❌ BN VM has no IP (is it running?)"; exit 1; }
+        echo "BN local address: $BN_IP"
+
+        bash scripts/network/gen-appstate.sh "{{.NET_STATE_DIR}}" \
+          "$BN_IP" "$PUBLISHER_IP" "$PARTNER_IP" "$PUBLIC_IP" "$BACKFILL_IP" "$RESTRICTED_IP"
+
+        echo "Copying application-state files -> $BN_IP:{{.NET_APPSTATE_DIR}} ..."
+        ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} {{.VM_USER}}@$BN_IP \
+          "sudo mkdir -p {{.NET_APPSTATE_DIR}} && sudo chown {{.VM_USER}}:{{.VM_USER}} {{.NET_APPSTATE_DIR}}"
+        scp -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} \
+          "{{.NET_STATE_DIR}}/known-publishers.json" \
+          "{{.NET_STATE_DIR}}/inbound-partners.json" \
+          "{{.NET_STATE_DIR}}/outbound-partners.json" \
+          {{.VM_USER}}@$BN_IP:{{.NET_APPSTATE_DIR}}/
+        echo "✓ application-state files seeded"
+
+  network:install:
+    desc: "Install the block node with firewall + traffic shaping on the BN VM (peers as the statusz roster)"
+    deps:
+      - vm:start
+    cmds:
+      - |
+        set -eu
+        [ -f "{{.NET_HOSTS_FILE}}" ] || { echo "❌ run 'task network:up' first"; exit 1; }
+        . "{{.NET_HOSTS_FILE}}"
+        BN_IP="$({{.GET_VM_IP}} get_vm_ip)"
+        [ -z "$BN_IP" ] && { echo "❌ BN VM has no IP"; exit 1; }
+        # ASSUMPTION: mgmt allowlist must include whatever we SSH from, or --firewall-enabled
+        # locks us out. Default to the BN VM's /24 (covers the host + peers). Override with
+        # NET_MGMT_CIDRS=... if your host reaches the VM from a different subnet.
+        MGMT_CIDRS="{{.NET_MGMT_CIDRS | default ""}}"
+        [ -z "$MGMT_CIDRS" ] && MGMT_CIDRS="$(echo "$BN_IP" | cut -d. -f1-3).0/24"
+        echo "Installing block node on $BN_IP (traffic shaping + firewall; mgmt=$MGMT_CIDRS)..."
+        # PREREQ: the provisioner + daemon binaries are built in the VM (task build in /mnt/solo-weaver)
+        # and solo-provisioner is installed. This task only runs the block-node install itself.
+        ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} {{.VM_USER}}@$BN_IP "
+          cd /mnt/solo-weaver &&
+          sudo solo-provisioner block node install -p local \
+            --traffic-shaping-enabled --egress-interface {{.NET_EGRESS_IFACE}} --link-rate 1gbit \
+            --firewall-enabled --mgmt-cidrs '$MGMT_CIDRS' \
+            --daemon-bin bin/solo-provisioner-daemon-linux-{{.NET_DAEMON_ARCH}} -VV
+        "
+        echo "✓ block node installed; the daemon reconciles the peer roster from statusz"
+
+  network:status:
+    desc: "Show the BN + peers VM status and the captured peer IPs"
+    cmds:
+      - |
+        echo "BN VM    ({{.VM_NAME}}):    $(utmctl status "{{.VM_NAME}}" 2>/dev/null || echo not-found)"
+        echo "Peers VM ({{.NET_PEERS_VM}}): $(utmctl status "{{.NET_PEERS_VM}}" 2>/dev/null || echo not-found)"
+        echo ""
+        if [ -f "{{.NET_HOSTS_FILE}}" ]; then cat "{{.NET_HOSTS_FILE}}"; else echo "(no captured IPs — run 'task network:up')"; fi
+
+  network:ip:
+    desc: "Print the captured peer source IPs"
+    cmds:
+      - |
+        [ -f "{{.NET_HOSTS_FILE}}" ] && cat "{{.NET_HOSTS_FILE}}" || { echo "run 'task network:up' first"; exit 1; }
+
+  network:ssh:
+    desc: "SSH into the peers VM (starts it if stopped)"
+    silent: true
+    interactive: true
+    cmds:
+      - |
+        set -eu
+        PEERS="{{.NET_PEERS_VM}}"
+        # Live LAN-IP resolver: skip the guest's docker0 (172.17–172.31), loopback and
+        # link-local so we get the bridged address we actually SSH to.
+        peers_ip() {
+          utmctl ip-address "$PEERS" 2>/dev/null \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -Ev '^(127\.|169\.254\.|172\.(1[7-9]|2[0-9]|3[01])\.)' \
+            | head -1
+        }
+
+        # The peers VM must exist (created by network:up) — utmctl status fails otherwise.
+        STATUS="$(utmctl status "$PEERS" 2>/dev/null || true)"
+        [ -z "$STATUS" ] && { echo "❌ peers VM '$PEERS' not found — run 'task network:up' first"; exit 1; }
+
+        # Start it if it is not already running; the DHCP lease can change across boots,
+        # so we always resolve the IP live rather than trusting a possibly-stale hosts.env.
+        if [ "$STATUS" != "started" ]; then
+          echo "Peers VM is '$STATUS'; starting it..."
+          for _ in $(seq 1 10); do
+            [ "$(utmctl status "$PEERS" 2>/dev/null)" = "started" ] && break
+            utmctl start --hide "$PEERS" 2>/dev/null || true
+            sleep 3
+          done
+        fi
+
+        echo "Waiting for peers VM LAN IP..."
+        PEERS_IP=""
+        for _ in $(seq 1 24); do PEERS_IP="$(peers_ip)"; [ -n "$PEERS_IP" ] && break; sleep 5; done
+        # Fall back to the IP captured by network:up if the guest agent is not responding.
+        if [ -z "$PEERS_IP" ] && [ -f "{{.NET_HOSTS_FILE}}" ]; then
+          PEERS_IP="$(. "{{.NET_HOSTS_FILE}}"; printf '%s' "${PEERS_VM_IP:-}")"
+          [ -n "$PEERS_IP" ] && echo "⚠️  using captured IP $PEERS_IP (guest agent gave none; it may be stale)"
+        fi
+        [ -z "$PEERS_IP" ] && { echo "❌ peers VM has no reachable IP (still booting? try again shortly)"; exit 1; }
+
+        # Wait for sshd to accept connections (the VM may still be booting).
+        echo "Waiting for SSH on $PEERS_IP..."
+        for _ in $(seq 1 24); do
+          if ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} -o ConnectTimeout=3 -o BatchMode=yes {{.VM_USER}}@$PEERS_IP true 2>/dev/null; then
+            break
+          fi
+          sleep 5
+        done
+
+        echo "Connecting to peers VM at $PEERS_IP..."
+        env -i HOME="$HOME" USER="$USER" TERM="${TERM:-xterm}" \
+        ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} -t {{.VM_USER}}@$PEERS_IP "exec \$SHELL -l"
+
+  network:down:
+    desc: "Stop and delete the peers VM and clear captured state"
+    cmds:
+      - |
+        PEERS="{{.NET_PEERS_VM}}"
+        if utmctl status "$PEERS" >/dev/null 2>&1; then
+          echo "Stopping and deleting peers VM '$PEERS'..."
+          utmctl stop "$PEERS" 2>/dev/null || true
+          sleep 1
+          utmctl delete "$PEERS" 2>/dev/null || true
+          echo "✓ peers VM removed"
+        else
+          echo "Peers VM '$PEERS' not found in UTM registry."
+        fi
+        # Also remove the .utm directory; utmctl delete does not always clean up files,
+        # and a stale directory causes the next network:up clone to use a numbered suffix
+        # (e.g. "…-peers 2.utm"), breaking the config.plist resource-strip path.
+        PEERS_UTM_DIR="{{.UTM_VMS_DIR}}/$PEERS.utm"
+        if [ -d "$PEERS_UTM_DIR" ]; then
+          echo "Removing VM directory: $PEERS_UTM_DIR"
+          rm -rf "$PEERS_UTM_DIR"
+        fi
+        rm -rf "{{.NET_STATE_DIR}}"
+        echo "✓ cleared {{.NET_STATE_DIR}}"

--- a/taskfiles/network.yaml
+++ b/taskfiles/network.yaml
@@ -33,6 +33,31 @@ vars:
   NET_DAEMON_ARCH: '{{.NET_DAEMON_ARCH | default "arm64"}}'
 
 tasks:
+  network:all:
+    desc: "End-to-end: build, self-install the provisioner on the BN VM, then up + seed-statusz + bn-deploy"
+    cmds:
+      # 1. Build the host + linux binaries (visible in the BN VM via the /mnt/solo-weaver mount).
+      - task: build
+      # 2. Self-install the provisioner on the BN VM (puts `solo-provisioner` on PATH for bn-deploy).
+      - task: vm:start
+      - |
+        set -eu
+        BN_IP="$({{.GET_VM_IP}} get_vm_ip)"
+        [ -z "$BN_IP" ] && { echo "❌ BN VM has no IP (is it running?)"; exit 1; }
+        echo "Self-installing solo-provisioner on the BN VM ($BN_IP)..."
+        ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} {{.VM_USER}}@$BN_IP \
+          "cd /mnt/solo-weaver && sudo bin/solo-provisioner-linux-{{.NET_DAEMON_ARCH}} install"
+        # Verify by effect: a failed install can leave a 0-byte binary that runs and exits 0
+        # (so every later command silently no-ops). `version` (which prints to STDERR) must
+        # return a real version, so capture 2>&1.
+        VER="$(ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} {{.VM_USER}}@$BN_IP "solo-provisioner version 2>&1" | head -1)"
+        [ -z "$VER" ] && { echo "❌ self-install failed: 'solo-provisioner version' returned nothing (installed binary may be 0 bytes — check the BN VM's /etc/passwd for NUL corruption, then re-run)"; exit 1; }
+        echo "✓ provisioner installed on the BN VM: $VER"
+      # 3-5. Bring up the peers VM, seed the statusz roster, deploy the BN with shaping + firewall.
+      - task: network:up
+      - task: network:seed-statusz
+      - task: network:bn-deploy
+
   network:up:
     desc: "Clone a stripped 'peers' VM, bring up 5 macvlan source IPs + iperf3, and capture the peer IPs"
     deps:
@@ -43,19 +68,6 @@ tasks:
         mkdir -p "{{.NET_STATE_DIR}}"
         PEERS="{{.NET_PEERS_VM}}"
         GOLDEN="{{.VM_GOLDEN_NAME}}"
-        # Resolve the peers VM's real LAN IP. The golden image runs Docker, so the guest
-        # also carries a docker0 address (172.17.0.1); utmctl ip-address lists every
-        # interface and the previous `head -1` could pick that (or a loopback/link-local)
-        # instead of the bridged NIC — the address we SSH to and derive macvlan IPs from.
-        # Return ONLY the bridged address (empty until DHCP assigns it) so the wait loop
-        # below keeps polling instead of latching onto docker0, which is up from boot.
-        # Excludes docker (172.17–172.31), loopback (127.) and link-local (169.254.).
-        peers_ip() {
-          utmctl ip-address "$PEERS" 2>/dev/null \
-            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
-            | grep -Ev '^(127\.|169\.254\.|172\.(1[7-9]|2[0-9]|3[01])\.)' \
-            | head -1
-        }
 
         # 1. Clone the golden -> peers VM (reuse if already present).
         if ! utmctl status "$PEERS" >/dev/null 2>&1; then
@@ -113,83 +125,16 @@ tasks:
           sleep 3
         done
 
-        # 4. Wait for the UTM guest agent to come up. IMPORTANT: qemu-guest-agent answers
-        #    `id` probes early in boot but silently no-ops file writes until the guest is
-        #    fully up, AND utmctl exec does not forward guest stdout here — so its exit code
-        #    cannot be trusted. We therefore do not rely on exit codes: guest setup is
-        #    VERIFIED by its real effect (a working SSH login, step 7). gexec() still exists
-        #    to retry the transient OSStatus -2700 the agent throws right after boot.
-        gexec() {
-          _n=0
-          while [ "$_n" -lt 8 ]; do
-            if utmctl exec "$PEERS" --cmd /bin/bash -c "$1" 2>/dev/null; then return 0; fi
-            _n=$((_n + 1)); sleep 2
-          done
-          return 1
-        }
-        echo "Waiting for the UTM guest agent to stabilize..."
-        _hits=0
-        for _ in $(seq 1 60); do
-          if utmctl exec "$PEERS" --cmd /usr/bin/id >/dev/null 2>&1; then
-            _hits=$((_hits + 1))
-            if [ "$_hits" -ge 3 ]; then break; fi
-          else
-            _hits=0
-          fi
-          sleep 2
-        done
+        # 4. Provision the guest: DHCP de-confliction + SSH-key install, and resolve the
+        #    stable bridged LAN IP. All the finicky guest-agent shell lives in the helper
+        #    (real bash, testable); it logs progress to stderr and prints the IP on stdout.
+        echo "Provisioning peers guest (DHCP de-confliction + SSH key)..."
+        PEERS_IP="$(bash scripts/network/provision-peers.sh \
+          "$PEERS" "{{.SSH_PRIVATE_KEY}}" "{{.SSH_PUBLIC_KEY}}" "{{.VM_USER}}" "{{.NET_ROLES}}" "{{.SSH_OPTS}}" | tail -1)"
+        [ -z "$PEERS_IP" ] && { echo "❌ peers guest provisioning failed"; exit 1; }
+        echo "✓ peers VM ready at $PEERS_IP"
 
-        # 5. De-conflict DHCP and stop the dhcpcd<->macvlan ARP churn — done BEFORE the IP
-        #    wait because it restarts dhcpcd (the lease settles afterwards). A clone inherits
-        #    the golden's persistent dhcpcd DUID, so the peers and BN VMs present the SAME
-        #    DHCP identity; and dhcpcd's ARP conflict-detection on the macvlan parent makes
-        #    it decline and re-request leases endlessly (the IP "flips" through the pool).
-        #    Fix: identify by the now-unique MAC via `clientid`, drop the inherited DUID,
-        #    add `noarp`, and ignore the macvlan children. The guard runs INSIDE the guest
-        #    shell so it is reliable and idempotent; the denyinterfaces list must match the
-        #    macvlan devices created in step 8.
-        echo "Applying DHCP de-confliction (idempotent)..."
-        gexec 'if ! grep -q "^clientid" /etc/dhcpcd.conf; then sed -i "s/^duid$/clientid/" /etc/dhcpcd.conf; grep -q "^noarp$" /etc/dhcpcd.conf || echo noarp >> /etc/dhcpcd.conf; grep -q "^denyinterfaces " /etc/dhcpcd.conf || echo "denyinterfaces publisher0 partner0 public0 backfill0 restricted0" >> /etc/dhcpcd.conf; rm -f /var/lib/dhcpcd/duid; dhcpcd -k enp0s1 2>/dev/null; sleep 1; dhcpcd -b enp0s1 2>/dev/null; fi' || true
-
-        # 6. Wait for a STABLE primary LAN IP: two consecutive equal reads, so we do not
-        #    latch onto a lease that is still settling right after the dhcpcd restart.
-        #    (macvlan source IPs do not exist yet, so peers_ip only sees the primary NIC.)
-        echo "Waiting for a stable peers VM LAN IP..."
-        PEERS_IP=""; _last=""
-        for _ in $(seq 1 30); do
-          _cur="$(peers_ip)"
-          if [ -n "$_cur" ] && [ "$_cur" = "$_last" ]; then PEERS_IP="$_cur"; break; fi
-          _last="$_cur"; sleep 5
-        done
-        if [ -z "$PEERS_IP" ]; then
-          # Last resort: never stabilized. Take the current best LAN address so the run can
-          # proceed, but warn — a still-flipping IP means the de-confliction did not apply.
-          PEERS_IP="$(peers_ip)"
-          [ -n "$PEERS_IP" ] && echo "⚠️  peers LAN IP did not stabilize; proceeding with $PEERS_IP (verify it is not flipping)"
-        fi
-        [ -z "$PEERS_IP" ] && { echo "❌ peers VM never got an IP"; exit 1; }
-        echo "✓ peers VM at $PEERS_IP"
-
-        # 7. Install the SSH key and VERIFY it by an actual login. The guest agent reports
-        #    success even when an early write did not persist, so re-install and re-test in
-        #    a loop until `ssh` truly connects. BatchMode=yes keeps a failed attempt from
-        #    blocking on a password prompt.
-        echo "Installing SSH key and verifying login..."
-        PUBKEY="$(cat {{.SSH_PUBLIC_KEY}})"
-        SSH_OK=""
-        for _ in $(seq 1 15); do
-          gexec "mkdir -p /home/{{.VM_USER}}/.ssh && chmod 700 /home/{{.VM_USER}}/.ssh" || true
-          gexec "printf '%s\\n' \"$PUBKEY\" > /home/{{.VM_USER}}/.ssh/authorized_keys && chmod 600 /home/{{.VM_USER}}/.ssh/authorized_keys && chown -R {{.VM_USER}}:{{.VM_USER}} /home/{{.VM_USER}}/.ssh" || true
-          gexec "systemctl start ssh 2>/dev/null || systemctl start sshd 2>/dev/null || true" || true
-          if ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} -o BatchMode=yes -o ConnectTimeout=5 {{.VM_USER}}@$PEERS_IP true 2>/dev/null; then
-            SSH_OK=1; break
-          fi
-          sleep 5
-        done
-        [ -z "$SSH_OK" ] && { echo "❌ SSH key never took effect on the peers VM (login still failing)"; exit 1; }
-        echo "✓ SSH key working on $PEERS_IP"
-
-        # 8. Provision the five macvlan source IPs + iperf3.
+        # 5. Provision the five macvlan source IPs + iperf3.
         #    macvlan (mode bridge) gives each peer a distinct MAC/IP on the peers NIC;
         #    child<->external (the BN VM) works, which is all we need for source-IP
         #    classification. ASSUMPTION: the UTM network forwards these child MACs
@@ -217,8 +162,8 @@ tasks:
         echo "✓ peer source IPs captured:"
         cat "{{.NET_HOSTS_FILE}}"
 
-  network:seed:
-    desc: "Generate the 3 application-state JSON files from captured peer IPs and copy them into the BN VM"
+  network:seed-statusz:
+    desc: "Render the 3 statusz application-state JSON files from captured peer IPs and copy them into the BN VM"
     deps:
       - vm:start   # the BN working VM's IP is the BN local address in the files
     cmds:
@@ -243,8 +188,8 @@ tasks:
           {{.VM_USER}}@$BN_IP:{{.NET_APPSTATE_DIR}}/
         echo "✓ application-state files seeded"
 
-  network:install:
-    desc: "Install the block node with firewall + traffic shaping on the BN VM (peers as the statusz roster)"
+  network:bn-deploy:
+    desc: "Deploy the block node on the BN VM with firewall + traffic shaping (peers as the statusz roster)"
     deps:
       - vm:start
     cmds:
@@ -254,6 +199,13 @@ tasks:
         . "{{.NET_HOSTS_FILE}}"
         BN_IP="$({{.GET_VM_IP}} get_vm_ip)"
         [ -z "$BN_IP" ] && { echo "❌ BN VM has no IP"; exit 1; }
+        # Pre-flight: the installed provisioner must be a working binary. A failed
+        # self-install can leave a 0-byte binary that runs and exits 0, turning the
+        # block-node install into a silent no-op that falsely reports success.
+        # `version` prints to STDERR, so capture 2>&1.
+        VER="$(ssh -i {{.SSH_PRIVATE_KEY}} {{.SSH_OPTS}} {{.VM_USER}}@$BN_IP "solo-provisioner version 2>&1" | head -1)"
+        [ -z "$VER" ] && { echo "❌ solo-provisioner is not a working binary on the BN VM ('version' returned nothing). Run 'task network:all' (or self-install) first; if it persists, check the BN VM's /etc/passwd for NUL corruption."; exit 1; }
+        echo "Using $VER on the BN VM"
         # ASSUMPTION: mgmt allowlist must include whatever we SSH from, or --firewall-enabled
         # locks us out. Default to the BN VM's /24 (covers the host + peers). Override with
         # NET_MGMT_CIDRS=... if your host reaches the VM from a different subnet.
@@ -294,14 +246,8 @@ tasks:
       - |
         set -eu
         PEERS="{{.NET_PEERS_VM}}"
-        # Live LAN-IP resolver: skip the guest's docker0 (172.17–172.31), loopback and
-        # link-local so we get the bridged address we actually SSH to.
-        peers_ip() {
-          utmctl ip-address "$PEERS" 2>/dev/null \
-            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' \
-            | grep -Ev '^(127\.|169\.254\.|172\.(1[7-9]|2[0-9]|3[01])\.)' \
-            | head -1
-        }
+        # Bridged LAN IP via the shared resolver (skips docker0 / loopback / link-local).
+        peers_ip() { bash scripts/network/peers-ip.sh "$PEERS"; }
 
         # The peers VM must exist (created by network:up) — utmctl status fails otherwise.
         STATUS="$(utmctl status "$PEERS" 2>/dev/null || true)"


### PR DESCRIPTION
## Description

Adds a local **multi-peer** test environment for the block-node **network plane** (traffic shaper + firewall), addressing #953. Today `taskfiles/vm.yaml` manages only a single UTM VM; validating the plane needs several peers presenting **distinct source IPs** — the plane classifies and firewalls on `ip saddr`, and requires the BN Service to use `externalTrafficPolicy: Local` so the BN sees the real client IP (no SNAT).

Rather than five sim VMs (compute-heavy) or host-side Docker (NAT'd through Docker Desktop's VM — the BN would see one collapsed source IP), this adds a new `taskfiles/network.yaml` that stands up **one small "peers" VM** — a stripped clone of the golden — presenting **five macvlan source IPs** (publisher, partner, public, backfill, restricted), each with a traffic generator, alongside the existing BN working VM.

New tasks (flatten-included, reusing `vm.yaml` primitives):
- `network:up` — clone golden → peers VM (best-effort vCPU/RAM strip), start, configure SSH, bring up 5 macvlan IPs + `iperf3`, capture IPs to `.network-uat/hosts.env`.
- `network:seed` — generate the three `application-state` JSON files from the captured IPs and copy them into the BN VM's application-state volume so statusz reports the peers.
- `network:install` — `block node install --traffic-shaping-enabled --firewall-enabled` on the BN VM.
- `network:status` / `network:ip` / `network:down`.

### Files changed

| File | Change |
| --- | --- |
| `taskfiles/network.yaml` | New — the `network:*` task family |
| `scripts/network/gen-appstate.sh` | New — renders the 3 `application-state` JSON files |
| `Taskfile.yaml` | Register the `network` include (`flatten: true`) |
| `.gitignore` | Ignore the `.network-uat/` scratch dir |

### Known assumptions (validate on-hardware)

Marked `ASSUMPTION` in `network.yaml`:
- **macvlan-over-UTM** — child MACs must be forwarded by the UTM network (bridged: yes; "shared": validate). The load-bearing unknown; documented fallback is five tiny VMs.
- **config.plist resource strip** — assumes UTM 4.x `System:CPUCount` / `System:MemorySize`; non-fatal if the schema differs.
- **egress NIC** (`enp0s1` default) and **mgmt-cidrs** (defaulted to the BN VM's /24 so `--firewall-enabled` does not SSH-lock the host out).
- `network:install` assumes the provisioner + daemon binaries are prebuilt in the VM.

### Review guide

**Code review checklist**
- `taskfiles/network.yaml`: registered via `includes:` + `flatten: true` in root `Taskfile.yaml`; SPDX header; `version: 3`; no `includes:` inside the sub-Taskfile — matches taskfile conventions.
- Reuses `vm.yaml` primitives (`utmctl clone/exec/status/ip-address`, SSH key/opts) instead of duplicating; `vm.yaml` is untouched (stays single-VM).
- `scripts/network/gen-appstate.sh`: emits valid JSON in the `application-state` shape — publisher on 40984; `public` entries with empty `remote.address`; outbound backfill as `ip:port`.
- `.network-uat/` is gitignored; no secrets or generated state committed.

**Test commands (no VMs required)**
```bash
task --list | grep 'network:'          # 6 tasks registered
bash scripts/network/gen-appstate.sh /tmp/as 10.0.0.1 10.0.0.201 10.0.0.202 10.0.0.203 10.0.0.204 10.0.0.205
python3 -m json.tool /tmp/as/inbound-partners.json >/dev/null && echo "valid JSON"
```

**Manual UAT (macOS + UTM; needs the golden image)**
1. Ensure the BN working VM is up and provisioner is built/installed in it (existing flow): `task vm:reset`, then `task vm:ssh` → `cd /mnt/solo-weaver && task build && sudo solo-provisioner install`.
2. `task network:up` — expect: peers VM cloned + started; 5 macvlan IPs printed; `.network-uat/hosts.env` populated. Verify in the peers VM: `ip -br addr | grep -E 'publisher0|partner0|public0|backfill0|restricted0'`.
3. `task network:seed` — expect the 3 JSON files under the BN VM's `/mnt/fast-storage/application-state/`: `task vm:ssh` → `ls -1 /mnt/fast-storage/application-state/`.
4. `task network:install` — expect block node install to complete with both gates enabled.
5. Confirm classification by real source IP on the BN:
   ```bash
   sudo nft list table inet weaver         # @bn-publisher / @bn-partner-out / @bn-backfill hold the peer IPs
   sudo tc -s class show dev <egress-nic>   # egress classes present
   ```
   Drive load from a peer source IP and confirm the BN sees it un-NAT'd:
   ```bash
   # peers VM:
   sudo iperf3 -B <publisher-ip> -c <bn-ip> -p 40984 -t 5
   # BN VM:
   sudo tcpdump -ni any src <publisher-ip>   # source preserved (etp: Local, no SNAT)
   ```
6. `task network:down` — peers VM deleted, `.network-uat/` cleared.

**Risks / rollback**
- macvlan visibility under UTM "shared" networking is the main risk; if the BN sees a collapsed/NAT'd source, switch the UTM network to bridged (wired USB-Ethernet on the M5 — UTM #7658) or fall back to five tiny VMs.
- Purely additive (new taskfile + one include line + a script); rollback = revert the commit.

### Related Issues

* Closes #953
