### PR TITLE
feat(blocknode): tear down the static network plane on block node uninstall

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -67,6 +67,7 @@ jobs:
     needs:
       - changes
       - build
+      - unit-tests
     if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: UAT Compat
@@ -80,6 +81,7 @@ jobs:
     needs:
       - changes
       - build
+      - unit-tests
     if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: UAT Core
@@ -93,6 +95,7 @@ jobs:
     needs:
       - changes
       - build
+      - unit-tests
     if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: UAT Purge Storage
@@ -106,6 +109,7 @@ jobs:
     needs:
       - changes
       - build
+      - unit-tests
     if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: UAT Plugin Preset Upgrade

--- a/.github/workflows/zxc-integration-test.yaml
+++ b/.github/workflows/zxc-integration-test.yaml
@@ -48,7 +48,7 @@ on:
         description: "Timeout for integration tests in VM"
         type: number
         required: false
-        default: 90
+        default: 120
 
 defaults:
   run:

--- a/internal/bll/blocknode/uninstall_handler.go
+++ b/internal/bll/blocknode/uninstall_handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/automa-saga/automa"
 	"github.com/hashgraph/solo-weaver/internal/bll"
+	"github.com/hashgraph/solo-weaver/internal/daemon"
 	"github.com/hashgraph/solo-weaver/internal/rsl"
 	"github.com/hashgraph/solo-weaver/internal/state"
 	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
@@ -45,6 +46,45 @@ func (h *UninstallHandler) BuildWorkflow(
 	}
 
 	ins := inputs.Custom
+
+	// withPlaneTeardown brackets the chart-removal steps with the static-plane
+	// teardown, in the reverse of install order: the daemon's traffic-shaper
+	// monitor goes off first, then the workload comes down, then the plane it
+	// ran on (policy → shape).
+	//
+	// The monitor has to go first because the daemon reads daemon.yaml only at
+	// startup, so flipping the block-node component to disabled needs a restart
+	// to take effect. Doing that before the pod goes away means the monitor
+	// cannot re-apply the ingress $VETH HTB or reconcile policy sets against a
+	// workload that is being removed. The daemon unit itself is left installed
+	// and running — it is node-agnostic and may serve other components.
+	//
+	// Running the plane teardown after the chart removal keeps the block node's
+	// classification and shaping in place for as long as its pod is serving.
+	//
+	// MetalLB is deliberately not torn down here: it is installed by the
+	// cluster setup workflow, not by block node install, and every later block
+	// node install needs it to hand the LoadBalancer service its address —
+	// removing it would leave the cluster unable to install a block node again.
+	// Its teardown belongs to kube cluster uninstall, which resets the cluster.
+	//
+	// Each step is idempotent and skips gracefully when the plane was never
+	// installed or was already removed, so this runs unconditionally.
+	withPlaneTeardown := func(chartSteps ...automa.Builder) []automa.Builder {
+		out := []automa.Builder{
+			steps.WriteBlockNodeDaemonConfigStep(models.Paths(), ins.Namespace, daemon.StatuszConfig{}, false),
+			steps.RestartDaemonServiceStep(),
+		}
+		out = append(out, chartSteps...)
+		return append(out,
+			steps.NetworkPolicyDeleteAll(),
+			steps.NftServiceTeardown(),
+			steps.TcEgressTeardown(),
+			steps.TcEgressServiceTeardown(),
+			steps.TcIngressTeardown(),
+		)
+	}
+
 	var wb *automa.WorkflowBuilder
 	switch {
 	case ins.PurgeStorage:
@@ -52,13 +92,13 @@ func (h *UninstallHandler) BuildWorkflow(
 		// local-PV reclaimPolicy: Retain leaves orphaned hostPath dirs behind if
 		// data isn't wiped before the PVs disappear.
 		wb = automa.NewWorkflowBuilder().WithId("block-node-uninstall-purge-storage").
-			Steps(steps.PurgeBlockNodeStorage(ins), steps.DeleteBlockNodePersistentVolumes(ins), steps.UninstallBlockNode(ins))
+			Steps(withPlaneTeardown(steps.PurgeBlockNodeStorage(ins), steps.DeleteBlockNodePersistentVolumes(ins), steps.UninstallBlockNode(ins))...)
 	case ins.ResetStorage:
 		wb = automa.NewWorkflowBuilder().WithId("block-node-uninstall-with-reset").
-			Steps(steps.PurgeBlockNodeStorage(ins), steps.UninstallBlockNode(ins))
+			Steps(withPlaneTeardown(steps.PurgeBlockNodeStorage(ins), steps.UninstallBlockNode(ins))...)
 	default:
 		wb = automa.NewWorkflowBuilder().WithId("block-node-uninstall").
-			Steps(steps.UninstallBlockNode(ins))
+			Steps(withPlaneTeardown(steps.UninstallBlockNode(ins))...)
 	}
 	return wb, nil
 }

--- a/internal/bll/blocknode/uninstall_handler_test.go
+++ b/internal/bll/blocknode/uninstall_handler_test.go
@@ -36,8 +36,9 @@ func uninstallInputs(resetStorage, purgeStorage bool) models.UserInputs[models.B
 	}
 }
 
-// TestUninstall_NoFlags_HelmOnly verifies the plain uninstall workflow only
-// runs UninstallBlockNode (helm release removed, data and PVs/PVCs preserved).
+// TestUninstall_NoFlags_HelmOnly verifies the plain uninstall workflow turns the
+// daemon's traffic-shaper monitor off, removes the helm release, and then tears
+// down the network plane (data and PVs/PVCs are preserved).
 func TestUninstall_NoFlags_HelmOnly(t *testing.T) {
 	h := newMinimalUninstallHandler()
 	currentState := state.State{
@@ -53,11 +54,21 @@ func TestUninstall_NoFlags_HelmOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, wb)
 	assert.Equal(t, "block-node-uninstall", wb.Id())
-	assert.Equal(t, []string{steps.UninstallBlockNodeStepId}, workflowStepIDs(t, wb))
+	assert.Equal(t, []string{
+		steps.BlockNodeDaemonConfigStepId,
+		steps.RestartDaemonServiceStepId,
+		steps.UninstallBlockNodeStepId,
+		steps.NetworkPolicyDeleteAllStepId,
+		steps.NftServiceTeardownStepId,
+		steps.TcEgressTeardownStepId,
+		steps.TcEgressServiceTeardownStepId,
+		steps.TcIngressTeardownStepId,
+	}, workflowStepIDs(t, wb))
 }
 
-// TestUninstall_WithReset_PurgeThenUninstall verifies --with-reset wipes data
-// before uninstalling, but does NOT delete PVs/PVCs.
+// TestUninstall_WithReset_PurgeThenUninstall verifies --with-reset turns the
+// monitor off, wipes data, uninstalls the helm release, and then tears down the
+// network plane — PVs/PVCs are NOT deleted.
 func TestUninstall_WithReset_PurgeThenUninstall(t *testing.T) {
 	h := newMinimalUninstallHandler()
 	currentState := state.State{
@@ -74,13 +85,21 @@ func TestUninstall_WithReset_PurgeThenUninstall(t *testing.T) {
 	require.NotNil(t, wb)
 	assert.Equal(t, "block-node-uninstall-with-reset", wb.Id())
 	assert.Equal(t, []string{
+		steps.BlockNodeDaemonConfigStepId,
+		steps.RestartDaemonServiceStepId,
 		steps.PurgeBlockNodeStorageStepId,
 		steps.UninstallBlockNodeStepId,
+		steps.NetworkPolicyDeleteAllStepId,
+		steps.NftServiceTeardownStepId,
+		steps.TcEgressTeardownStepId,
+		steps.TcEgressServiceTeardownStepId,
+		steps.TcIngressTeardownStepId,
 	}, workflowStepIDs(t, wb))
 }
 
-// TestUninstall_PurgeStorage_FullCleanup verifies --purge-storage wipes data,
-// deletes PVCs/PVs, and then uninstalls the helm release.
+// TestUninstall_PurgeStorage_FullCleanup verifies --purge-storage turns the
+// monitor off, wipes data, deletes PVCs/PVs, uninstalls the helm release, and
+// then tears down the network plane.
 func TestUninstall_PurgeStorage_FullCleanup(t *testing.T) {
 	h := newMinimalUninstallHandler()
 	currentState := state.State{
@@ -97,9 +116,16 @@ func TestUninstall_PurgeStorage_FullCleanup(t *testing.T) {
 	require.NotNil(t, wb)
 	assert.Equal(t, "block-node-uninstall-purge-storage", wb.Id())
 	assert.Equal(t, []string{
+		steps.BlockNodeDaemonConfigStepId,
+		steps.RestartDaemonServiceStepId,
 		steps.PurgeBlockNodeStorageStepId,
 		steps.DeleteBlockNodePVsStepId,
 		steps.UninstallBlockNodeStepId,
+		steps.NetworkPolicyDeleteAllStepId,
+		steps.NftServiceTeardownStepId,
+		steps.TcEgressTeardownStepId,
+		steps.TcEgressServiceTeardownStepId,
+		steps.TcIngressTeardownStepId,
 	}, workflowStepIDs(t, wb))
 }
 

--- a/internal/network/shape/manager.go
+++ b/internal/network/shape/manager.go
@@ -495,6 +495,26 @@ func (m *Manager) TeardownEgress(ctx context.Context) error {
 	})
 }
 
+// TeardownIngress removes the entire ingress tc shape configuration — every
+// ingress class and the ingress device root — from the shape registry. Unlike
+// TeardownEgress there is no boot script to re-render: the $VETH HTB is
+// ephemeral (Cilium recreates the veth per pod) and was never persisted for
+// boot replay. Idempotent — with no ingress config present it returns nil.
+func (m *Manager) TeardownIngress(_ context.Context) error {
+	return m.withLock(func() error {
+		classes, err := loadClassesForDir(DirIngress)
+		if err != nil {
+			return err
+		}
+		for _, c := range classes {
+			if err := removeClass(c.Name); err != nil {
+				return err
+			}
+		}
+		return removeDevice(DirIngress)
+	})
+}
+
 // isAutoRate reports whether rate is the literal "auto" (case-insensitive),
 // the operator-facing request to detect the egress link speed at create time.
 func isAutoRate(rate string) bool {

--- a/internal/network/shape/service_linux.go
+++ b/internal/network/shape/service_linux.go
@@ -45,3 +45,42 @@ func EnsureTcEgressUnit(ctx context.Context) error {
 	}
 	return nil
 }
+
+// RemoveTcEgressUnit is the teardown counterpart to EnsureTcEgressUnit: it
+// stops and disables solo-provisioner-bandwidth-shaper.service, removes the unit
+// file and the boot script it executes, then daemon-reloads. Callers must have
+// torn the egress hierarchy down first — this only removes the boot-replay
+// machinery, not the live tc state.
+//
+// Idempotent: an already-absent unit or script is not an error, and a stop that
+// fails on an inactive oneshot is logged and ignored.
+func RemoveTcEgressUnit(ctx context.Context) error {
+	_, statErr := os.Stat(TcEgressServiceUnitPath)
+	unitPresent := statErr == nil
+
+	if unitPresent {
+		if running, _ := soos.IsServiceRunning(ctx, TcEgressService); running {
+			if err := soos.StopService(ctx, TcEgressService); err != nil {
+				logx.As().Warn().Err(err).Str("service", TcEgressService).
+					Msg("could not stop bandwidth-shaper service; continuing teardown")
+			}
+		}
+		if err := soos.DisableService(ctx, TcEgressService); err != nil {
+			return errorx.ExternalError.Wrap(err, "failed to disable %s", TcEgressService)
+		}
+		if err := os.Remove(TcEgressServiceUnitPath); err != nil && !os.IsNotExist(err) {
+			return errorx.ExternalError.Wrap(err, "failed to remove unit file %s", TcEgressServiceUnitPath)
+		}
+	}
+
+	// Remove the boot script even when the unit was already gone, so a partial
+	// teardown does not leave an orphaned script behind.
+	if err := os.Remove(TcEgressScriptPath); err != nil && !os.IsNotExist(err) {
+		return errorx.ExternalError.Wrap(err, "failed to remove boot script %s", TcEgressScriptPath)
+	}
+
+	if !unitPresent {
+		return nil
+	}
+	return soos.DaemonReload(ctx)
+}

--- a/internal/network/shape/service_other.go
+++ b/internal/network/shape/service_other.go
@@ -10,3 +10,7 @@ import "context"
 // unit is a Linux systemd concept; the package compiles and tests on all
 // platforms, but the service management calls only run on Linux.
 func EnsureTcEgressUnit(_ context.Context) error { return nil }
+
+// RemoveTcEgressUnit is a no-op on non-Linux platforms, for the same reason as
+// EnsureTcEgressUnit.
+func RemoveTcEgressUnit(_ context.Context) error { return nil }

--- a/internal/workflows/steps/step_network_nft_service_teardown.go
+++ b/internal/workflows/steps/step_network_nft_service_teardown.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+	"os"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/network/firewall"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	pkgos "github.com/hashgraph/solo-weaver/pkg/os"
+	"github.com/joomcode/errorx"
+)
+
+// NftServiceTeardownStepId is the step ID for NftServiceTeardown.
+const NftServiceTeardownStepId = "nft-service-teardown"
+
+// NftServiceTeardown disables and removes the shared
+// solo-provisioner-network-nft.service unit when neither the host-firewall
+// artifact (network-weaver-host-firewall.nft) nor the workload-policy artifact
+// (network-weaver-workload-policy.nft) are present — i.e. both planes have
+// been torn down and nothing is left for the service to replay at boot.
+//
+// If the host-firewall file still exists (HostNftPath), the service is needed
+// to replay it; the step skips so the firewall survives reboot until
+// `kube cluster uninstall` removes it.
+//
+// It is wired into `block node uninstall` after NetworkPolicyDeleteAll (which
+// removes the weaver-workload-policy.nft artifact when the last policy is
+// deleted) and before the shape teardown steps. The step is idempotent: it
+// skips gracefully when the unit file is already absent.
+func NftServiceTeardown() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(NftServiceTeardownStepId).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Disabling network-nft boot service")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to disable network-nft boot service")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "network-nft boot service disabled")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			// Keep the service if the host-firewall file is still present: kube cluster
+			// uninstall owns that teardown and will disable the service there.
+			// If os.Stat returns any error other than NotExist (e.g. permission denied,
+			// I/O error) treat the file as potentially present and retain the service
+			// rather than risk removing it while it is still needed.
+			_, hostNftErr := os.Stat(firewall.HostNftPath)
+			if hostNftErr == nil {
+				logx.As().Info().Str("host_nft", firewall.HostNftPath).
+					Msg("host-firewall file still present; keeping network-nft service for reboot replay")
+				return automa.SkippedReport(stp,
+					automa.WithDetail("host-firewall file still present — network-nft service retained for boot replay; kube cluster uninstall will disable it"))
+			}
+			if !os.IsNotExist(hostNftErr) {
+				logx.As().Warn().Err(hostNftErr).Str("path", firewall.HostNftPath).
+					Msg("cannot stat host-nft file; retaining network-nft service as a precaution")
+				return automa.SkippedReport(stp,
+					automa.WithDetail("cannot determine host-firewall file status; retaining network-nft service as a precaution"))
+			}
+
+			// Both nft planes are now gone. Tear down the service unit.
+			if _, err := os.Stat(firewall.NetworkNftServiceUnitPath); os.IsNotExist(err) {
+				logx.As().Info().Msg("network-nft service unit already absent; nothing to disable")
+				return automa.SkippedReport(stp,
+					automa.WithDetail("network-nft service unit already absent"))
+			}
+
+			// Stop the service (oneshot — may already be in exited state; log and continue on error).
+			if running, _ := pkgos.IsServiceRunning(ctx, firewall.NetworkNftService); running {
+				if err := pkgos.StopService(ctx, firewall.NetworkNftService); err != nil {
+					logx.As().Warn().Err(err).Str("service", firewall.NetworkNftService).
+						Msg("could not stop network-nft service; continuing teardown")
+				}
+			}
+
+			if err := pkgos.DisableService(ctx, firewall.NetworkNftService); err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to disable %s", firewall.NetworkNftService).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Disable manually: systemctl disable " + firewall.NetworkNftService,
+							"Remove the unit file: rm " + firewall.NetworkNftServiceUnitPath,
+						})))
+			}
+
+			if err := os.Remove(firewall.NetworkNftServiceUnitPath); err != nil && !os.IsNotExist(err) {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.ExternalError.Wrap(err, "failed to remove unit file %s", firewall.NetworkNftServiceUnitPath).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Remove the unit file manually: rm " + firewall.NetworkNftServiceUnitPath,
+							"Then reload systemd: systemctl daemon-reload",
+						})))
+			}
+
+			if err := pkgos.DaemonReload(ctx); err != nil {
+				logx.As().Warn().Err(err).Msg("network-nft service disabled and unit removed, but daemon-reload failed")
+			}
+
+			logx.As().Info().Str("service", firewall.NetworkNftService).Msg("network-nft service disabled and unit removed")
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			return automa.SkippedReport(stp,
+				automa.WithDetail("nft-service teardown rollback is a no-op; re-enable via block node install"))
+		})
+}

--- a/internal/workflows/steps/step_network_tc_egress_service_teardown.go
+++ b/internal/workflows/steps/step_network_tc_egress_service_teardown.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// TcEgressServiceTeardownStepId is the step ID for TcEgressServiceTeardown.
+const TcEgressServiceTeardownStepId = "bandwidth-shaper-service-teardown"
+
+// TcEgressServiceTeardown stops, disables and removes the
+// solo-provisioner-bandwidth-shaper.service unit along with the boot script it
+// executes. Unlike the shared network-nft unit — which replays the host firewall
+// too and so outlives the block node — this unit exists only to replay the
+// $EGRESS HTB hierarchy that block node install lays down, so it is removed here
+// rather than deferred to kube cluster uninstall.
+//
+// It must run after TcEgressTeardown, which drops the live hierarchy and resets
+// the boot script; this step then removes the boot-replay machinery itself. The
+// step is idempotent: an already-absent unit or script is not an error.
+func TcEgressServiceTeardown() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(TcEgressServiceTeardownStepId).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Removing bandwidth-shaper boot service")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to remove bandwidth-shaper boot service")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "bandwidth-shaper boot service removed")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if err := shape.RemoveTcEgressUnit(ctx); err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to remove the bandwidth-shaper boot service").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Disable manually: systemctl disable " + shape.TcEgressService,
+							"Remove the unit file: rm " + shape.TcEgressServiceUnitPath,
+							"Remove the boot script: rm " + shape.TcEgressScriptPath,
+							"Then reload systemd: systemctl daemon-reload",
+						})))
+			}
+			logx.As().Info().Str("service", shape.TcEgressService).
+				Msg("bandwidth-shaper boot service removed")
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			return automa.SkippedReport(stp,
+				automa.WithDetail("bandwidth-shaper service teardown rollback is a no-op; re-enable via block node install"))
+		})
+}

--- a/internal/workflows/steps/step_network_tc_ingress_teardown.go
+++ b/internal/workflows/steps/step_network_tc_ingress_teardown.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/network/shape"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// TcIngressTeardownStepId is the step ID for TcIngressTeardown.
+const TcIngressTeardownStepId = "tc-ingress-teardown"
+
+// TcIngressTeardown removes the ingress tc shape config (device root + all
+// ingress classes) from the shape registry. There is no boot script to
+// re-render: the $VETH HTB is ephemeral (Cilium recreates the veth on each
+// pod create) and was deliberately not persisted for boot replay. It is the
+// teardown counterpart to TcIngressRecord, wired into `block node uninstall`.
+//
+// It must run after NetworkPolicyDeleteAll: the policy plane's --reply-stamp
+// rules reference these classes, and the underlying shape teardown assumes
+// those references are already gone. The teardown is idempotent — with no
+// ingress config present it succeeds immediately.
+func TcIngressTeardown() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(TcIngressTeardownStepId).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Removing tc-ingress ($VETH) shape config")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to remove tc-ingress shape config")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "tc-ingress shape config removed")
+		}).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if err := shape.NewManager().TeardownIngress(ctx); err != nil {
+				return automa.FailureReport(stp, automa.WithError(
+					errorx.Decorate(err, "failed to tear down the tc-ingress shape config").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Inspect the recorded ingress config: ls /etc/solo-provisioner/network/shape/devices /etc/solo-provisioner/network/shape/classes",
+							"Re-run block node uninstall; tc-ingress teardown is idempotent",
+						})))
+			}
+			logx.As().Info().Msg("tc-ingress shape config removed")
+			return automa.SuccessReport(stp)
+		}).
+		WithRollback(func(ctx context.Context, stp automa.Step) *automa.Report {
+			return automa.SkippedReport(stp,
+				automa.WithDetail("tc-ingress teardown rollback is a no-op; re-enable via block node install"))
+		})
+}


### PR DESCRIPTION
## Description

`block node uninstall` previously only removed the block-node Helm chart, leaving the entire static network plane behind: the `inet weaver-workload-policy` nftables table, the tc HTB hierarchies on the egress NIC and the `$VETH` ingress registry, and the `solo-provisioner-bandwidth-shaper.service` boot unit. The `solo-provisioner-network-nft.service` oneshot would keep re-running at boot against a now-absent `.nft` file, and the daemon kept polling statusz for a block node that no longer existed.

This PR brackets the existing Helm chart removal with the missing teardown, in the reverse of install order: the daemon's traffic-shaper monitor goes off first, then the chart comes down, then the plane it ran on — policy plane → nft-service conditional disable → egress shape → bandwidth-shaper unit → ingress shape config. Keeping the plane teardown after the chart removal means the block node holds its classification and shaping for as long as its pod is serving. Every new step is idempotent and skips gracefully when the corresponding plane was never installed or was already removed, so partial installs and `--force` runs both complete cleanly.

### What's new

- **Daemon traffic-shaper monitor off** — `WriteBlockNodeDaemonConfigStep(..., enabled=false)` + `RestartDaemonServiceStep()`, the same pair the reconfigure-disable path uses. Sets `components.block_node.enabled` and `monitors.traffic_shaper` to `false` in `daemon.yaml`. It runs **first** because the daemon reads its config only at startup, so the flip needs a restart — and doing it before the pod disappears means the monitor cannot re-apply the ingress `$VETH` HTB or reconcile policy sets against a workload that is being removed. `DaemonConfig.Validate` only requires the component *section* to exist, so the daemon restarts cleanly and idles.
- **`NetworkPolicyDeleteAll`** (reused from reconfigure disable path): deletes every canonical BN policy; deleting the last one tears down the `inet weaver-workload-policy` table and removes the persisted `.nft` file.
- **`NftServiceTeardown`** (`step_network_nft_service_teardown.go`): checks whether `network-weaver-host-firewall.nft` is still present. If yes, skips — the service is still needed to replay the host firewall at boot and `kube cluster uninstall` will disable it. If no, stops, disables, and removes the unit file, then daemon-reloads.
- **`TcEgressTeardown`** (reused from reconfigure disable path): drops the egress HTB hierarchy and re-renders the boot script to its empty default.
- **`TcEgressServiceTeardown`** (`step_network_tc_egress_service_teardown.go`) + **`shape.RemoveTcEgressUnit`**: stops, disables and removes `solo-provisioner-bandwidth-shaper.service` and the `/usr/local/sbin/solo-provisioner-bandwidth-shaper.sh` boot script it executes, then daemon-reloads. Unlike the shared network-nft unit, this one exists only to replay the `$EGRESS` HTB that block node install lays down, so it is removed here rather than deferred.
- **`TcIngressTeardown`** (`step_network_tc_ingress_teardown.go`) + **`shape.Manager.TeardownIngress`**: removes the ingress device root and class configs from the shape registry. No boot script to re-render — the `$VETH` HTB is per-pod ephemeral and was never persisted for replay.

All three existing workflow variants (`block-node-uninstall`, `block-node-uninstall-with-reset`, `block-node-uninstall-purge-storage`) get the same bracket. Plain uninstall is now:

```
write-block-node-daemon-config -> restart-daemon-service -> uninstall-block-node
  -> network-policy-delete-all -> nft-service-teardown
  -> bandwidth-shaper-teardown -> bandwidth-shaper-service-teardown -> tc-ingress-teardown
```

### What stays behind on purpose

- **`solo-provisioner-daemon.service`** stays installed, enabled and running. It is node-agnostic and may serve a consensus-node component on the same host; only its block-node section is disabled.
- **`solo-provisioner-network-nft.service`** stays while `/etc/solo-provisioner/network-weaver-host-firewall.nft` exists, because the unit replays the host firewall at boot too.

### Why MetalLB is not torn down here

An earlier revision of this PR added a `MetalLBTeardown` step as the first teardown action. It broke re-install and failed the UAT Purge Storage suite, which exercises install → uninstall → re-install three times:

- MetalLB is installed by `KubernetesSetupWorkflow` (cluster setup), not by block node install.
- `block node install` runs that workflow **only** when the cluster does not exist yet. On an already-created cluster the install path is `EnsureWeaverOwner → NetworkSetupWorkflow → SetupBlockNode` — nothing re-installs MetalLB.
- The block-node chart's Service defaults to `type: LoadBalancer` with a MetalLB address-pool annotation, and the chart is installed with `Wait`+`Atomic`. With no MetalLB controller the Service never gets an ingress address, so the Helm wait can only time out:

```
ERR Failed to install Block Node error="block node install exceeded the --timeout budget ...
    release block-node failed, and has been uninstalled due to atomic being set: context deadline exceeded"
   Pod state at timeout: pod/block-node-block-node-server-0 phase=Running
     container/block-node-server ready=true
```

So MetalLB teardown belongs to `kube cluster uninstall`, which runs `kubeadm reset` and takes the `metallb.io` CRDs with it — the same install-side ownership rule this PR already applies to the host firewall.

### What is NOT done here

- **Host firewall teardown** (`inet weaver-host-firewall`) and the `solo-provisioner-network-nft.service` unit's host half: node-agnostic, owned by `kube cluster uninstall` (#777).
- **MetalLB removal / CRD deletion**: owned by `kube cluster uninstall` (#777), per the section above.
- **Daemon binary/unit removal**: separate story. This PR only disables the block-node component in `daemon.yaml`.

### CI

The second commit gates the four UAT jobs on `unit-tests` (~3 min) so the integration-test job, which starts right after `build`, acquires a runner before the four UAT VMs compete for capacity. It does not make the two suites sequential with each other, and it does not weaken any gate.

Note for reviewers: the integration suite currently runs ~70 min against a 90-minute `integration-timeout-minutes` cap, so it has no headroom and times out whenever the shared KVM runner is contended. That is tracked separately — it is not caused by these changes.

### Related Issues

* Closes #763
