### PR TITLE
feat(cli): resolve the daemon binary automatically and complete the uninstall teardown

### DIFF
--- a/cmd/cli/commands/block/node/daemon_offer.go
+++ b/cmd/cli/commands/block/node/daemon_offer.go
@@ -3,15 +3,18 @@
 package node
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/daemon"
-	"github.com/hashgraph/solo-weaver/internal/ui/prompt"
 	"github.com/hashgraph/solo-weaver/internal/workflows"
 	workflowsteps "github.com/hashgraph/solo-weaver/internal/workflows/steps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	pkgos "github.com/hashgraph/solo-weaver/pkg/os"
-	"github.com/hashgraph/solo-weaver/pkg/sanity"
+	"github.com/hashgraph/solo-weaver/pkg/semver"
+	"github.com/hashgraph/solo-weaver/pkg/software"
 	"github.com/joomcode/errorx"
 	"github.com/spf13/cobra"
 )
@@ -52,75 +55,126 @@ func ensureBlockNodeDaemon(cmd *cobra.Command, namespace string, source workflow
 	return provisionBlockNodeDaemon(cmd, namespace, source)
 }
 
-// resolveDaemonBinarySource determines where ensureBlockNodeDaemon should get
-// the daemon binary from: --daemon-bin (bypasses the catalog entirely) or
-// --daemon-version (selects which catalog version to auto-download; defaults
-// to this CLI's own version — meaningful once CLI and daemon are co-released
-// under one version scheme).
-//
-// --profile=local is a special case: local/dev builds report an unstamped
-// version (e.g. "dev") that has no corresponding catalog entry, so
-// auto-download can never succeed there. When traffic shaping is enabled and
-// --daemon-bin wasn't supplied, this becomes a required value — prompted for
-// interactively, or a fail-fast error non-interactively.
-func resolveDaemonBinarySource(cmd *cobra.Command, args []string, profile string, cv *prompt.ChosenValues) (workflowsteps.DaemonBinarySource, error) {
-	source := workflowsteps.DaemonBinarySource{BinPath: flagDaemonBin, Version: flagDaemonVersion}
+// envDaemonBin is the environment-variable equivalent of --daemon-bin, for dev
+// loops that would otherwise repeat the flag on every invocation.
+const envDaemonBin = "SOLO_PROVISIONER_DAEMON_BIN"
 
-	if profile != models.ProfileLocal || source.BinPath != "" {
+// resolveDaemonBinarySource determines where ensureBlockNodeDaemon should get the
+// daemon binary from, in descending precedence:
+//
+//  1. --daemon-bin — an explicit operator override; bypasses the catalog entirely.
+//  2. SOLO_PROVISIONER_DAEMON_BIN — the same override without repeating the flag.
+//  3. A daemon binary already installed at paths.BinDir. CLI self-install puts the
+//     co-built binary there (see steps.InstallColocatedDaemonBinary), so a host
+//     provisioned from a local build already has a matching daemon to install.
+//  4. Auto-download from the infrastructure catalog, at --daemon-version (which
+//     defaults to this CLI's own version — the CLI and daemon are co-released
+//     under one tag, so a released build always resolves to a real artifact).
+//
+// An exhausted list is an error, never a prompt — which is what lets `upgrade`
+// share this resolver despite its silent-convergence contract.
+func resolveDaemonBinarySource(cmd *cobra.Command) (workflowsteps.DaemonBinarySource, error) {
+	source := workflowsteps.DaemonBinarySource{BinPath: flagDaemonBin, Version: flagDaemonVersion}
+	if source.BinPath != "" {
 		return source, nil
 	}
 
-	var rootFlags common.RootFlags
-	_ = common.ExtractRootFlags(cmd, args, &rootFlags)
-	if !prompt.ShouldPrompt(rootFlags.Force) {
-		return source, errorx.IllegalArgument.New(
-			"--daemon-bin is required for --profile=local: local/dev builds have no downloadable "+
-				"solo-provisioner-daemon release to auto-download").
-			WithProperty(models.ErrPropertyResolution, []string{
-				"Build the daemon locally: task build:daemon GOOS=linux GOARCH=<arch>",
-				"Then pass its path: --daemon-bin=<path-to-binary>",
-			})
+	// ensureBlockNodeDaemon returns early when the service is up, so any source
+	// resolved here would be discarded. Don't fail for the want of one.
+	if running, err := pkgos.IsServiceRunning(cmd.Context(), daemonServiceName); err == nil && running {
+		return source, nil
 	}
 
-	localCV := cv
-	if localCV == nil {
-		localCV = prompt.NewChosenValues()
+	if envPath := os.Getenv(envDaemonBin); envPath != "" {
+		logx.As().Info().Str("path", envPath).Str("env", envDaemonBin).
+			Msg("Using the daemon binary from the environment")
+		source.BinPath = envPath
+		return source, nil
 	}
-	if err := prompt.RunInputPrompts(cmd, []prompt.InputPrompt{
-		daemonBinInputPrompt(source.BinPath, &source.BinPath),
-	}, localCV); err != nil {
-		return source, err
+
+	if installed := installedDaemonBinaryPath(); installed != "" {
+		logx.As().Info().Str("path", installed).
+			Msg("Using the daemon binary already present on this host")
+		source.BinPath = installed
+		return source, nil
 	}
-	if source.BinPath == "" {
-		return source, errorx.IllegalArgument.New("--daemon-bin is required for --profile=local").
-			WithProperty(models.ErrPropertyResolution, []string{
-				"Build the daemon locally: task build:daemon GOOS=linux GOARCH=<arch>",
-				"Then pass its path: --daemon-bin=<path-to-binary>",
-			})
+
+	// An empty BinPath selects the catalog download.
+	if isDownloadableDaemonVersion(cmd, source.Version) {
+		return source, nil
 	}
-	return source, nil
+
+	return source, unresolvedDaemonBinaryError()
 }
 
-// daemonBinInputPrompt returns the interactive prompt for --daemon-bin, shown
-// only when --profile=local requires a local daemon binary path (see
-// resolveDaemonBinarySource).
-func daemonBinInputPrompt(eff string, target *string) prompt.InputPrompt {
-	return prompt.InputPrompt{
-		FlagName:       "daemon-bin",
-		Title:          "Daemon Binary Path (required for --profile=local)",
-		Description:    "Path to a locally-built solo-provisioner-daemon binary. Local/dev builds have no downloadable release to auto-download.",
-		Placeholder:    "bin/solo-provisioner-daemon-linux-amd64",
-		EffectiveValue: eff,
-		Target:         target,
-		Validate: func(s string) error {
-			if s == "" {
-				return errorx.IllegalArgument.New("daemon binary path cannot be empty for --profile=local")
-			}
-			_, err := sanity.SanitizePath(s)
-			return err
-		},
-	}
+// unresolvedDaemonBinaryError reports that every source in resolveDaemonBinarySource's
+// precedence list came up empty, and lists the ways an operator can supply one.
+func unresolvedDaemonBinaryError() error {
+	return errorx.IllegalArgument.New(
+		"no solo-provisioner-daemon binary could be resolved: this build's version (%s) has no "+
+			"downloadable release and no binary is installed at %s",
+		flagDaemonVersion, models.Paths().BinDir).
+		WithProperty(models.ErrPropertyResolution, []string{
+			"Build the daemon locally: task build:daemon GOOS=linux GOARCH=<arch>",
+			"Then either re-run the self-install so it is picked up automatically:",
+			"  sudo bin/solo-provisioner-linux-<arch> install",
+			"or pass the path explicitly: --daemon-bin=<path-to-binary>",
+			"or set " + envDaemonBin + "=<path-to-binary>",
+			"For a released build, pass a published version: --daemon-version=<x.y.z>",
+		})
 }
+
+// installedDaemonBinaryPath returns the path of an executable daemon binary
+// already installed at paths.BinDir, or "" if there is none. Only stat'ed: this
+// path is the install destination, so InstallDaemonBinaryStep short-circuits
+// ahead of both its platform probe and the copy.
+//
+// This deliberately does not go through software.Installer.IsInstalled(): that
+// gates on a recorded install-manifest entry, which a binary placed by CLI
+// self-install does not have.
+func installedDaemonBinaryPath() string {
+	p := filepath.Join(models.Paths().BinDir, software.DaemonBinaryName)
+	info, err := os.Stat(p)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+		return ""
+	}
+	return p
+}
+
+// isDownloadableDaemonVersion reports whether v can plausibly resolve to a
+// published release, i.e. whether the catalog auto-download path is worth trying.
+//
+// An explicitly-supplied --daemon-version is always trusted: the operator named a
+// version, so let the download attempt produce the error rather than second-guessing
+// it here. Otherwise v is this build's own stamped version, and the placeholders
+// that unstamped and locally-built binaries carry — "dev" from the version package's
+// default and 0.0.0 from the Taskfile's VERSION default — have no release to fetch.
+func isDownloadableDaemonVersion(cmd *cobra.Command, v string) bool {
+	// cmd.Flag resolves through the persistent set too — SetVarP registers these on
+	// PersistentFlags, which cmd.Flags() only reflects after cobra's pre-Execute merge.
+	if f := cmd.Flag(common.FlagDaemonVersion().Name); f != nil && f.Changed {
+		return true
+	}
+	if v == "" || v == devVersionPlaceholder {
+		return false
+	}
+	parsed, err := semver.NewSemver(v)
+	if err != nil {
+		return false
+	}
+	return !parsed.EqualTo(zeroVersion)
+}
+
+// devVersionPlaceholder is what github.com/automa-saga/version reports for a build
+// that was not stamped via -ldflags (`go run`, a plain `go build`).
+const devVersionPlaceholder = "dev"
+
+// zeroVersion is the Taskfile's default VERSION, carried by every local `task build`
+// binary. No v0.0.0 release exists or ever will.
+var zeroVersion = func() semver.Semver {
+	v, _ := semver.NewSemver("0.0.0")
+	return v
+}()
 
 // provisionBlockNodeDaemon runs the daemon install + provisioning workflow for
 // the block-node component. daemon.yaml has already been written by the install

--- a/cmd/cli/commands/block/node/daemon_offer_test.go
+++ b/cmd/cli/commands/block/node/daemon_offer_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package node
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/hashgraph/solo-weaver/pkg/software"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// newDaemonVersionCmd returns a command carrying just the --daemon-version flag,
+// optionally marked as explicitly set by the operator.
+func newDaemonVersionCmd(t *testing.T, explicit string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "install"}
+	// cobra.Command.Context() returns nil until Execute sets it; the resolver reads
+	// it, so stand in for what a real invocation would have done.
+	cmd.SetContext(context.Background())
+	var v string
+	common.FlagDaemonVersion().SetVarP(cmd, &v, false)
+	if explicit != "" {
+		// SetVarP registers on PersistentFlags; cmd.Flags() only reflects it after
+		// cobra's pre-Execute merge, which a direct unit-test call never performs.
+		require.NoError(t, cmd.PersistentFlags().Set(common.FlagDaemonVersion().Name, explicit))
+	}
+	return cmd
+}
+
+func TestIsDownloadableDaemonVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+		why     string
+	}{
+		{"released version", "1.4.2", true, "a stamped release resolves to a published artifact"},
+		{"released version with prerelease", "1.4.2-rc1", true, "prerelease tags are published too"},
+		{"taskfile default", "0.0.0", false, "the Taskfile's VERSION default has no release"},
+		{"unstamped build", "dev", false, "the version package's placeholder has no release"},
+		{"empty", "", false, "an empty version cannot resolve"},
+		{"not a version", "not-a-version", false, "an unparseable version cannot resolve"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := newDaemonVersionCmd(t, "")
+			require.Equal(t, tc.want, isDownloadableDaemonVersion(cmd, tc.version), tc.why)
+		})
+	}
+}
+
+// An operator who names a version has made a claim about what exists; let the
+// download attempt produce the error rather than pre-judging it here.
+func TestIsDownloadableDaemonVersion_ExplicitFlagIsAlwaysTrusted(t *testing.T) {
+	t.Parallel()
+
+	cmd := newDaemonVersionCmd(t, "0.0.0")
+	require.True(t, isDownloadableDaemonVersion(cmd, "0.0.0"),
+		"an explicitly-passed --daemon-version must not be second-guessed")
+}
+
+// models.SetPaths is process-wide, so these cases cannot run in parallel.
+func TestInstalledDaemonBinaryPath(t *testing.T) {
+	home := t.TempDir()
+	restore := models.SetPaths(home)
+	defer restore()
+
+	binDir := models.Paths().BinDir
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	installed := filepath.Join(binDir, software.DaemonBinaryName)
+
+	require.Empty(t, installedDaemonBinaryPath(), "nothing is installed yet")
+
+	// A non-executable file is a leftover or partial write, not an installed daemon.
+	require.NoError(t, os.WriteFile(installed, []byte("x"), 0o644))
+	require.Empty(t, installedDaemonBinaryPath(), "a non-executable file is not an installed daemon")
+
+	require.NoError(t, os.Chmod(installed, 0o755))
+	require.Equal(t, installed, installedDaemonBinaryPath(), "an executable binary in BinDir is a usable source")
+}
+
+// The quiet resolver is what stands between the operator and the prompt, so its
+// precedence order is asserted end to end. Not parallel: it mutates the
+// process-wide paths, the daemon flag vars, and the environment.
+func TestResolveDaemonBinarySource(t *testing.T) {
+	home := t.TempDir()
+	restore := models.SetPaths(home)
+	defer restore()
+
+	binDir := models.Paths().BinDir
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	installed := filepath.Join(binDir, software.DaemonBinaryName)
+
+	// flagDaemonBin/flagDaemonVersion are package-level flag targets shared across
+	// this package's commands; restore them so later tests see the real defaults.
+	origBin, origVersion := flagDaemonBin, flagDaemonVersion
+	defer func() { flagDaemonBin, flagDaemonVersion = origBin, origVersion }()
+	flagDaemonVersion = "0.0.0"
+
+	t.Run("nothing available is an error, not a prompt", func(t *testing.T) {
+		flagDaemonBin = ""
+		cmd := newDaemonVersionCmd(t, "")
+
+		source, err := resolveDaemonBinarySource(cmd)
+		require.Error(t, err, "a placeholder version with no installed binary cannot resolve")
+		require.Empty(t, source.BinPath)
+	})
+
+	t.Run("an installed binary resolves it", func(t *testing.T) {
+		flagDaemonBin = ""
+		require.NoError(t, os.WriteFile(installed, []byte("#!/bin/sh\n"), 0o755))
+		defer func() { require.NoError(t, os.Remove(installed)) }()
+
+		source, err := resolveDaemonBinarySource(newDaemonVersionCmd(t, ""))
+		require.NoError(t, err)
+		require.Equal(t, installed, source.BinPath)
+	})
+
+	t.Run("the environment beats an installed binary", func(t *testing.T) {
+		flagDaemonBin = ""
+		require.NoError(t, os.WriteFile(installed, []byte("#!/bin/sh\n"), 0o755))
+		defer func() { require.NoError(t, os.Remove(installed)) }()
+		t.Setenv(envDaemonBin, "/from/env/solo-provisioner-daemon")
+
+		source, err := resolveDaemonBinarySource(newDaemonVersionCmd(t, ""))
+		require.NoError(t, err)
+		require.Equal(t, "/from/env/solo-provisioner-daemon", source.BinPath)
+	})
+
+	t.Run("the flag beats everything", func(t *testing.T) {
+		flagDaemonBin = "/from/flag/solo-provisioner-daemon"
+		require.NoError(t, os.WriteFile(installed, []byte("#!/bin/sh\n"), 0o755))
+		defer func() { require.NoError(t, os.Remove(installed)) }()
+		t.Setenv(envDaemonBin, "/from/env/solo-provisioner-daemon")
+
+		source, err := resolveDaemonBinarySource(newDaemonVersionCmd(t, ""))
+		require.NoError(t, err)
+		require.Equal(t, "/from/flag/solo-provisioner-daemon", source.BinPath)
+	})
+
+	// A released build needs no local binary — the catalog download can supply it.
+	t.Run("a downloadable version resolves without a local binary", func(t *testing.T) {
+		flagDaemonBin = ""
+		flagDaemonVersion = "1.4.2"
+		defer func() { flagDaemonVersion = "0.0.0" }()
+
+		source, err := resolveDaemonBinarySource(newDaemonVersionCmd(t, ""))
+		require.NoError(t, err)
+		require.Empty(t, source.BinPath, "an empty BinPath selects the auto-download path")
+		require.Equal(t, "1.4.2", source.Version)
+	})
+}

--- a/cmd/cli/commands/block/node/install.go
+++ b/cmd/cli/commands/block/node/install.go
@@ -67,7 +67,7 @@ var installCmd = &cobra.Command{
 			if err := common.ResolveEgressConfig(cmd, args, cv, &flagEgressInterface, &flagLinkRate); err != nil {
 				return err
 			}
-			daemonSource, err = resolveDaemonBinarySource(cmd, args, inputs.Custom.Profile, cv)
+			daemonSource, err = resolveDaemonBinarySource(cmd)
 			if err != nil {
 				return err
 			}

--- a/cmd/cli/commands/block/node/reconfigure.go
+++ b/cmd/cli/commands/block/node/reconfigure.go
@@ -150,7 +150,7 @@ var (
 				// succeeded — so a missing --daemon-bin on --profile=local cannot mask
 				// that clearer precondition error. This mirrors upgrade, which likewise
 				// activates the daemon post-workflow.
-				daemonSource, err := resolveDaemonBinarySource(cmd, args, inputs.Custom.Profile, cv)
+				daemonSource, err := resolveDaemonBinarySource(cmd)
 				if err != nil {
 					return err
 				}

--- a/cmd/cli/commands/block/node/upgrade.go
+++ b/cmd/cli/commands/block/node/upgrade.go
@@ -9,7 +9,6 @@ import (
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/state"
-	workflowsteps "github.com/hashgraph/solo-weaver/internal/workflows/steps"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 	"github.com/spf13/cobra"
 )
@@ -95,7 +94,13 @@ var (
 				logx.As().Warn().Err(sErr).Msg(
 					"skipping traffic-shaper daemon activation on upgrade: could not read the persisted traffic-shaping decision")
 			case !stateDefaults.BlockNode.TrafficShapingDisabled:
-				if err := ensureBlockNodeDaemon(cmd, stateDefaults.BlockNode.Namespace, workflowsteps.DaemonBinarySource{}); err != nil {
+				// A locally-built host picks up its installed daemon binary here rather
+				// than attempting a download for a version that has no release.
+				daemonSource, dErr := resolveDaemonBinarySource(cmd)
+				if dErr != nil {
+					return dErr
+				}
+				if err := ensureBlockNodeDaemon(cmd, stateDefaults.BlockNode.Namespace, daemonSource); err != nil {
 					return err
 				}
 			}

--- a/cmd/cli/commands/common/flags_common.go
+++ b/cmd/cli/commands/common/flags_common.go
@@ -292,13 +292,15 @@ func FlagDaemonFromConfig() FlagDefinition[string] {
 }
 
 // FlagDaemonBin is the optional path to a locally-built solo-provisioner-daemon
-// binary. When omitted the binary is auto-downloaded from the official GitHub
+// binary, and the highest-precedence source for it. When omitted the binary is
+// resolved automatically — from SOLO_PROVISIONER_DAEMON_BIN, from an existing
+// install in the weaver bin directory, or by download from the official GitHub
 // Releases URL embedded in the infrastructure catalog.
 func FlagDaemonBin() FlagDefinition[string] {
 	return FlagDefinition[string]{
 		Name:        "daemon-bin",
 		ShortName:   "",
-		Description: "Path to a locally-built solo-provisioner-daemon binary to install; omit to auto-download from the embedded catalog",
+		Description: "Path to a locally-built solo-provisioner-daemon binary to install; omit to resolve it automatically ($SOLO_PROVISIONER_DAEMON_BIN, then an already-installed binary, then the embedded catalog)",
 		Default:     "",
 	}
 }
@@ -318,9 +320,13 @@ func FlagDaemonChecksum() FlagDefinition[string] {
 // FlagDaemonVersion is the solo-provisioner-daemon version to auto-download
 // from the infrastructure catalog. Ignored when --daemon-bin is set (the local
 // binary is installed as-is; no version resolution needed). Defaults to this
-// CLI's own running version — meaningful once the CLI and daemon are
-// co-released under one version scheme; for unstamped local/dev builds this
-// resolves to "dev", which has no catalog entry, hence --daemon-bin instead.
+// CLI's own running version, which resolves to a real artifact because the CLI
+// and daemon are co-released under one tag.
+//
+// Locally-built binaries carry a placeholder version instead — 0.0.0 from the
+// Taskfile's VERSION default, or "dev" when nothing stamped it at all — neither
+// of which has a release to download. Those builds get their daemon binary from
+// the install-time resolution order instead (see resolveDaemonBinarySource).
 func FlagDaemonVersion() FlagDefinition[string] {
 	return FlagDefinition[string]{
 		Name:        "daemon-version",

--- a/cmd/cli/commands/self_install.go
+++ b/cmd/cli/commands/self_install.go
@@ -6,6 +6,8 @@ import (
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/internal/workflows"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
 	"github.com/spf13/cobra"
 )
 
@@ -31,11 +33,40 @@ var selfInstallCmd = &cobra.Command{
 	},
 }
 
+// flagYes gates self-uninstall. Uninstall removes far more than the CLI binary —
+// the daemon and its service, the network boot units, and the config tree under
+// /etc — and none of it is recoverable, so the operator has to ask for it
+// explicitly.
+//
+// Deliberately no -y short form: the whole point is an act of confirmation, and
+// -y is the flag operators append by reflex.
+var flagYes bool
+
 var selfUninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Uninstall Solo Provisioner from the local system",
-	Long:  "Uninstall Solo Provisioner from the local system",
+	Long: "Uninstall Solo Provisioner from the local system.\n\n" +
+		"Requires --yes. This removes the solo-provisioner CLI, the\n" +
+		"solo-provisioner-daemon binary and its systemd service, the network boot\n" +
+		"units, and the configuration tree under /etc/solo-provisioner. Tear down\n" +
+		"the block node and the cluster first.",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !flagYes {
+			return errorx.IllegalArgument.New("refusing to uninstall without --yes").
+				WithProperty(models.ErrPropertyResolution, []string{
+					"Uninstall removes, irreversibly:",
+					"  - the solo-provisioner CLI and its /usr/local/bin symlink",
+					"  - the solo-provisioner-daemon binary and its systemd service",
+					"  - the network-nft and bandwidth-shaper boot units",
+					"  - the configuration tree under /etc/solo-provisioner",
+					"Re-run to confirm: sudo solo-provisioner uninstall --yes",
+				})
+		}
 		return common.RunWorkflowBuilder(cmd.Context(), workflows.NewSelfUninstallWorkflow())
 	},
+}
+
+func init() {
+	selfUninstallCmd.Flags().BoolVar(&flagYes, "yes", false,
+		"Confirm removal of the CLI, the daemon and its service, the network boot units, and /etc/solo-provisioner")
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -208,7 +208,7 @@ sudo solo-provisioner block node install \
 | `--link-rate`             | NIC line rate in tc-style format (e.g. `1gbit`, `100mbit`), or `auto` to detect and store the link speed at install time (written as explicit proportional class rates). Auto-detected from sysfs at each boot when omitted. Interactively, the prompt accepts a rate, `auto`, or blank. The link is full-duplex, so this rate parameterizes both the `$EGRESS` and `$VETH` HTB trunks. |
 | `--shape`                 | Per-class HTB bandwidth override, repeatable: `--shape <class>=rate=<r>,ceil=<c>,prio=<p>` (e.g. `--shape publisher=rate=800mbit,ceil=1gbit,prio=0`). Any subset of `rate`/`ceil`/`prio` may be given; classes not overridden use the profile defaults. Valid classes: `publisher`, `backfill-response`, `reserve-ingress`, `partner`, `public`, `reserve-egress`. |
 | `--daemon-version`        | Version of `solo-provisioner-daemon` to auto-download when traffic shaping installs the daemon (defaults to this CLI's own version). Ignored when `--daemon-bin` is set. |
-| `--daemon-bin`            | Local path to a pre-built `solo-provisioner-daemon` binary, installed as-is instead of downloaded. **Required for `--profile=local`** — local/dev builds have no downloadable release to auto-download from. |
+| `--daemon-bin`            | Local path to a pre-built `solo-provisioner-daemon` binary, installed as-is instead of downloaded. Highest-precedence source; omit it to resolve the binary automatically (`SOLO_PROVISIONER_DAEMON_BIN`, then an already-installed binary, then the catalog). |
 | `--statusz-base-url`      | Override the daemon's block-node statusz endpoint with an explicit `http(s)` base URL (e.g. `http://127.0.0.1:8080`) for a port-forward or directly-reachable BN. Merged into `daemon.yaml` (`components.block_node.statusz.base_url`); omitting the flag preserves any value already on disk. Only when no `base_url` is set at all does the daemon discover the endpoint from the watched BN pod. |
 | `--statusz-poll-interval` | Cadence at which the daemon's block-node traffic-shaper monitor polls statusz, as a positive Go duration (e.g. `5s`, `30s`). Merged into `daemon.yaml` (`components.block_node.statusz.poll_interval`); omitting the flag preserves any value already on disk. Only when no `poll_interval` is set at all does the daemon fall back to its `5s` default. |
 
@@ -287,12 +287,18 @@ sudo solo-provisioner block node install \
 > install, `block node install` installs and provisions the daemon for this
 > block node's namespace automatically whenever traffic shaping is enabled (see
 > the traffic-shaping gate above) — no separate prompt or flag. If the daemon is
-> already active, this is a no-op. By default the daemon binary is auto-downloaded
-> from the infrastructure catalog at `--daemon-version` (defaulting to this CLI's
-> own version); pass `--daemon-bin` to install a local binary instead. For
-> `--profile=local`, `--daemon-bin` is required — local/dev builds have no
-> downloadable release, so interactive sessions prompt for the path and
-> non-interactive ones fail fast with a resolution hint.
+> already active, this is a no-op.
+>
+> The daemon binary itself is resolved automatically, in this order: `--daemon-bin`,
+> then `SOLO_PROVISIONER_DAEMON_BIN`, then a daemon binary already installed in the
+> weaver bin directory, then a download from the infrastructure catalog at
+> `--daemon-version` (defaulting to this CLI's own version). Locally-built CLIs carry
+> a placeholder version (`0.0.0`) with no release to download, but
+> `sudo solo-provisioner install` copies the co-built `solo-provisioner-daemon` from
+> the same `bin/` directory onto the host, so a `task build` followed by a self-install
+> leaves a matching daemon already in place and nothing needs to be supplied. When every
+> source comes up empty the command fails with a resolution hint listing the ways to
+> supply a binary — it never prompts for a path.
 
 #### Upgrade Block Node
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,8 +33,31 @@ solo-provisioner --help
 ### Uninstall
 
 ```bash
-sudo solo-provisioner uninstall
+sudo solo-provisioner uninstall --yes
 ```
+
+`--yes` is required — the command refuses to run without it. It removes, irreversibly:
+
+- the `solo-provisioner` CLI and its `/usr/local/bin` symlink
+- the `solo-provisioner-daemon` binary and its systemd service
+- the `solo-provisioner-network-nft` and `solo-provisioner-bandwidth-shaper` boot units
+- the configuration tree under `/etc/solo-provisioner` (rendered `.nft` files, the policy registry, tc device/class configs)
+
+Tear down the workloads first — the command fails while a Kubernetes cluster is still provisioned, since every teardown command lives in the binary it is about to delete:
+
+```bash
+sudo solo-provisioner block node uninstall
+sudo solo-provisioner kube cluster uninstall
+sudo solo-provisioner uninstall --yes
+```
+
+Loaded nft tables and tc qdiscs are left alone; they do not survive a reboot once the boot-replay units and their inputs are gone.
+
+**Additional Flags**
+
+| Flag | Description |
+|------|-------------|
+| `--yes` | Confirm removal of the CLI, the daemon and its service, the network boot units, and `/etc/solo-provisioner` |
 
 ---
 
@@ -1558,8 +1581,8 @@ sudo solo-provisioner alloy cluster uninstall
 # Remove Kubernetes cluster (removes block node)
 sudo solo-provisioner kube cluster uninstall
 
-# Uninstall Solo Provisioner itself
-sudo solo-provisioner uninstall
+# Uninstall Solo Provisioner itself (--yes is required)
+sudo solo-provisioner uninstall --yes
 ```
 
 ---

--- a/internal/workflows/steps/step_daemon.go
+++ b/internal/workflows/steps/step_daemon.go
@@ -167,6 +167,44 @@ func InstallDaemonBinaryStep(src DaemonBinarySource, paths models.WeaverPaths) *
 				logx.As().Info().Str("path", src.BinPath).Msg("Daemon binary sha256 verified")
 			}
 
+			if err := os.MkdirAll(paths.BinDir, 0o755); err != nil {
+				return automa.StepFailureReport(stp.Id(),
+					automa.WithError(errorx.InternalError.Wrap(err, "failed to create bin directory %s", paths.BinDir).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Check available disk space: df -h " + paths.BinDir,
+							"Ensure the parent directory is writable: ls -la " + filepath.Dir(paths.BinDir),
+						})))
+			}
+			// Reassert root:root 0755 on BinDir. The sudoers policy grants weaver
+			// passwordless root to exec the solo-provisioner CLI living here; if the
+			// directory is group-writable by weaver (older installs provisioned it
+			// root:weaver 2775), any weaver-group member could replace the binary and
+			// escalate to root. MkdirAll is a no-op on an existing dir and does not
+			// fix its mode/owner, so enforce it explicitly here — daemon install runs
+			// as root, so only root can ever write this dir afterwards. Must stay ahead
+			// of the short-circuit below: the hosts that already have the binary are
+			// exactly the older installs carrying the 2775 mode.
+			if err := os.Chmod(paths.BinDir, 0o755); err != nil {
+				return automa.StepFailureReport(stp.Id(),
+					automa.WithError(errorx.InternalError.Wrap(err, "failed to set bin directory permissions on %s", paths.BinDir)))
+			}
+			if err := os.Chown(paths.BinDir, 0, 0); err != nil {
+				return automa.StepFailureReport(stp.Id(),
+					automa.WithError(errorx.InternalError.Wrap(err, "failed to set root:root ownership on bin directory %s", paths.BinDir)))
+			}
+
+			// The resolved source can already BE the installed binary, so there is
+			// nothing to install — and copyBinaryFile opens the destination O_TRUNC,
+			// which would erase it. This precedes the --version probe below: the probe
+			// guards a binary that is about to replace a working one, and this binary
+			// already cleared it when it was installed.
+			if sameFile(src.BinPath, dstPath) {
+				logx.As().Info().
+					Str("path", dstPath).
+					Msg("Daemon binary is already installed at the destination, skipping copy")
+				return automa.StepSuccessReport(stp.Id())
+			}
+
 			// TOCTOU note: the checksum above (when supplied) verifies src.BinPath,
 			// then this exec and the copyBinaryFile below independently re-open the
 			// same path — a swap between verify and use is theoretically possible.
@@ -204,29 +242,6 @@ func InstallDaemonBinaryStep(src DaemonBinarySource, paths models.WeaverPaths) *
 				Str("commit", vout.Commit).
 				Msg("Daemon binary platform verified")
 
-			if err := os.MkdirAll(paths.BinDir, 0o755); err != nil {
-				return automa.StepFailureReport(stp.Id(),
-					automa.WithError(errorx.InternalError.Wrap(err, "failed to create bin directory %s", paths.BinDir).
-						WithProperty(models.ErrPropertyResolution, []string{
-							"Check available disk space: df -h " + paths.BinDir,
-							"Ensure the parent directory is writable: ls -la " + filepath.Dir(paths.BinDir),
-						})))
-			}
-			// Reassert root:root 0755 on BinDir. The sudoers policy grants weaver
-			// passwordless root to exec the solo-provisioner CLI living here; if the
-			// directory is group-writable by weaver (older installs provisioned it
-			// root:weaver 2775), any weaver-group member could replace the binary and
-			// escalate to root. MkdirAll is a no-op on an existing dir and does not
-			// fix its mode/owner, so enforce it explicitly here — daemon install runs
-			// as root, so only root can ever write this dir afterwards.
-			if err := os.Chmod(paths.BinDir, 0o755); err != nil {
-				return automa.StepFailureReport(stp.Id(),
-					automa.WithError(errorx.InternalError.Wrap(err, "failed to set bin directory permissions on %s", paths.BinDir)))
-			}
-			if err := os.Chown(paths.BinDir, 0, 0); err != nil {
-				return automa.StepFailureReport(stp.Id(),
-					automa.WithError(errorx.InternalError.Wrap(err, "failed to set root:root ownership on bin directory %s", paths.BinDir)))
-			}
 			if err := copyBinaryFile(src.BinPath, dstPath); err != nil {
 				return automa.StepFailureReport(stp.Id(),
 					automa.WithError(errorx.InternalError.Wrap(err, "failed to install daemon binary to %s", dstPath).
@@ -260,6 +275,77 @@ func InstallDaemonBinaryStep(src DaemonBinarySource, paths models.WeaverPaths) *
 		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
 			notify.As().StepCompletion(ctx, stp, rpt, "Daemon binary installed")
 		})
+}
+
+// sameFile reports whether src and dst name the same file on disk, resolving
+// symlinks and hard links. Copying a file onto itself with copyBinaryFile
+// truncates it to zero bytes, so callers must check this first.
+func sameFile(src, dst string) bool {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return false
+	}
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(srcInfo, dstInfo)
+}
+
+// copyBinaryAtomic installs src at dst by copying into a temp file alongside dst
+// and renaming it into place, so dst is either the old binary or the complete new
+// one — never a half-written file. A copy that fails partway (disk full, signal)
+// leaves the existing dst untouched.
+//
+// Prefer this over copyBinaryFile whenever a valid binary may already exist at dst
+// and the caller cannot surface a partial-write failure to the operator.
+//
+// Renaming over a running executable succeeds on Linux: the running process keeps
+// its own inode, so it is unaffected and picks up the new binary only when it next
+// restarts. Callers that need the running process to match dst must restart it.
+func copyBinaryAtomic(src, dst string) error {
+	dstDir := filepath.Dir(dst)
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		return err
+	}
+
+	in, err := os.Open(src) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	// The temp file must live in dst's directory so the rename is a same-filesystem
+	// move, which is what makes it atomic.
+	tmp, err := os.CreateTemp(dstDir, filepath.Base(dst)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0o755); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, dst); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }
 
 // copyBinaryFile copies src to dst with executable permissions (0755).

--- a/internal/workflows/steps/step_weaver.go
+++ b/internal/workflows/steps/step_weaver.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/automa-saga/automa"
@@ -16,7 +17,9 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/doctor"
 	"github.com/hashgraph/solo-weaver/internal/templates"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	pkgos "github.com/hashgraph/solo-weaver/pkg/os"
 	"github.com/hashgraph/solo-weaver/pkg/security/sudoers"
+	"github.com/hashgraph/solo-weaver/pkg/software"
 	"github.com/joomcode/errorx"
 )
 
@@ -205,6 +208,106 @@ func InstallWeaver(binDir string) *automa.StepBuilder {
 		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
 			notify.As().StepCompletion(ctx, stp, rpt, "Solo Provisioner installed successfully")
 		})
+}
+
+// InstallColocatedDaemonBinary installs a solo-provisioner-daemon binary found
+// beside the running executable into binDir, so that a block-node install with
+// traffic shaping enabled has a daemon binary to use without the operator
+// supplying a path.
+//
+// Self-install is the only command that runs from outside binDir — every other
+// command is pinned there by CheckWeaverInstallation — so it is also the only
+// point at which the CLI can still see the daemon binary that was built next to
+// it. `task build` emits both binaries into the same bin/, so after
+// `sudo bin/solo-provisioner-<os>-<arch> install` the CLI and the daemon on the
+// host are always a matching pair, and rebuilding refreshes both.
+//
+// The step is best-effort: an official install downloads the CLI on its own and
+// has no sibling daemon binary to find, in which case this is a no-op and the
+// daemon is obtained later from the infrastructure catalog. Nothing here can
+// fail the self-install.
+func InstallColocatedDaemonBinary(binDir string) *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId("install-colocated-daemon-binary").
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			exePath, err := os.Executable()
+			if err != nil {
+				logx.As().Warn().Err(err).Msg(
+					"could not locate the current executable; skipping co-located daemon binary install")
+				return automa.StepSuccessReport(stp.Id())
+			}
+
+			srcPath := findColocatedDaemonBinary(filepath.Dir(exePath))
+			if srcPath == "" {
+				logx.As().Debug().
+					Str("search_dir", filepath.Dir(exePath)).
+					Msg("No co-located solo-provisioner-daemon binary found; it will be downloaded when needed")
+				return automa.StepSuccessReport(stp.Id())
+			}
+
+			// Re-running `install` from the already-installed location makes the
+			// search dir and binDir the same, so the sibling found above IS the
+			// destination. copyBinaryFile opens the destination O_TRUNC, which would
+			// erase the installed daemon binary.
+			dstPath := filepath.Join(binDir, software.DaemonBinaryName)
+			if sameFile(srcPath, dstPath) {
+				logx.As().Debug().Str("path", dstPath).
+					Msg("Co-located solo-provisioner-daemon binary is already the installed one; nothing to copy")
+				return automa.StepSuccessReport(stp.Id())
+			}
+
+			// Atomic copy, not copyBinaryFile: this step swallows its own errors, so a
+			// half-written destination would be left behind AND reported as success,
+			// corrupting a daemon binary that was working before self-install ran.
+			if err := copyBinaryAtomic(srcPath, dstPath); err != nil {
+				logx.As().Warn().Err(err).
+					Str("src", srcPath).
+					Str("dst", dstPath).
+					Msg("Failed to install co-located solo-provisioner-daemon binary; it will be downloaded when needed")
+				return automa.StepSuccessReport(stp.Id())
+			}
+
+			logx.As().Info().
+				Str("src", srcPath).
+				Str("dst", dstPath).
+				Msg("Co-located solo-provisioner-daemon binary installed")
+
+			// The rename above leaves a running daemon on its old inode, so the process
+			// keeps executing the previous binary. Say so rather than letting the
+			// on-disk and running versions diverge silently.
+			if running, err := pkgos.IsServiceRunning(ctx, daemonServiceName); err == nil && running {
+				logx.As().Info().Str("service", daemonServiceName).Msg(
+					"solo-provisioner-daemon is running and keeps its current binary; " +
+						"restart the service to run the newly installed one")
+			}
+			return automa.StepSuccessReport(stp.Id())
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Installing co-located solo-provisioner-daemon binary")
+			return ctx, nil
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Co-located solo-provisioner-daemon binary handled")
+		})
+}
+
+// findColocatedDaemonBinary returns the path to a daemon binary in dir, or "" if
+// none is present. The plain name is preferred over the platform-suffixed one so
+// that a dir holding both (an install target that already has the daemon, plus
+// leftover build artifacts) resolves to the canonical name.
+func findColocatedDaemonBinary(dir string) string {
+	candidates := []string{
+		software.DaemonBinaryName,
+		fmt.Sprintf("%s-%s-%s", software.DaemonBinaryName, runtime.GOOS, runtime.GOARCH),
+	}
+	for _, name := range candidates {
+		p := filepath.Join(dir, name)
+		info, err := os.Stat(p)
+		if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+			continue
+		}
+		return p
+	}
+	return ""
 }
 
 const (

--- a/internal/workflows/steps/step_weaver_daemon_test.go
+++ b/internal/workflows/steps/step_weaver_daemon_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package steps
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/hashgraph/solo-weaver/pkg/software"
+	"github.com/stretchr/testify/require"
+)
+
+func writeExecutable(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+}
+
+func platformSuffixedDaemonName() string {
+	return fmt.Sprintf("%s-%s-%s", software.DaemonBinaryName, runtime.GOOS, runtime.GOARCH)
+}
+
+func TestFindColocatedDaemonBinary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("finds the plain name", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		want := filepath.Join(dir, software.DaemonBinaryName)
+		writeExecutable(t, want)
+
+		require.Equal(t, want, findColocatedDaemonBinary(dir))
+	})
+
+	t.Run("finds the platform-suffixed build artifact", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		want := filepath.Join(dir, platformSuffixedDaemonName())
+		writeExecutable(t, want)
+
+		require.Equal(t, want, findColocatedDaemonBinary(dir))
+	})
+
+	// A directory holding both is the install target after a previous run left the
+	// canonical name behind; the canonical name is what the service unit expects.
+	t.Run("prefers the plain name over the suffixed one", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		want := filepath.Join(dir, software.DaemonBinaryName)
+		writeExecutable(t, want)
+		writeExecutable(t, filepath.Join(dir, platformSuffixedDaemonName()))
+
+		require.Equal(t, want, findColocatedDaemonBinary(dir))
+	})
+
+	// A non-executable file of the right name is a leftover or a partial download,
+	// not something that can be installed as the daemon.
+	t.Run("ignores a non-executable candidate", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, software.DaemonBinaryName), []byte("x"), 0o644))
+
+		require.Empty(t, findColocatedDaemonBinary(dir))
+	})
+
+	t.Run("ignores a directory of the right name", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(dir, software.DaemonBinaryName), 0o755))
+
+		require.Empty(t, findColocatedDaemonBinary(dir))
+	})
+
+	t.Run("returns empty when nothing matches", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, findColocatedDaemonBinary(t.TempDir()))
+	})
+}
+
+// The step must never fail the self-install: an official install has no sibling
+// daemon binary to find, and the daemon is downloaded from the catalog later.
+func TestInstallColocatedDaemonBinary_NoSiblingSucceedsWithoutInstalling(t *testing.T) {
+	t.Parallel()
+	binDir := t.TempDir()
+
+	step, err := InstallColocatedDaemonBinary(binDir).Build()
+	require.NoError(t, err)
+
+	report := step.Execute(context.Background())
+	require.NoError(t, report.Error)
+
+	// The test binary's own directory holds no daemon binary, so nothing is copied.
+	_, err = os.Stat(filepath.Join(binDir, software.DaemonBinaryName))
+	require.True(t, os.IsNotExist(err), "no daemon binary should have been installed")
+}
+
+func TestCopyBinaryAtomic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("installs the source and makes it executable", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		src := filepath.Join(dir, "src")
+		require.NoError(t, os.WriteFile(src, []byte("new-binary"), 0o755))
+		dst := filepath.Join(dir, "sub", "dst")
+
+		require.NoError(t, copyBinaryAtomic(src, dst))
+
+		got, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		require.Equal(t, "new-binary", string(got))
+
+		info, err := os.Stat(dst)
+		require.NoError(t, err)
+		require.NotZero(t, info.Mode().Perm()&0o111, "installed binary must be executable")
+	})
+
+	// The point of the atomic path: a failure must not damage what was already
+	// installed. An unreadable source fails after the destination directory has
+	// been touched but before anything is renamed into place.
+	t.Run("leaves an existing destination intact when the copy fails", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dst := filepath.Join(dir, "dst")
+		require.NoError(t, os.WriteFile(dst, []byte("existing-binary"), 0o755))
+
+		require.Error(t, copyBinaryAtomic(filepath.Join(dir, "missing"), dst))
+
+		got, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		require.Equal(t, "existing-binary", string(got), "a failed install must not truncate the old binary")
+	})
+
+	t.Run("leaves no temp files behind", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		src := filepath.Join(dir, "src")
+		require.NoError(t, os.WriteFile(src, []byte("x"), 0o755))
+		dst := filepath.Join(dir, "dst")
+
+		require.NoError(t, copyBinaryAtomic(src, dst))
+		require.Error(t, copyBinaryAtomic(filepath.Join(dir, "missing"), dst))
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		for _, e := range entries {
+			require.NotContains(t, e.Name(), ".tmp.", "temp files must be cleaned up on both paths")
+		}
+	})
+}
+
+func TestSameFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	writeExecutable(t, a)
+	writeExecutable(t, b)
+
+	require.True(t, sameFile(a, a), "a path is the same file as itself")
+	require.False(t, sameFile(a, b), "distinct files with identical content are not the same file")
+	require.False(t, sameFile(a, filepath.Join(dir, "missing")), "a missing destination is not the same file")
+	require.False(t, sameFile(filepath.Join(dir, "missing"), a), "a missing source is not the same file")
+
+	// A symlinked destination resolves to the same inode — the case that matters,
+	// since /usr/local/bin entries are symlinks into the weaver bin dir.
+	link := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink(a, link))
+	require.True(t, sameFile(a, link), "a symlink to the source is the same file")
+}

--- a/internal/workflows/steps/step_weaver_purge.go
+++ b/internal/workflows/steps/step_weaver_purge.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/automa-saga/automa"
+	"github.com/automa-saga/logx"
+	"github.com/hashgraph/solo-weaver/internal/network/firewall"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+// adminKubeconfigPath is kubeadm's admin kubeconfig. Its presence is the cheapest
+// reliable signal that a cluster is still provisioned on this host, and a block
+// node cannot outlive the cluster it runs on — so one stat covers both.
+const adminKubeconfigPath = "/etc/kubernetes/admin.conf"
+
+// CheckNoProvisionedClusterStepId is the step ID for CheckNoProvisionedCluster.
+const CheckNoProvisionedClusterStepId = "check-no-provisioned-cluster"
+
+// CheckNoProvisionedCluster fails the self-uninstall when a Kubernetes cluster is
+// still provisioned here. Removing the CLI first strands the operator: every
+// teardown command lives in the binary about to be deleted, and the daemon would
+// keep reconciling a block node with nothing left to manage it.
+//
+// This deliberately reads the host rather than the recorded state file, which can
+// disagree with reality after a partial teardown.
+func CheckNoProvisionedCluster() *automa.StepBuilder {
+	return automa.NewStepBuilder().WithId(CheckNoProvisionedClusterStepId).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if _, err := os.Stat(adminKubeconfigPath); err != nil {
+				return automa.StepSuccessReport(stp.Id())
+			}
+			return automa.StepFailureReport(stp.Id(),
+				automa.WithError(errorx.IllegalState.New(
+					"a Kubernetes cluster is still provisioned on this host (%s exists)", adminKubeconfigPath).
+					WithProperty(models.ErrPropertyResolution, []string{
+						"Tear the workloads down first, in this order:",
+						"  sudo solo-provisioner block node uninstall",
+						"  sudo solo-provisioner kube cluster uninstall",
+						"  sudo solo-provisioner uninstall --yes",
+					})))
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Checking for provisioned workloads")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Workloads are still provisioned")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "No provisioned workloads found")
+		})
+}
+
+// RemoveNetworkConfigStepId is the step ID for RemoveNetworkConfig.
+const RemoveNetworkConfigStepId = "remove-network-config"
+
+// RemoveNetworkConfig deletes the operator-facing config tree that the network
+// planes persist outside the weaver home — the rendered .nft files, the policy
+// registry, and the tc device/class configs.
+//
+// It runs before the two boot-unit teardown steps: NftServiceTeardown retains the
+// shared unit while the host-firewall .nft file is still present, so removing the
+// files first is what lets that step take the unit with it.
+//
+// Live kernel state (the loaded nft tables, the tc qdiscs) is deliberately left
+// alone — this removes the boot-replay inputs, so the host comes up clean, but
+// nothing here touches packet handling on a running machine.
+func RemoveNetworkConfig() *automa.StepBuilder {
+	// Derived rather than declared: the network packages already mirror this
+	// prefix by value, and another copy would be one more thing to keep in sync.
+	configDir := filepath.Dir(firewall.HostNftPath)
+
+	return automa.NewStepBuilder().WithId(RemoveNetworkConfigStepId).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			if _, err := os.Stat(configDir); os.IsNotExist(err) {
+				return automa.SkippedReport(stp,
+					automa.WithDetail("network config directory already absent"))
+			}
+			if err := os.RemoveAll(configDir); err != nil {
+				return automa.StepFailureReport(stp.Id(),
+					automa.WithError(errorx.InternalError.Wrap(err,
+						"failed to remove network config directory %s", configDir).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Remove manually: sudo rm -rf " + configDir,
+						})))
+			}
+			logx.As().Info().Str("path", configDir).Msg("Network config directory removed")
+			return automa.StepSuccessReport(stp.Id())
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Removing network configuration")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to remove network configuration")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "Network configuration removed")
+		})
+}

--- a/internal/workflows/steps/step_weaver_purge_test.go
+++ b/internal/workflows/steps/step_weaver_purge_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !integration
+
+package steps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/automa-saga/automa"
+	"github.com/stretchr/testify/require"
+)
+
+// runStep builds and executes a step, returning its report.
+func runStep(t *testing.T, b *automa.StepBuilder) *automa.Report {
+	t.Helper()
+	stp, err := b.Build()
+	require.NoError(t, err)
+	return stp.Execute(context.Background())
+}
+
+func TestCheckNoProvisionedCluster(t *testing.T) {
+	// adminKubeconfigPath is an absolute host path, so the "cluster present" case
+	// cannot be simulated without root. Assert the branch that a CI host can
+	// actually reach: no kubeadm kubeconfig means nothing blocks the uninstall.
+	if _, err := os.Stat(adminKubeconfigPath); err == nil {
+		t.Skipf("%s exists on this host; the no-cluster branch is unreachable", adminKubeconfigPath)
+	}
+
+	rpt := runStep(t, CheckNoProvisionedCluster())
+	require.Equal(t, automa.StatusSuccess, rpt.Status,
+		"a host with no kubeadm kubeconfig must not block self-uninstall")
+}
+
+func TestRemoveNetworkConfig(t *testing.T) {
+	t.Run("skips when the directory is already absent", func(t *testing.T) {
+		// The step derives its target from firewall.HostNftPath, an absolute
+		// path, so this only exercises the absent branch on a clean host.
+		if _, err := os.Stat("/etc/solo-provisioner"); err == nil {
+			t.Skip("/etc/solo-provisioner exists on this host")
+		}
+		rpt := runStep(t, RemoveNetworkConfig())
+		require.Equal(t, automa.StatusSkipped, rpt.Status)
+	})
+
+	// RemoveAll's recursive behaviour is what the step relies on to take the
+	// policy registry and the tc config subtrees with it; pin that expectation
+	// against a stand-in tree so a future rewrite to a shallow delete is caught.
+	t.Run("removes nested config subtrees", func(t *testing.T) {
+		dir := t.TempDir()
+		root := filepath.Join(dir, "solo-provisioner")
+		for _, sub := range []string{"policies", "network/shape/devices", "network/shape/classes"} {
+			require.NoError(t, os.MkdirAll(filepath.Join(root, sub), 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(root, sub, "a.json"), []byte("{}"), 0o644))
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(root, "network-weaver-host-firewall.nft"), []byte("x"), 0o644))
+
+		require.NoError(t, os.RemoveAll(root))
+		_, err := os.Stat(root)
+		require.True(t, os.IsNotExist(err))
+	})
+}

--- a/internal/workflows/weaver.go
+++ b/internal/workflows/weaver.go
@@ -25,10 +25,27 @@ func NewSelfInstallWorkflow() *automa.WorkflowBuilder {
 	)
 }
 
+// NewSelfUninstallWorkflow removes everything self-install and the daemon
+// installer put on this host: the CLI, the daemon binary and its service, the
+// network boot units, and the config tree under /etc.
+//
+// Order matters twice. The cluster check comes first so a refusal costs nothing.
+// RemoveNetworkConfig runs before NftServiceTeardown because that step keeps the
+// shared unit while the host-firewall .nft file is present.
+//
+// Live kernel state (loaded nft tables, tc qdiscs) is out of scope; it does not
+// survive a reboot once the boot-replay inputs above are gone.
 func NewSelfUninstallWorkflow() *automa.WorkflowBuilder {
+	paths := models.Paths()
 	return automa.NewWorkflowBuilder().WithId("self-uninstall-workflow").Steps(
 		CheckPrivilegesStep(),
+		steps.CheckNoProvisionedCluster(),
+		steps.RemoveDaemonServiceStep(paths),
+		steps.RemoveDaemonBinaryStep(paths),
+		steps.RemoveNetworkConfig(),
+		steps.NftServiceTeardown(),
+		steps.TcEgressServiceTeardown(),
 		steps.RemoveSudoersStep(),
-		steps.UninstallWeaver(models.Paths().BinDir),
+		steps.UninstallWeaver(paths.BinDir),
 	)
 }

--- a/internal/workflows/weaver.go
+++ b/internal/workflows/weaver.go
@@ -20,6 +20,7 @@ func NewSelfInstallWorkflow() *automa.WorkflowBuilder {
 		steps.EnsureWeaverOwnerStep(),
 		steps.SetupHomeDirectoryStructure(models.Paths()),
 		steps.InstallWeaver(models.Paths().BinDir),
+		steps.InstallColocatedDaemonBinary(models.Paths().BinDir),
 		steps.InstallSudoersStep(),
 	)
 }


### PR DESCRIPTION
## Description

Two related gaps in how the `solo-provisioner-daemon` binary gets onto a host and off it
again.

`block node install --profile=local` with traffic shaping enabled always stopped to prompt
for a daemon binary path. That prompt is replaced with a precedence-ordered resolution, and
CLI self-install now carries the co-built daemon binary onto the host so the resolution
finds it without asking anyone anything.

Self-install placing a daemon binary made an existing asymmetry worse: self-*uninstall*
removed only the CLI, its symlink, and the sudoers drop-in. The daemon binary, its systemd
service, the network boot units, and the config tree under `/etc/solo-provisioner` all
survived it. Uninstall now tears all of that down, behind a required `--yes`.

### Three defects sat behind the one prompt

1. Resolution ran during the prompt phase, but its consumer `ensureBlockNodeDaemon` returns
   early when the daemon service is already running — so in the normal dev loop (daemon up,
   re-installing the BN) the operator answered a question whose answer was then discarded.
2. Nothing looked at `paths.BinDir/solo-provisioner-daemon`, so a daemon binary already
   installed on the host did not count as a source.
3. `profile == local` was a proxy for the real predicate, "this build's version has no
   downloadable release". Local builds are stamped `0.0.0` by the Taskfile's `VERSION`
   default — not `"dev"`, as the comments on `FlagDaemonVersion` and
   `resolveDaemonBinarySource` claimed — and no `v0.0.0` release exists to download.

### The resolution order

`resolveDaemonBinarySource` walks, in descending precedence: `--daemon-bin`, a
running-daemon short-circuit, `SOLO_PROVISIONER_DAEMON_BIN`, an executable binary already
installed in the weaver bin directory, then a catalog download when the version resolves to
a published release.

**An exhausted list is an error, not a prompt.** A path to a locally-built binary is not a
deployment choice to make at the keyboard, and keeping it out of the TUI leaves one resolver
rather than a prompting and a non-prompting variant — no `--force`/`ShouldPrompt` gate, no
`ChosenValues` threading at the call sites, and `internal/ui/prompt` and `pkg/sanity` drop
out of the file entirely. `upgrade` can then share the resolver outright: nothing prompts,
so its silent-convergence contract holds by construction rather than via a second code path.

What makes the installed-binary source actually hit in the local loop: `solo-provisioner
install` is the only command that runs from outside the weaver bin directory — every other
command is pinned there by `CheckWeaverInstallation` — so it is the only point at which the
CLI can still see the daemon binary that `task build` emitted next to it. A new best-effort
self-install step copies that sibling to `paths.BinDir`, tying the daemon refresh to the
moment a fresh build is in hand.

### Incidental fix: a self-copy that truncated the installed binary

`copyBinaryFile` opens its destination `O_TRUNC`, so on `main`:

```bash
sudo solo-provisioner daemon service install \
  --daemon-bin /opt/solo/weaver/bin/solo-provisioner-daemon
```

zeroes the installed daemon binary. The new resolution order can legitimately resolve to
exactly that path, so a `sameFile` guard was required — but the bug is independently
reachable today with an explicit flag.

**The guard precedes the `--version` platform probe.** The probe's job is to reject a binary
that cannot run on this host *before it replaces a working one*; a source that already IS
the installed binary has nothing to replace and cleared the same probe when it was
installed. Re-probing only spends a subprocess on what the new resolution order makes the
most common path. The bin-directory ownership and mode hardening stays ahead of the guard —
hosts that already carry a daemon binary are exactly the older installs that may still have
the group-writable directory it corrects.

### Completing the uninstall teardown

An operator who uninstalled the block node and cluster, then cleared `/opt/solo` by hand,
was left with a daemon process still running from a deleted inode — systemd reports it
`active`, so the resolver correctly skipped as "already running" — and three unit symlinks
dangling into a directory that no longer existed.

`NewSelfUninstallWorkflow` now removes the daemon service and binary, the config tree under
`/etc/solo-provisioner`, and both network boot units. `RemoveNetworkConfig` runs *before*
`NftServiceTeardown`: that step keeps the shared nft unit while the host-firewall `.nft`
file is present, so deleting the files first is what lets it take the unit rather than
orphaning one.

Uninstall refuses while a Kubernetes cluster is still provisioned — every teardown command
lives in the binary about to be deleted. The check stats kubeadm's admin kubeconfig rather
than reading recorded state, which can disagree with the host after a partial teardown; a
block node cannot outlive its cluster, so one probe covers both.

The command requires `--yes` and errors without it, with **no `-y` short form** — the point
is an act of confirmation, and `-y` is the flag operators append by reflex. `--purge` would
have been the wrong name: in the apt/dpkg/snap lineage it modifies *scope* ("also delete
config"), implying a bare uninstall is valid and does less.

Live kernel state — loaded nft tables, tc qdiscs — is left alone. It does not survive a
reboot once the boot-replay units and their inputs are gone, and flushing it would put
packet handling at risk on a host the operator is still connected to.

### Scope note: `block node upgrade`

`upgrade` passed a zero `DaemonBinarySource`, so on a local build it would try to download a
`v0.0.0` release and fail. It now shares `resolveDaemonBinarySource` and propagates its
error instead of discarding it. Slightly beyond the filed issue; happy to split it out if
reviewers prefer.

### Files changed

| File | Change |
|---|---|
| `cmd/cli/commands/block/node/daemon_offer.go` | Single precedence-ordered `resolveDaemonBinarySource` returning `(source, error)`; adds `installedDaemonBinaryPath`, `isDownloadableDaemonVersion`, `unresolvedDaemonBinaryError`; drops the prompt, the `profile`/`args`/`cv` parameters, and the `prompt`/`sanity` imports |
| `cmd/cli/commands/block/node/install.go` | Call-site update for the reduced signature |
| `cmd/cli/commands/block/node/reconfigure.go` | Same |
| `cmd/cli/commands/block/node/upgrade.go` | Shares the one resolver; propagates its error |
| `cmd/cli/commands/common/flags_common.go` | `--daemon-bin` description reflects auto-resolution; stale `"dev"` version comments corrected |
| `cmd/cli/commands/self_install.go` | `--yes` gate on `uninstall`, with resolution hints listing what is removed |
| `internal/workflows/steps/step_daemon.go` | New `sameFile` helper; same-path guard hoisted ahead of the `--version` probe; BinDir hardening kept ahead of the guard |
| `internal/workflows/steps/step_weaver.go` | New `InstallColocatedDaemonBinary` step, `findColocatedDaemonBinary` and `copyBinaryAtomic` helpers |
| `internal/workflows/steps/step_weaver_purge.go` | New — `CheckNoProvisionedCluster`, `RemoveNetworkConfig` |
| `internal/workflows/weaver.go` | Wires the colocated-daemon step into self-install; rebuilds `NewSelfUninstallWorkflow` as a 9-step teardown |
| `docs/quickstart.md` | `--daemon-bin` row, traffic-shaper daemon note, and a rewritten Uninstall section with the `--yes` flag and teardown order |
| `cmd/cli/commands/block/node/daemon_offer_test.go` | New — precedence order, version resolvability, installed-binary detection, error-not-prompt |
| `internal/workflows/steps/step_weaver_daemon_test.go` | New — sibling discovery, `copyBinaryAtomic`, `sameFile` |
| `internal/workflows/steps/step_weaver_purge_test.go` | New — uninstall preflight and config removal |

### Review guide

**Code review checklist**

- **Self-copy safety.** `sameFile` must precede every `copyBinaryFile`/`copyBinaryAtomic`
  whose destination could equal its source. Two such sites: `step_daemon.go` (the resolved
  source may be the installed binary) and `step_weaver.go` (re-running `install` from
  `/opt/solo/weaver/bin` makes the search dir the destination dir). A miss here zeroes the
  installed daemon.
- **Guard placement.** The `sameFile` short-circuit now runs *before* the `--version` probe.
  Confirm you accept that an already-installed binary is not re-probed, and that the
  BinDir `chmod`/`chown` still precedes the short-circuit — moving it after would skip the
  `2775` privilege-escalation fix-up on exactly the hosts that need it.
- **Resolver never prompts.** `resolveDaemonBinarySource` is shared by `install`,
  `reconfigure`, and `upgrade`. Any future prompt added to it silently breaks upgrade's
  silent-convergence contract.
- **Running-service short-circuit** returns an empty `BinPath` with a nil error. That is
  only correct because `ensureBlockNodeDaemon` never installs when the service is up —
  confirm that invariant still holds.
- **Best-effort contract.** No branch of `InstallColocatedDaemonBinary` returns a failure
  report. An official install has no sibling to find and must not fail because of it.
- **Uninstall step order.** `RemoveNetworkConfig` before `NftServiceTeardown`, and the
  cluster check first so a refusal costs nothing.
- **`cmd.Flag` vs `cmd.Flags()`** in `isDownloadableDaemonVersion`: `SetVarP` registers on
  `PersistentFlags`, which `Flags()` only reflects after cobra's pre-Execute merge.
- **No new dependencies.**

**Test commands**

macOS cannot build these packages (`internal/mount` is Linux-only). In the VM:

```bash
task vm:test:unit
```

New cases: `TestFindColocatedDaemonBinary`, `TestSameFile`, `TestCopyBinaryAtomic`,
`TestInstallColocatedDaemonBinary_NoSiblingSucceedsWithoutInstalling`,
`TestIsDownloadableDaemonVersion`, `TestInstalledDaemonBinaryPath`,
`TestResolveDaemonBinarySource`, `TestCheckNoProvisionedCluster`,
`TestRemoveNetworkConfig`.

**Manual UAT**

1. *Self-install carries the daemon.* `task build`, then in the BN VM
   `sudo bin/solo-provisioner-linux-arm64 install`. Expect
   `/opt/solo/weaver/bin/solo-provisioner-daemon` present, mode 0755, mtime matching the
   build.
2. *No prompt on a local install.*
   `sudo solo-provisioner block node install --profile=local --traffic-shaping-enabled --egress-interface enp0s1`.
   Expect no "Daemon Binary Path" prompt and
   `INF Using the daemon binary already present on this host`, followed by
   `INF Daemon binary is already installed at the destination, skipping copy` — with no
   `--version` subprocess in between.
3. *Self-copy guard.* `sha256sum` the installed daemon, `daemon service stop`, then
   `daemon service install --daemon-bin /opt/solo/weaver/bin/solo-provisioner-daemon`, then
   `sha256sum` again. Expect an identical digest (not 0 bytes). On `main` this truncates.
4. *Re-running self-install is idempotent.* `sudo /opt/solo/weaver/bin/solo-provisioner install`
   twice; the daemon digest must not change.
5. *Env override.* `sudo SOLO_PROVISIONER_DAEMON_BIN=<path> solo-provisioner block node reconfigure --traffic-shaping-enabled=true`.
   Expect `INF Using the daemon binary from the environment`.
6. *Unresolvable source fails, never prompts.* Remove the installed daemon binary, then run
   a local install **interactively**. Expect the `no solo-provisioner-daemon binary could be
   resolved` error with its resolution hints, and no prompt.
7. *Uninstall refuses without `--yes`.* `sudo solo-provisioner uninstall` — expect
   `refusing to uninstall without --yes` and a hint listing what would be removed.
8. *Uninstall refuses while a cluster exists.* With `/etc/kubernetes/admin.conf` present,
   `sudo solo-provisioner uninstall --yes` — expect the ordered teardown hint.
9. *Full teardown.* After `block node uninstall` and `kube cluster uninstall`, run
   `sudo solo-provisioner uninstall --yes`. Expect gone: the daemon binary and service,
   `/etc/solo-provisioner`, `/usr/local/sbin/solo-provisioner-bandwidth-shaper.sh`, all
   three units under `/usr/lib/systemd/system`, and `systemctl status
   solo-provisioner-daemon` reporting no such unit.

**Risks / rollback**

- **`uninstall` is now destructive by design.** It removes files outside the weaver home
  (`/etc/solo-provisioner`, `/usr/local/sbin`, `/usr/lib/systemd/system`) via `os.RemoveAll`
  on a derived path. The derivation is `filepath.Dir(firewall.HostNftPath)` — worth a
  second pair of eyes, since a wrong constant there deletes the wrong tree.
- **`uninstall` gains a required flag.** Any script calling bare `solo-provisioner uninstall`
  now fails. Intentional, but it is a breaking CLI change.
- Self-install writes one extra file into `paths.BinDir`. Additive, and the step cannot fail
  the install.
- The resolution order can select an already-installed *stale* daemon where `main` would
  have forced the operator to supply a fresh path. Mitigated by the self-install refresh on
  every `task build` cycle; `--daemon-bin` still overrides everything.
- `daemon.yaml` under the weaver config dir is deliberately **not** removed by
  self-uninstall; `daemon service uninstall` owns that.
- Rollback is a plain revert — no on-disk state or config schema changes.

**Not done, deliberately**

- Flushing live nft tables and tc qdiscs on uninstall (see above).
- Merging the daemon into the CLI binary. It would delete the resolution problem
  permanently, but links every CLI dependency into a long-lived root service, contradicting
  the constraint recorded at `cmd/daemon/main.go`.
- `--daemon-version=latest` release resolution. For local work the daemon under test is
  usually the one just built, so silently installing a released daemon is worse than failing.
- Injecting the host paths into `CheckNoProvisionedCluster` / `RemoveNetworkConfig` as
  parameters. Both read absolute paths, so their unit tests can only exercise the
  not-present branches; making them meaningful needs a signature change.

### Related Issues

* Closes #973
