### PR TITLE
perf(network/firewall): split the input chain by address family

### DIFF
--- a/internal/network/firewall/firewall_test.go
+++ b/internal/network/firewall/firewall_test.go
@@ -54,6 +54,28 @@ func dualStackTable() *Table {
 	}
 }
 
+// chainBody returns the rules of the named chain from a rendered document,
+// excluding the `chain <name> {` header and the closing brace. Ordering
+// assertions have to be made per-chain: once the family dispatch is in place
+// the document order is no longer the evaluation order, because the jumped-to
+// chains are defined below the base chain but run before it reaches the rules
+// that follow the dispatch.
+//
+// The header is excluded so that negative assertions stay meaningful — the
+// chain names themselves carry family tokens, so leaving `chain input_ipv6 {`
+// in the returned text would make a NotContains check for "ipv6" match the
+// header instead of a rule.
+func chainBody(t *testing.T, doc, name string) string {
+	t.Helper()
+	header := "\tchain " + name + " {\n"
+	start := strings.Index(doc, header)
+	require.Greater(t, start, -1, "chain %s not found in rendered document", name)
+	rest := doc[start+len(header):]
+	end := strings.Index(rest, "\n\t}\n")
+	require.Greater(t, end, -1, "chain %s is not terminated", name)
+	return rest[:end]
+}
+
 // newTestManager wires a Manager with a fakeRunner and temp paths. The
 // applyViaService closure sets r.exists = true and increments applyCount so
 // tests can assert on how many times rules were applied without touching
@@ -99,23 +121,60 @@ func TestRender_SecurityInvariants(t *testing.T) {
 	require.Contains(t, doc, "icmp type echo-request drop")
 	require.Contains(t, doc, "ip saddr 10.4.0.0/24 tcp dport @in_cluster_ports accept")
 
-	// Ordering is load-bearing: the echo-request rate limit must be evaluated
-	// BEFORE `ct state established,related accept`. netfilter conntrack tracks
-	// ICMP echo flows, so if the established fast-path ran first, every packet
-	// of a sustained ping after the first would bypass the limit.
-	limitIdx := strings.Index(doc, "icmp type echo-request limit rate 10/second accept")
-	dropIdx := strings.Index(doc, "icmp type echo-request drop")
-	// LastIndex: the comment above the rule also references the phrase; the real
-	// rule is the last occurrence.
-	estIdx := strings.LastIndex(doc, "ct state established,related accept")
-	require.Greater(t, dropIdx, limitIdx, "echo drop must follow the echo rate limit")
-	require.Greater(t, estIdx, dropIdx, "established,related accept must come after the ICMP echo rules")
+	// Ordering is load-bearing. ICMP must be evaluated BEFORE the conntrack
+	// fast-path: netfilter conntrack tracks ICMP echo flows, so if the
+	// established fast-path ran first, every packet of a sustained ping after
+	// the first would bypass the rate limit. The l4proto dispatch is what puts
+	// ICMP first, so it must precede the ct vmap in the base chain.
+	base := chainBody(t, doc, "input")
+	icmpDispatchIdx := strings.Index(base, "meta l4proto vmap { icmp : jump input_icmp_ipv4, icmpv6 : jump input_icmp_ipv6 }")
+	ctIdx := strings.Index(base, "ct state vmap { established : accept, related : accept, invalid : drop }")
+	require.Greater(t, icmpDispatchIdx, -1, "base chain must dispatch ICMP by l4proto")
+	require.Greater(t, ctIdx, -1, "base chain must carry the collapsed conntrack vmap")
+	require.Less(t, icmpDispatchIdx, ctIdx, "ICMP dispatch must precede the conntrack fast-path")
 
-	// The block list must be evaluated before established/related so an
+	// Within the ICMP chain: invalid is dropped first, so a forged ICMP error
+	// cannot be admitted by the blanket path-health accepts that follow; then
+	// the rate limit; then the explicit drop for over-budget echo.
+	icmp4 := chainBody(t, doc, "input_icmp_ipv4")
+	invalidIdx := strings.Index(icmp4, "ct state invalid drop")
+	limitIdx := strings.Index(icmp4, "icmp type echo-request limit rate 10/second accept")
+	dropIdx := strings.Index(icmp4, "icmp type echo-request drop")
+	require.Greater(t, invalidIdx, -1, "ICMPv4 chain must drop invalid before the path-health accepts")
+	require.Less(t, invalidIdx, limitIdx, "invalid drop must precede the ICMP accepts")
+	require.Greater(t, dropIdx, limitIdx, "echo drop must follow the echo rate limit")
+
+	// The block list must be evaluated before the conntrack fast-path so an
 	// operator-added CIDR also kills already-open connections, not just new ones.
-	blockedIdx := strings.Index(doc, "ip saddr @blocked_addrs drop")
-	require.Greater(t, blockedIdx, 0)
-	require.Less(t, blockedIdx, estIdx, "blocked-CIDR drop must precede established,related accept")
+	blockedIdx := strings.Index(base, "ip saddr @blocked_addrs drop")
+	require.Greater(t, blockedIdx, -1)
+	require.Less(t, blockedIdx, ctIdx, "blocked-CIDR drop must precede the conntrack fast-path")
+}
+
+// TestRender_FamilySplit pins the point of the per-family chains: a packet must
+// never be evaluated against a rule belonging to the other address family.
+func TestRender_FamilySplit(t *testing.T) {
+	doc, err := dualStackTable().Render()
+	require.NoError(t, err)
+
+	require.Contains(t, chainBody(t, doc, "input"),
+		"meta nfproto vmap { ipv4 : jump input_ipv4, ipv6 : jump input_ipv6 }")
+
+	v4 := chainBody(t, doc, "input_ipv4")
+	require.Contains(t, v4, "ip saddr @mgmt_addrs tcp dport 22 accept")
+	require.NotContains(t, v4, "ip6 ")
+
+	v6 := chainBody(t, doc, "input_ipv6")
+	require.Contains(t, v6, "ip6 saddr @mgmt_addrs6 tcp dport 22 accept")
+	require.NotContains(t, v6, "ip saddr")
+
+	icmp4 := chainBody(t, doc, "input_icmp_ipv4")
+	require.Contains(t, icmp4, "icmp type echo-request drop")
+	require.NotContains(t, icmp4, "icmpv6")
+
+	icmp6 := chainBody(t, doc, "input_icmp_ipv6")
+	require.Contains(t, icmp6, "icmpv6 type echo-request drop")
+	require.NotContains(t, icmp6, "icmp type")
 }
 
 func TestRender_NoMgmtNoPod(t *testing.T) {
@@ -157,12 +216,24 @@ func TestRender_DualStack(t *testing.T) {
 	require.Contains(t, doc, "icmpv6 type packet-too-big accept")
 	require.NotContains(t, doc, "nd-redirect")
 
-	// NDP must precede the established/related fast-path, same reasoning as the
-	// v4 ICMP ordering.
-	ndpIdx := strings.Index(doc, "nd-neighbor-solicit")
-	estIdx := strings.LastIndex(doc, "ct state established,related accept")
-	require.Greater(t, ndpIdx, 0)
-	require.Less(t, ndpIdx, estIdx, "NDP accepts must precede established,related accept")
+	// NDP must be reached before the conntrack fast-path, same reasoning as the
+	// v4 ICMP ordering: the NDP accepts live in the ICMPv6 chain, and the
+	// dispatch into it precedes the ct vmap in the base chain. The invalid drop
+	// still leads that chain, preserving the pre-split relative order.
+	// Assert both anchors are present before comparing offsets: a missing rule
+	// yields index -1, which would satisfy the Less() check vacuously and let
+	// the invalid drop be deleted without failing this test.
+	icmp6 := chainBody(t, doc, "input_icmp_ipv6")
+	require.Contains(t, icmp6, "ct state invalid drop")
+	require.Contains(t, icmp6, "nd-neighbor-solicit")
+	require.Less(t, strings.Index(icmp6, "ct state invalid drop"), strings.Index(icmp6, "nd-neighbor-solicit"),
+		"invalid drop must still precede the NDP accepts")
+
+	base := chainBody(t, doc, "input")
+	icmpDispatchIdx := strings.Index(base, "meta l4proto vmap { icmp : jump input_icmp_ipv4, icmpv6 : jump input_icmp_ipv6 }")
+	ctIdx := strings.Index(base, "ct state vmap { established : accept, related : accept, invalid : drop }")
+	require.Greater(t, icmpDispatchIdx, -1)
+	require.Less(t, icmpDispatchIdx, ctIdx, "ICMPv6 dispatch must precede the conntrack fast-path")
 }
 
 func TestRoundTrip_RenderParseRender(t *testing.T) {

--- a/internal/network/firewall/testdata/network-weaver-host-firewall.golden.nft
+++ b/internal/network/firewall/testdata/network-weaver-host-firewall.golden.nft
@@ -8,21 +8,70 @@ table inet weaver-host-firewall {
 	set blocked_addrs6 { type ipv6_addr; flags interval; }
 	set in_cluster_ports { type inet_service; elements = { 4244, 6443, 7472, 10250 }; }
 
+	# The hooked chain carries only what applies to every packet regardless of
+	# address family, then dispatches into the regular chains below — so an IPv4
+	# packet never evaluates an IPv6 rule and vice versa. A jump that returns
+	# without a verdict falls through to the rest of this chain, ending at the
+	# `policy drop`.
 	chain input {
 		type filter hook input priority 0; policy drop;
 
-		# Drop invalid; admit loopback. `iif "lo"` covers both 127.0.0.0/8 and
-		# ::1 since this is an `inet` (dual-family) table.
-		ct state invalid drop
-
 		# Operator-curated block list (`network firewall --blocked-cidrs`). Runs
-		# before every other rule, including established/related, so an entry
-		# added here drops already-open connections too. Purely operator-managed:
-		# nothing else ever writes to these sets. One rule per family.
+		# before every other rule, including the conntrack fast-path below, so an
+		# entry added here drops already-open connections too. Purely
+		# operator-managed: nothing else ever writes to these sets. One rule per
+		# family — two address compares are cheaper than a dispatch.
 		ip saddr @blocked_addrs drop
 		ip6 saddr @blocked_addrs6 drop
 
+		# Admit loopback. `iif "lo"` covers both 127.0.0.0/8 and ::1 since this is
+		# an `inet` (dual-family) table. It precedes the ICMP dispatch so pinging
+		# localhost is not rate-limited, which also means loopback is admitted
+		# without a conntrack state check — the host talking to itself.
 		iif "lo" accept
+
+		# ICMP is dispatched BEFORE the conntrack fast-path below. netfilter
+		# conntrack DOES track ICMP echo as a flow (keyed on the echo id), so a
+		# sustained ping shares one entry and every packet after the first would
+		# otherwise match `established` and bypass the echo-request rate limit.
+		# Handling ICMP first keeps the limit effective. `meta l4proto` selects
+		# the family on its own (protocol 1 vs 58) and resolves past IPv6
+		# extension headers, so it doubles as the family split for ICMP.
+		meta l4proto vmap { icmp : jump input_icmp_ipv4, icmpv6 : jump input_icmp_ipv6 }
+
+		# Conntrack fast-path for everything else (TCP/UDP). A single state
+		# lookup covers both the invalid drop and the established/related accept.
+		# ICMP that fell through the chains above lands here too, so a solicited
+		# echo-reply is still admitted as `established`.
+		ct state vmap { established : accept, related : accept, invalid : drop }
+
+		meta nfproto vmap { ipv4 : jump input_ipv4, ipv6 : jump input_ipv6 }
+	}
+
+	# ICMPv4. Runs ahead of the base chain's conntrack vmap, so it re-drops
+	# invalid itself: that ordering is what stops a forged ICMP error from being
+	# admitted by the blanket path-health accepts below.
+	chain input_icmp_ipv4 {
+		ct state invalid drop
+
+		# Full ICMP from management sources (ping, traceroute, diagnostics) — no rate limit.
+		ip saddr @mgmt_addrs icmp type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem } accept
+
+		# From everyone else: always allow the path-health subset (Path MTU
+		# Discovery + traceroute), and rate-limit echo-request to prevent floods.
+		# The trailing drop keeps over-budget echo from falling back to the base
+		# chain's established accept (a sustained ping is established after the
+		# first reply).
+		icmp type destination-unreachable accept
+		icmp type time-exceeded accept
+		icmp type echo-request limit rate 10/second accept
+		icmp type echo-request drop
+	}
+
+	# ICMPv6. Same invalid-first ordering, and for the same reason, as the IPv4
+	# chain above.
+	chain input_icmp_ipv6 {
+		ct state invalid drop
 
 		# --- IPv6 Neighbor Discovery + MLD (REQUIRED under policy drop) ---
 		# IPv6 is non-functional without Neighbor Discovery: address resolution
@@ -36,28 +85,8 @@ table inet weaver-host-firewall {
 		# the solicited-node multicast that NDP relies on.
 		icmpv6 type { mld-listener-query, mld-listener-report, mld-listener-done } accept
 
-		# ICMP is evaluated BEFORE the established/related fast-path. netfilter
-		# conntrack DOES track ICMP echo as a flow (keyed on the echo id), so a
-		# sustained ping shares one entry and every packet after the first would
-		# otherwise match `ct state established,related accept` and bypass the
-		# echo-request rate limit. Handling ICMP first keeps the limit effective.
-		# Explicit accepts are still required because the default-drop policy
-		# would otherwise break new-flow ping and path diagnostics (PMTUD,
-		# traceroute), which the established state does not cover for a NEW flow.
-
-		# Full ICMP from management sources (ping, traceroute, diagnostics) — no rate limit.
-		ip saddr @mgmt_addrs icmp type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem } accept
+		# Full ICMPv6 from management sources — no rate limit.
 		ip6 saddr @mgmt_addrs6 icmpv6 type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem, packet-too-big } accept
-
-		# From everyone else: always allow the path-health subset (Path MTU
-		# Discovery + traceroute), and rate-limit echo-request to prevent floods.
-		# The trailing drop keeps over-budget echo from being rescued by the
-		# established accept below (a sustained ping is established after the
-		# first reply).
-		icmp type destination-unreachable accept
-		icmp type time-exceeded accept
-		icmp type echo-request limit rate 10/second accept
-		icmp type echo-request drop
 
 		# IPv6 path health for everyone. packet-too-big is the IPv6 PMTUD signal —
 		# IPv6 routers never fragment, so dropping it silently blackholes any flow
@@ -68,15 +97,18 @@ table inet weaver-host-firewall {
 		icmpv6 type parameter-problem accept
 		icmpv6 type echo-request limit rate 10/second accept
 		icmpv6 type echo-request drop
+	}
 
-		# Conntrack fast-path for TCP/UDP (and solicited ICMP replies).
-		ct state established,related accept
-
-		# SSH / management access from the allowlist only (both families).
+	chain input_ipv4 {
+		# SSH / management access from the allowlist only.
 		ip saddr @mgmt_addrs tcp dport 22 accept
-		ip6 saddr @mgmt_addrs6 tcp dport 22 accept
 
 		# In-cluster host-service ports, reachable from the pod CIDR only.
 		ip saddr 10.4.0.0/24 tcp dport @in_cluster_ports accept
+	}
+
+	chain input_ipv6 {
+		# SSH / management access from the allowlist only.
+		ip6 saddr @mgmt_addrs6 tcp dport 22 accept
 	}
 }

--- a/internal/templates/files/network/network-weaver-host-firewall.nft.tmpl
+++ b/internal/templates/files/network/network-weaver-host-firewall.nft.tmpl
@@ -8,21 +8,70 @@ table inet weaver-host-firewall {
 	set blocked_addrs6 { type ipv6_addr; flags interval;{{if .BlockedElements6}} elements = { {{.BlockedElements6}} };{{end}} }
 	set in_cluster_ports { type inet_service;{{if .PortElements}} elements = { {{.PortElements}} };{{end}} }
 
+	# The hooked chain carries only what applies to every packet regardless of
+	# address family, then dispatches into the regular chains below — so an IPv4
+	# packet never evaluates an IPv6 rule and vice versa. A jump that returns
+	# without a verdict falls through to the rest of this chain, ending at the
+	# `policy drop`.
 	chain input {
 		type filter hook input priority 0; policy drop;
 
-		# Drop invalid; admit loopback. `iif "lo"` covers both 127.0.0.0/8 and
-		# ::1 since this is an `inet` (dual-family) table.
-		ct state invalid drop
-
 		# Operator-curated block list (`network firewall --blocked-cidrs`). Runs
-		# before every other rule, including established/related, so an entry
-		# added here drops already-open connections too. Purely operator-managed:
-		# nothing else ever writes to these sets. One rule per family.
+		# before every other rule, including the conntrack fast-path below, so an
+		# entry added here drops already-open connections too. Purely
+		# operator-managed: nothing else ever writes to these sets. One rule per
+		# family — two address compares are cheaper than a dispatch.
 		ip saddr @blocked_addrs drop
 		ip6 saddr @blocked_addrs6 drop
 
+		# Admit loopback. `iif "lo"` covers both 127.0.0.0/8 and ::1 since this is
+		# an `inet` (dual-family) table. It precedes the ICMP dispatch so pinging
+		# localhost is not rate-limited, which also means loopback is admitted
+		# without a conntrack state check — the host talking to itself.
 		iif "lo" accept
+
+		# ICMP is dispatched BEFORE the conntrack fast-path below. netfilter
+		# conntrack DOES track ICMP echo as a flow (keyed on the echo id), so a
+		# sustained ping shares one entry and every packet after the first would
+		# otherwise match `established` and bypass the echo-request rate limit.
+		# Handling ICMP first keeps the limit effective. `meta l4proto` selects
+		# the family on its own (protocol 1 vs 58) and resolves past IPv6
+		# extension headers, so it doubles as the family split for ICMP.
+		meta l4proto vmap { icmp : jump input_icmp_ipv4, icmpv6 : jump input_icmp_ipv6 }
+
+		# Conntrack fast-path for everything else (TCP/UDP). A single state
+		# lookup covers both the invalid drop and the established/related accept.
+		# ICMP that fell through the chains above lands here too, so a solicited
+		# echo-reply is still admitted as `established`.
+		ct state vmap { established : accept, related : accept, invalid : drop }
+
+		meta nfproto vmap { ipv4 : jump input_ipv4, ipv6 : jump input_ipv6 }
+	}
+
+	# ICMPv4. Runs ahead of the base chain's conntrack vmap, so it re-drops
+	# invalid itself: that ordering is what stops a forged ICMP error from being
+	# admitted by the blanket path-health accepts below.
+	chain input_icmp_ipv4 {
+		ct state invalid drop
+
+		# Full ICMP from management sources (ping, traceroute, diagnostics) — no rate limit.
+		ip saddr @mgmt_addrs icmp type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem } accept
+
+		# From everyone else: always allow the path-health subset (Path MTU
+		# Discovery + traceroute), and rate-limit echo-request to prevent floods.
+		# The trailing drop keeps over-budget echo from falling back to the base
+		# chain's established accept (a sustained ping is established after the
+		# first reply).
+		icmp type destination-unreachable accept
+		icmp type time-exceeded accept
+		icmp type echo-request limit rate 10/second accept
+		icmp type echo-request drop
+	}
+
+	# ICMPv6. Same invalid-first ordering, and for the same reason, as the IPv4
+	# chain above.
+	chain input_icmp_ipv6 {
+		ct state invalid drop
 
 		# --- IPv6 Neighbor Discovery + MLD (REQUIRED under policy drop) ---
 		# IPv6 is non-functional without Neighbor Discovery: address resolution
@@ -36,28 +85,8 @@ table inet weaver-host-firewall {
 		# the solicited-node multicast that NDP relies on.
 		icmpv6 type { mld-listener-query, mld-listener-report, mld-listener-done } accept
 
-		# ICMP is evaluated BEFORE the established/related fast-path. netfilter
-		# conntrack DOES track ICMP echo as a flow (keyed on the echo id), so a
-		# sustained ping shares one entry and every packet after the first would
-		# otherwise match `ct state established,related accept` and bypass the
-		# echo-request rate limit. Handling ICMP first keeps the limit effective.
-		# Explicit accepts are still required because the default-drop policy
-		# would otherwise break new-flow ping and path diagnostics (PMTUD,
-		# traceroute), which the established state does not cover for a NEW flow.
-
-		# Full ICMP from management sources (ping, traceroute, diagnostics) — no rate limit.
-		ip saddr @mgmt_addrs icmp type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem } accept
+		# Full ICMPv6 from management sources — no rate limit.
 		ip6 saddr @mgmt_addrs6 icmpv6 type { echo-request, echo-reply, destination-unreachable, time-exceeded, parameter-problem, packet-too-big } accept
-
-		# From everyone else: always allow the path-health subset (Path MTU
-		# Discovery + traceroute), and rate-limit echo-request to prevent floods.
-		# The trailing drop keeps over-budget echo from being rescued by the
-		# established accept below (a sustained ping is established after the
-		# first reply).
-		icmp type destination-unreachable accept
-		icmp type time-exceeded accept
-		icmp type echo-request limit rate 10/second accept
-		icmp type echo-request drop
 
 		# IPv6 path health for everyone. packet-too-big is the IPv6 PMTUD signal —
 		# IPv6 routers never fragment, so dropping it silently blackholes any flow
@@ -68,19 +97,24 @@ table inet weaver-host-firewall {
 		icmpv6 type parameter-problem accept
 		icmpv6 type echo-request limit rate 10/second accept
 		icmpv6 type echo-request drop
+	}
 
-		# Conntrack fast-path for TCP/UDP (and solicited ICMP replies).
-		ct state established,related accept
-
-		# SSH / management access from the allowlist only (both families).
+	chain input_ipv4 {
+		# SSH / management access from the allowlist only.
 		ip saddr @mgmt_addrs tcp dport {{.SSHPort}} accept
-		ip6 saddr @mgmt_addrs6 tcp dport {{.SSHPort}} accept
 {{- if .PodCIDR}}
 
 		# In-cluster host-service ports, reachable from the pod CIDR only.
 		ip saddr {{.PodCIDR}} tcp dport @in_cluster_ports accept
 {{- end}}
+	}
+
+	chain input_ipv6 {
+		# SSH / management access from the allowlist only.
+		ip6 saddr @mgmt_addrs6 tcp dport {{.SSHPort}} accept
 {{- if .PodCIDR6}}
+
+		# In-cluster host-service ports, reachable from the pod CIDR only.
 		ip6 saddr {{.PodCIDR6}} tcp dport @in_cluster_ports accept
 {{- end}}
 	}


### PR DESCRIPTION
## Description

The `inet weaver-host-firewall` `input` chain was a single flat list of ~23 rules. Every family-specific rule was written twice (`ip …` then `ip6 …`), conntrack state was matched twice, and the 15-rule ICMP block sat between the two `ct` matches — so all non-ICMP traffic was evaluated against every ICMP rule before reaching the conntrack fast-path.

The hooked chain now carries only what applies to every packet — the operator blocklist, loopback, and the dispatches — and family-specific rules move into `input_icmp_ipv4`, `input_icmp_ipv6`, `input_ipv4` and `input_ipv6`. An established inbound TCP packet reaches its verdict in 5 rules instead of ~18.

This is a pure restructure: no change to which addresses or ports are allowed, with one documented exception noted below.

### Why the conntrack collapse is only partial

The issue asked for the two `ct state` matches to collapse into a single vmap. That turns out not to be safe as stated. `ct state invalid drop` was load-bearing exactly where it sat — ahead of the blanket `icmp type destination-unreachable accept` — because without it there, a forged ICMP error from any source is admitted.

So the base chain carries one `ct state vmap { established : accept, related : accept, invalid : drop }` covering TCP/UDP (the common path, two matches down to one), and each ICMP chain retains its own `ct state invalid drop` to reproduce the original ordering exactly. ICMP is dispatched by `meta l4proto` ahead of that vmap, which is what keeps the echo rate limit from being bypassed — conntrack tracks ICMP echo as a flow, so packets 2..N of a sustained ping would otherwise match `established`.

`meta nfproto` is used for the family dispatch rather than `meta protocol`: in an `inet` table it reads the netfilter protocol family directly instead of depending on the skb's ethertype, which is not guaranteed for locally generated traffic or non-Ethernet interfaces.

### Behavior change

`iif "lo" accept` now precedes the invalid drop, so **invalid loopback traffic is accepted** where it was previously dropped. Loopback has to stay above the ICMP dispatch or `ping localhost` becomes rate-limited. This is the host talking to itself.

### Files changed

| File | Change |
|---|---|
| `internal/templates/files/network/network-weaver-host-firewall.nft.tmpl` | Base chain reduced to blocklist → `iif lo` → ICMP dispatch → ct vmap → family dispatch; four new per-family chains |
| `internal/network/firewall/firewall_test.go` | New `chainBody` helper; ordering assertions rewritten per-chain; new `TestRender_FamilySplit` |
| `internal/network/firewall/testdata/network-weaver-host-firewall.golden.nft` | Regenerated |

`internal/network/firewall/parse.go` is deliberately untouched. Its regexes scan the whole document rather than anchoring to chain position, so they survive the layout change — `TestRoundTrip_RenderParseRender` passing **unmodified** is the proof.

### Review guide

**Document order is no longer evaluation order.** The ICMP chains are defined below the base chain but execute before it reaches the ct vmap, via the jump. Three existing assertions used `strings.Index` over the whole document, which is now meaningless for ordering — hence the `chainBody` helper. Any new ordering assertion must be scoped to one chain body.

Ordering invariants to verify, each of which fails *silently* (the ruleset still loads):

- ICMP dispatch precedes the ct vmap — otherwise the echo rate limit is bypassed.
- Blocklist drops precede the ct vmap — otherwise an operator-added CIDR stops killing already-open connections.
- `ct state invalid drop` leads both ICMP chains — otherwise forged ICMP errors reach the path-health accepts.
- `iif "lo" accept` stays above the ICMP dispatch — otherwise localhost ping is rate-limited.
- NDP keeps hop-limit 255; `nd-redirect` stays excluded.
- Rule text for `ip saddr @mgmt_addrs tcp dport N accept` and the two `@in_cluster_ports` rules is byte-identical, since `parse.go` matches on it.

**Test commands**

```bash
go test ./internal/network/firewall/...

# Linux-only packages (internal/mount does not build on macOS)
GOOS=linux GOARCH=arm64 go test -c -tags='!integration' -o /tmp/steps.test ./internal/workflows/steps/
docker run --rm -v /tmp:/t debian:stable-slim /t/steps.test

task vm:test:integration TEST_NAME='^TestNetworkFirewall'
```

**nft validation against a real kernel.** Unit tests only compare strings and cannot tell you whether `nft` accepts the ruleset, so this was verified directly on nftables v1.1.3 — both the golden and a dual-stack variant with populated v6 sets load, re-apply idempotently, and all jumps resolve:

```bash
docker run --rm --privileged -v <dir>:/t debian:stable-slim sh -c \
  'apt-get update -qq && apt-get install -y -qq nftables && \
   nft -f /t/host.nft && nft -f /t/host.nft && nft list table inet weaver-host-firewall'
```

The kernel normalizes `icmpv6` → `ipv6-icmp` in the l4proto vmap and reorders the ct vmap keys; both are expected and neither affects semantics.

### Manual UAT

Run on a provisioned node. Every step maps to one of the silent-failure constraints above — the ruleset loads cleanly whether or not these hold, so string tests cannot cover any of them.

You need three vantage points: the node itself, a host inside `--mgmt-cidrs` (`$MGMT`), and a host outside it (`$OUTSIDE`). Set `$NODE` to the node's address on each client.

> **Step 8 deliberately severs your own SSH session.** Have console access or a second path in before you start.

**Setup — render the table**

```bash
sudo solo-provisioner network firewall create \
  --mgmt-cidrs 203.0.113.10/32 \
  --pod-cidr 10.244.0.0/16 \
  --in-cluster-ports 6443,4244,7472,10250 \
  --ssh-port 22 \
  --force
```

`create` is create-if-missing, so `--force` is what re-renders an existing table. Defaults if you omit them: `--ssh-port 22`, `--in-cluster-ports 6443,4244,7472,10250`, and `--pod-cidr` auto-detected from the local node's `.spec.podCIDR`.

**1. Five chains exist and every jump resolves**

```bash
sudo nft list table inet weaver-host-firewall | grep -E 'chain |jump'
```

```
	chain input {
		meta l4proto vmap { icmp : jump input_icmp_ipv4, ipv6-icmp : jump input_icmp_ipv6 }
		meta nfproto vmap { ipv4 : jump input_ipv4, ipv6 : jump input_ipv6 }
	chain input_icmp_ipv4 {
	chain input_icmp_ipv6 {
	chain input_ipv4 {
	chain input_ipv6 {
```

`ipv6-icmp` rather than `icmpv6` is the kernel's normalization, not a defect. An unresolved jump would have failed the load outright, so reaching this output is itself the check.

**2. Base-chain rule order**

```bash
sudo nft -a list chain inet weaver-host-firewall input
```

Confirm this exact relative order — this is where three of the invariants live:

```
ip saddr @blocked_addrs drop          # blocklist ...
ip6 saddr @blocked_addrs6 drop        # ... before the ct vmap
iif "lo" accept                       # loopback above the ICMP dispatch
meta l4proto vmap { icmp : jump …}    # ICMP dispatch ...
ct state vmap { established : …}      # ... before the ct vmap
meta nfproto vmap { ipv4 : jump …}
```

**3. Idempotent re-apply**

```bash
sudo nft -f /etc/solo-provisioner/network-weaver-host-firewall.nft
sudo nft -f /etc/solo-provisioner/network-weaver-host-firewall.nft
sudo nft list table inet weaver-host-firewall | grep -c 'jump'
```

Both loads silent, and the jump count unchanged (`2`) — proves the `add`/`delete`/`add table` header replaces rather than appends.

**4. SSH allowlist**

```bash
# from $MGMT — succeeds
ssh -o ConnectTimeout=5 "$NODE" true && echo OK

# from $OUTSIDE — hangs, then times out
nc -zv -w5 "$NODE" 22
```

Expected on `$OUTSIDE`:

```
nc: connect to <node> port 22 (tcp) timed out: Operation now in progress
```

A **timeout**, not `Connection refused` — the chain policy is `drop`, so nothing is sent back. A refusal would mean the packet reached a closed port past the firewall.

**5. Echo rate limit from a non-mgmt source** — the highest-value step

```bash
# from $OUTSIDE
sudo ping -f -w 10 -q "$NODE"
```

```
--- <node> ping statistics ---
8231 packets transmitted, 103 received, 98.7% packet loss
```

Roughly 100 replies over 10 s ≈ the 10/second cap. **If you see ~0% loss, the ICMP dispatch has fallen below the ct vmap** — packets 2..N match `established` and bypass the limit entirely. That is the regression this restructure is most likely to introduce, and nothing else in the suite catches it.

**6. Echo from a mgmt source is unlimited**

```bash
# from $MGMT
sudo ping -f -w 10 -q "$NODE"
```

Near-0% loss and thousands of packets — the `@mgmt_addrs` accept in `input_icmp_ipv4` precedes the rate limit.

**7. Localhost is unlimited**

```bash
# on the node
sudo ping -f -w 10 -q localhost
```

Near-0% loss. Proves `iif "lo" accept` is still above the ICMP dispatch; if it slipped below, this caps at 10/s.

**8. Blocklist kills established connections**

With an SSH session open from `$MGMT`, from your *second* path:

```bash
sudo solo-provisioner network firewall add --blocked-cidr 203.0.113.10/32
```

The live session must die immediately — that only happens if the blocklist drops sit ahead of `ct state established accept`. Then restore:

```bash
sudo solo-provisioner network firewall remove --blocked-cidr 203.0.113.10/32
```

Note the verbs: `add`/`remove` take the **singular** `--blocked-cidr`; `set --blocked-cidrs` replaces the whole list atomically.

**9. In-cluster ports reachable from the pod CIDR only**

```bash
# from inside the cluster — succeeds
kubectl run uat-probe --rm -it --restart=Never --image=nicolaka/netshoot -- \
  nc -zv "$NODE" 10250

# same port from $OUTSIDE — times out
nc -zv -w5 "$NODE" 10250
```

**10. IPv6 / NDP** — run this rather than assume it

```bash
sudo nft list chain inet weaver-host-firewall input_icmp_ipv6 | grep -E 'hoplimit|redirect'
ip -6 neigh show
ping6 -c3 "fe80::1%$(ip -o -6 route show default | awk '{print $5}')"
```

Expect the NDP accept to carry `ip6 hoplimit 255`, **no** `nd-redirect` rule, a populated neighbour table, and working link-local ping. Some kernels flag NDP as `invalid`; the pre-existing relative order (invalid drop before the NDP accepts) is preserved exactly, so behavior is unchanged either way — but if NDP were already being dropped, this PR would not surface it.

**11. Survives a reboot**

```bash
sudo reboot
# once back up
systemctl status solo-provisioner-network-nft.service
sudo nft list table inet weaver-host-firewall | grep -c 'chain '
```

Unit `active (exited)`, chain count `5`. The boot loader replays the same artifact, so a layout that only works when applied by the CLI would show up here.

**Risks / rollback.** No startup migration re-renders this template. The only re-render paths are `step_network_firewall.go` (block-node install / reconfigure-upgrade) and the `network firewall` CLI verbs, both create-if-missing — so the new layout cannot leak silently into already-provisioned clusters. Old and new layouts will coexist across the fleet until each node is explicitly re-rendered, which is safe because the artifact is replaced wholesale rather than patched. Rollback is a straight revert plus re-apply; there is no migration to undo.

### Related Issues

* Closes #976
