### PR TITLE
feat(cli): add eso secret create command

### DIFF
--- a/cmd/cli/commands/common/flags_common.go
+++ b/cmd/cli/commands/common/flags_common.go
@@ -121,6 +121,51 @@ func FlagESOChartVersion() FlagDefinition[string] {
 	}
 }
 
+func FlagESOSecretStore() FlagDefinition[string] {
+	return FlagDefinition[string]{
+		Name:        "store",
+		ShortName:   "",
+		Description: "Name of the ClusterSecretStore resource to sync from",
+		Default:     "",
+	}
+}
+
+func FlagESOSecretName() FlagDefinition[string] {
+	return FlagDefinition[string]{
+		Name:        "name",
+		ShortName:   "",
+		Description: "Name of the resulting Kubernetes Secret (and the ExternalSecret)",
+		Default:     "",
+	}
+}
+
+func FlagESOSecretNamespace() FlagDefinition[string] {
+	return FlagDefinition[string]{
+		Name:        "namespace",
+		ShortName:   "",
+		Description: "Namespace for both the ExternalSecret and the Kubernetes Secret",
+		Default:     "",
+	}
+}
+
+func FlagESORefreshInterval() FlagDefinition[string] {
+	return FlagDefinition[string]{
+		Name:        "refresh-interval",
+		ShortName:   "",
+		Description: "How often ESO re-syncs the secret from the store",
+		Default:     "1h",
+	}
+}
+
+func FlagESOSecretSet() RepeatableStringFlagDefinition {
+	return RepeatableStringFlagDefinition{
+		Name:        "set",
+		ShortName:   "",
+		Description: "Map a Secret key to a store path (format: KEY=store/path[#field]). Can be specified multiple times.",
+		Default:     nil,
+	}
+}
+
 func FlagMetricsServer() FlagDefinition[bool] {
 	return FlagDefinition[bool]{
 		Name:        "metrics-server",

--- a/cmd/cli/commands/eso/eso.go
+++ b/cmd/cli/commands/eso/eso.go
@@ -5,6 +5,7 @@ package eso
 import (
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
 	"github.com/hashgraph/solo-weaver/cmd/cli/commands/eso/operator"
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/eso/secret"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +18,7 @@ var esoCmd = &cobra.Command{
 
 func init() {
 	esoCmd.AddCommand(operator.GetCmd())
+	esoCmd.AddCommand(secret.GetCmd())
 }
 
 func GetCmd() *cobra.Command {

--- a/cmd/cli/commands/eso/secret/create.go
+++ b/cmd/cli/commands/eso/secret/create.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"time"
+
+	"github.com/automa-saga/logx"
+	"github.com/joomcode/errorx"
+	"github.com/spf13/cobra"
+
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/hashgraph/solo-weaver/internal/workflows"
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
+)
+
+var (
+	flagSecretStore           string
+	flagSecretName            string
+	flagSecretNamespace       string
+	flagSecretRefreshInterval string
+	flagSecretSet             []string
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create or update an ExternalSecret",
+	Long: `Create (or update) an ExternalSecret resource that the External Secrets
+Operator reconciles into a Kubernetes Secret.
+
+The command uses server-side apply, so re-running it with the same --name and
+--namespace updates the existing ExternalSecret in place.
+
+A ClusterSecretStore named by --store and the target --namespace must both
+already exist in the cluster.
+
+Example:
+  solo-provisioner eso secret create \
+    --store=vault-store \
+    --name=grafana-alloy-secrets \
+    --namespace=grafana-alloy \
+    --set PROMETHEUS_PASSWORD_PRIMARY=secret/data/grafana/alloy/prod/prometheus/primary#password \
+    --set LOKI_PASSWORD_PRIMARY=secret/data/grafana/alloy/prod/loki/primary#password`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := sanity.ValidateIdentifier(flagSecretStore); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --store")
+		}
+		if err := sanity.ValidateIdentifier(flagSecretName); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --name")
+		}
+		if err := sanity.ValidateIdentifier(flagSecretNamespace); err != nil {
+			return errorx.IllegalArgument.Wrap(err, "invalid --namespace")
+		}
+		refreshInterval, err := normalizeRefreshInterval(flagSecretRefreshInterval)
+		if err != nil {
+			return err
+		}
+
+		entries, err := parseSetFlags(flagSecretSet)
+		if err != nil {
+			return err
+		}
+
+		l := logx.As()
+		l.Debug().
+			Strs("args", args).
+			Str("store", flagSecretStore).
+			Str("name", flagSecretName).
+			Str("namespace", flagSecretNamespace).
+			Int("entries", len(entries)).
+			Msg("Creating ExternalSecret")
+
+		wb := workflows.NewESOSecretCreateWorkflow(workflows.ESOSecretOptions{
+			Name:            flagSecretName,
+			Namespace:       flagSecretNamespace,
+			StoreName:       flagSecretStore,
+			RefreshInterval: refreshInterval,
+			Data:            entries,
+		})
+
+		if err := common.RunWorkflowBuilder(cmd.Context(), wb); err != nil {
+			return err
+		}
+
+		l.Info().Msg("Successfully created ExternalSecret")
+		return nil
+	},
+}
+
+// normalizeRefreshInterval validates the --refresh-interval value as a
+// non-negative Go duration and returns it in the canonical form ESO stores
+// (e.g. 1h -> 1h0m0s), so identical re-runs stay server-side-apply no-ops.
+// It returns an IllegalArgument error on malformed or negative input.
+func normalizeRefreshInterval(s string) (string, error) {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return "", errorx.IllegalArgument.Wrap(err, "invalid --refresh-interval %q, expected a Go duration (e.g. 1h, 30m)", s)
+	}
+	if d < 0 {
+		return "", errorx.IllegalArgument.New("invalid --refresh-interval %q, duration must not be negative", s)
+	}
+	return d.String(), nil
+}
+
+func init() {
+	common.FlagESOSecretStore().SetVar(createCmd, &flagSecretStore, true)
+	common.FlagESOSecretName().SetVar(createCmd, &flagSecretName, true)
+	common.FlagESOSecretNamespace().SetVar(createCmd, &flagSecretNamespace, true)
+	common.FlagESORefreshInterval().SetVar(createCmd, &flagSecretRefreshInterval, false)
+	// --set required-ness is enforced by parseSetFlags (at least one entry).
+	common.FlagESOSecretSet().SetVar(createCmd, &flagSecretSet, false)
+}

--- a/cmd/cli/commands/eso/secret/create_test.go
+++ b/cmd/cli/commands/eso/secret/create_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_normalizeRefreshInterval_Valid(t *testing.T) {
+	cases := map[string]struct {
+		input string
+		want  string
+	}{
+		"hours":            {"1h", "1h0m0s"},
+		"minutes":          {"30m", "30m0s"},
+		"compound":         {"2h30m", "2h30m0s"},
+		"minutes overflow": {"90m", "1h30m0s"},
+		"fractional hours": {"1.5h", "1h30m0s"},
+		"seconds":          {"10s", "10s"},
+		"sub-second":       {"500ms", "500ms"},
+		"zero":             {"0", "0s"}, // ESO "fetch once" semantics
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := normalizeRefreshInterval(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func Test_normalizeRefreshInterval_Invalid(t *testing.T) {
+	cases := map[string]string{
+		"empty":               "",
+		"not a duration":      "banana",
+		"bad unit":            "1x",
+		"negative":            "-1h",
+		"number without unit": "15",
+		"newline injection":   "1h\n  deletionPolicy: Delete",
+	}
+
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := normalizeRefreshInterval(input)
+			require.ErrorContains(t, err, "invalid --refresh-interval")
+		})
+	}
+}

--- a/cmd/cli/commands/eso/secret/parse_set.go
+++ b/cmd/cli/commands/eso/secret/parse_set.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/joomcode/errorx"
+
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/hashgraph/solo-weaver/pkg/sanity"
+)
+
+// remoteRefValuePattern bounds the store path and property to a charset without
+// `"` or `\`, so values cannot escape the quoted scalars of the rendered manifest.
+var remoteRefValuePattern = regexp.MustCompile(`^[A-Za-z0-9._/@+=-]+$`)
+
+// parseSetFlags parses repeatable --set values of the form KEY=store/path[#field]
+// into ExternalSecret data entries, validating each field. At least one value is
+// required. It returns an IllegalArgument error on missing, malformed, or unsafe
+// input.
+func parseSetFlags(flags []string) ([]models.ESOSecretDataEntry, error) {
+	if len(flags) == 0 {
+		return nil, errorx.IllegalArgument.New("at least one --set KEY=store/path[#field] is required")
+	}
+
+	entries := make([]models.ESOSecretDataEntry, 0, len(flags))
+	seenKeys := make(map[string]struct{}, len(flags))
+	for _, flag := range flags {
+		rawKey, rawValue, found := strings.Cut(flag, "=")
+		key := strings.TrimSpace(rawKey)
+		value := strings.TrimSpace(rawValue)
+		if !found || key == "" {
+			return nil, errorx.IllegalArgument.New("invalid --set %q, expected KEY=store/path[#field]", flag)
+		}
+
+		if err := sanity.ValidateIdentifier(key); err != nil {
+			return nil, errorx.IllegalArgument.Wrap(err, "invalid secret key %q in --set %q", key, flag)
+		}
+
+		// Duplicate keys would render duplicate secretKey entries, which ESO's webhook rejects; fail fast here.
+		if _, dup := seenKeys[key]; dup {
+			return nil, errorx.IllegalArgument.New("duplicate secret key %q in --set %q", key, flag)
+		}
+		seenKeys[key] = struct{}{}
+
+		remoteKey, property, _ := strings.Cut(value, "#")
+
+		if !remoteRefValuePattern.MatchString(remoteKey) {
+			return nil, errorx.IllegalArgument.New("invalid store path %q in --set %q", remoteKey, flag)
+		}
+		if property != "" && !remoteRefValuePattern.MatchString(property) {
+			return nil, errorx.IllegalArgument.New("invalid property %q in --set %q", property, flag)
+		}
+
+		entries = append(entries, models.ESOSecretDataEntry{
+			SecretKey: key,
+			RemoteKey: remoteKey,
+			Property:  property,
+		})
+	}
+
+	return entries, nil
+}

--- a/cmd/cli/commands/eso/secret/parse_set_test.go
+++ b/cmd/cli/commands/eso/secret/parse_set_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashgraph/solo-weaver/pkg/models"
+)
+
+func Test_parseSetFlags_Valid(t *testing.T) {
+	entries, err := parseSetFlags([]string{
+		"PROMETHEUS_PASSWORD_PRIMARY=secret/data/grafana/alloy/prod/prometheus/primary#password",
+		"LOKI_PASSWORD_PRIMARY=secret/data/loki/primary",
+	})
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	assert.Equal(t, models.ESOSecretDataEntry{
+		SecretKey: "PROMETHEUS_PASSWORD_PRIMARY",
+		RemoteKey: "secret/data/grafana/alloy/prod/prometheus/primary",
+		Property:  "password",
+	}, entries[0])
+
+	assert.Equal(t, models.ESOSecretDataEntry{
+		SecretKey: "LOKI_PASSWORD_PRIMARY",
+		RemoteKey: "secret/data/loki/primary",
+		Property:  "", // no #field
+	}, entries[1])
+}
+
+func Test_parseSetFlags_Malformed(t *testing.T) {
+	cases := map[string]struct {
+		input    string
+		errorMsg string
+	}{
+		"empty list":        {"", "at least one --set"},
+		"no equals":         {"PROMETHEUS_PASSWORD", "expected KEY=store/path[#field]"},
+		"empty key":         {"=secret/data/foo", "expected KEY=store/path[#field]"},
+		"empty path":        {"KEY=", "invalid store path"},
+		"bad key char":      {"BAD KEY=secret/data/foo", "invalid secret key"},
+		"path with space":   {"KEY=secret/data /foo", "invalid store path"},
+		"path with newline": {"KEY=secret/data\nfoo", "invalid store path"},
+		"path with quote":   {"KEY=secret/\"data\"/foo", "invalid store path"},
+		"bad property char": {"KEY=secret/data/foo#bad prop", "invalid property"},
+		"multiple hashes":   {"KEY=secret/data/foo#bad#prop", "invalid property"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var flags []string
+			if tc.input != "" {
+				flags = []string{tc.input}
+			}
+			_, err := parseSetFlags(flags)
+			require.ErrorContains(t, err, tc.errorMsg)
+		})
+	}
+}
+
+func Test_parseSetFlags_DuplicateKey(t *testing.T) {
+	_, err := parseSetFlags([]string{"FOO=secret/data/a", "FOO=secret/data/b"})
+	require.ErrorContains(t, err, "duplicate secret key")
+}
+
+func Test_parseSetFlags_TrailingHashMeansNoProperty(t *testing.T) {
+	entries, err := parseSetFlags([]string{"FOO=secret/data/a#"})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "secret/data/a", entries[0].RemoteKey)
+	assert.Equal(t, "", entries[0].Property)
+}

--- a/cmd/cli/commands/eso/secret/secret.go
+++ b/cmd/cli/commands/eso/secret/secret.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"github.com/hashgraph/solo-weaver/cmd/cli/commands/common"
+	"github.com/spf13/cobra"
+)
+
+var secretCmd = &cobra.Command{
+	Use:   "secret",
+	Short: "Manage External Secrets Operator secrets",
+	Long:  "Manage ExternalSecret resources that the External Secrets Operator (ESO) reconciles into Kubernetes Secrets.",
+	RunE:  common.DefaultRunE, // ensure we have a default action to make it runnable
+}
+
+func init() {
+	secretCmd.AddCommand(createCmd)
+}
+
+func GetCmd() *cobra.Command {
+	return secretCmd
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1068,6 +1068,31 @@ sudo solo-provisioner eso operator uninstall --namespace my-eso
 |---------------|--------------------|--------------------------------------------------------------------|
 | `--namespace` | `external-secrets` | Kubernetes namespace for the External Secrets Operator |
 
+#### Create an ExternalSecret
+
+Create (or update) an `ExternalSecret` that ESO reconciles into a Kubernetes Secret. The command uses server-side apply, so re-running it with the same `--name`/`--namespace` updates the existing `ExternalSecret` in place.
+
+> **Prerequisite:** a `ClusterSecretStore` named by `--store` and the target `--namespace` must both already exist in the cluster (the store points to your secrets backend — Vault, AWS, GCP, …). Setting up the `ClusterSecretStore` is cluster-operator configuration and is out of scope for this command.
+
+```bash
+sudo solo-provisioner eso secret create \
+  --store=vault-store \
+  --name=grafana-alloy-secrets \
+  --namespace=grafana-alloy \
+  --set PROMETHEUS_PASSWORD_PRIMARY=secret/data/grafana/alloy/prod/prometheus/primary#password \
+  --set LOKI_PASSWORD_PRIMARY=secret/data/grafana/alloy/prod/loki/primary#password
+```
+
+**Additional Flags**:
+
+| Flag                 | Default | Description                                                                             |
+|----------------------|---------|-----------------------------------------------------------------------------------------|
+| `--store`            | —       | **Required.** Name of the `ClusterSecretStore` resource to sync from                    |
+| `--name`             | —       | **Required.** Name of the resulting Kubernetes Secret (and the ExternalSecret)          |
+| `--namespace`        | —       | **Required.** Namespace for both the ExternalSecret and the Kubernetes Secret           |
+| `--set`              | —       | Repeatable. Map a Secret key to a store path: `KEY=store/path[#field]`. At least one required |
+| `--refresh-interval` | `1h`    | How often ESO re-syncs the secret from the store                                        |
+
 ---
 
 ### Alloy Commands
@@ -1677,6 +1702,7 @@ sudo solo-provisioner teleport cluster uninstall
 # EXTERNAL SECRETS OPERATOR (ESO)
 sudo solo-provisioner eso operator install    [--namespace=<ns>] [--chart-version=<version>]
 sudo solo-provisioner eso operator uninstall  [--namespace=<ns>]
+sudo solo-provisioner eso secret create       --store=<name> --name=<secret> --namespace=<ns> --set KEY=store/path[#field] [--refresh-interval=<interval>]
 
 # ALLOY
 sudo solo-provisioner alloy cluster install   [--monitor-block-node] [--cluster-name=<name>]

--- a/internal/templates/files/eso/external-secret.yaml
+++ b/internal/templates/files/eso/external-secret.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: "{{ .Name }}"
+  namespace: "{{ .Namespace }}"
+spec:
+  refreshInterval: "{{ .RefreshInterval }}"
+  secretStoreRef:
+    name: "{{ .StoreName }}"
+    kind: ClusterSecretStore
+  target:
+    name: "{{ .Name }}"
+    creationPolicy: Owner
+  data:
+{{- range .Data }}
+    - secretKey: "{{ .SecretKey }}"
+      remoteRef:
+        key: "{{ .RemoteKey }}"
+{{- if .Property }}
+        property: "{{ .Property }}"
+{{- end }}
+{{- end }}

--- a/internal/workflows/eso.go
+++ b/internal/workflows/eso.go
@@ -23,3 +23,13 @@ func NewESOInstallWorkflow(opts ESOInstallOptions) (*automa.WorkflowBuilder, err
 func NewESOUninstallWorkflow(namespace string) *automa.WorkflowBuilder {
 	return steps.TeardownExternalSecrets(namespace)
 }
+
+// ESOSecretOptions aliases the steps-layer options so cmd callers need not
+// import internal/workflows/steps.
+type ESOSecretOptions = steps.ESOSecretOptions
+
+// NewESOSecretCreateWorkflow creates a workflow that applies an ExternalSecret to
+// the cluster, which ESO reconciles into the target Kubernetes Secret.
+func NewESOSecretCreateWorkflow(opts ESOSecretOptions) *automa.WorkflowBuilder {
+	return steps.SetupESOSecret(opts)
+}

--- a/internal/workflows/steps/step_eso_secret.go
+++ b/internal/workflows/steps/step_eso_secret.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"context"
+	"os"
+	"path"
+
+	"github.com/automa-saga/automa"
+	"github.com/hashgraph/solo-weaver/internal/kube"
+	"github.com/hashgraph/solo-weaver/internal/templates"
+	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/joomcode/errorx"
+)
+
+const (
+	SetupESOSecretStepId  = "setup-eso-secret"
+	CreateESOSecretStepId = "create-eso-secret"
+
+	esoExternalSecretTemplatePath = "files/eso/external-secret.yaml"
+)
+
+// esoSecretManifestFilePath is where the rendered ExternalSecret manifest is
+// written before it is applied to the cluster.
+var esoSecretManifestFilePath = path.Join(models.Paths().TempDir, "eso-external-secret.yaml")
+
+// ESOSecretOptions parameterizes the ExternalSecret create workflow. Its exported
+// fields are consumed directly by the manifest template.
+type ESOSecretOptions struct {
+	Name            string
+	Namespace       string
+	StoreName       string
+	RefreshInterval string
+	Data            []models.ESOSecretDataEntry
+}
+
+// SetupESOSecret returns a workflow builder that applies an ExternalSecret to the
+// cluster from the given options.
+func SetupESOSecret(opts ESOSecretOptions) *automa.WorkflowBuilder {
+	return automa.NewWorkflowBuilder().WithId(SetupESOSecretStepId).Steps(
+		createESOSecret(opts),
+	).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Creating ExternalSecret")
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to create ExternalSecret")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "ExternalSecret created successfully")
+		})
+}
+
+// renderESOSecretManifest renders the ExternalSecret manifest for the given
+// options. Extracted so it can be unit-tested without a cluster.
+func renderESOSecretManifest(opts ESOSecretOptions) (string, error) {
+	return templates.Render(esoExternalSecretTemplatePath, opts)
+}
+
+func createESOSecret(opts ESOSecretOptions) automa.Builder {
+	return automa.NewStepBuilder().WithId(CreateESOSecretStepId).
+		WithExecute(func(ctx context.Context, stp automa.Step) *automa.Report {
+			rendered, err := renderESOSecretManifest(opts)
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(
+					errorx.InternalError.Wrap(err, "failed to render ExternalSecret manifest").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Check the solo-provisioner logs for details: /opt/solo/weaver/logs/solo-provisioner.log",
+						})))
+			}
+
+			if err := os.WriteFile(esoSecretManifestFilePath, []byte(rendered), models.DefaultFilePerm); err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(
+					errorx.ExternalError.Wrap(err, "failed to write ExternalSecret manifest to %s", esoSecretManifestFilePath).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Check free disk space and write permissions for " + models.Paths().TempDir,
+						})))
+			}
+
+			k, err := kube.NewClient()
+			if err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(
+					errorx.ExternalError.Wrap(err, "failed to initialise Kubernetes client").
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Verify the cluster is reachable: kubectl cluster-info",
+							"Ensure the Kubernetes cluster is installed: solo-provisioner kube cluster install",
+						})))
+			}
+
+			if err := k.ApplyManifest(ctx, esoSecretManifestFilePath); err != nil {
+				return automa.StepFailureReport(stp.Id(), automa.WithError(
+					errorx.ExternalError.Wrap(err, "failed to apply ExternalSecret %q in namespace %q", opts.Name, opts.Namespace).
+						WithProperty(models.ErrPropertyResolution, []string{
+							"Ensure the External Secrets Operator is installed: solo-provisioner eso operator install",
+							"Ensure the namespace exists: kubectl get namespace " + opts.Namespace,
+							"If the error mentions the ESO webhook, wait for the operator to become ready and retry",
+							"Inspect the rendered manifest: " + esoSecretManifestFilePath,
+						})))
+			}
+
+			return automa.StepSuccessReport(stp.Id(), automa.WithMetadata(map[string]string{"created": "true"}))
+		}).
+		WithPrepare(func(ctx context.Context, stp automa.Step) (context.Context, error) {
+			notify.As().StepStart(ctx, stp, "Applying ExternalSecret %s", opts.Name)
+			return ctx, nil
+		}).
+		WithOnFailure(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepFailure(ctx, stp, rpt, "Failed to apply ExternalSecret")
+		}).
+		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
+			notify.As().StepCompletion(ctx, stp, rpt, "ExternalSecret applied successfully")
+		})
+}

--- a/internal/workflows/steps/step_eso_secret_test.go
+++ b/internal/workflows/steps/step_eso_secret_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package steps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/hashgraph/solo-weaver/pkg/models"
+)
+
+func Test_renderESOSecretManifest(t *testing.T) {
+	opts := ESOSecretOptions{
+		Name:            "grafana-alloy-secrets",
+		Namespace:       "grafana-alloy",
+		StoreName:       "vault-store",
+		RefreshInterval: "30m",
+		Data: []models.ESOSecretDataEntry{
+			{SecretKey: "PROMETHEUS_PASSWORD_PRIMARY", RemoteKey: "secret/data/prom/primary", Property: "password"},
+			{SecretKey: "LOKI_PASSWORD_PRIMARY", RemoteKey: "secret/data/loki/primary"},
+		},
+	}
+
+	rendered, err := renderESOSecretManifest(opts)
+	require.NoError(t, err)
+
+	// Must be valid YAML and carry the resolved fields.
+	var doc map[string]interface{}
+	require.NoError(t, yaml.Unmarshal([]byte(rendered), &doc), "rendered manifest must be valid YAML")
+
+	assert.Equal(t, "external-secrets.io/v1", doc["apiVersion"])
+	assert.Equal(t, "ExternalSecret", doc["kind"])
+
+	meta := doc["metadata"].(map[string]interface{})
+	assert.Equal(t, "grafana-alloy-secrets", meta["name"])
+	assert.Equal(t, "grafana-alloy", meta["namespace"])
+
+	spec := doc["spec"].(map[string]interface{})
+	assert.Equal(t, "30m", spec["refreshInterval"])
+	assert.Equal(t, "vault-store", spec["secretStoreRef"].(map[string]interface{})["name"])
+	assert.Equal(t, "ClusterSecretStore", spec["secretStoreRef"].(map[string]interface{})["kind"])
+	assert.Equal(t, "grafana-alloy-secrets", spec["target"].(map[string]interface{})["name"])
+
+	data := spec["data"].([]interface{})
+	require.Len(t, data, 2)
+
+	first := data[0].(map[string]interface{})
+	assert.Equal(t, "PROMETHEUS_PASSWORD_PRIMARY", first["secretKey"])
+	firstRef := first["remoteRef"].(map[string]interface{})
+	assert.Equal(t, "secret/data/prom/primary", firstRef["key"])
+	assert.Equal(t, "password", firstRef["property"])
+
+	second := data[1].(map[string]interface{})
+	assert.Equal(t, "LOKI_PASSWORD_PRIMARY", second["secretKey"])
+	secondRef := second["remoteRef"].(map[string]interface{})
+	assert.Equal(t, "secret/data/loki/primary", secondRef["key"])
+	_, hasProperty := secondRef["property"]
+	assert.False(t, hasProperty, "entry without #field must omit property")
+}
+
+func Test_renderESOSecretManifest_QuotedScalars(t *testing.T) {
+	// Values that plain YAML scalars would mangle (parse as int/bool, or reject
+	// outright for a leading @) must survive as strings via the quoted template.
+	opts := ESOSecretOptions{
+		Name:            "123",
+		Namespace:       "default",
+		StoreName:       "vault-store",
+		RefreshInterval: "0",
+		Data: []models.ESOSecretDataEntry{
+			{SecretKey: "FOO", RemoteKey: "@env/1234", Property: "0"},
+		},
+	}
+
+	rendered, err := renderESOSecretManifest(opts)
+	require.NoError(t, err)
+
+	var doc map[string]interface{}
+	require.NoError(t, yaml.Unmarshal([]byte(rendered), &doc), "rendered manifest must be valid YAML")
+
+	meta := doc["metadata"].(map[string]interface{})
+	assert.Equal(t, "123", meta["name"], "numeric-looking name must stay a string")
+
+	spec := doc["spec"].(map[string]interface{})
+	assert.Equal(t, "0", spec["refreshInterval"], "zero interval must stay a string")
+
+	entry := spec["data"].([]interface{})[0].(map[string]interface{})
+	ref := entry["remoteRef"].(map[string]interface{})
+	assert.Equal(t, "@env/1234", ref["key"], "leading @ and digits must stay a string")
+	assert.Equal(t, "0", ref["property"], "numeric property must stay a string")
+}

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -352,6 +352,16 @@ type AlloyRemoteConfig struct {
 	LabelProfile string `yaml:"labelProfile" json:"labelProfile"` // Label profile name (e.g. ops) for auto-derived labels
 }
 
+// ESOSecretDataEntry maps one key of a Kubernetes Secret to a location in the
+// external store, parsed from a single `eso secret create --set` value
+// (KEY=store/path[#field]). It renders into one entry of an ExternalSecret's
+// spec.data.
+type ESOSecretDataEntry struct {
+	SecretKey string `yaml:"secretKey" json:"secretKey"` // key in the resulting K8s Secret
+	RemoteKey string `yaml:"remoteKey" json:"remoteKey"` // path/key in the external store
+	Property  string `yaml:"property" json:"property"`   // optional field within the remote entry
+}
+
 // AlloyConfig represents the `alloy` configuration block for observability.
 // Note: Passwords are managed via Vault and External Secrets Operator, not in config files.
 type AlloyConfig struct {


### PR DESCRIPTION
## Description
Adds `solo-provisioner eso secret create`, which applies an `ExternalSecret` resource that the
External Secrets Operator reconciles into a Kubernetes Secret. This is the command the rest of
#377 exists for: it provisions the `grafana-alloy-secrets` Secret that `alloy cluster install`
consumes (the `alloy` help already references `eso secret create`).

What it does:

* Adds the `eso secret create` command (`cmd/cli/commands/eso/secret/…`), registered under `eso`.
* Required flags `--store`, `--name`, `--namespace`; repeatable `--set KEY=store/path[#field]`
  (at least one required); `--refresh-interval` (default `1h`) — validated and normalized to
  Go's canonical duration form at the CLI (`1h` → `1h0m0s`, matching how ESO's controller
  serializes `metav1.Duration`), so invalid values fail fast with `IllegalArgument` and
  identical re-runs are true server-side-apply no-ops.
* Parses `--set` in a helper (mirrors `alloy`'s `parse_remote.go`): splits `KEY=path[#field]`,
  validates the KEY as a K8s-safe identifier (`sanity.ValidateIdentifier`), bounds the store
  path/property to a YAML-safe charset so a value can't break out of the rendered manifest, and
  rejects duplicate KEYs (duplicate `secretKey` entries would be denied late by ESO's admission
  webhook — the CLI fails fast instead).
* Renders an `ExternalSecret` from a new embedded template and applies it via
  `kube.ApplyManifest` (server-side apply), inside a one-step automa workflow — same UX and
  error-handling as `eso operator install`/`uninstall`, and the same render→temp-file→apply
  pattern as the metallb config step. All templated scalars are double-quoted (Helm
  `| quote` convention) so user values can't be YAML-type-guessed (`--name=123` stays a
  string) or render unparseable scalars; the validated charsets exclude `"` and `\`, so
  values can't escape the quotes.
* Idempotent by construction: server-side apply creates or updates the `ExternalSecret` in place.

**Prerequisite (out of scope, documented):** a `ClusterSecretStore` named by `--store` and the
target `--namespace` must both already exist — the store points to the secrets backend
(Vault/AWS/GCP) and is cluster-operator configuration that varies by environment (#377 declares
it out of scope). Both prerequisites are stated in the command help and quickstart; the
apply-failure resolution hints cover the missing-namespace case. A missing store cannot fail the
apply at all — the ExternalSecret is admitted and ESO reports the failure asynchronously on the
resource's status (`READY False`), discoverable via kubectl.

### Review guide

* **Apply architecture** — a one-step workflow (`SetupESOSecret` → `createESOSecret`) rather than
  a bare apply in `RunE`, for TUI + doctor-error-handling parity with the other `eso` commands.
  The render→`os.WriteFile(TempDir)`→`ApplyManifest` sequence mirrors metallb's config step.
* **Input validation is at the CLI boundary** — `--store`/`--name`/`--namespace` via
  `sanity.ValidateIdentifier` and `--refresh-interval` via `time.ParseDuration` (+ canonical-form
  normalization) in `create.go`; each `--set` KEY via `ValidateIdentifier` and the store
  path/property via a YAML-safe regexp in `parse_set.go` (create renders untrusted input
  into a YAML manifest, so boundary validation matters here). Malformed input fails with an
  `IllegalArgument` error before any cluster call.
* **Idempotency** is server-side apply, not an explicit exists-check.
### Manual UAT

Run inside a VM/host with a reachable cluster (requires `sudo`). Copy-paste top-to-bottom. The
scenario mirrors the real #377 use case — the `grafana-alloy-secrets` Secret that
`alloy cluster install` consumes — with mock values.

**Setup** — install ESO + a `ClusterSecretStore`. For a self-contained test (no external Vault),
ESO's built-in `fake` provider (`fake` is the provider's API name) stands in for the real
secrets backend, serving mock passwords at Vault-style paths:

```bash
sudo solo-provisioner eso operator install
cat <<'EOF' | sudo KUBECONFIG=/etc/kubernetes/admin.conf kubectl apply -f -
apiVersion: external-secrets.io/v1
kind: ClusterSecretStore
metadata:
  name: fake-store
spec:
  provider:
    fake:
      data:
        - key: "/grafana/alloy/prometheus/primary"
          value: "mock-prometheus-password"
        - key: "/grafana/alloy/loki/primary"
          value: "mock-loki-password"
EOF
```

**1. Create → ESO syncs the K8s Secret**

```bash
sudo solo-provisioner eso secret create \
  --store=fake-store --name=grafana-alloy-secrets --namespace=default \
  --set PROMETHEUS_PASSWORD_PRIMARY=/grafana/alloy/prometheus/primary \
  --set LOKI_PASSWORD_PRIMARY=/grafana/alloy/loki/primary
```

Expected: an interactive progress run that exits 0, ending in `Completed successfully` (visible
workflow line `ExternalSecret created successfully`). ESO then reconciles the Secret — the real proof:

```bash
sudo KUBECONFIG=/etc/kubernetes/admin.conf kubectl get externalsecret grafana-alloy-secrets -n default
# → STATUS SecretSynced, READY True
sudo KUBECONFIG=/etc/kubernetes/admin.conf kubectl get secret grafana-alloy-secrets -n default -o jsonpath='{.data.PROMETHEUS_PASSWORD_PRIMARY}' | base64 -d
# → mock-prometheus-password    (LOKI_PASSWORD_PRIMARY → mock-loki-password)
```

**2. Idempotency / update (server-side apply)**

```bash
# re-run identical → exit 0 and the ExternalSecret is untouched: the CLI applies the
# canonical duration form, so this is a true server-side-apply no-op (even
# metadata.resourceVersion stays constant — compare it before/after if you want proof)
sudo solo-provisioner eso secret create --store=fake-store --name=grafana-alloy-secrets --namespace=default \
  --set PROMETHEUS_PASSWORD_PRIMARY=/grafana/alloy/prometheus/primary \
  --set LOKI_PASSWORD_PRIMARY=/grafana/alloy/loki/primary

# change the key set → apply updates the ExternalSecret in place
sudo solo-provisioner eso secret create --store=fake-store --name=grafana-alloy-secrets --namespace=default \
  --set PROMETHEUS_PASSWORD_PRIMARY=/grafana/alloy/prometheus/primary \
  --set LOKI_PASSWORD_SECONDARY=/grafana/alloy/loki/primary

# the ExternalSecret maps the new key set…
sudo KUBECONFIG=/etc/kubernetes/admin.conf kubectl get externalsecret grafana-alloy-secrets -n default -o jsonpath='{.spec.data[*].secretKey}'; echo
# → PROMETHEUS_PASSWORD_PRIMARY LOKI_PASSWORD_SECONDARY

# …and ESO re-syncs the Secret to match (old key pruned; may take a few seconds)
sudo KUBECONFIG=/etc/kubernetes/admin.conf kubectl describe secret grafana-alloy-secrets -n default
# → Data section lists LOKI_PASSWORD_SECONDARY + PROMETHEUS_PASSWORD_PRIMARY,
#   and LOKI_PASSWORD_PRIMARY is gone
```

**3. Malformed `--set` — rejected before any cluster call**

```bash
sudo solo-provisioner eso secret create --store=fake-store --name=n --namespace=default --set "BAD KEY=/grafana/alloy/loki/primary"
```

Expected: non-zero exit with `common.illegal_argument: invalid secret key "BAD KEY" in --set "BAD KEY=/grafana/alloy/loki/primary" …`.

**Cleanup**

```bash
sudo KUBECONFIG=/etc/kubernetes/admin.conf kubectl delete externalsecret,secret grafana-alloy-secrets -n default --ignore-not-found
sudo KUBECONFIG=/etc/kubernetes/admin.conf kubectl delete clustersecretstore fake-store --ignore-not-found
```

### Related Issues

* Closes #672
* Part of #377