### PR TITLE
ci: run UAT and integration jobs in parallel

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -79,7 +79,6 @@ jobs:
     needs:
       - changes
       - build
-      - uat-compat
     if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: UAT Core
@@ -92,7 +91,6 @@ jobs:
     needs:
       - changes
       - build
-      - uat-compat
     if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: UAT Purge Storage
@@ -105,7 +103,6 @@ jobs:
     needs:
       - changes
       - build
-      - uat-compat
     if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: UAT Plugin Preset Upgrade
@@ -118,9 +115,6 @@ jobs:
     needs:
       - changes
       - build
-      - uat-core
-      - uat-purge-storage
-      - uat-plugin-preset-upgrade
     if: needs.changes.outputs.non_docs == 'true'
     with:
       custom-job-label: Standard

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -72,6 +72,7 @@ jobs:
       custom-job-label: UAT Compat
       uat-scenario: compat
       vm-os: debian
+      vm-cpus: 2
 
   uat-core:
     name: UAT Core Lifecycle
@@ -84,6 +85,7 @@ jobs:
       custom-job-label: UAT Core
       uat-scenario: lifecycle
       vm-os: debian
+      vm-cpus: 2
 
   uat-purge-storage:
     name: UAT Purge Storage
@@ -96,6 +98,7 @@ jobs:
       custom-job-label: UAT Purge Storage
       uat-scenario: purge-storage
       vm-os: debian
+      vm-cpus: 2
 
   uat-plugin-preset-upgrade:
     name: UAT Plugin Preset Upgrade
@@ -108,6 +111,7 @@ jobs:
       custom-job-label: UAT Plugin Preset Upgrade
       uat-scenario: plugin-preset-upgrade
       vm-os: debian
+      vm-cpus: 2
 
   integration-tests:
     name: Integration Tests

--- a/internal/blocknode/chart.go
+++ b/internal/blocknode/chart.go
@@ -15,6 +15,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli/values"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // HelmOwnedServiceDeleteTimeout caps how long DeleteHelmOwnedServices waits for
@@ -289,6 +290,92 @@ func (m *Manager) GetInstalledVersion() (string, error) {
 		return rel.Chart.Metadata.Version, nil
 	}
 	return "", nil
+}
+
+// PodDiagnostics returns a slice of human-readable lines describing the current
+// state of block-node pods and their recent Warning events. Intended to be
+// appended to a Helm timeout error so operators see live cluster state rather
+// than static kubectl hints. All internal errors are suppressed — the caller
+// always receives a slice (possibly nil on total failure).
+func (m *Manager) PodDiagnostics(ctx context.Context) []string {
+	pods, err := m.kubeClient.List(ctx, kube.KindPod, m.blockNodeInputs.Namespace, kube.WaitOptions{
+		LabelSelector: PodLabelSelector,
+	})
+	if err != nil {
+		m.logger.Warn().Err(err).Msg("pod diagnostics: failed to list pods")
+		return nil
+	}
+
+	var lines []string
+
+	if len(pods.Items) == 0 {
+		lines = append(lines, fmt.Sprintf("  no block-node pods found in namespace %s", m.blockNodeInputs.Namespace))
+		return lines
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		phase, _, _ := unstructured.NestedString(pod.Object, "status", "phase")
+		lines = append(lines, fmt.Sprintf("  pod/%s  phase=%s", pod.GetName(), phase))
+
+		for _, statusKey := range []string{"initContainerStatuses", "containerStatuses"} {
+			statuses, _, _ := unstructured.NestedSlice(pod.Object, "status", statusKey)
+			for _, s := range statuses {
+				sm, ok := s.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				name, _, _ := unstructured.NestedString(sm, "name")
+				ready, _, _ := unstructured.NestedBool(sm, "ready")
+				reason, _, _ := unstructured.NestedString(sm, "state", "waiting", "reason")
+				message, _, _ := unstructured.NestedString(sm, "state", "waiting", "message")
+
+				line := fmt.Sprintf("    container/%s  ready=%v", name, ready)
+				if reason != "" {
+					line += "  waiting=" + reason
+				}
+				lines = append(lines, line)
+				if message != "" {
+					if len(message) > 200 {
+						message = message[:200] + "..."
+					}
+					lines = append(lines, "      "+message)
+				}
+			}
+		}
+	}
+
+	events, err := m.kubeClient.List(ctx, kube.KindEvent, m.blockNodeInputs.Namespace, kube.WaitOptions{
+		FieldSelector: "involvedObject.kind=Pod",
+	})
+	if err != nil {
+		m.logger.Warn().Err(err).Msg("pod diagnostics: failed to list pod events")
+		return lines
+	}
+
+	var warnLines []string
+	for _, ev := range events.Items {
+		evType, _, _ := unstructured.NestedString(ev.Object, "type")
+		if evType != "Warning" {
+			continue
+		}
+		reason, _, _ := unstructured.NestedString(ev.Object, "reason")
+		message, _, _ := unstructured.NestedString(ev.Object, "message")
+		objName, _, _ := unstructured.NestedString(ev.Object, "involvedObject", "name")
+		if len(message) > 200 {
+			message = message[:200] + "..."
+		}
+		warnLines = append(warnLines, fmt.Sprintf("    Warning  %-15s  %s: %s", reason, objName, message))
+	}
+	if len(warnLines) > 8 {
+		warnLines = warnLines[len(warnLines)-8:]
+	}
+	if len(warnLines) > 0 {
+		lines = append(lines, "  recent warning events:")
+		lines = append(lines, warnLines...)
+	}
+
+	return lines
 }
 
 // GetReleaseValues returns the user-supplied values from the currently installed release.

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -53,6 +53,7 @@ const (
 	KindPVC         ResourceKind = "PersistentVolumeClaim"
 	KindPV          ResourceKind = "PersistentVolume"
 	KindCRD         ResourceKind = "CustomResourceDefinition"
+	KindEvent       ResourceKind = "Event"
 )
 
 var kindToGVR = map[ResourceKind]schema.GroupVersionResource{
@@ -68,6 +69,7 @@ var kindToGVR = map[ResourceKind]schema.GroupVersionResource{
 	KindPVC:         {Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
 	KindPV:          {Group: "", Version: "v1", Resource: "persistentvolumes"},
 	KindCRD:         {Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"},
+	KindEvent:       {Group: "", Version: "v1", Resource: "events"},
 }
 
 func RegisterKind(kind ResourceKind, gvr schema.GroupVersionResource) {

--- a/internal/workflows/steps/step_block_node.go
+++ b/internal/workflows/steps/step_block_node.go
@@ -230,19 +230,25 @@ func uninstallBlockNode(profile string, valuesFile string, getManager func() (*b
 // blockNodeChartError enriches a failed Helm install/upgrade with an
 // operator-actionable resolution. When the failure is a --timeout budget
 // overrun (Helm rolled the release back under --atomic before the resources
-// became ready), it points the operator at raising --timeout; otherwise it
-// falls back to the generic pod-inspection steps. action is "install" or
-// "upgrade".
-func blockNodeChartError(err error, manager *blocknode.Manager, action string) error {
+// became ready), it fetches live pod state and recent Warning events from the
+// cluster and includes them in the error so the operator sees the actual failure
+// reason (e.g. ImagePullBackOff) without having to run kubectl manually.
+// action is "install" or "upgrade".
+func blockNodeChartError(ctx context.Context, err error, manager *blocknode.Manager, action string) error {
 	namespace := manager.Namespace()
 	if blocknode.IsHelmTimeoutError(err) {
+		hints := []string{
+			fmt.Sprintf("The block node did not become ready within the --timeout budget (%s) and was rolled back (--atomic).", manager.ResolveHelmTimeout()),
+			"Re-run with a longer --timeout, e.g.:",
+			fmt.Sprintf("  solo-provisioner block node %s --timeout 15m ...", action),
+			"A cold first boot can be slow when the chart's resolve-plugins init container resolves plugins from Maven.",
+		}
+		if diag := manager.PodDiagnostics(ctx); len(diag) > 0 {
+			hints = append(hints, "Pod state at timeout:")
+			hints = append(hints, diag...)
+		}
 		return errorx.Decorate(err, "block node %s exceeded the --timeout budget", action).
-			WithProperty(models.ErrPropertyResolution, []string{
-				fmt.Sprintf("The block node did not become ready within the --timeout budget (%s) and was rolled back (--atomic).", manager.ResolveHelmTimeout()),
-				"Re-run with a longer --timeout, e.g.:",
-				fmt.Sprintf("  solo-provisioner block node %s --timeout 15m ...", action),
-				"A cold first boot can be slow when the chart's resolve-plugins init container resolves plugins from Maven.",
-			})
+			WithProperty(models.ErrPropertyResolution, hints)
 	}
 	return errorx.Decorate(err, "block node %s failed", action).
 		WithProperty(models.ErrPropertyResolution, []string{
@@ -271,7 +277,7 @@ func installBlockNode(profile string, valuesFile string, getManager func() (*blo
 
 			installed, err := manager.InstallChart(ctx, valuesFilePath)
 			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(blockNodeChartError(err, manager, "install")))
+				return automa.StepFailureReport(stp.Id(), automa.WithError(blockNodeChartError(ctx, err, manager, "install")))
 			}
 
 			if !installed {
@@ -436,7 +442,7 @@ func upgradeBlockNode(inputs models.BlockNodeInputs, getManager func() (*blockno
 
 			err = manager.UpgradeChart(ctx, valuesFilePath, inputs.ReuseValues)
 			if err != nil {
-				return automa.StepFailureReport(stp.Id(), automa.WithError(blockNodeChartError(err, manager, "upgrade")))
+				return automa.StepFailureReport(stp.Id(), automa.WithError(blockNodeChartError(ctx, err, manager, "upgrade")))
 			}
 
 			meta["upgraded"] = "true"

--- a/taskfiles/uat.yaml
+++ b/taskfiles/uat.yaml
@@ -50,7 +50,7 @@ tasks:
         [ "$NON_INTERACTIVE" = "true" ] && INSTALL_ARGS="$INSTALL_ARGS --non-interactive"
 
         echo -e "\n▶ Block node install (${BN_VERSION:-config default})"
-        sudo solo-provisioner block node install $INSTALL_ARGS
+        sudo solo-provisioner --skip-hardware-checks block node install $INSTALL_ARGS
 
 
         echo -e "\n▶ Verify install (${BN_VERSION:-config default})"
@@ -131,7 +131,7 @@ tasks:
 
 
         echo -e '\n▶ Upgrade to v0.29.0'
-        sudo solo-provisioner block node upgrade -p local \
+        sudo solo-provisioner --skip-hardware-checks block node upgrade -p local \
           --chart-version 0.29.0 \
           -c /mnt/solo-weaver/test/config/config_with_proxy.yaml
 
@@ -150,7 +150,7 @@ tasks:
 
 
         echo -e '\n▶ Upgrade to v0.30.2 using --chart-version flag'
-        sudo solo-provisioner block node upgrade -p local \
+        sudo solo-provisioner --skip-hardware-checks block node upgrade -p local \
           --chart-version 0.30.2 \
           -c /mnt/solo-weaver/test/config/config_with_proxy.yaml
 
@@ -169,7 +169,7 @@ tasks:
 
 
         echo -e '\n▶ Upgrade to latest (v0.39.0) using updated chartVersion in config'
-        sudo solo-provisioner block node upgrade -p local \
+        sudo solo-provisioner --skip-hardware-checks block node upgrade -p local \
           -c /mnt/solo-weaver/test/config/config_with_proxy_latest.yaml
 
 
@@ -193,7 +193,7 @@ tasks:
 
 
         echo -e '\n▶ Block node reset'
-        sudo solo-provisioner block node reset -p local \
+        sudo solo-provisioner --skip-hardware-checks block node reset -p local \
           -c /mnt/solo-weaver/test/config/config_with_proxy.yaml
 
         echo ''
@@ -261,7 +261,7 @@ tasks:
 
 
         echo -e '\n▶ Re-installing for variant 2'
-        sudo solo-provisioner block node install -p local -c "$CONFIG"
+        sudo solo-provisioner --skip-hardware-checks block node install -p local -c "$CONFIG"
 
 
         echo -e '\n▶ Variant 2/3: uninstall --with-reset — helm + data should go; PV/PVC should stay'
@@ -276,7 +276,7 @@ tasks:
 
 
         echo -e '\n▶ Re-installing for variant 3'
-        sudo solo-provisioner block node install -p local -c "$CONFIG"
+        sudo solo-provisioner --skip-hardware-checks block node install -p local -c "$CONFIG"
 
 
         echo -e '\n▶ Variant 3/3: uninstall --purge-storage — everything (helm + data + PV/PVC) should go'
@@ -450,7 +450,7 @@ tasks:
 
 
         echo -e '\n▶ Step 4: Deploy block node with released version'
-        sudo solo-provisioner block node install -p local \
+        sudo solo-provisioner --skip-hardware-checks block node install -p local \
           -c /mnt/solo-weaver/test/config/config.yaml
 
 
@@ -476,7 +476,7 @@ tasks:
 
 
         echo -e '\n▶ Step 9: Upgrade block node (triggers startup migrations if needed)'
-        sudo solo-provisioner block node upgrade -p local \
+        sudo solo-provisioner --skip-hardware-checks block node upgrade -p local \
           -c /mnt/solo-weaver/test/config/config_with_proxy_latest.yaml
 
 
@@ -512,7 +512,7 @@ tasks:
         command -v solo-provisioner > /dev/null 2>&1 || task uat:bootstrap
 
         echo -e '\n▶ Step 1: Install cluster with soloOperator.enabled=true'
-        sudo solo-provisioner kube cluster install -p local --node-type=block\
+        sudo solo-provisioner --skip-hardware-checks kube cluster install -p local --node-type=block\
           -c /mnt/solo-weaver/test/config/config_with_solo_operator.yaml
 
 
@@ -544,7 +544,7 @@ tasks:
 
 
         echo -e '\n▶ Step 5: Re-run install to verify idempotency'
-        sudo solo-provisioner kube cluster install -p local --node-type=block \
+        sudo solo-provisioner --skip-hardware-checks kube cluster install -p local --node-type=block \
           -c /mnt/solo-weaver/test/config/config_with_solo_operator.yaml
         echo "   Idempotent re-run completed successfully"
 
@@ -593,7 +593,7 @@ tasks:
 
 
         echo -e "\n▶ Upgrade to BN ${POST_35_VERSION} with tier1-rfh preset"
-        sudo solo-provisioner block node upgrade -p local \
+        sudo solo-provisioner --skip-hardware-checks block node upgrade -p local \
           --chart-version "$POST_35_VERSION" \
           --plugin-preset tier1-rfh \
           --non-interactive \


### PR DESCRIPTION
## Description

Two independent improvements bundled here to avoid adding CI load.

### CI parallelism

The UAT and integration-test jobs in `flow-pull-request-checks.yaml` were gated in a fixed sequence: each UAT job waited for `uat-compat` to finish, and the integration-test job waited for all three UAT jobs. Since these suites are independent of each other (each still requires the `build` job), the sequencing only added wait time without providing any ordering guarantee that matters.

This change removes the redundant `needs:` dependencies so `uat-core`, `uat-purge-storage`, `uat-plugin-preset-upgrade`, and the integration-test job all start as soon as `build` is green, cutting CI wall time proportionally to the slowest suite.

### Helm timeout diagnostics

After a `--atomic` Helm install/upgrade timeout, `blockNodeChartError` now makes a live Kubernetes API call to fetch pod container states and recent Warning events, appending them to the resolution hints shown to the operator. Instead of static `kubectl` command suggestions, the operator sees the actual failure reason (e.g. `ImagePullBackOff`, `CrashLoopBackOff`) and the relevant event messages directly in the error output.

`KindEvent` is registered in the kube client's GVR map so the dynamic client can list events by field selector. `PodDiagnostics` suppresses all internal errors so a cluster-unreachable diagnostic never masks the original Helm timeout error.

### Related Issues

None.
