### PR TITLE
refactor(network/shape): collapse egress render/apply pipeline and single-source tc encoding

### DIFF
--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -122,7 +122,7 @@ func (m *Manager) CreateDevice(ctx context.Context, dev *DeviceConfig, force boo
 			return err
 		}
 		if dev.Dir == DirEgress {
-			if err := m.renderAndApplyEgress(ctx); err != nil {
+			if err := m.applyEgressScript(ctx, "", applyRestart); err != nil {
 				return err
 			}
 		}
@@ -186,7 +186,7 @@ func (m *Manager) CreateClass(ctx context.Context, cls *ClassConfig, force bool)
 			return err
 		}
 		if ci.Dir == DirEgress {
-			if err := m.renderAndApplyEgress(ctx); err != nil {
+			if err := m.applyEgressScript(ctx, "", applyRestart); err != nil {
 				return err
 			}
 		}
@@ -258,8 +258,9 @@ func (m *Manager) SetClass(ctx context.Context, name string, rate, ceil *string,
 			}
 			// Persist the boot script for reboot without restarting the service:
 			// the live tc class change above already updated the kernel, and a
-			// restart would tear down and rebuild the root qdisc.
-			if err := m.persistEgressScript(nic); err != nil {
+			// restart would tear down and rebuild the root qdisc. Reuse the NIC
+			// detected above rather than re-detecting.
+			if err := m.applyEgressScript(ctx, nic, applyPersistOnly); err != nil {
 				return errorx.Decorate(err,
 					"live tc class change applied but boot script re-render failed; reboot may revert the change")
 			}
@@ -405,7 +406,7 @@ func (m *Manager) DeleteClass(ctx context.Context, name string) error {
 			return err
 		}
 		if ci.Dir == DirEgress {
-			if err := m.renderAndApplyEgress(ctx); err != nil {
+			if err := m.applyEgressScript(ctx, "", applyRestart); err != nil {
 				return errorx.Decorate(err,
 					"class config deleted but boot script re-render failed; restart tc-egress.service to sync")
 			}
@@ -446,7 +447,7 @@ func (m *Manager) DeleteDevice(ctx context.Context, dir string) error {
 		}
 		if dir == DirEgress {
 			// Re-render with default (empty) egress config.
-			if err := m.renderAndApplyEgress(ctx); err != nil {
+			if err := m.applyEgressScript(ctx, "", applyRestart); err != nil {
 				return errorx.Decorate(err,
 					"device config deleted but boot script re-render failed; restart tc-egress.service to sync")
 			}
@@ -482,11 +483,11 @@ func (m *Manager) TeardownEgress(ctx context.Context) error {
 		}
 		// Re-render an unshape boot script (delete root qdisc, re-add nothing) and
 		// apply it so both the boot script and the live kernel hierarchy are reset
-		// to unshaped. This must NOT go through renderAndApplyEgress: with the
-		// device/class registry now empty, that path falls through to the default
-		// shaping render and would re-apply the stock HTB hierarchy instead of
-		// removing it.
-		if err := m.renderAndApplyUnshapeEgress(ctx); err != nil {
+		// to unshaped. applyUnshape (not applyRestart) is required: with the
+		// device/class registry now empty, the normal render falls through to the
+		// default shaping render and would re-apply the stock HTB hierarchy instead
+		// of removing it.
+		if err := m.applyEgressScript(ctx, "", applyUnshape); err != nil {
 			return errorx.Decorate(err,
 				"egress shape config removed but boot script re-render failed; restart tc-egress.service to sync")
 		}
@@ -536,45 +537,84 @@ func (m *Manager) resolveAutoRate(dev *DeviceConfig) {
 	dev.Rate = m.resolveAutoRateString(dev.Rate)
 }
 
-// renderAndApplyEgress detects the egress NIC, re-renders the boot script from
-// stored config (or the default if no device config exists), and applies via
-// service restart.
-func (m *Manager) renderAndApplyEgress(ctx context.Context) error {
-	nic, err := m.nicDetect()
-	if err != nil {
-		return errorx.Decorate(err, "cannot re-render tc-egress script: egress NIC detection failed")
-	}
-	return m.renderAndApplyScript(ctx, nic)
-}
+// egressApplyMode selects what applyEgressScript does after (re-)rendering the
+// tc-egress boot script. It turns the "restart vs no-restart vs direct
+// qdisc-del" reasoning — previously scattered across four near-synonymous
+// methods — into one explicit decision.
+type egressApplyMode int
 
-// renderAndApplyUnshapeEgress renders the teardown-only (unshape) boot script for
-// the detected egress NIC, persists it, drops the live HTB hierarchy directly,
-// and restarts the tc-egress oneshot so the on-disk state matches. Used
-// exclusively by TeardownEgress — the registry is already empty at that point, so
-// the normal render would re-apply default shaping instead of removing it.
+const (
+	// applyRestart writes the freshly rendered boot script and restarts the
+	// tc-egress oneshot so the kernel replays the full HTB hierarchy. Used by
+	// structural mutations (device/class create or delete), where a full
+	// re-apply is the correct way to reach the new state.
+	applyRestart egressApplyMode = iota
+
+	// applyPersistOnly writes the boot script for reboot persistence WITHOUT
+	// restarting the service. Used by `set`, whose live `tc class change` has
+	// already updated the running kernel: restarting the oneshot would run the
+	// boot script, which deletes and re-adds the root qdisc — reintroducing
+	// exactly the qdisc teardown a live update is meant to avoid.
+	applyPersistOnly
+
+	// applyUnshape writes a teardown-only boot script (delete the root qdisc,
+	// re-add nothing) and drops the live HTB hierarchy directly via the tc
+	// runner. Used by TeardownEgress: the registry is empty at that point, so a
+	// normal render would fall through to the default-shaping render and
+	// re-apply the stock hierarchy instead of removing it. The direct
+	// `tc qdisc del dev <nic> root` makes teardown immediate and deterministic
+	// rather than relying on the (now unshape) boot script re-running via a
+	// restart — the boot script's job is to ADD the hierarchy, so restarting to
+	// REMOVE it would be indirect. The unshape script keeps the NIC unshaped
+	// across reboots.
+	applyUnshape
+)
+
+// applyEgressScript (re-)renders the tc-egress boot script and reconciles it
+// with the live kernel according to mode. It is the single egress apply path,
+// replacing the former renderAndApplyEgress / renderAndApplyScript /
+// persistEgressScript / renderAndApplyUnshapeEgress tangle.
 //
-// The live root qdisc is deleted directly via the tc runner rather than relying
-// solely on the systemd oneshot re-running the (now unshape) boot script: the
-// boot script's job is to ADD the hierarchy, so using a service restart to REMOVE
-// it is indirect. A direct `tc qdisc del dev <nic> root` makes the teardown
-// immediate and deterministic; the unshape boot script written above keeps the
-// NIC unshaped across reboots.
-func (m *Manager) renderAndApplyUnshapeEgress(ctx context.Context) error {
-	nic, err := m.nicDetect()
-	if err != nil {
-		return errorx.Decorate(err, "cannot re-render tc-egress script: egress NIC detection failed")
+// nic is the target egress interface. When empty it is auto-detected (the
+// operator-verb path: create/delete). Callers that already hold the NIC pass it
+// explicitly to avoid a redundant detection — `block node install` passing the
+// operator-chosen --egress-interface, and `set` reusing the NIC it detected for
+// the live `tc class change`.
+func (m *Manager) applyEgressScript(ctx context.Context, nic string, mode egressApplyMode) error {
+	if nic == "" {
+		var err error
+		if nic, err = m.nicDetect(); err != nil {
+			return errorx.Decorate(err, "cannot re-render tc-egress script: egress NIC detection failed")
+		}
 	}
-	rendered, err := renderTcEgressUnshapeScript(nic)
+
+	// applyUnshape renders a teardown-only script; every other mode renders from
+	// the current registry (or the sysfs-detect default when no device exists).
+	var rendered string
+	var err error
+	if mode == applyUnshape {
+		rendered, err = renderTcEgressUnshapeScript(nic)
+	} else {
+		rendered, err = m.renderEgressScript(nic)
+	}
 	if err != nil {
 		return err
 	}
 	if err := m.writeEgressScript(rendered); err != nil {
 		return err
 	}
-	// Drop the live hierarchy now, independent of systemd. Best-effort: a NIC with
-	// no root qdisc is not an error (see TCRunner.QdiscDelRoot).
-	if err := m.tcRunner.QdiscDelRoot(ctx, nic); err != nil {
-		return errorx.Decorate(err, "failed to delete live tc-egress root qdisc on %s", nic)
+
+	switch mode {
+	case applyPersistOnly:
+		// Live `tc class change` already applied by the caller; the boot script is
+		// now persisted for reboot. A restart would churn the root qdisc, so skip it.
+		return nil
+	case applyUnshape:
+		// Drop the live hierarchy now, independent of systemd. Best-effort: a NIC
+		// with no root qdisc is not an error (see TCRunner.QdiscDelRoot).
+		if err := m.tcRunner.QdiscDelRoot(ctx, nic); err != nil {
+			return errorx.Decorate(err, "failed to delete live tc-egress root qdisc on %s", nic)
+		}
 	}
 	return m.applyEgress(ctx)
 }
@@ -619,34 +659,6 @@ func (m *Manager) writeEgressScript(rendered string) error {
 	return atomicWriteFile(m.scriptPath, rendered, 0o755)
 }
 
-// renderAndApplyScript renders the boot script, persists it, and restarts the
-// tc-egress oneshot so the kernel replays the full hierarchy. Used by mutations
-// that change the qdisc structure (create/delete of a device or class), where a
-// full re-apply is the correct way to reach the new state.
-func (m *Manager) renderAndApplyScript(ctx context.Context, nic string) error {
-	rendered, err := m.renderEgressScript(nic)
-	if err != nil {
-		return err
-	}
-	if err := m.writeEgressScript(rendered); err != nil {
-		return err
-	}
-	return m.applyEgress(ctx)
-}
-
-// persistEgressScript renders and writes the boot script for reboot persistence
-// WITHOUT restarting the service. Used by `set`, whose live `tc class change`
-// has already updated the running kernel: restarting the oneshot would run the
-// boot script, which deletes and re-adds the root qdisc — reintroducing exactly
-// the qdisc teardown a live update is meant to avoid.
-func (m *Manager) persistEgressScript(nic string) error {
-	rendered, err := m.renderEgressScript(nic)
-	if err != nil {
-		return err
-	}
-	return m.writeEgressScript(rendered)
-}
-
 // provisionDefaults resolves trunkRate (possibly "auto"), materialises the
 // profile's device + class set with any --shape overrides merged in, validates
 // the merged set against the trunk budget, and writes device + all classes
@@ -689,7 +701,7 @@ func (m *Manager) provisionDefaults(prof defaultProfile, trunkRate string, overr
 // source of truth from first install.
 func (m *Manager) ProvisionDefaultEgress(ctx context.Context, nicName, trunkRate string, overrides map[string]ClassOverride) error {
 	return m.provisionDefaults(egressProfile, trunkRate, overrides, func() error {
-		return m.renderAndApplyScript(ctx, nicName)
+		return m.applyEgressScript(ctx, nicName, applyRestart)
 	})
 }
 
@@ -733,7 +745,7 @@ func ProvisionDefaultIngressShape(ctx context.Context, nicName, trunkRate string
 // Used when no trunk rate is supplied (e.g. block node reconfigure without
 // --link-rate).
 func RenderAndApplyDefaultEgress(ctx context.Context, nic string) error {
-	return NewManager().renderAndApplyScript(ctx, nic)
+	return NewManager().applyEgressScript(ctx, nic, applyRestart)
 }
 
 // withLock serialises a mutation behind a cross-command flock so concurrent

--- a/internal/network/shape/shape_test.go
+++ b/internal/network/shape/shape_test.go
@@ -120,7 +120,7 @@ func TestRenderTcEgressUnshapeScript(t *testing.T) {
 // systemd), writes the unshape boot script for reboot persistence, and triggers
 // the apply. This is the runtime half of the fix for TeardownEgress leaving the
 // NIC shaped.
-func TestRenderAndApplyUnshapeEgress_DeletesLiveRootAndPersists(t *testing.T) {
+func TestApplyEgressScript_Unshape_DeletesLiveRootAndPersists(t *testing.T) {
 	tc := &recordingTCRunner{}
 	scriptPath := filepath.Join(t.TempDir(), "tc-egress.sh")
 	applied := false
@@ -133,8 +133,8 @@ func TestRenderAndApplyUnshapeEgress_DeletesLiveRootAndPersists(t *testing.T) {
 		ApplyEgress: func(_ context.Context) error { applied = true; return nil },
 	})
 
-	if err := m.renderAndApplyUnshapeEgress(context.Background()); err != nil {
-		t.Fatalf("renderAndApplyUnshapeEgress: %v", err)
+	if err := m.applyEgressScript(context.Background(), "", applyUnshape); err != nil {
+		t.Fatalf("applyEgressScript(applyUnshape): %v", err)
 	}
 
 	// Live hierarchy dropped directly on the detected NIC.
@@ -770,7 +770,7 @@ func TestEffectiveCeil_DefaultsToRate(t *testing.T) {
 // --- Device-only rendering tests ---
 //
 // When a device root is configured but no class configs exist yet,
-// renderAndApplyScript branches on defaultEgressConfig(dev.Rate): an explicit
+// renderEgressScript branches on defaultEgressConfig(dev.Rate): an explicit
 // rate yields the three default egress classes at proportional explicit rates
 // (no SPEED variable); "auto" or any unparseable rate makes defaultEgressConfig
 // fail and the render falls back to sysfs auto-detect. These tests pin that
@@ -778,7 +778,7 @@ func TestEffectiveCeil_DefaultsToRate(t *testing.T) {
 
 func TestDefaultEgressConfig_AutoRateFallsBack(t *testing.T) {
 	// "auto" is not a parseable bandwidth, so defaultEgressConfig returns an
-	// error — the signal renderAndApplyScript uses to fall back to sysfs detect.
+	// error — the signal renderEgressScript uses to fall back to sysfs detect.
 	if _, _, err := defaultEgressConfig("auto"); err == nil {
 		t.Error("expected defaultEgressConfig(\"auto\") to error, got nil")
 	}
@@ -789,7 +789,7 @@ func TestDefaultEgressConfig_AutoRateFallsBack(t *testing.T) {
 }
 
 func TestDeviceOnly_ExplicitRate_NoSpeed(t *testing.T) {
-	// Device-only explicit render reuses the same path as renderAndApplyScript:
+	// Device-only explicit render reuses the same path as renderEgressScript:
 	// defaultEgressConfig(rate) → renderTcEgressScriptFromConfig(dev, classes).
 	dev := &DeviceConfig{Dir: DirEgress, Rate: "500mbit", DefaultClass: "reserve-egress"}
 	_, classes, err := defaultEgressConfig(dev.Rate)
@@ -863,11 +863,11 @@ func TestResolveAutoRate_ExplicitRateUntouched(t *testing.T) {
 	}
 }
 
-func TestPersistEgressScript_NoServiceRestart(t *testing.T) {
+func TestApplyEgressScript_PersistOnly_NoServiceRestart(t *testing.T) {
 	// `set` persists the boot script for reboot but must NOT restart the service:
 	// its live `tc class change` already updated the kernel, and a restart would
-	// tear down and rebuild the root qdisc. persistEgressScript writes; only
-	// renderAndApplyScript restarts.
+	// tear down and rebuild the root qdisc. applyPersistOnly writes; only
+	// applyRestart restarts.
 	scriptPath := filepath.Join(t.TempDir(), "tc-egress.sh")
 	applied := false
 	m := NewManagerWithConfig(Config{
@@ -876,23 +876,23 @@ func TestPersistEgressScript_NoServiceRestart(t *testing.T) {
 		ApplyEgress: func(context.Context) error { applied = true; return nil },
 	})
 
-	if err := m.persistEgressScript("eth0"); err != nil {
-		t.Fatalf("persistEgressScript: %v", err)
+	if err := m.applyEgressScript(context.Background(), "eth0", applyPersistOnly); err != nil {
+		t.Fatalf("applyEgressScript(applyPersistOnly): %v", err)
 	}
 	if applied {
-		t.Error("persistEgressScript must not restart the service (no qdisc churn)")
+		t.Error("applyPersistOnly must not restart the service (no qdisc churn)")
 	}
 	if _, err := os.Stat(scriptPath); err != nil {
 		t.Errorf("expected boot script persisted to disk: %v", err)
 	}
 
-	// Contrast: renderAndApplyScript does restart the service.
+	// Contrast: applyRestart does restart the service.
 	applied = false
-	if err := m.renderAndApplyScript(context.Background(), "eth0"); err != nil {
-		t.Fatalf("renderAndApplyScript: %v", err)
+	if err := m.applyEgressScript(context.Background(), "eth0", applyRestart); err != nil {
+		t.Fatalf("applyEgressScript(applyRestart): %v", err)
 	}
 	if !applied {
-		t.Error("renderAndApplyScript must restart the service")
+		t.Error("applyRestart must restart the service")
 	}
 }
 

--- a/internal/network/shape/tc.go
+++ b/internal/network/shape/tc.go
@@ -2,7 +2,10 @@
 
 package shape
 
-import "context"
+import (
+	"context"
+	"strconv"
+)
 
 // TCRunner abstracts live kernel tc qdisc/class operations for testability. The
 // egress path drives ClassChange (live tuning of an already-installed
@@ -44,4 +47,49 @@ type TCRunner interface {
 	// cumulative counters keyed by tc handle (e.g. "1:40"). It is the read
 	// counterpart to the write verbs above, backing `network shape watch`.
 	ClassStats(ctx context.Context, dev string) (map[string]ClassStat, error)
+}
+
+// The tc*Args helpers are the single source of the tc command argument
+// encoding: HTB argument order and the field set for each qdisc/class verb.
+// The live path (execTCRunner, tc_linux.go) executes these arg slices, and the
+// tc-egress boot-script template renders the same commands as shell text; a
+// lockstep test (tc_encoding_test.go) asserts the two encodings match token for
+// token so a change to one side cannot silently drift from the other. They are
+// build-tag-free (this file) so the live path, the render path, and that test
+// all reference one definition. nic is a literal interface name on the live
+// path; the boot script passes the shell variable "$NIC".
+
+// tcQdiscDelRootArgs builds `qdisc del dev <nic> root`.
+func tcQdiscDelRootArgs(nic string) []string {
+	return []string{"qdisc", "del", "dev", nic, "root"}
+}
+
+// tcQdiscAddRootArgs builds `qdisc add dev <nic> root handle 1: htb default
+// <defaultMinor>`.
+func tcQdiscAddRootArgs(nic, defaultMinor string) []string {
+	return []string{"qdisc", "add", "dev", nic, "root", "handle", "1:", "htb", "default", defaultMinor}
+}
+
+// tcClassAddRootArgs builds `class add dev <nic> parent 1: classid 1:1 htb rate
+// <rate> ceil <ceil>` — the trunk class.
+func tcClassAddRootArgs(nic, rate, ceil string) []string {
+	return []string{"class", "add", "dev", nic, "parent", "1:", "classid", "1:1", "htb", "rate", rate, "ceil", ceil}
+}
+
+// tcClassAddArgs builds `class add dev <nic> parent 1:1 classid 1:<minor> htb
+// rate <rate> ceil <ceil> prio <prio>` — a per-class leaf under the trunk.
+func tcClassAddArgs(nic, minor, rate, ceil string, prio int) []string {
+	return []string{"class", "add", "dev", nic, "parent", "1:1", "classid", "1:" + minor, "htb", "rate", rate, "ceil", ceil, "prio", strconv.Itoa(prio)}
+}
+
+// tcClassChangeArgs builds `class change dev <nic> parent 1:1 classid 1:<minor>
+// htb rate <rate> ceil <ceil> prio <prio>` — live tuning of an existing leaf.
+func tcClassChangeArgs(nic, minor, rate, ceil string, prio int) []string {
+	return []string{"class", "change", "dev", nic, "parent", "1:1", "classid", "1:" + minor, "htb", "rate", rate, "ceil", ceil, "prio", strconv.Itoa(prio)}
+}
+
+// tcQdiscAddFqCodelArgs builds `qdisc add dev <nic> parent 1:<minor> handle
+// <handle>: fq_codel` — the leaf qdisc for a class.
+func tcQdiscAddFqCodelArgs(nic, minor, handle string) []string {
+	return []string{"qdisc", "add", "dev", nic, "parent", "1:" + minor, "handle", handle + ":", "fq_codel"}
 }

--- a/internal/network/shape/tc_encoding_test.go
+++ b/internal/network/shape/tc_encoding_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package shape
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// normalizeTcLine turns a rendered boot-script `tc ...` line into the token
+// slice the tc*Args builders produce: drop the leading "tc", strip the
+// best-effort redirection suffix (`2>/dev/null || true`) and the shell quotes
+// the template wraps rates/device in, and collapse the template's cosmetic
+// column-alignment whitespace. The device stays as the shell variable "$NIC".
+func normalizeTcLine(line string) []string {
+	line = strings.TrimSpace(line)
+	if i := strings.Index(line, " 2>/dev/null"); i >= 0 {
+		line = line[:i]
+	}
+	line = strings.ReplaceAll(line, "\"", "")
+	line = strings.TrimPrefix(line, "tc ")
+	return strings.Fields(line) // Fields collapses any run of whitespace
+}
+
+// TestBootScriptTcEncodingMatchesArgBuilders is the lockstep guard for #946
+// AC#2: the tc command encoding must live in one place. The live path
+// (execTCRunner) executes the tc*Args slices; the tc-egress boot script renders
+// the same commands as shell text. This renders the explicit-rate boot script
+// for a concrete egress config and asserts every `tc ...` line equals the
+// arg-builder encoding token for token (whitespace- and quote-insensitive), so
+// a change to HTB argument order or the field set on either side fails here.
+func TestBootScriptTcEncodingMatchesArgBuilders(t *testing.T) {
+	dev := &DeviceConfig{Dir: DirEgress, Rate: "500mbit", DefaultClass: "reserve-egress"}
+	classes := []*ClassConfig{
+		{Name: "partner", Rate: "200mbit", Ceil: "350mbit", Prio: 0},
+		{Name: "public", Rate: "150mbit", Ceil: "350mbit", Prio: 5},
+		{Name: "reserve-egress", Rate: "150mbit", Prio: 1}, // ceil defaults to rate
+	}
+
+	// The rendered tc lines reference the shell variable "$NIC" regardless of the
+	// nicName passed here (which only fills the NIC="..." assignment), so the
+	// expected builder encoding uses "$NIC" as the device.
+	const nic = "$NIC"
+	rendered, err := renderTcEgressScriptFromConfig("enp0s1", dev, classes)
+	if err != nil {
+		t.Fatalf("renderTcEgressScriptFromConfig: %v", err)
+	}
+
+	def, err := lookupClassInfo(dev.DefaultClass)
+	if err != nil {
+		t.Fatalf("lookupClassInfo(%q): %v", dev.DefaultClass, err)
+	}
+	expected := [][]string{
+		tcQdiscDelRootArgs(nic),
+		tcQdiscAddRootArgs(nic, def.Minor),
+		tcClassAddRootArgs(nic, dev.Rate, dev.Rate),
+	}
+	for _, c := range classes {
+		ci, err := lookupClassInfo(c.Name)
+		if err != nil {
+			t.Fatalf("lookupClassInfo(%q): %v", c.Name, err)
+		}
+		expected = append(expected,
+			tcClassAddArgs(nic, ci.Minor, c.Rate, c.effectiveCeil(), c.Prio),
+			tcQdiscAddFqCodelArgs(nic, ci.Minor, ci.Handle),
+		)
+	}
+
+	var actual [][]string
+	for _, ln := range strings.Split(rendered, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(ln), "tc ") {
+			actual = append(actual, normalizeTcLine(ln))
+		}
+	}
+
+	if len(actual) != len(expected) {
+		t.Fatalf("boot script has %d tc lines, arg-builders produce %d\nscript:\n%s",
+			len(actual), len(expected), rendered)
+	}
+	for i := range expected {
+		if !reflect.DeepEqual(actual[i], expected[i]) {
+			t.Errorf("tc line %d encoding drift:\n  boot script:  %v\n  arg-builders: %v",
+				i, actual[i], expected[i])
+		}
+	}
+}

--- a/internal/network/shape/tc_linux.go
+++ b/internal/network/shape/tc_linux.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/joomcode/errorx"
@@ -51,37 +50,30 @@ func (r *execTCRunner) run(ctx context.Context, args ...string) error {
 }
 
 func (r *execTCRunner) ClassChange(ctx context.Context, nic, minor, rate, ceil string, prio int) error {
-	return r.run(ctx, "class", "change",
-		"dev", nic, "parent", "1:1", "classid", "1:"+minor,
-		"htb", "rate", rate, "ceil", ceil, "prio", strconv.Itoa(prio))
+	return r.run(ctx, tcClassChangeArgs(nic, minor, rate, ceil, prio)...)
 }
 
 func (r *execTCRunner) QdiscDelRoot(ctx context.Context, nic string) error {
 	// Best-effort: swallow the error so a fresh veth (no root qdisc yet) or a
 	// recycled veth name both start from a clean rebuild.
-	_ = exec.CommandContext(ctx, tcBin, "qdisc", "del", "dev", nic, "root").Run()
+	_ = exec.CommandContext(ctx, tcBin, tcQdiscDelRootArgs(nic)...).Run()
 	return nil
 }
 
 func (r *execTCRunner) QdiscAddRoot(ctx context.Context, nic, defaultMinor string) error {
-	return r.run(ctx, "qdisc", "add",
-		"dev", nic, "root", "handle", "1:", "htb", "default", defaultMinor)
+	return r.run(ctx, tcQdiscAddRootArgs(nic, defaultMinor)...)
 }
 
 func (r *execTCRunner) ClassAddRoot(ctx context.Context, nic, rate, ceil string) error {
-	return r.run(ctx, "class", "add",
-		"dev", nic, "parent", "1:", "classid", "1:1", "htb", "rate", rate, "ceil", ceil)
+	return r.run(ctx, tcClassAddRootArgs(nic, rate, ceil)...)
 }
 
 func (r *execTCRunner) ClassAdd(ctx context.Context, nic, minor, rate, ceil string, prio int) error {
-	return r.run(ctx, "class", "add",
-		"dev", nic, "parent", "1:1", "classid", "1:"+minor,
-		"htb", "rate", rate, "ceil", ceil, "prio", strconv.Itoa(prio))
+	return r.run(ctx, tcClassAddArgs(nic, minor, rate, ceil, prio)...)
 }
 
 func (r *execTCRunner) QdiscAddFqCodel(ctx context.Context, nic, minor, handle string) error {
-	return r.run(ctx, "qdisc", "add",
-		"dev", nic, "parent", "1:"+minor, "handle", handle+":", "fq_codel")
+	return r.run(ctx, tcQdiscAddFqCodelArgs(nic, minor, handle)...)
 }
 
 func (r *execTCRunner) ClassStats(ctx context.Context, dev string) (map[string]ClassStat, error) {


### PR DESCRIPTION
## Description

Behavior-preserving cleanup of the egress render/apply pipeline in `internal/network/shape`, the follow-up refactor filed from #949. Two things get untangled:

1. **The six-method egress pipeline** in `manager.go` was spread across near-synonymous methods (`renderAndApplyEgress`, `renderAndApplyUnshapeEgress`, `renderAndApplyScript`, `persistEgressScript`, plus the pure `renderEgressScript` and the `writeEgressScript` primitive). You could not tell from a call site which to use, and the "restart vs no-restart vs direct-qdisc-del" fan-out was an implicit state machine. This collapses the four *pipeline* methods into **one `applyEgressScript(ctx, nic, mode)`** with an explicit `egressApplyMode` enum (`applyRestart` / `applyPersistOnly` / `applyUnshape`), keeping `renderEgressScript` (pure) and `writeEgressScript` (write primitive). The "why no restart here / why a direct qdisc-del" reasoning now lives in one place — the enum doc comments.

2. **The tc command encoding was hand-written twice** — as Go `[]string` args in `tc_linux.go` and as shell text in the boot-script template — with nothing tying the HTB argument order and field set together. This extracts the encoding into build-tag-free `tc*Args` builders in `tc.go` that the live path (`execTCRunner`) now executes, and adds a **lockstep test** asserting the boot script renders the same commands token-for-token, so the two encodings cannot silently drift.

No functional change. NIC resolution is preserved exactly: empty `nic` auto-detects (operator create/delete verbs, keeping the old detect-and-decorate error); an explicit `nic` is used verbatim (the provision path passing the operator-chosen `--egress-interface`, and `set` reusing the NIC it already detected for the live `tc class change` — no double-detect). The boot-script template and the deliberately out-of-scope legacy SPEED path are untouched; golden script output is identical.

### Stacking note

Stacked on `refactor-traffic-shaper-engine` (PR #949), **not** `main` — this is the structural follow-up #949's description points at. Review/merge after #949.

### Files changed

| File | Change |
|---|---|
| `internal/network/shape/manager.go` | Add `egressApplyMode` enum + single `applyEgressScript`; delete `renderAndApplyEgress` / `renderAndApplyUnshapeEgress` / `renderAndApplyScript` / `persistEgressScript`; update 8 internal call sites (messages unchanged). |
| `internal/network/shape/tc.go` | Add build-tag-free `tc*Args` arg-builders — the single source of the tc encoding. |
| `internal/network/shape/tc_linux.go` | `execTCRunner` methods call the shared builders; drop now-unused `strconv`. |
| `internal/network/shape/tc_encoding_test.go` (new) | Lockstep test: renders the boot script, asserts each `tc` line equals the arg-builder encoding (whitespace/quote-insensitive). |
| `internal/network/shape/shape_test.go` | Update 3 call sites + comments to the new API; rename 2 tests. |

### Review guide

Checklist:
- `manager.go` `applyEgressScript` — `applyPersistOnly` returns before `applyEgress` (no service restart); `applyUnshape` renders the *unshape* script → write → direct `QdiscDelRoot` → `applyEgress` (same order as the old `renderAndApplyUnshapeEgress`); `applyRestart` = write → `applyEgress`.
- NIC source: `SetClass` passes its already-detected `nic`; `ProvisionDefaultEgress` / `RenderAndApplyDefaultEgress` pass the caller's explicit NIC (must **not** auto-detect — matters on multi-NIC hosts); create/delete verbs pass `""`.
- `tc.go` builders reproduce the exact prior arg slices (`1:`+minor, `handle+":"`, `strconv.Itoa(prio)`); `solo-provisioner-tc-egress.sh.tmpl` is untouched.
- Exported surface unchanged (`RenderAndApplyDefaultEgress`, `ProvisionDefaultEgressShape`, `ProvisionDefaultIngressShape`, `TeardownEgress`).

Tests:
```bash
go test ./internal/network/shape/...
GOOS=linux go vet ./internal/network/shape/... && GOOS=linux go test -c -o /dev/null ./internal/network/shape/
task lint
```
All pass (84 on darwin incl. `TestBootScriptTcEncodingMatchesArgBuilders`); lint 0 issues; `go vet` clean.

Manual UAT (UTM VM):
1. **Install renders identically** — `block node install …`, then `cat /opt/solo/tc-egress.sh`. The rendered HTB hierarchy is byte-identical to a pre-change install (same `tc qdisc/class` lines, same rates).
2. **`set` does not restart the oneshot** — `network shape set --class partner --rate 200mbit`, then `systemctl show -p ExecMainStartTimestamp solo-provisioner-tc-egress`: the timestamp is unchanged (live `tc class change` applied, no qdisc churn), and `/opt/solo/tc-egress.sh` shows the new rate for reboot persistence.
3. **create/delete restarts and matches live** — `network shape create --device egress --rate 1gbit --default reserve-egress` then `network shape delete --device egress`: the oneshot restarts each time and `tc -s qdisc show dev <nic>` / `tc class show dev <nic>` match the registry.
4. **Teardown unshapes (not re-shapes)** — disable traffic shaping (BN uninstall / `TeardownEgress`), then `tc qdisc show dev <nic>`: the root qdisc is **dropped**, not replaced with the stock default HTB hierarchy.
5. **Encoding lockstep holds** — edit the HTB arg order in either `tc.go` or the template and run `go test ./internal/network/shape/...`: `TestBootScriptTcEncodingMatchesArgBuilders` fails, proving the two encodings are tied.

### Related Issues

* Closes #946
