### PR TITLE
feat(daemon/shaper): raise default statusz poll interval to 5 min

### DIFF
--- a/cmd/cli/commands/block/node/init.go
+++ b/cmd/cli/commands/block/node/init.go
@@ -198,7 +198,7 @@ func validateBlockNodeFlags(cmd *cobra.Command) error {
 		sc := daemon.StatuszConfig{BaseURL: flagStatuszBaseURL, PollInterval: flagStatuszPollInterval}
 		if err := sc.Validate(); err != nil {
 			return errorx.IllegalArgument.Wrap(err,
-				"invalid --statusz-base-url / --statusz-poll-interval: base URL must be an http(s) URL with a host and poll interval a positive Go duration (e.g. 5s)")
+				"invalid --statusz-base-url / --statusz-poll-interval: base URL must be an http(s) URL with a host and poll interval a positive Go duration (e.g. 5m)")
 		}
 	}
 	return nil

--- a/cmd/cli/commands/common/flags_blocknode.go
+++ b/cmd/cli/commands/common/flags_blocknode.go
@@ -226,7 +226,7 @@ func FlagStatuszPollInterval() FlagDefinition[string] {
 	return FlagDefinition[string]{
 		Name:        "statusz-poll-interval",
 		ShortName:   "",
-		Description: "Cadence at which the daemon's block-node traffic-shaper monitor polls statusz, as a positive Go duration (e.g. 5s, 30s). Merged into daemon.yaml (components.block_node.statusz.poll_interval); omitting the flag preserves any value already on disk. Only when no poll_interval is set at all does the daemon fall back to its 5s default",
+		Description: "Cadence at which the daemon's block-node traffic-shaper monitor polls statusz, as a positive Go duration (e.g. 5m, 30s). Merged into daemon.yaml (components.block_node.statusz.poll_interval); omitting the flag preserves any value already on disk. Only when no poll_interval is set at all does the daemon fall back to its 5m default",
 		Default:     "",
 	}
 }

--- a/docs/dev/daemon/traffic-shaper-statusz.md
+++ b/docs/dev/daemon/traffic-shaper-statusz.md
@@ -20,7 +20,7 @@ statusz endpoint — discovered from the watched BN pod, with an optional
 ## What the poll loop does
 
 The traffic-shaper monitor runs a poll loop that, on a fixed cadence
-(default 5s):
+(default 5m):
 
 1. fetches the BN's `statusz/inbound` and `statusz/outbound` endpoints,
 2. buckets the returned endpoints by category,
@@ -31,13 +31,32 @@ The loop reconciles **nftables set membership only** — the dynamic plane. The
 tc HTB class hierarchy is static (installed once); traffic lands in the correct
 class via nftables `skb->priority` marking, not via runtime tc changes.
 
-### Outage behaviour
+### Startup and reboot behaviour
+
+The poll loop reconciles **once immediately on entry** — before the first
+ticker tick fires. This means:
+
+- After a **daemon restart**, the nft set membership is rehydrated as soon as
+  the daemon starts and the BN statusz endpoint is reachable, without waiting
+  a full poll interval.
+- After a **host reboot**, the nft set elements are not boot-persistent (the
+  static table structure is replayed from `.nft` files, but membership is not).
+  The entry reconcile rehydrates the sets as soon as the daemon starts and
+  statusz responds. If statusz is not yet up, `superviseResponsibility` retries
+  with exponential back-off — convergence is bounded by BN startup time, not
+  the poll interval.
+
+### Steady-state behaviour
 
 A failed poll (statusz unreachable, diff error, or apply error) is logged and
 retried on the next tick, leaving the **last-good** nftables state in place. A
 BN outage therefore never drops existing rules; once the BN's statusz is
 reachable again, membership re-converges within one poll cycle. During initial
 BN bootstrap the sets simply stay empty until statusz responds.
+
+Even when the membership digest is unchanged, the loop forces a full apply every
+`statuszForceResyncInterval` (default 1 h) to self-heal any out-of-band edits
+to the daemon-owned nft sets.
 
 ## statusz endpoints
 
@@ -120,19 +139,26 @@ components:
       traffic_shaper: true
     statusz:                          # optional
       base_url: http://127.0.0.1:8080 # where the poll loop fetches statusz
-      poll_interval: 5s               # optional; defaults to 5s
+      poll_interval: 5m               # optional; defaults to 5m
 ```
 
 | Field | Required | Meaning |
 |---|---|---|
 | `base_url` | no | Root URL the `statusz/...` paths resolve against. Must be `http(s)` with a host. When set, **overrides** pod discovery. |
-| `poll_interval` | no | Poll cadence as a Go duration (e.g. `5s`, `10s`). Defaults to `5s`. |
+| `poll_interval` | no | Poll cadence as a Go duration (e.g. `5m`, `30s`). Defaults to `5m`. |
 
 When `base_url` is set it takes precedence over discovery — an explicit override
 pointing at a directly reachable BN or a port-forward. When it is empty (or the
 `statusz` block is absent), the monitor discovers the endpoint from the BN pod;
 until a ready BN pod is observed the poll loop idles quietly and starts polling
 as soon as one appears.
+
+**Using pod discovery without `base_url`:** after a daemon restart or host
+reboot, the entry reconcile fires immediately but skips if no URL has been
+discovered yet. Convergence then waits until the pod watcher observes a ready
+BN pod, after which the next ticker tick (up to one poll interval) triggers
+the reconcile. For the lowest post-reboot convergence latency, set `base_url`
+to a stable statusz endpoint (e.g. a node-local port-forward).
 
 ### Enablement at install time
 

--- a/docs/dev/traffic-shaper.md
+++ b/docs/dev/traffic-shaper.md
@@ -121,12 +121,14 @@ The monitor runs two independently-supervised responsibilities (each retried wit
    ingress HTB from the persisted class configs. On pod delete it best-effort
    `tc-detach`es (the kernel removes veth qdiscs with the interface anyway).
 2. **Statusz poll loop -> the policy plane's nft set membership.** Every
-   `poll_interval` (default 5 s) it resolves the block node's statusz base URL
+   `poll_interval` (default 5 m) it resolves the block node's statusz base URL
    (operator override, else discovered from the ready pod's IP + health port),
    runs an unprivileged `--check` digest probe, and only when the digest changed
-   (or the URL changed, or a periodic force-resync elapses) execs `block node
+   (or the URL changed, or the hourly force-resync elapses) execs `block node
    reconcile-shaper` via sudo to apply. The periodic forced apply self-heals
-   out-of-band nft edits.
+   out-of-band nft edits. On daemon startup (including after a host reboot) the
+   loop reconciles once immediately before the first tick, so nft set membership
+   is rehydrated as soon as the daemon starts and statusz is reachable.
 
 **statusz** is the block node's own health API — `statusz/inbound` and
 `statusz/outbound` JSON endpoints served on the pod's health port (default
@@ -246,7 +248,7 @@ fill in the parts that are deliberately **not** persisted (see below).
 | Artifact | Persisted at boot? | Rebuilt by |
 |---|---|---|
 | nft tables, chains, rules (both tables) | Yes — replayed from the `.nft` files via `nft -f` | — |
-| nft **set elements** (the CIDR membership of `bn-*` sets) | **No** | daemon statusz poll loop, ~5 s after boot |
+| nft **set elements** (the CIDR membership of `bn-*` sets) | **No** | daemon statusz poll loop — entry reconcile fires immediately on daemon start; bounded by BN startup time when `base_url` is set, or by pod readiness + up to one poll interval with pod discovery |
 | `$EGRESS` HTB hierarchy | Yes — the `solo-provisioner-bandwidth-shaper.sh` script | — |
 | `$VETH` (per-pod) HTB hierarchy | **No** | daemon pod-lifecycle watcher, on the next pod-create event |
 

--- a/internal/daemon/blocknode/traffic_shaper_monitor.go
+++ b/internal/daemon/blocknode/traffic_shaper_monitor.go
@@ -182,15 +182,18 @@ func (m *TrafficShaperMonitor) superviseResponsibility(ctx context.Context, name
 // a monitor constructed with a non-positive interval — only reachable in tests;
 // daemon.go always passes StatuszConfig.EffectivePollInterval() — still ticks at
 // a sane cadence rather than panicking in time.NewTicker.
-const defaultStatuszPollInterval = 5 * time.Second
+const defaultStatuszPollInterval = 5 * time.Minute
 
 // statuszForceResyncInterval bounds how long the poll loop trusts the
 // desired-membership digest before forcing a full apply even when the digest is
 // unchanged. The digest is computed over the desired membership (from statusz),
 // not the live nft sets, so a pure digest gate would never notice an
 // out-of-band edit to the daemon-owned sets; a periodic forced apply re-diffs
-// live nft and self-heals that drift. A var (not const) so tests can shrink it.
-var statuszForceResyncInterval = time.Minute
+// live nft and self-heals that drift. Must be greater than the poll interval so
+// the digest-delta optimisation has teeth; at the default 5m poll cadence a 1h
+// force-resync means only one in twelve ticks is a forced apply. A var (not
+// const) so tests can shrink it.
+var statuszForceResyncInterval = time.Hour
 
 // effectiveStatuszURL returns the statusz base URL the poll loop should reconcile
 // against this tick: the operator-configured base_url override when set,
@@ -223,7 +226,7 @@ func (m *TrafficShaperMonitor) effectiveStatuszURL() string {
 // apply (a root sudo exec) fires only when the desired membership changed, the
 // resolved URL changed, or the force-resync interval has elapsed since the last
 // apply. A worker-exec failure is returned to superviseResponsibility, which
-// retries with the 5s→5min back-off; a ctx cancellation returns nil (clean
+// retries with exponential back-off; a ctx cancellation returns nil (clean
 // shutdown).
 func (m *TrafficShaperMonitor) runStatuszPoll(ctx context.Context) error {
 	interval := m.pollInterval
@@ -324,8 +327,19 @@ func (m *TrafficShaperMonitor) runStatuszPoll(ctx context.Context) error {
 		return nil
 	}
 
-	// Reconcile once on entry so a fresh daemon converges immediately instead of
-	// waiting a full interval for the first tick.
+	// Reconcile once on entry so the daemon converges immediately on startup
+	// (including after a host reboot) without waiting a full interval for the
+	// first tick. The nft set elements are not boot-persistent; this entry probe
+	// is what rehydrates them as soon as the daemon starts and the BN statusz
+	// endpoint is reachable. If statusz is not yet up, runReconcile returns an
+	// error and superviseResponsibility retries with back-off — convergence is
+	// bounded by BN startup time, not the poll interval.
+	//
+	// Pod-discovery caveat: when base_url is not configured, effectiveStatuszURL
+	// returns "" until the pod watcher observes a ready BN pod. In that case this
+	// entry reconcile is a silent no-op (not an error), and convergence after a
+	// restart waits for pod discovery plus up to one poll interval for the next
+	// tick. Set base_url for guaranteed immediate convergence after a reboot.
 	if err := runReconcile(); err != nil {
 		return err
 	}

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -21,8 +21,14 @@ const (
 
 	// DefaultStatuszPollInterval is the steady-state cadence at which the
 	// traffic-shaper monitor polls statusz when statusz.poll_interval is unset.
-	// The design specifies a 5-second poll loop.
-	DefaultStatuszPollInterval = 5 * time.Second
+	// 5 minutes is appropriate for a steady-state background reconciler: the
+	// daemon reconciles once immediately on startup (before the first tick) so
+	// convergence after a restart is bounded by how fast the BN pod responds to
+	// statusz, not by the poll interval — provided base_url is configured. When
+	// relying on pod discovery (no base_url), the entry reconcile skips until a
+	// ready BN pod is observed; convergence is then bounded by pod readiness plus
+	// up to one poll interval.
+	DefaultStatuszPollInterval = 5 * time.Minute
 )
 
 // DaemonConfig is parsed from daemon.yaml at startup.
@@ -48,7 +54,7 @@ const (
 //	      traffic_shaper: true
 //	    statusz:                     # optional local-fallback statusz source
 //	      base_url: http://127.0.0.1:8080
-//	      poll_interval: 5s
+//	      poll_interval: 5m
 type DaemonConfig struct {
 	// SchemaVersion identifies the config file format. Always written as
 	// CurrentSchemaVersion by WriteDaemonConfig. A value of 0 means the file
@@ -142,9 +148,10 @@ type StatuszConfig struct {
 	PollInterval string `yaml:"poll_interval,omitempty"`
 }
 
-// EffectivePollInterval returns the configured poll interval, or the 5-second
-// default when unset. It assumes the value has already passed Validate, and
-// falls back to the default for any residual parse failure rather than erroring.
+// EffectivePollInterval returns the configured poll interval, or
+// DefaultStatuszPollInterval when unset. It assumes the value has already
+// passed Validate, and falls back to the default for any residual parse failure
+// rather than erroring.
 func (s StatuszConfig) EffectivePollInterval() time.Duration {
 	if s.PollInterval == "" {
 		return DefaultStatuszPollInterval

--- a/internal/daemon/config_statusz_test.go
+++ b/internal/daemon/config_statusz_test.go
@@ -43,7 +43,7 @@ func TestStatuszConfig_EffectivePollInterval(t *testing.T) {
 		in   string
 		want time.Duration
 	}{
-		{"empty defaults to 5s", "", daemon.DefaultStatuszPollInterval},
+		{"empty defaults to 5m", "", daemon.DefaultStatuszPollInterval},
 		{"parses value", "10s", 10 * time.Second},
 		{"unparseable falls back to default", "banana", daemon.DefaultStatuszPollInterval},
 		{"non-positive falls back to default", "0s", daemon.DefaultStatuszPollInterval},

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -112,7 +112,7 @@ func NewFromConfig(paths models.WeaverPaths, cfg DaemonConfig) (*Daemon, error) 
 	if bn != nil && bn.Enabled {
 		// statusz is optional (see BlockNodeComponentConfig.Statusz): when it is
 		// nil or its base_url is empty, the poll loop idles. EffectivePollInterval
-		// already applies the 5s default.
+		// already applies the 5m default.
 		var statuszBaseURL string
 		var statuszPollInterval time.Duration
 		if bn.Statusz != nil {


### PR DESCRIPTION
## Description

The traffic-shaper monitor's default `statusz` poll interval was 5 seconds — too
aggressive for a steady-state background reconciler that spawns a privileged sudo
worker on every tick even when nothing has changed. This raises the default to
5 minutes.

`statuszForceResyncInterval` (which forces a full nft apply even when the
membership digest is unchanged, to self-heal out-of-band edits) was 1 minute.
Because 1 min is always shorter than the 5-minute poll interval, the
digest-delta optimisation was dead code — every tick triggered a forced apply.
Raised to 1 hour so the optimisation is meaningful: at the default cadence only
one in twelve ticks is a forced re-apply.

### Startup and reboot convergence guarantee

The poll loop already reconciles **once immediately on entry** before the first
ticker tick. This means nft set membership is rehydrated as fast as the BN
`statusz` endpoint responds after a daemon restart or host reboot — not bounded
by the poll interval. The entry-reconcile comment is expanded to make this
guarantee explicit, and both developer docs are updated to call it out.

When `base_url` is not configured (pod-discovery path), the entry reconcile
skips until the pod watcher observes a ready BN pod; convergence after reboot is
then bounded by up to one poll interval after pod discovery. Operators who need
the lowest post-reboot latency should set `base_url` to a stable node-local
endpoint.

### Files changed

| File | Change |
|---|---|
| `internal/daemon/config.go` | `DefaultStatuszPollInterval` `5s` → `5m`; updated example and doc comments |
| `internal/daemon/blocknode/traffic_shaper_monitor.go` | `defaultStatuszPollInterval` `5s` → `5m`; `statuszForceResyncInterval` `1m` → `1h`; expanded entry-reconcile comment |
| `internal/daemon/daemon.go` | Comment `5s default` → `5m default` |
| `cmd/cli/commands/common/flags_blocknode.go` | Flag description example updated |
| `cmd/cli/commands/block/node/init.go` | Error message example updated |
| `internal/daemon/config_statusz_test.go` | Test name `"empty defaults to 5s"` → `"empty defaults to 5m"` |
| `docs/dev/daemon/traffic-shaper-statusz.md` | New "Startup and reboot behaviour" section; `5s` → `5m` throughout; force-resync note; pod-discovery caveat |
| `docs/dev/traffic-shaper.md` | `5s` → `5m`; entry-reconcile note in prose and reboot table |

### Related Issues

* Closes #964
