### PR TITLE
refactor(blocknode): unify the firewall and traffic-shaping gated network-feature wiring

### DIFF
--- a/cmd/cli/commands/block/node/reconfigure.go
+++ b/cmd/cli/commands/block/node/reconfigure.go
@@ -3,13 +3,11 @@
 package node
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/automa-saga/automa"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
-	"github.com/hashgraph/solo-weaver/internal/network/firewall"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/spf13/cobra"
@@ -46,15 +44,23 @@ var (
 
 			// Seed the enable/disable prompts from the block node's CURRENT state so a
 			// no-flag / default-accept reconfigure keeps whatever is already deployed
-			// and only an explicit toggle enables or tears a feature down. Traffic
-			// shaping's current state comes from the persisted install decision; the
-			// host firewall's from whether the inet host table currently exists.
+			// and only an explicit toggle enables or tears a feature down. Both features
+			// now use the same source of truth — the persisted install/reconfigure
+			// decision (#947): traffic shaping from BlockNodeState.TrafficShapingDisabled,
+			// the host firewall from MachineState.Firewall. (The live inet-table probe is
+			// a reconciliation detail inside NetworkFirewallCreate, not a prompt seed.)
+			// On an unreadable state file, bias both to enabled so a default-accept never
+			// tears an established plane down.
 			stateDefaults, err := state.ReadPromptDefaultsFromDisk()
 			if err != nil {
 				logx.As().Debug().Err(err).Msg("could not read state file for reconfigure seeds; using conservative defaults")
 			}
-			currentTrafficShaping := !stateDefaults.BlockNode.TrafficShapingDisabled
-			firewallSeed := currentFirewallEnabledSeed(cmd, cmd.Context())
+			firewallSeed := true
+			currentTrafficShaping := true
+			if err == nil {
+				firewallSeed = stateDefaults.Firewall != nil && !stateDefaults.Firewall.Disabled
+				currentTrafficShaping = !stateDefaults.BlockNode.TrafficShapingDisabled
+			}
 
 			// Traffic shaping is independently gated from the host firewall — it covers
 			// the BN workload network-policy plane, tc HTB shaping, and the daemon's
@@ -163,24 +169,6 @@ var (
 		},
 	}
 )
-
-// currentFirewallEnabledSeed returns the default the reconfigure host-firewall
-// prompt should fall back to: whether the inet host table is currently present on
-// the host. When the flag was set on the CLI the seed is unused (the flag wins),
-// so it returns false without probing. If the probe fails it biases to enabled so
-// an unreadable state never leads to an accidental teardown on default-accept.
-func currentFirewallEnabledSeed(cmd *cobra.Command, ctx context.Context) bool {
-	if cmd.Flags().Changed(common.FlagNameFirewallEnabled) {
-		return false
-	}
-	active, err := firewall.NewManager().IsActive(ctx)
-	if err != nil {
-		logx.As().Debug().Err(err).Msg(
-			"could not probe the inet host table; seeding the firewall prompt as enabled to avoid accidental teardown")
-		return true
-	}
-	return active
-}
 
 func init() {
 	common.FlagWithStorageReset().SetVarP(reconfigureCmd, &flagWithReset, false)

--- a/cmd/cli/commands/common/gated_feature.go
+++ b/cmd/cli/commands/common/gated_feature.go
@@ -88,8 +88,8 @@ func resolveFeatureGate(cmd *cobra.Command, args []string, f gatedFeature, seedE
 }
 
 // effectiveBool returns the effective value for a bool flag: the flag when
-// explicitly set, else cfgVal (the caller-supplied "unset" default). Shared by
-// the gated-feature gates and the host-firewall content resolution.
+// explicitly set, else cfgVal (the caller-supplied "unset" default). Used by
+// resolveFeatureGate to resolve each feature's enable/disable gate.
 func effectiveBool(cmd *cobra.Command, name string, cfgVal bool) bool {
 	if cmd.Flags().Changed(name) {
 		v, _ := cmd.Flags().GetBool(name)

--- a/cmd/cli/commands/common/gated_feature.go
+++ b/cmd/cli/commands/common/gated_feature.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+)
+
+// gatedFeature describes a block-node "gated network feature" — the host
+// firewall and traffic shaping are the two instances. Each is toggled by a
+// single opt-in bool flag; the feature's other ("content") flags are only
+// meaningful once the gate is on. The descriptor supplies the per-feature
+// specifics as data so resolveFeatureGate can drive the identical
+// force-fetch → effective-bool → confirm-prompt → mismatch-guard skeleton for
+// both (issue #947).
+type gatedFeature struct {
+	// GateFlag is the opt-in bool flag that turns the feature on/off
+	// (e.g. FlagNameFirewallEnabled, FlagNameTrafficShapingEnabled).
+	GateFlag string
+	// Noun names the feature in prompts/errors, phrased so it reads correctly
+	// in both "<noun> is not enabled" and "configure <noun>"
+	// (e.g. "the host firewall", "traffic shaping").
+	Noun string
+	// PromptTitle / PromptDesc drive the interactive enable/disable confirm.
+	PromptTitle string
+	PromptDesc  string
+	// ContentFlags are the feature-only flags that do nothing without the gate.
+	// Supplying any of them non-interactively while the gate is off is a hard
+	// error (they would otherwise be silently dropped — there is no confirm
+	// prompt to catch the mismatch once the opt-in default resolves to false).
+	ContentFlags []string
+}
+
+// resolveFeatureGate resolves the enable/disable decision for a gated network
+// feature. Precedence: CLI gate flag > interactive confirm > seedEnabled
+// default. It also enforces the "content flag without the gate" guard for
+// non-interactive callers. Shared by ResolveHostFirewallConfig and
+// ResolveTrafficShapingConfig so the two features decide "on or off?" the same
+// way; each caller then resolves its own content once the gate is on.
+//
+// seedEnabled is the default the choice falls back to when neither the flag nor
+// a prompt decides it: `install` passes false (opt-in), while `reconfigure`
+// passes the block node's persisted install/reconfigure decision so a no-flag /
+// default-accept run keeps whatever was last chosen.
+//
+// It requires the feature's gate flag to have been registered on cmd.
+func resolveFeatureGate(cmd *cobra.Command, args []string, f gatedFeature, seedEnabled bool) (bool, error) {
+	force, err := FlagForce().Value(cmd, args)
+	if err != nil {
+		return false, errorx.IllegalArgument.Wrap(err, "failed to get %s flag", FlagForce().Name)
+	}
+
+	// Seeded from the caller-supplied default, overridden by the flag when set.
+	enabled := effectiveBool(cmd, f.GateFlag, seedEnabled)
+
+	// Prompt for the enable/disable choice only when it wasn't already decided
+	// on the CLI. Declining here skips the feature's content prompts entirely —
+	// there's nothing left to ask once the feature itself is turned off.
+	if prompt.ShouldPrompt(force) && !cmd.Flags().Changed(f.GateFlag) {
+		confirmed, err := prompt.RunConfirm(f.PromptTitle, f.PromptDesc, enabled)
+		if err != nil {
+			return false, err
+		}
+		enabled = confirmed
+	}
+
+	// Non-interactive callers that supply the feature's content flags without
+	// also passing its gate flag would otherwise have those flags silently
+	// ignored: with the opt-in default there's no confirm prompt to catch the
+	// mismatch, and the caller just skips configuring any of it.
+	if !enabled && !prompt.ShouldPrompt(force) {
+		for _, name := range f.ContentFlags {
+			if cmd.Flags().Changed(name) {
+				return false, errorx.IllegalArgument.New(
+					"--%s was supplied but %s is not enabled (--%s defaults to false)", name, f.Noun, f.GateFlag).
+					WithProperty(models.ErrPropertyResolution, []string{
+						"Pass --" + f.GateFlag + "=true to actually apply these settings",
+						"Or drop --" + name + " if you did not intend to configure " + f.Noun,
+					})
+			}
+		}
+	}
+
+	return enabled, nil
+}
+
+// effectiveBool returns the effective value for a bool flag: the flag when
+// explicitly set, else cfgVal (the caller-supplied "unset" default). Shared by
+// the gated-feature gates and the host-firewall content resolution.
+func effectiveBool(cmd *cobra.Command, name string, cfgVal bool) bool {
+	if cmd.Flags().Changed(name) {
+		v, _ := cmd.Flags().GetBool(name)
+		return v
+	}
+	return cfgVal
+}

--- a/cmd/cli/commands/common/gated_feature_test.go
+++ b/cmd/cli/commands/common/gated_feature_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// testFeature is a minimal gatedFeature used to exercise resolveFeatureGate in
+// isolation from the firewall/traffic-shaping specifics.
+func testFeature() gatedFeature {
+	return gatedFeature{
+		GateFlag:     "feature-enabled",
+		Noun:         "the test feature",
+		PromptTitle:  "Enable the test feature?",
+		PromptDesc:   "desc",
+		ContentFlags: []string{"feature-content"},
+	}
+}
+
+// newGateCmd builds a command with the gate flag, one content flag, and --force
+// registered. Tests pass --force so ShouldPrompt is always false: the confirm
+// prompt is skipped and the seed/flag/mismatch-guard logic runs deterministically
+// without a TTY.
+func newGateCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "x", RunE: func(*cobra.Command, []string) error { return nil }}
+	cmd.Flags().Bool("feature-enabled", false, "")
+	cmd.Flags().String("feature-content", "", "")
+	var force bool
+	FlagForce().SetVarP(cmd, &force, false)
+	return cmd
+}
+
+func TestResolveFeatureGate_SeedAndFlag(t *testing.T) {
+	cases := []struct {
+		name    string
+		setGate string // "" = leave unset, else the value to Set
+		seed    bool
+		want    bool
+	}{
+		{"unset seeds enabled", "", true, true},
+		{"unset seeds disabled", "", false, false},
+		{"flag true overrides seed false", "true", false, true},
+		{"flag false overrides seed true", "false", true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cmd := newGateCmd()
+			if c.setGate != "" {
+				if err := cmd.Flags().Set("feature-enabled", c.setGate); err != nil {
+					t.Fatalf("set gate: %v", err)
+				}
+			}
+			got, err := resolveFeatureGate(cmd, []string{"--force"}, testFeature(), c.seed)
+			if err != nil {
+				t.Fatalf("resolveFeatureGate: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("enabled = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestResolveFeatureGate_ContentFlagWithoutGateErrors(t *testing.T) {
+	cmd := newGateCmd()
+	if err := cmd.Flags().Set("feature-content", "x"); err != nil {
+		t.Fatalf("set content: %v", err)
+	}
+	// Gate left off (seed=false, flag unset): supplying a content flag must be a
+	// hard error rather than silently dropping the value.
+	_, err := resolveFeatureGate(cmd, []string{"--force"}, testFeature(), false)
+	if err == nil {
+		t.Fatal("expected an error when a content flag is set without the gate, got nil")
+	}
+}
+
+func TestResolveFeatureGate_ContentFlagAllowedWhenGated(t *testing.T) {
+	cmd := newGateCmd()
+	if err := cmd.Flags().Set("feature-enabled", "true"); err != nil {
+		t.Fatalf("set gate: %v", err)
+	}
+	if err := cmd.Flags().Set("feature-content", "x"); err != nil {
+		t.Fatalf("set content: %v", err)
+	}
+	got, err := resolveFeatureGate(cmd, []string{"--force"}, testFeature(), false)
+	if err != nil {
+		t.Fatalf("resolveFeatureGate: %v", err)
+	}
+	if !got {
+		t.Error("enabled = false, want true when gate flag is set")
+	}
+}

--- a/cmd/cli/commands/common/host_firewall.go
+++ b/cmd/cli/commands/common/host_firewall.go
@@ -99,6 +99,20 @@ func RegisterHostFirewallFlags(cmd *cobra.Command) {
 		"Host-service ports reachable from the pod CIDR by the node host firewall (comma-separated)")
 }
 
+// hostFirewallFeature describes the host firewall as a gated network feature for
+// resolveFeatureGate: the --firewall-enabled opt-in gate plus the content flags
+// that are meaningless without it.
+func hostFirewallFeature() gatedFeature {
+	return gatedFeature{
+		GateFlag:    FlagNameFirewallEnabled,
+		Noun:        "the host firewall",
+		PromptTitle: "Enable host firewall?",
+		PromptDesc: "Apply the node-level inet host firewall (SSH/mgmt allowlist, ICMP policy, in-cluster ports). " +
+			"Opt-in, default No — choose Yes to have this tool manage the host firewall.",
+		ContentFlags: []string{FlagNameMgmtCIDRs, FlagNameBlockedCIDRs, FlagNameSSHPort, FlagNamePodCIDR, FlagNameInClusterPorts},
+	}
+}
+
 // ResolveHostFirewallConfig determines the effective host firewall configuration
 // (enabled, management CIDR allowlist, SSH port, pod CIDR, in-cluster
 // host-service ports) and applies it to the global config so the
@@ -118,10 +132,11 @@ func RegisterHostFirewallFlags(cmd *cobra.Command) {
 // seedEnabled is the default the enable/disable choice falls back to when neither
 // the flag nor an interactive prompt decides it. `install` passes false (opt-in —
 // a fresh install without the flag installs no firewall), while `reconfigure`
-// passes whether the inet host table currently exists on the host, so a no-flag /
-// default-accept reconfigure keeps the current state rather than silently tearing
-// an established firewall down. It is intentionally NOT derived from cfg.Disabled:
-// config.yaml's zero value cannot distinguish "enabled" from "never configured".
+// passes the block node's persisted firewall decision (MachineState.Firewall), so
+// a no-flag / default-accept reconfigure keeps the last-chosen state rather than
+// silently tearing an established firewall down. It is intentionally NOT derived
+// from cfg.Disabled: config.yaml's zero value cannot distinguish "enabled" from
+// "never configured".
 //
 // It requires RegisterHostFirewallFlags to have been called on cmd.
 func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues, seedEnabled bool) error {
@@ -131,39 +146,13 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.Cho
 	}
 
 	cfg := config.Get().Host
-	firewallEnabled := effectiveBool(cmd, FlagNameFirewallEnabled, seedEnabled)
 
-	// Prompt for the enable/disable choice only when it wasn't already decided
-	// on the CLI. Declining here skips the allowlist/port prompts below entirely
-	// — there's nothing left to ask once the firewall itself is turned off.
-	if prompt.ShouldPrompt(force) && !cmd.Flags().Changed(FlagNameFirewallEnabled) {
-		enabled, err := prompt.RunConfirm(
-			"Enable host firewall?",
-			"Apply the node-level inet host firewall (SSH/mgmt allowlist, ICMP policy, in-cluster ports). "+
-				"Opt-in, default No — choose Yes to have this tool manage the host firewall.",
-			firewallEnabled,
-		)
-		if err != nil {
-			return err
-		}
-		firewallEnabled = enabled
-	}
-
-	// Non-interactive callers that supply host-firewall config flags without also
-	// passing --firewall-enabled=true would otherwise have those flags silently
-	// ignored: with the opt-in default there's no confirm prompt to catch the
-	// mismatch, and the early return below drops out without applying anything.
-	if !firewallEnabled && !prompt.ShouldPrompt(force) {
-		for _, name := range []string{FlagNameMgmtCIDRs, FlagNameBlockedCIDRs, FlagNameSSHPort, FlagNamePodCIDR, FlagNameInClusterPorts} {
-			if cmd.Flags().Changed(name) {
-				return errorx.IllegalArgument.New(
-					"--%s was supplied but the host firewall is not enabled (--firewall-enabled defaults to false)", name).
-					WithProperty(models.ErrPropertyResolution, []string{
-						"Pass --firewall-enabled=true to actually apply the host firewall settings",
-						"Or drop --" + name + " if you did not intend to configure the host firewall",
-					})
-			}
-		}
+	// Resolve the enable/disable gate through the shared gated-feature resolver
+	// (flag > confirm-prompt > seed, plus the content-flag-without-gate guard),
+	// identical to how traffic shaping is gated.
+	firewallEnabled, err := resolveFeatureGate(cmd, args, hostFirewallFeature(), seedEnabled)
+	if err != nil {
+		return err
 	}
 
 	// An explicit opt-out skips resolving/prompting for the allowlist/port
@@ -239,17 +228,6 @@ func ResolveHostFirewallConfig(cmd *cobra.Command, args []string, cv *prompt.Cho
 	return nil
 }
 
-// effectiveBool returns the effective value for a bool flag: the flag when
-// explicitly set, else cfgVal (which already carries the correct "unset"
-// default via HostConfig.Disabled's negative polarity).
-func effectiveBool(cmd *cobra.Command, name string, cfgVal bool) bool {
-	if cmd.Flags().Changed(name) {
-		v, _ := cmd.Flags().GetBool(name)
-		return v
-	}
-	return cfgVal
-}
-
 // effectiveCSV returns the effective comma-joined value for a StringSlice flag:
 // the flag when explicitly set, else the config value.
 func effectiveCSV(cmd *cobra.Command, name string, cfgVal []string) string {
@@ -313,8 +291,8 @@ func joinInts(in []int) string {
 // It is the "state" tier of the flag > config > state > default precedence for the
 // firewall allowlist: the returned config seeds the effective* helpers, where a
 // CLI flag still takes priority. Only the allowlist content is merged — the
-// enable/disable decision is resolved separately (flag / prompt / live probe), so
-// the persisted Firewall.Disabled is intentionally ignored here. Returns cfg
+// enable/disable decision is resolved separately (flag / prompt / persisted
+// state), so the persisted Firewall.Disabled is intentionally ignored here. Returns cfg
 // unchanged when no firewall was ever persisted or the state read fails.
 func mergeHostFirewallFromState(cfg models.HostConfig) models.HostConfig {
 	defaults, err := state.ReadPromptDefaultsFromDisk()

--- a/cmd/cli/commands/common/traffic_shaping.go
+++ b/cmd/cli/commands/common/traffic_shaping.go
@@ -4,8 +4,6 @@ package common
 
 import (
 	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
-	"github.com/hashgraph/solo-weaver/pkg/models"
-	"github.com/joomcode/errorx"
 	"github.com/spf13/cobra"
 )
 
@@ -39,58 +37,34 @@ func RegisterTrafficShapingFlags(cmd *cobra.Command) {
 // seedEnabled is the default the choice falls back to when neither the flag nor
 // an interactive prompt decides it: `install` passes false (opt-in — a fresh
 // install without the flag stays unshaped), while `reconfigure` passes the block
-// node's CURRENT traffic-shaping state (from BlockNodeState.TrafficShapingDisabled)
+// node's persisted traffic-shaping decision (BlockNodeState.TrafficShapingDisabled)
 // so a no-flag / default-accept reconfigure keeps the existing decision rather than
 // silently tearing an established plane down.
 //
 // It requires RegisterTrafficShapingFlags to have been called on cmd.
 func ResolveTrafficShapingConfig(cmd *cobra.Command, args []string, cv *prompt.ChosenValues, seedEnabled bool) (bool, error) {
-	force, err := FlagForce().Value(cmd, args)
-	if err != nil {
-		return false, errorx.IllegalArgument.Wrap(err, "failed to get %s flag", FlagForce().Name)
-	}
+	// Traffic shaping and the host firewall are gated identically (flag >
+	// confirm-prompt > seed, plus the content-flag-without-gate guard); the only
+	// difference is the flag/noun/prompt wording and the content-flag set, which
+	// trafficShapingFeature supplies as data.
+	return resolveFeatureGate(cmd, args, trafficShapingFeature(), seedEnabled)
+}
 
-	// Seeded from the caller-supplied default (opt-in false for install; the
-	// current persisted state for reconfigure), overridden by the flag when set.
-	enabled := effectiveBool(cmd, FlagNameTrafficShapingEnabled, seedEnabled)
-
-	// Prompt for the enable/disable choice only when it wasn't already decided
-	// on the CLI. Declining here skips the egress prompts below entirely —
-	// there's nothing left to ask once the plane itself is turned off.
-	if prompt.ShouldPrompt(force) && !cmd.Flags().Changed(FlagNameTrafficShapingEnabled) {
-		confirmed, err := prompt.RunConfirm(
-			"Enable traffic shaping?",
-			"Create the BN workload network-policy plane (inet weaver classification) and tc HTB "+
-				"traffic shaping, and install the traffic-shaper daemon. Opt-in, default No — choose Yes "+
-				"to get all three.",
-			enabled,
-		)
-		if err != nil {
-			return false, err
-		}
-		enabled = confirmed
-	}
-
-	// Non-interactive callers that supply traffic-shaping-only flags (egress
-	// NIC/link-rate, --shape overrides, daemon binary source) without also
-	// passing --traffic-shaping-enabled=true would otherwise have those flags
-	// silently ignored: with the opt-in default there's no confirm prompt to
-	// catch the mismatch, and the caller just skips configuring any of it.
-	if !enabled && !prompt.ShouldPrompt(force) {
-		for _, name := range []string{
+// trafficShapingFeature describes traffic shaping as a gated network feature for
+// resolveFeatureGate: the --traffic-shaping-enabled opt-in gate plus the
+// traffic-shaping-only flags (egress NIC/link-rate, --shape overrides, daemon
+// binary source) that are meaningless without it.
+func trafficShapingFeature() gatedFeature {
+	return gatedFeature{
+		GateFlag:    FlagNameTrafficShapingEnabled,
+		Noun:        "traffic shaping",
+		PromptTitle: "Enable traffic shaping?",
+		PromptDesc: "Create the BN workload network-policy plane (inet weaver classification) and tc HTB " +
+			"traffic shaping, and install the traffic-shaper daemon. Opt-in, default No — choose Yes " +
+			"to get all three.",
+		ContentFlags: []string{
 			FlagNameEgressInterface, FlagNameLinkRate, FlagNameShape,
 			FlagDaemonBin().Name, FlagDaemonVersion().Name,
-		} {
-			if cmd.Flags().Changed(name) {
-				return false, errorx.IllegalArgument.New(
-					"--%s was supplied but traffic shaping is not enabled (--traffic-shaping-enabled defaults to false)", name).
-					WithProperty(models.ErrPropertyResolution, []string{
-						"Pass --traffic-shaping-enabled=true to actually apply these settings",
-						"Or drop --" + name + " if you did not intend to configure traffic shaping",
-					})
-			}
-		}
+		},
 	}
-
-	return enabled, nil
 }

--- a/internal/bll/blocknode/network_plane.go
+++ b/internal/bll/blocknode/network_plane.go
@@ -4,8 +4,7 @@ package blocknode
 
 import (
 	"github.com/automa-saga/automa"
-	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
-	"github.com/hashgraph/solo-weaver/pkg/config"
+	"github.com/hashgraph/solo-weaver/internal/workflows"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 )
 
@@ -21,75 +20,24 @@ import (
 //     allowTeardown=false: it re-asserts (create-if-missing) whatever the install
 //     decision was, but never tears anything down from a routine version bump.
 //
-// Every step is idempotent, so the same list is safe to re-run: create steps are
-// create-if-missing and teardown steps are delete-if-present. The step ordering
-// mirrors NetworkSetupWorkflow — firewall first, then NetworkPolicyCreate before
-// NftWeaverPersist so the policy registry is populated when the weaver table is
-// rendered.
+// It is a thin adapter over workflows.NetworkPlaneSteps — the single assembler
+// also used by the install path (via NetworkSetupWorkflow) — that maps the
+// block-node inputs onto the shared options and always requests the inline daemon
+// reload (both reconfigure and upgrade may run against a live daemon whose
+// daemon.yaml changed). See workflows.NetworkPlaneSteps for the step semantics.
 //
 // trafficShapingEnabled is the resolved traffic-shaping target. force is the
-// operator's --force, threaded into NetworkPolicyCreate for the enable path.
-// healthPort is the resolved block-node health/statusz port (from
-// blocknode.ResolveHealthPort against the operator's effective values), threaded
-// into NetworkPolicyCreate so the bn-mgmt set tracks the port the BN actually
-// listens on — matching the install path.
+// operator's --force. healthPort is the resolved block-node health/statusz port.
 func networkPlaneSteps(ins models.BlockNodeInputs, force, trafficShapingEnabled, allowTeardown bool, healthPort string) []automa.Builder {
-	var out []automa.Builder
-
-	// Host firewall: desired-state convergence. NetworkFirewallCreate self-gates
-	// on config.Host.Disabled, so it is always safe to include; a delete only runs
-	// when teardown is permitted (reconfigure) AND the operator resolved the
-	// firewall to disabled.
-	if allowTeardown && config.Get().Host.Disabled {
-		out = append(out, steps.NetworkFirewallDelete())
-	} else {
-		// reconcile=allowTeardown: reconfigure (allowTeardown=true) force
-		// re-renders the host firewall so changed settings actually take effect;
-		// upgrade (allowTeardown=false) re-asserts create-if-missing only.
-		out = append(out, steps.NetworkFirewallCreate(allowTeardown))
-	}
-
-	switch {
-	case trafficShapingEnabled:
-		// Enable: create the BN policy plane, persist the weaver table, (re)provision
-		// tc egress/ingress shaping, enable the daemon's traffic-shaper monitor, and
-		// restart the daemon so that change takes effect. The daemon reads daemon.yaml
-		// only at startup (no hot-reload) and the post-workflow ensureBlockNodeDaemon
-		// is a no-op when the daemon is already running — so re-enabling on a host
-		// where the daemon is up (e.g. a prior disable left it running with the
-		// monitor off) would otherwise never start the monitor, and the ingress $VETH
-		// HTB would never be (re)installed. Restarting here reloads daemon.yaml; the
-		// monitor's initial pod list then shapes the current pod's veth immediately,
-		// and the subsequent rollout-restart's new veth via a watch event.
-		// RestartDaemonServiceStep self-skips when the daemon is not running (fresh
-		// enable), where post-workflow ensureBlockNodeDaemon installs and starts it.
-		shapeOverrides := toClassOverrides(ins.ShapeOverrides)
-		out = append(out,
-			steps.NetworkPolicyCreate(force, healthPort),
-			steps.NftWeaverPersist(),
-			steps.TcEgressPersist(ins.EgressInterface, ins.LinkRate, shapeOverrides),
-			steps.TcIngressRecord(ins.EgressInterface, ins.LinkRate, shapeOverrides),
-			steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace, true),
-			steps.RestartDaemonServiceStep(),
-		)
-	case allowTeardown:
-		// Disable: remove every BN policy (the last delete tears the inet weaver
-		// table down, so no NftWeaverPersist is needed), drop the tc egress hierarchy,
-		// turn the daemon's block-node traffic-shaper monitor off, and restart the
-		// daemon so that change takes effect. The daemon reads daemon.yaml only at
-		// startup (no hot-reload), so without the restart the live monitor keeps
-		// running and re-applies the ingress $VETH HTB on the next BN pod create —
-		// which, on the default reconfigure path, is triggered by the rollout-restart
-		// that runs right after these network steps. Restarting here (before that pod
-		// churn) ensures the monitor is gone when the new veth appears, so it comes up
-		// unshaped. RestartDaemonServiceStep self-skips when the daemon is not running.
-		out = append(out,
-			steps.NetworkPolicyDeleteAll(),
-			steps.TcEgressTeardown(),
-			steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace, false),
-			steps.RestartDaemonServiceStep(),
-		)
-	}
-
-	return out
+	return workflows.NetworkPlaneSteps(workflows.NetworkPlaneOptions{
+		Force:                 force,
+		TrafficShapingEnabled: trafficShapingEnabled,
+		HealthPort:            healthPort,
+		Namespace:             ins.Namespace,
+		EgressInterface:       ins.EgressInterface,
+		LinkRate:              ins.LinkRate,
+		ShapeOverrides:        toClassOverrides(ins.ShapeOverrides),
+		AllowTeardown:         allowTeardown,
+		WithDaemonReload:      true,
+	})
 }

--- a/internal/workflows/network_setup.go
+++ b/internal/workflows/network_setup.go
@@ -9,8 +9,124 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/network/shape"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
 	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
+	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 )
+
+// NetworkPlaneOptions parameterizes NetworkPlaneSteps for the three block-node
+// commands that converge the static network plane (install, reconfigure,
+// upgrade). All three share the same host-firewall + traffic-shaping step
+// bundle; they differ only in the fields below (issue #947).
+type NetworkPlaneOptions struct {
+	// Force is the operator's --force, threaded into NetworkPolicyCreate.
+	Force bool
+	// TrafficShapingEnabled is the resolved traffic-shaping target: the BN
+	// workload policy plane + tc HTB shaping + daemon monitor as one bundle.
+	TrafficShapingEnabled bool
+	// HealthPort is the resolved block-node health/statusz port, threaded into
+	// NetworkPolicyCreate so the bn-mgmt set tracks the port the BN listens on.
+	HealthPort string
+	// Namespace is the block-node namespace, used by the daemon-config step when
+	// WithDaemonReload is set.
+	Namespace string
+	// EgressInterface / LinkRate / ShapeOverrides feed the tc egress/ingress steps.
+	EgressInterface string
+	LinkRate        string
+	ShapeOverrides  map[string]shape.ClassOverride
+
+	// AllowTeardown permits deleting a feature resolved to off. reconfigure sets
+	// it (turning a feature off deletes it); install/upgrade leave it false and
+	// re-assert create-if-missing only, so a routine run never tears anything down.
+	AllowTeardown bool
+	// WithDaemonReload appends the daemon-config write + service restart inline
+	// after the shaping steps so a live daemon reloads the changed daemon.yaml
+	// (it reads the file only at startup — no hot-reload). reconfigure/upgrade set
+	// this; install leaves it false and instead writes the daemon config as a
+	// separate later phase (BlockNodeDaemonConfigWorkflow) and starts the service
+	// post-workflow, once the deployment the daemon watches exists.
+	WithDaemonReload bool
+}
+
+// NetworkPlaneSteps builds the static network-plane step list — host firewall
+// (inet host) convergence plus, when enabled, the BN traffic-shaping bundle
+// (policy plane + weaver table + $EGRESS/$VETH tc HTB shaping + daemon monitor)
+// — shared by `block node install`, `reconfigure`, and `upgrade`. Every step is
+// idempotent, so the same list is safe to re-run: create steps are
+// create-if-missing and teardown steps are delete-if-present.
+//
+// The three commands drive it through NetworkPlaneOptions:
+//   - install: AllowTeardown=false, WithDaemonReload=false (wrapped in the
+//     "Network Setup" phase by NetworkSetupWorkflow; daemon handled separately).
+//   - reconfigure: AllowTeardown=true, WithDaemonReload=true (operator-resolved
+//     target, allowed to tear a feature down).
+//   - upgrade: AllowTeardown=false, WithDaemonReload=true (persisted-state target,
+//     re-assert create-if-missing only).
+//
+// Ordering: firewall first, then NetworkPolicyCreate before NftWeaverPersist so
+// the policy registry is populated when the weaver table is rendered (an empty
+// registry would persist a policy-drop chain).
+func NetworkPlaneSteps(opts NetworkPlaneOptions) []automa.Builder {
+	var out []automa.Builder
+
+	// Host firewall: desired-state convergence. NetworkFirewallCreate self-gates
+	// on config.Host.Disabled, so it is always safe to include; a delete only runs
+	// when teardown is permitted (reconfigure) AND the operator resolved the
+	// firewall to disabled. reconcile=AllowTeardown: reconfigure force re-renders
+	// the host firewall so changed settings take effect; install/upgrade re-assert
+	// create-if-missing only.
+	if opts.AllowTeardown && config.Get().Host.Disabled {
+		out = append(out, steps.NetworkFirewallDelete())
+	} else {
+		out = append(out, steps.NetworkFirewallCreate(opts.AllowTeardown))
+	}
+
+	switch {
+	case opts.TrafficShapingEnabled:
+		// Enable: create the BN policy plane, persist the weaver table, (re)provision
+		// tc egress/ingress shaping, then — for the reload callers — enable the
+		// daemon's traffic-shaper monitor and restart the daemon so the change takes
+		// effect. The daemon reads daemon.yaml only at startup (no hot-reload) and the
+		// post-workflow ensureBlockNodeDaemon is a no-op when the daemon is already
+		// running, so re-enabling on a host where the daemon is up would otherwise
+		// never start the monitor and the ingress $VETH HTB would never be
+		// (re)installed. RestartDaemonServiceStep self-skips when the daemon is not
+		// running (fresh enable), where post-workflow ensureBlockNodeDaemon installs it.
+		out = append(out,
+			steps.NetworkPolicyCreate(opts.Force, opts.HealthPort),
+			steps.NftWeaverPersist(),
+			steps.TcEgressPersist(opts.EgressInterface, opts.LinkRate, opts.ShapeOverrides),
+			steps.TcIngressRecord(opts.EgressInterface, opts.LinkRate, opts.ShapeOverrides),
+		)
+		if opts.WithDaemonReload {
+			out = append(out,
+				steps.WriteBlockNodeDaemonConfigStep(models.Paths(), opts.Namespace, true),
+				steps.RestartDaemonServiceStep(),
+			)
+		}
+	case opts.AllowTeardown:
+		// Disable (reconfigure only): remove every BN policy (the last delete tears
+		// the inet weaver table down, so no NftWeaverPersist is needed), drop the tc
+		// egress hierarchy, then turn the daemon's monitor off and restart the daemon.
+		// The restart matters because the daemon reads daemon.yaml only at startup:
+		// without it the live monitor keeps re-applying the ingress $VETH HTB on the
+		// next BN pod create (triggered by the rollout-restart that runs right after
+		// these steps). Restarting here — before that pod churn — ensures the monitor
+		// is gone when the new veth appears, so it comes up unshaped.
+		// RestartDaemonServiceStep self-skips when the daemon is not running.
+		out = append(out,
+			steps.NetworkPolicyDeleteAll(),
+			steps.TcEgressTeardown(),
+		)
+		if opts.WithDaemonReload {
+			out = append(out,
+				steps.WriteBlockNodeDaemonConfigStep(models.Paths(), opts.Namespace, false),
+				steps.RestartDaemonServiceStep(),
+			)
+		}
+	}
+
+	return out
+}
 
 // NetworkSetupWorkflow lays down the block node's static network plane: the
 // node-level host firewall (inet host), the weaver policy-table persistence
@@ -31,15 +147,20 @@ import (
 // When false, none of the four steps are added: there is no inet weaver table
 // to persist and no tc config to shape traffic with.
 func NetworkSetupWorkflow(egressInterface, linkRate string, shapeOverrides map[string]shape.ClassOverride, force bool, trafficShapingEnabled bool, healthPort string) *automa.WorkflowBuilder {
-	stepList := []automa.Builder{steps.NetworkFirewallCreate(false)}
-	if trafficShapingEnabled {
-		stepList = append(stepList,
-			steps.NetworkPolicyCreate(force, healthPort),
-			steps.NftWeaverPersist(),
-			steps.TcEgressPersist(egressInterface, linkRate, shapeOverrides),
-			steps.TcIngressRecord(egressInterface, linkRate, shapeOverrides),
-		)
-	}
+	// Install shares the network-plane bundle with reconfigure/upgrade via
+	// NetworkPlaneSteps but never tears down (AllowTeardown=false) and defers the
+	// daemon monitor to the separate BlockNodeDaemonConfigWorkflow phase, which
+	// runs after the deployment it watches is in place (WithDaemonReload=false).
+	stepList := NetworkPlaneSteps(NetworkPlaneOptions{
+		Force:                 force,
+		TrafficShapingEnabled: trafficShapingEnabled,
+		HealthPort:            healthPort,
+		EgressInterface:       egressInterface,
+		LinkRate:              linkRate,
+		ShapeOverrides:        shapeOverrides,
+		AllowTeardown:         false,
+		WithDaemonReload:      false,
+	})
 
 	return automa.NewWorkflowBuilder().
 		WithId("block-node-network-setup").


### PR DESCRIPTION
## Description

The host **firewall** and **traffic-shaping** features are sibling operator-gated network-plane
features (toggled on `block node install` / `reconfigure` / `upgrade` and persisted in state), but they
landed incrementally and ended up doing the same things in materially different ways. Every future
network-plane change (#945 IPv6, #942 FQDN) had to be applied twice, differently. This PR unifies the
wiring behind three shared pieces.

Design decisions (the issue left these open): **one source of truth = persisted state** for both
features; a **lighter shared resolver** (not the optional full RSL `EffectiveValue[bool]` migration); and
the gate seed unified in the **CLI/common** layer.

1. **One shared gate resolver.** New `common/gated_feature.go` exposes `resolveFeatureGate(cmd, args,
   gatedFeature, seed)`, which drives the identical force-fetch → effective-bool → confirm-prompt →
   mismatch-guard skeleton for both features. Each feature supplies only its flag / noun / prompt text /
   content-flag set as a `gatedFeature` descriptor (`hostFirewallFeature()`, `trafficShapingFeature()`).
   `effectiveBool` moves here (it was firewall-owned but shaping already depended on it).
2. **One source of truth for “currently enabled?”.** `reconfigure` now seeds **both** gates from persisted
   state — firewall from `MachineState.Firewall.Disabled`, shaping from `TrafficShapingDisabled` — with a
   symmetric conservative bias to *enabled* on an unreadable state file. The firewall live inet-table probe
   (`currentFirewallEnabledSeed` → `firewall.NewManager().IsActive`) is deleted as a prompt seed;
   reconciliation stays inside `NetworkFirewallCreate`, which already probes `IsActive` for rollback.
3. **One step assembler.** New `workflows.NetworkPlaneSteps(NetworkPlaneOptions{...})` is the single
   source of the firewall + traffic-shaping step bundle. `NetworkSetupWorkflow` (install) and the bll
   `networkPlaneSteps` (reconfigure/upgrade, now a thin wrapper) both delegate to it; the two options
   `AllowTeardown` and `WithDaemonReload` capture the only differences between the three commands.

The persisted-state *content* fallback for shaping (NIC / link-rate / overrides in
`resolveBlocknodeEffectiveInputs`) deliberately stays in the BLL: it is what makes `upgrade` re-assert the
operator's original shaping, and moving it would break the `BlockNodeInputs` passthrough invariant. Only
the enable/disable **gate** is unified in the CLI layer.

### Behavior change

`reconfigure`'s firewall gate seed moves from a live host probe to persisted state. A manually-flushed
`inet host` table (dropped out-of-band, e.g. `nft flush ruleset`) no longer suppresses re-create on a
default-accept `reconfigure` — desired-state wins, matching how shaping already behaves and how the
workflow step reconciles. The emitted step lists are otherwise byte-for-byte unchanged (existing
handler step-id assertions pass unmodified).

### Risks

* **Migration edge:** a firewall present on-host but never persisted (a pre-#932 old binary that applied a
  table without recording it) would seed *disabled* on the first `reconfigure` under this change. #932
  persists the firewall on every install/reconfigure, so this self-heals after one run; realistic hosts on
  a current binary already have `MachineState.Firewall` populated.
* Higher blast radius than a pure shaping change (touches the firewall path + its tests), which is why it
  is sequenced behind the shape-engine cleanup and stacked on that branch (below).
* No CLI flag was added, removed, or renamed — no `docs/quickstart.md` change required.

### Stacking note

Stacked on **`refactor-traffic-shaper-engine`** (PR #949), not `main` — review/merge that first. This is
the #947 follow-up filed from that branch's deep-analysis review.

### Files changed

| File | Change |
|------|--------|
| `cmd/cli/commands/common/gated_feature.go` | **new** — `gatedFeature` descriptor + `resolveFeatureGate` + `effectiveBool` |
| `cmd/cli/commands/common/gated_feature_test.go` | **new** — seed / flag-override / mismatch-guard unit tests |
| `cmd/cli/commands/common/host_firewall.go` | `ResolveHostFirewallConfig` calls the shared gate; `hostFirewallFeature()` descriptor |
| `cmd/cli/commands/common/traffic_shaping.go` | `ResolveTrafficShapingConfig` collapses to the shared gate; `trafficShapingFeature()` |
| `cmd/cli/commands/block/node/reconfigure.go` | symmetric persisted-state seed for both gates; deletes `currentFirewallEnabledSeed` + live probe |
| `internal/workflows/network_setup.go` | new `NetworkPlaneOptions` / `NetworkPlaneSteps`; `NetworkSetupWorkflow` delegates |
| `internal/bll/blocknode/network_plane.go` | `networkPlaneSteps` is now a thin adapter over `workflows.NetworkPlaneSteps` |

### Review guide

**Checklist**

* `resolveFeatureGate` reproduces the prior guard error shape for both features (noun + gate-flag
  substitution keep the firewall/shaping messages identical; only the firewall hint-1 wording is
  normalized to “these settings”).
* `NetworkPlaneSteps` emits identical step lists to the old assemblers: install = 4-step enable bundle
  (no inline daemon steps), reconfigure/upgrade = 6-step (adds daemon-config write + restart), reconfigure
  teardown branch, and firewall create-vs-delete on `AllowTeardown && config.Host.Disabled`.
* reconfigure firewall seed: persisted-state; unreadable state → conservative `true`.
* shaping BLL content fallback (`resolveBlocknodeEffectiveInputs`) untouched — passthrough invariant intact.

**Tests** — these packages can't run on macOS (transitive Linux-only `internal/mount`). Run in the VM, or
cross-compile on host + execute in a Linux container:

```bash
task vm:test:unit                 # sanctioned full suite in the UTM VM

# or, targeted, non-disruptive:
for p in cmd/cli/commands/common internal/bll/blocknode internal/workflows; do
  GOOS=linux GOARCH=arm64 go test -tags='!integration' -c -o /tmp/t/$(basename $p).test ./$p/
  docker run --rm -v "$PWD":/src -v /tmp/t:/t -w /src/$p debian:stable-slim /t/$(basename $p).test -test.count=1
done
```

All three PASS; `task lint` = 0 issues.

**Manual UAT (block-node host in the VM)**

1. Install with both features on:
   ```bash
   solo-provisioner block node install --firewall-enabled --mgmt-cidrs <cidr> \
     --traffic-shaping-enabled --egress-interface eth0 --link-rate 1gbit -y
   ```
   Expect: `inet host` table + `inet weaver` policy plane + `$EGRESS`/`$VETH` tc HTB all present
   (`nft list table inet host`, `tc qdisc show`).
2. **Behavior-change check** — drop the firewall out-of-band, then default-accept reconfigure:
   ```bash
   sudo nft flush ruleset
   solo-provisioner block node reconfigure -y
   ```
   Expect: firewall **re-created** from persisted state (old live-probe build would have left it off).
3. Explicit firewall opt-out tears only the firewall down, leaving shaping:
   ```bash
   solo-provisioner block node reconfigure --firewall-enabled=false -y
   ```
   Expect: `inet host` deleted; `inet weaver` + tc HTB still present.
4. Routine upgrade re-asserts both, never tears down:
   ```bash
   solo-provisioner block node upgrade --version <newer> -y
   ```
   Expect: firewall + shaping re-asserted create-if-missing; no delete steps in the run.
5. Non-interactive mismatch guard still fires:
   ```bash
   solo-provisioner block node install --mgmt-cidrs <cidr> --non-interactive
   ```
   Expect: hard error — `--mgmt-cidrs was supplied but the host firewall is not enabled` with resolution
   hints. Same for `--egress-interface` without `--traffic-shaping-enabled`.

### Related Issues

* Closes #947
