### PR TITLE
feat(errors): errx foundation and pkg/sanity migration 1

### DIFF
--- a/.claude/skills/errorx-conventions/SKILL.md
+++ b/.claude/skills/errorx-conventions/SKILL.md
@@ -1,13 +1,27 @@
 ---
 name: errorx-conventions
-description: Use this skill BEFORE writing or modifying any Go error construction in this repo — e.g. "add error handling", "return an error from this function", any edit that introduces a new `return err` site, any urge to type `errors.New` or `fmt.Errorf` in production code under `cmd/`, `internal/`, `pkg/`. Production code must use `github.com/joomcode/errorx` and is enforced by `golangci-lint` (forbidigo). Captures the rule, the namespace mapping table, the sentinel pattern using `errors.Join`, and the test-file exemption. Read this BEFORE picking an errorx namespace — the wrong namespace silently degrades the doctor layer's error styling and exit-code mapping.
+description: Use this skill BEFORE writing or modifying any Go error construction in this repo — e.g. "add error handling", "return an error from this function", any edit that introduces a new `return err` site, any urge to type `errors.New` or `fmt.Errorf` in production code under `cmd/`, `internal/`, `pkg/`. Also read it before attaching a reason code or remediation hint with `errx` (`errx.Decorate`, `errx.WithReason`, `errx.WithHints`), picking a `reasons.*` constant from `pkg/reasons`, or declaring a new typed error / `errorx.NewNamespace`. Production code must use `github.com/joomcode/errorx` and is enforced by `golangci-lint` (forbidigo). Captures the rule, the namespace mapping table, when a typed error is justified, the sentinel pattern using `errors.Join`, the boundary rule for errx decoration, and the test-file exemption. Read this BEFORE picking an errorx namespace — the wrong namespace silently degrades the doctor layer's error styling and exit-code mapping.
 ---
 
 # errorx conventions for solo-weaver
 
-`github.com/joomcode/errorx` is the standard error library for all production code under `cmd/`, `internal/`, and `pkg/`. The stdlib `errors.New` and `fmt.Errorf` are **forbidden** in production code — the `.golangci.yml` `forbidigo` linter rejects new occurrences via the `lint:errorx` task wired into `task lint` and `task lint:check`.
+`github.com/joomcode/errorx` is the standard error library for all production code under `cmd/`, `internal/`, and `pkg/`. The stdlib `errors.New` and `fmt.Errorf` are **forbidden** there — the `.golangci.yml` `forbidigo` linter rejects new occurrences via the `lint:errorx` task wired into `task lint` and `task lint:check`.
 
-This skill captures *which* `errorx.<Type>` to pick for each shape of error and the few migration traps that catch the unwary.
+This skill captures *which* `errorx.<Type>` to pick for each shape of error, when a typed error is justified, and the migration traps that catch the unwary.
+
+> **Companion library — `errx`.** This skill answers *what kind* of error it is. `github.com/automa-saga/errx` answers *why it failed* and *what the operator should do*, via a reason code and remediation hints. It stores its data as `errorx` properties, so everything here still applies unchanged.
+>
+> When the error **crosses a package boundary** — an exported `error` return, an `automa.StepFailureReport`, or a `RunE` return in `cmd/` — also decorate it:
+>
+> ```go
+> return errx.Decorate(
+>     errorx.IllegalArgument.New("file does not exist: %s", path),
+>     reasons.FileMissing,
+>     "Check the path and that the file exists and is a regular file.",
+> )
+> ```
+>
+> Errors that stay inside the package get **no** decoration — decorating every layer duplicates hints and overwrites the reason as it propagates. Pick the reason from the target-vocabulary table in `docs/dev/error-handling.md`, which has the full contract.
 
 ---
 
@@ -21,7 +35,7 @@ This skill captures *which* `errorx.<Type>` to pick for each shape of error and 
 
 The lint scope is `new-from-rev: origin/main`: only **lines you change relative to main** are checked. Pre-existing neighbouring `fmt.Errorf` lines are not your problem unless you touch them.
 
-`errors.Is`, `errors.As`, `errors.Join`, and `errors.Unwrap` remain allowed and **are the right tools** for testing typed/sentinel errors — `errorx` errors implement the `Unwrap()` contract and play well with the stdlib `errors` utility functions. The skill bans construction primitives, not inspection primitives.
+`errors.Is`, `errors.As`, `errors.Join`, and `errors.Unwrap` remain allowed and **are the right tools** for testing typed/sentinel errors — `errorx` errors implement the `Unwrap()` contract. The skill bans construction primitives, not inspection primitives.
 
 ---
 
@@ -29,112 +43,96 @@ The lint scope is `new-from-rev: origin/main`: only **lines you change relative 
 
 Pick the namespace by the *shape of the failure*, not by the file the code lives in.
 
-| Call site shape | `errorx` target | Example |
-|---|---|---|
-| File I/O failure (`os.Open`, `os.Stat`, `os.ReadFile`) | `errorx.ExternalError.Wrap(err, "...")` | `errorx.ExternalError.Wrap(err, "failed to open %s", path)` |
-| Shell / exec command failure (`exec.Command`, `automa_steps.RunBashScript`) | `errorx.ExternalError.Wrap` | `errorx.ExternalError.Wrap(err, "failed to initialize cluster with kubeadm")` |
-| Helm / kubectl / kubernetes API call failure | `errorx.ExternalError.Wrap` | `errorx.ExternalError.Wrap(err, "failed to read K8s Secret %q in namespace %q", name, ns)` |
-| `crypto/rand`, `net.Dial`, HTTP request failure | `errorx.ExternalError.Wrap` | `errorx.ExternalError.Wrap(err, "endpoint %s is not reachable", url)` |
-| Template render / `text/template` `Execute` failure | `errorx.InternalError.Wrap` | `errorx.InternalError.Wrap(err, "failed to render core config")` |
-| Internal computation that should not have failed but did | `errorx.InternalError.Wrap` | `errorx.InternalError.Wrap(err, "failed to create kubeconfig manager")` |
-| `json.Unmarshal` / `yaml.Unmarshal` / malformed payload | `errorx.IllegalFormat.Wrap` or `.New` | `errorx.IllegalFormat.New("invalid user entry at line %d, no colons present", index)` |
-| Catalog / config / schema validation failure | `errorx.IllegalFormat.New` (or `.Wrap` over a sub-error) | `errorx.IllegalFormat.New("missing type (must be %q or %q)", classic, oci)` |
-| Invariant breach ("should never happen", "redirect loop", unreachable type switch default) | `errorx.AssertionFailed.New` | `errorx.AssertionFailed.New("unsupported flag type: %T", zero)` |
-| User-supplied CLI flag value, config value, or flag combination rejected | `errorx.IllegalArgument.New` or `.Wrap` | `errorx.IllegalArgument.New("--plugins is required when --plugin-preset=%s", custom)` |
-| User cancelled an operation; permission/authorization refused; policy rejection | `errorx.RejectedOperation.New` or `.Wrap` | `errorx.RejectedOperation.New("aborted by user")` |
-| Inconsistent runtime state (cluster missing required resource, unexpected enum value, wrong phase) | `errorx.IllegalState.New` | `errorx.IllegalState.New("K8s Secret %q not found in namespace %q", name, ns)` |
-| Hardware / environment doesn't meet requirements | `errorx.IllegalState.New` | `errorx.IllegalState.New("CPU does not meet %s requirements (minimum %d cores)", t, n)` |
+| Call site shape | `errorx` target |
+|---|---|
+| File I/O failure (`os.Open`, `os.Stat`, `os.ReadFile`) | `errorx.ExternalError.Wrap` |
+| Shell / exec command failure (`exec.Command`, `automa_steps.RunBashScript`) | `errorx.ExternalError.Wrap` |
+| Helm / kubectl / Kubernetes API call failure | `errorx.ExternalError.Wrap` |
+| `crypto/rand`, `net.Dial`, HTTP request failure | `errorx.ExternalError.Wrap` |
+| Template render / `text/template` `Execute` failure | `errorx.InternalError.Wrap` |
+| Internal computation that should not have failed but did | `errorx.InternalError.Wrap` |
+| `json.Unmarshal` / `yaml.Unmarshal` / malformed payload | `errorx.IllegalFormat.Wrap` or `.New` |
+| Catalog / config / schema validation failure | `errorx.IllegalFormat.New` |
+| Invariant breach ("should never happen", unreachable type-switch default) | `errorx.AssertionFailed.New` |
+| User-supplied CLI flag value, config value, or flag combination rejected | `errorx.IllegalArgument.New` or `.Wrap` |
+| User cancelled; permission/authorization refused; policy rejection | `errorx.RejectedOperation.New` or `.Wrap` |
+| Inconsistent runtime state (missing cluster resource, unexpected enum, wrong phase) | `errorx.IllegalState.New` |
+| Hardware / environment doesn't meet requirements | `errorx.IllegalState.New` |
 
-When the right namespace is genuinely ambiguous, prefer the one that gives the **user the most actionable signal** when surfaced by `internal/doctor/`. `IllegalArgument` ("the operator can fix their input") is preferable to `IllegalState` ("something is wrong with the cluster") when the failing operation is gated by a CLI flag the user just passed.
+Two tie-breakers:
+
+- When the namespace is genuinely ambiguous, prefer the one that gives the operator the most actionable signal in `internal/doctor/`. `IllegalArgument` ("the operator can fix their input") beats `IllegalState` ("something is wrong with the cluster") when the failing operation is gated by a flag the user just passed.
+- A permission failure reading a file is the ambiguous case in practice: `ExternalError` when it is an I/O call that failed (`os.Stat` → `EACCES`), `RejectedOperation` when *we* are refusing the operation (the superuser check in `root.go`).
+- The I/O rows cover an I/O call's *expected* failure modes. A residual "should not happen" branch left after those are handled takes `InternalError` — see the stat handling in `pkg/sanity/sanity.go`, where `EACCES` is `ExternalError` with hints and an unexplained stat failure is `InternalError` with `reasons.Internal`.
+
+When wrapping, the message describes *what we were trying to do*, not the underlying cause — that is already in the wrapped error. `errorx.ExternalError.Wrap(err, "failed to open %s", path)`, not `"failed to open %s: %w"`.
 
 ---
 
-## Decision matrix — common solo-weaver shapes
+## Declaring a typed error
 
-These are the cases that come up most often when editing this codebase:
+**Default: don't.** Use a built-in `errorx.<Type>` from the table and let the `errx` reason code carry the classification. A typed error is justified only when some caller must **branch on this exact error** (`errorx.IsOfType` / `errors.Is`) and behave differently. That is the only reason the existing typed errors exist — `state.NotFoundError`, `helm.ErrNotFound`, `principal.UserNotFoundError`, `daemon.ErrConfigNotFound`, `fsx.FileNotFound`, `os.ErrSwapDeviceNotFound`.
 
-- `os.Stat(...) failed` / `os.Open(...) failed` → **`ExternalError.Wrap`**
-- `kubectl get ... failed` / `kube.Client(...).Foo(...)` returned err → **`ExternalError.Wrap`**
-- `helm install/upgrade/uninstall ...` returned err → **`ExternalError.Wrap`** (or one of the `pkg/helm/errors.go` typed errors if it's there — keep those)
-- `automa_steps.RunBashScript(...)` returned err → **`ExternalError.Wrap`**
-- Bad `--profile`, `--release-name`, `--plugins`, etc. → **`IllegalArgument.New`** (or `.Wrap` if there's an upstream parse error)
-- Unexpected enum value, missing required state field after it should have been set → **`IllegalState.New`**
-- "should never happen" type-switch default branch in a generic function → **`AssertionFailed.New`**
-- User pressed Ctrl-C in a `huh` prompt; intentional cancel → **`RejectedOperation.New`**
-- Template `Execute` failed; `tmpl.Parse` failed → **`InternalError.Wrap`**
-- YAML/JSON unmarshal failed on data already in the binary or under our control → **`IllegalFormat.Wrap`**
+When it *is* justified, declare it in the package's `errors.go` as a **subtype of the built-in**, not under a fresh namespace:
 
-When wrapping, the message should describe *what we were trying to do*, not the underlying cause (that's already in the wrapped error). `errorx.ExternalError.Wrap(err, "failed to open %s", path)` — not `"failed to open %s: %w"` and not `"open %s returned an error: %v"`. `errorx` handles the wrap formatting.
+```go
+// Right — still IsOfType(err, errorx.IllegalArgument), so doctor's code stays 10400.
+var ErrInvalidIdentifier = errorx.IllegalArgument.NewSubtype("invalid_identifier")
+
+// Wrong — a fresh namespace severs the built-in match; doctor reports 10500 instead.
+var errNS = errorx.NewNamespace("sanity")
+```
+
+`doctor.toErrorCode` keys off `IsOfType` against the built-ins, so a fresh namespace silently changes the reported error code. Traits survive a fresh namespace; parent-type identity does not. `TestToErrorCode_NamespaceChoice` pins this.
+
+The ~13 packages with an existing `errorx.NewNamespace` (mostly in an `errors.go`) are **grandfathered** — use them (`errorx.IsOfType(err, helm.ErrNotFound)`), don't rename them, and don't copy the pattern. Full rationale in `docs/dev/error-handling.md`.
 
 ---
 
 ## Sentinel errors — `errors.Join`, not `fmt.Errorf`
 
-When you need a sentinel that callers can detect with `errors.Is`, define it once at package scope as an `errorx` typed value:
+Define a sentinel once at package scope as an `errorx` typed value:
 
 ```go
 // internal/ui/prompt/prompt.go
 var ErrAborted = errorx.RejectedOperation.New("aborted by user")
 ```
 
-To wrap a sentinel with a runtime cause, **use `errors.Join`**, not `fmt.Errorf("%w: %w", ...)`. `errors.Join` produces a multi-error whose `errors.Is` walks both sides — callers can match either the sentinel or the cause:
+To attach a runtime cause, **use `errors.Join`** — it produces a multi-error whose `errors.Is` walks both sides, so callers can match either the sentinel or the cause:
 
 ```go
-// Wrong (and forbidden by the lint):
-return fmt.Errorf("%w: %w", ErrAborted, cause)
-
-// Right:
-return errors.Join(ErrAborted, cause)
+return fmt.Errorf("%w: %w", ErrAborted, cause)  // wrong, and forbidden by the lint
+return errors.Join(ErrAborted, cause)           // right
 ```
 
-`errors.Is(result, ErrAborted)` and `errors.Is(result, cause)` both return `true` after the `errors.Join` call. The `fmt.Errorf("%w: %w", ...)` pattern (Go 1.20+) is technically equivalent for inspection but uses the forbidden constructor, so the lint rejects it.
+For a pure sentinel return with no cause, return the sentinel value directly.
 
-For pure sentinel returns (no runtime cause to attach), just return the sentinel value directly:
-
-```go
-if errors.Is(err, huh.ErrUserAborted) {
-    return ErrAborted
-}
-```
+**errx caveat:** a reason/hints attached to a join *operand* are invisible to `errx.ReasonOf`/`errx.Hints` (joins expose `Unwrap() []error`, which the traversal doesn't follow). At a decorated boundary, decorate on top of the join — `errx.Decorate(errorx.Decorate(errors.Join(ErrAborted, cause), "…"), reason, hints…)` — see docs/dev/error-handling.md.
 
 ---
 
 ## Migration traps
 
-Things that catch people during a `fmt.Errorf` → `errorx.*.Wrap` conversion:
+1. **Don't drop the `fmt` import** when the file still uses `fmt.Sprintf` / `fmt.Fprintln` / `fmt.Printf`. A `goimports` pass will tell you, but it's easy to over-trim by hand.
 
-1. **Don't drop the `fmt` import when the file still uses `fmt.Sprintf` / `fmt.Fprintln` / `fmt.Printf`.** A `goimports` pass after the conversion will tell you, but it's easy to over-trim by hand. Look for any remaining `fmt.*` calls before deleting the import.
+2. **Keep the format-string verbs intact.** `New` and `.Wrap` accept printf verbs; just drop the `%w` — `.Wrap(err, "...")` handles the wrapping.
 
-2. **Keep the format-string verbs intact.** `errorx.<Type>.New` and `.Wrap` accept printf-style verbs (`%s`, `%q`, `%d`, etc.). Just drop the `%w` for the wrapped error — `.Wrap(err, "...")` handles the wrapping for you. `errorx.ExternalError.Wrap(err, "failed to open %s", path)` — not `"failed to open %s: %w"`.
+3. **`errors.Is` against an `errorx`-typed sentinel needs the same variable identity** — declared once at package scope, never re-created per call. `errorx` types implement `Is(target error) bool` matching on value identity, so `errors.Is(err, ErrFoo)` holds whether `err` is `ErrFoo` directly or `errors.Join(ErrFoo, cause)`.
 
-3. **`errors.Is` against an `errorx`-typed sentinel still works**, but the sentinel must be the same variable identity (`var ErrFoo = errorx.<Type>.New(...)` declared once at package scope, never re-created per call). `errorx` types implement an `Is(target error) bool` method that matches on value identity, so `errors.Is(err, ErrFoo)` returns `true` whether `err` is `ErrFoo` directly or `errors.Join(ErrFoo, cause)`.
-
-4. **Custom inner-wrapping constructors** (e.g. `software.NewExtractionError(innerErr, ...)`): convert the inner argument to `errorx.<Type>.New(...)` rather than rewriting the constructor. The custom constructor stays; only the inner stdlib error becomes errorx.
-
-5. **Existing custom namespaces in `pkg/os/errors.go`, `pkg/helm/errors.go`, `pkg/fsx/errors.go` are grandfathered** — they predate the standardisation and use `errorx.NewNamespace(...)` plus typed errors like `helm.ErrNotFound`. Don't replace them with the built-in namespaces; do use them via `errorx.IsOfType(err, helm.ErrNotFound)` when checking specific helm conditions.
-
-6. **No new custom `errorx.NewNamespace` declarations.** Stick to the eight built-in `errorx.<Type>` namespaces in the mapping table. The custom namespaces above are technical debt we tolerate, not a pattern to copy.
+4. **Custom inner-wrapping constructors** (e.g. `software.NewExtractionError(innerErr, ...)`): convert the inner argument to `errorx.<Type>.New(...)` and leave the constructor alone.
 
 ---
 
 ## Why tests are exempted
 
-`*_test.go` files keep `errors.New` / `fmt.Errorf` because:
-
-- Test assertions usually check error *shape* (`require.ErrorContains(t, err, "...")`) or *identity* against a test-local sentinel, not namespace.
-- Rich `errorx` typing in a test body adds noise that obscures what the assertion is actually checking.
-- Tests are local to a package and don't flow through `internal/doctor/`, so the namespace metadata isn't used downstream.
-
-If you find yourself wanting an `errorx` type in a test, it's a signal that the test is exercising production behaviour better expressed in a non-test helper.
+Test assertions check error *shape* or identity against a test-local sentinel, not namespace, and tests don't flow through `internal/doctor/` — so the namespace metadata is unused and rich `errorx` typing only obscures the assertion. Wanting an `errorx` type in a test is a signal the behaviour belongs in a non-test helper.
 
 ---
 
 ## When to *not* return an error
 
-Independent of the construct rule: don't add error returns that the caller can't act on. Some shapes that look like errors but aren't:
+Independent of the construct rule: don't add error returns the caller can't act on.
 
 - "I detected drift but I'm continuing" — log at `Warn`, return `nil`.
-- "This optional feature isn't configured" — return a zero value, `nil`, and let the caller's nil-check skip the feature.
-- Genuine programming-error states reachable only via a broken refactor — `panic` with a descriptive message rather than `errorx.AssertionFailed.New`. `chartSpec` in `internal/workflows/steps/catalog.go` is the existing example: the surrounding code can't meaningfully recover, so panicking surfaces the bug at the development boundary.
-
-Errors that *don't* belong here go via these three escape hatches, not via clever errorx typing.
+- "This optional feature isn't configured" — return a zero value and `nil`; let the caller's nil-check skip it.
+- Programming-error states reachable only via a broken refactor — `panic` with a descriptive message rather than `errorx.AssertionFailed.New`. `chartSpec` in `internal/workflows/steps/catalog.go` is the existing example: the surrounding code can't recover, so panicking surfaces the bug at the development boundary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,8 @@ Uses `github.com/automa-saga/logx` (zerolog-based). Trace IDs are initialized in
 ### Developer Documentation
 
 Detailed framework docs live in `docs/dev/`:
+- `error-handling.md` — `errorx` + `errx` contract: reason codes, hints, typed errors
+- `security-model.md` — Trust boundaries and sandbox binary risks
 - `migration-framework.md` — Migration system design and usage
 - `functionality-test-suite.md` — Testing approach and patterns
 - `acceptance-tests.md` — Acceptance/UAT test patterns
@@ -245,5 +247,8 @@ Detailed framework docs live in `docs/dev/`:
 - Deployment profiles: `local`, `perfnet`, `testnet`, `previewnet`, `mainnet`
 - PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/)
 - License headers (SPDX) are required on all source files — enforced by `task license:check`
-- **Every `automa.StepFailureReport` must attach resolution hints on the error passed to `automa.WithError(...)`** via `WithProperty(models.ErrPropertyResolution, []string{...})` (preferred; `doctor.ErrPropertyResolution` is an alias and a single string is also supported). The resolution list must include operator-actionable steps to resolve the failure (e.g. commands to run, paths to check). This is surfaced in the TUI and in error output to the operator; a failure report without resolution hints is incomplete — treat it the same as a missing error message.
+- **New or changed `automa.StepFailureReport`s attach a reason code and operator-actionable hints** via `errx.Decorate(err, reasons.X, "step", ...)` on the error passed to `automa.WithError(...)`. Hints are commands to run or paths to check; a report without them is as incomplete as one without a message — except internal bugs, which get `reasons.Internal` and no hints - see `docs/dev/error-handling.md`
+- **Decorate only where an error crosses a package boundary** — an exported `error` return, a `StepFailureReport`, or a `RunE` return. Errors staying inside a package keep a plain `errorx.<Type>.Wrap`; decorating every layer duplicates hints and overwrites the reason, since the outermost wins.
+- **Don't declare new typed errors or `errorx.NewNamespace`.** Use a built-in `errorx.<Type>` and let the reason code classify. If a caller must branch on one exact error, declare it as `errorx.<Builtin>.NewSubtype("…")` — a fresh namespace silently changes the operator-visible error code.
+- **Render errors on human surfaces through `doctor.OperatorMessage`, not `err.Error()`** — the latter carries the printable `{reason: X}`, which belongs in logs only.
 - Prefer pure-Go over shelling out to external binaries. Read cluster state through the Kubernetes API (`internal/kube` client, injected as `kube.ClientProviderFromContext` — pass `kube.ClientFromContext` at the call site) rather than execing tool binaries (`cilium`, `kubectl`, …) and parsing their stdout — running binaries from the sandbox bin dir is a malicious-binary risk (see `docs/dev/security-model.md`). Follow the `step_cluster_*` pattern: take a provider, resolve the client once in `Execute`, and read via a named helper

--- a/cmd/cli/commands/common/flags.go
+++ b/cmd/cli/commands/common/flags.go
@@ -7,12 +7,14 @@ import (
 	"time"
 
 	"github.com/automa-saga/automa"
+	"github.com/automa-saga/errx"
 	"github.com/automa-saga/logx"
 	"github.com/joomcode/errorx"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/hashgraph/solo-weaver/internal/doctor"
+	"github.com/hashgraph/solo-weaver/pkg/reasons"
 )
 
 // FlagDefinition defines a command-line flag typed by T.
@@ -149,7 +151,8 @@ func (fp FlagDefinition[T]) ValueOwnPersistent(cmd *cobra.Command, args []string
 // SetVarP sets up the persistent flag and exits on error.
 func (fp FlagDefinition[T]) SetVarP(cmd *cobra.Command, p *T, required bool) {
 	if err := fp.varP(cmd, p, required); err != nil {
-		doctor.CheckErr(context.Background(), err, "failed to set flag %s", fp.Name)
+		doctor.CheckErr(context.Background(), errx.WithReason(
+			errorx.InternalError.Wrap(err, "failed to set flag %s", fp.Name), reasons.Internal))
 	}
 }
 
@@ -159,14 +162,16 @@ func (fp FlagDefinition[T]) SetVarP(cmd *cobra.Command, p *T, required bool) {
 func (fp FlagDefinition[T]) SetVarPHidden(cmd *cobra.Command, p *T, required bool) {
 	fp.SetVarP(cmd, p, required)
 	if err := cmd.PersistentFlags().MarkHidden(fp.Name); err != nil {
-		doctor.CheckErr(context.Background(), err, "failed to mark flag %s as hidden", fp.Name)
+		doctor.CheckErr(context.Background(), errx.WithReason(
+			errorx.InternalError.Wrap(err, "failed to mark flag %s as hidden", fp.Name), reasons.Internal))
 	}
 }
 
 // SetVar sets up the non-persistent flag and exits on error.
 func (fp FlagDefinition[T]) SetVar(cmd *cobra.Command, p *T, required bool) {
 	if err := fp.varNP(cmd, p, required); err != nil {
-		doctor.CheckErr(context.Background(), err, "failed to set flag %s", fp.Name)
+		doctor.CheckErr(context.Background(), errx.WithReason(
+			errorx.InternalError.Wrap(err, "failed to set flag %s", fp.Name), reasons.Internal))
 	}
 }
 
@@ -353,20 +358,23 @@ func (fp CommaSplitStringsFlagDefinition) ValueOwnPersistent(cmd *cobra.Command,
 
 func (fp CommaSplitStringsFlagDefinition) SetVarP(cmd *cobra.Command, p *[]string, required bool) {
 	if err := fp.varP(cmd, p, required); err != nil {
-		doctor.CheckErr(context.Background(), err, "failed to set flag %s", fp.Name)
+		doctor.CheckErr(context.Background(), errx.WithReason(
+			errorx.InternalError.Wrap(err, "failed to set flag %s", fp.Name), reasons.Internal))
 	}
 }
 
 func (fp CommaSplitStringsFlagDefinition) SetVarPHidden(cmd *cobra.Command, p *[]string, required bool) {
 	fp.SetVarP(cmd, p, required)
 	if err := cmd.PersistentFlags().MarkHidden(fp.Name); err != nil {
-		doctor.CheckErr(context.Background(), err, "failed to mark flag %s as hidden", fp.Name)
+		doctor.CheckErr(context.Background(), errx.WithReason(
+			errorx.InternalError.Wrap(err, "failed to mark flag %s as hidden", fp.Name), reasons.Internal))
 	}
 }
 
 func (fp CommaSplitStringsFlagDefinition) SetVar(cmd *cobra.Command, p *[]string, required bool) {
 	if err := fp.varNP(cmd, p, required); err != nil {
-		doctor.CheckErr(context.Background(), err, "failed to set flag %s", fp.Name)
+		doctor.CheckErr(context.Background(), errx.WithReason(
+			errorx.InternalError.Wrap(err, "failed to set flag %s", fp.Name), reasons.Internal))
 	}
 }
 
@@ -482,20 +490,23 @@ func (fp RepeatableStringFlagDefinition) ValueOwnPersistent(cmd *cobra.Command, 
 
 func (fp RepeatableStringFlagDefinition) SetVarP(cmd *cobra.Command, p *[]string, required bool) {
 	if err := fp.varP(cmd, p, required); err != nil {
-		doctor.CheckErr(context.Background(), err, "failed to set flag %s", fp.Name)
+		doctor.CheckErr(context.Background(), errx.WithReason(
+			errorx.InternalError.Wrap(err, "failed to set flag %s", fp.Name), reasons.Internal))
 	}
 }
 
 func (fp RepeatableStringFlagDefinition) SetVarPHidden(cmd *cobra.Command, p *[]string, required bool) {
 	fp.SetVarP(cmd, p, required)
 	if err := cmd.PersistentFlags().MarkHidden(fp.Name); err != nil {
-		doctor.CheckErr(context.Background(), err, "failed to mark flag %s as hidden", fp.Name)
+		doctor.CheckErr(context.Background(), errx.WithReason(
+			errorx.InternalError.Wrap(err, "failed to mark flag %s as hidden", fp.Name), reasons.Internal))
 	}
 }
 
 func (fp RepeatableStringFlagDefinition) SetVar(cmd *cobra.Command, p *[]string, required bool) {
 	if err := fp.varNP(cmd, p, required); err != nil {
-		doctor.CheckErr(context.Background(), err, "failed to set flag %s", fp.Name)
+		doctor.CheckErr(context.Background(), errx.WithReason(
+			errorx.InternalError.Wrap(err, "failed to set flag %s", fp.Name), reasons.Internal))
 	}
 }
 

--- a/cmd/cli/commands/common/run.go
+++ b/cmd/cli/commands/common/run.go
@@ -233,7 +233,7 @@ func finalizeWorkflowReport(report *automa.Report) error {
 		printJSONSummary(report, totalDuration, reportPath)
 	}
 
-	if err := deepestFailureError(report); err != nil {
+	if err := doctor.DeepestFailureError(report); err != nil {
 		return err
 	}
 	return report.Error
@@ -270,30 +270,6 @@ func printJSONSummary(report *automa.Report, duration time.Duration, reportPath 
 func fileExists(p string) bool {
 	_, err := os.Stat(p)
 	return err == nil
-}
-
-// deepestFailureError descends through nested StepReports to return the
-// leaf-level failed step's Error. Mirrors doctor.GetInstructionsFromReport's
-// recursion so that errorx properties attached on a deeply nested step
-// (e.g. preflight superuser check, weaver installation check) are not masked
-// by automa's workflow-level "completed with N failures" wrapper.
-func deepestFailureError(r *automa.Report) error {
-	if r == nil {
-		return nil
-	}
-	for _, sr := range r.StepReports {
-		if sr == nil || sr.Status != automa.StatusFailed {
-			continue
-		}
-		if deeper := deepestFailureError(sr); deeper != nil {
-			return deeper
-		}
-		if sr.Error != nil {
-			return sr.Error
-		}
-		return errorx.IllegalState.New("step %q failed", sr.Id)
-	}
-	return nil
 }
 
 // RunPersistentPreRun is the body of the root PersistentPreRunE hook.

--- a/cmd/cli/commands/common/run_test.go
+++ b/cmd/cli/commands/common/run_test.go
@@ -14,7 +14,7 @@ import (
 
 // TestDeepestFailureError_NilReport verifies the nil guard.
 func TestDeepestFailureError_NilReport(t *testing.T) {
-	require.NoError(t, deepestFailureError(nil))
+	require.NoError(t, doctor.DeepestFailureError(nil))
 }
 
 // TestDeepestFailureError_NoFailures returns nil when every step succeeded.
@@ -23,7 +23,7 @@ func TestDeepestFailureError_NoFailures(t *testing.T) {
 		automa.StepSuccessReport("child-a"),
 		automa.StepSuccessReport("child-b"),
 	))
-	require.NoError(t, deepestFailureError(r))
+	require.NoError(t, doctor.DeepestFailureError(r))
 }
 
 // TestDeepestFailureError_TopLevelFailure returns the immediate step's error
@@ -36,7 +36,7 @@ func TestDeepestFailureError_TopLevelFailure(t *testing.T) {
 		automa.StepFailureReport("child-a", automa.WithError(leafErr)),
 	))
 
-	got := deepestFailureError(r)
+	got := doctor.DeepestFailureError(r)
 	require.ErrorIs(t, got, leafErr)
 
 	// Resolution metadata is preserved on the returned error.
@@ -69,7 +69,7 @@ func TestDeepestFailureError_NestedFailure(t *testing.T) {
 		automa.WithStepReports(subWorkflow),
 	)
 
-	got := deepestFailureError(root)
+	got := doctor.DeepestFailureError(root)
 	require.ErrorIs(t, got, leafErr,
 		"expected leaf error, not the workflow-level wrapper")
 
@@ -87,9 +87,23 @@ func TestDeepestFailureError_FailedStepWithNilError(t *testing.T) {
 		automa.StepFailureReport("silent-step"),
 	))
 
-	got := deepestFailureError(r)
+	got := doctor.DeepestFailureError(r)
 	require.Error(t, got)
 	require.Contains(t, got.Error(), `"silent-step"`)
+}
+
+// TestDeepestFailureError_ErrorWithoutFailedStatus covers the shape automa's own
+// IsFailed treats as a failure: an attached error with a non-failed status. The
+// panel reads its hints from whatever this returns, so it must not be skipped.
+func TestDeepestFailureError_ErrorWithoutFailedStatus(t *testing.T) {
+	leafErr := errorx.ExternalError.New("step boom").
+		WithProperty(doctor.ErrPropertyResolution, []string{"fix the step"})
+
+	got := doctor.DeepestFailureError(&automa.Report{
+		Error:       errorx.IllegalState.New("workflow failed"),
+		StepReports: []*automa.Report{{Status: automa.StatusSuccess, Error: leafErr}},
+	})
+	require.ErrorIs(t, got, leafErr)
 }
 
 // TestDeepestFailureError_PicksFirstFailureNotSecond verifies that when
@@ -105,7 +119,7 @@ func TestDeepestFailureError_PicksFirstFailureNotSecond(t *testing.T) {
 		automa.StepFailureReport("child-c", automa.WithError(second)),
 	))
 
-	got := deepestFailureError(r)
+	got := doctor.DeepestFailureError(r)
 	require.ErrorIs(t, got, first)
 }
 
@@ -135,7 +149,7 @@ func TestDeepestFailureError_SkipsSkippedAndSuccessSiblings(t *testing.T) {
 		automa.StepFailureReport("bad-step", automa.WithError(leafErr)),
 	))
 
-	got := deepestFailureError(r)
+	got := doctor.DeepestFailureError(r)
 	require.ErrorIs(t, got, leafErr)
 }
 

--- a/docs/dev/error-handling.md
+++ b/docs/dev/error-handling.md
@@ -1,0 +1,396 @@
+# Error Handling
+
+solo-weaver builds errors with [`errorx`](https://github.com/joomcode/errorx) and
+decorates the ones that cross a package boundary with
+[`errx`](https://github.com/automa-saga/errx). `errorx` answers *what kind of
+error is this*; `errx` answers *why it failed and what the operator should do*.
+
+`errx` stores its data as `errorx` properties and traverses `errorx` cause chains,
+so nothing about error *construction* changed: namespace selection still lives in
+`.claude/skills/errorx-conventions/SKILL.md`, and `errors.New` / `fmt.Errorf`
+remain forbidden in production code by `forbidigo`.
+
+---
+
+## Design principles
+
+The one-screen summary every migration PR follows; the sections below carry the
+rationale and the mechanics.
+
+**Construction**
+
+- `errx` carries reasons + operator hints; `errorx` stays the construction layer.
+  `errorx` answers *what kind of error*, `errx` answers *why and what to do*.
+- No bare `fmt.Errorf` / `errors.New` at package boundaries (`forbidigo`-enforced).
+- No new `errorx` namespaces or typed errors — built-in `errorx.<Type>` plus a
+  reason code. A fresh namespace silently changes the operator-visible error code.
+- A typed error is earned only when a caller must branch on that exact error —
+  then `errorx.<Builtin>.NewSubtype("…")` in that package's `errors.go`.
+- Already-namespaced packages stay as they are — reasons/hints are orthogonal to
+  renaming types.
+
+**Decoration**
+
+- Decorate only where the error leaves the package (exported return,
+  `StepFailureReport`, `RunE`); inner layers keep a plain `errorx.<Type>.Wrap` —
+  the outermost reason wins, so stacked decoration duplicates hints and
+  overwrites reasons.
+- Hints only for actionable failures (config/disk/RBAC/connectivity); internal
+  bugs get `reasons.Internal` and no hints.
+- Hints are commands to run or paths to check, attached as `[]string`, never a
+  bare string.
+- Never decorate an operand of `errors.Join` — decoration goes on top of the join.
+
+**Reason vocabulary**
+
+- One shared vocabulary in `pkg/reasons` (a leaf package), not per-package reason
+  files — reasons classify *what the operator must do*, not which package failed.
+- Prefer an existing constant; declare a new one only in the PR that first uses
+  it, and only when some consumer would treat it differently.
+- Package-local reasons are allowed for genuinely subsystem-specific failure modes.
+- Never rename or remove a shipped reason — the strings live in operator logs and
+  scripts.
+
+**Rendering**
+
+- Human surfaces render through `doctor.OperatorMessage`, never `err.Error()` —
+  the printable `{reason: X}` pair belongs in logs only.
+- `errx.Format()` is not used — the doctor panel's numbered resolution block is
+  richer.
+- **The error is the only hint channel.** Hints reach the panel by being attached
+  to the error; `CheckErr` takes no hints alongside it, and a failure report's
+  `Metadata` carries no `"instructions"` key. See *One hint channel* below.
+
+**Process**
+
+- Incremental per-package PRs, not one big refactor.
+- Each migration PR ships a boundary-decoration table test (one row per boundary:
+  expected reason + a hint fragment) and pins that neither the message nor the
+  `errorx` namespace changed.
+- Each PR rewrites its own package's legacy bare-string hint sites — no upfront
+  cross-cutting conversion pass.
+
+---
+
+## Usage
+
+```go
+// Reason only — nothing the operator can act on.
+return errx.WithReason(
+    errorx.InternalError.Wrap(err, "failed to stat file: %s", path),
+    reasons.Internal,
+)
+
+// Reason plus operator-actionable hints — the common case.
+return errx.Decorate(
+    errorx.IllegalArgument.New("file does not exist: %s", path),
+    reasons.FileMissing,
+    "Check the path and that the file exists and is a regular file.",
+)
+```
+
+`errx.ReasonOf(err)` and `errx.Hints(err)` read them back. Both follow the
+`errorx` cause chain *and* `errors.Unwrap`; when several layers carry the same
+property, **the outermost wins**. Neither sees inside `errors.Join` — never
+decorate a join operand; see the warning under *Compatibility during the
+migration*.
+
+Attach hints only where a real remediation exists — config, permissions,
+connectivity, a flag value. Internal bugs get a reason and no hints.
+
+---
+
+## Decorate at boundaries only
+
+**Decorate where the error leaves the package** — an exported `error` return, an
+`automa.StepFailureReport`, or a `RunE` return in `cmd/`. Everything else keeps a
+plain `errorx.<Type>.Wrap` with nothing attached.
+
+One operator-visible failure is often four or five stacked wraps. Decorating each
+duplicates hints in the output and, since the outermost reason wins, silently
+overwrites the reason as the error propagates.
+
+---
+
+## Typed errors vs reason codes
+
+**Default: do not declare a namespace or a typed error. Use the built-in
+`errorx.<Type>` and let the reason code carry the classification.** That is what
+issue #933's "package-level error types" requirement was for, and a reason code
+does the job better — it survives a type rename and lines up with the log's
+`reason=` field.
+
+A local namespace is not free. `doctor.toErrorCode` keys off `errorx.IsOfType`
+against the built-ins, so the same error declared three ways reports two codes:
+
+| Declaration | `IsOfType(…, IllegalArgument)` | Reported code |
+|---|---|---|
+| `errorx.IllegalArgument.New(…)` | true | 10400 |
+| `errorx.IllegalArgument.NewSubtype("invalid_identifier")` | true | 10400 |
+| `errorx.NewNamespace("sanity").NewType("invalid_identifier")` | **false** | **10500** |
+
+Traits do survive a local namespace — `NewNamespace("x", errorx.NotFound())` still
+yields 10404 — but parent-type identity does not.
+`TestToErrorCode_NamespaceChoice` pins all of it.
+
+So:
+
+1. **Default — no new type.** Built-in namespace + `errx.Decorate`, as in
+   `pkg/sanity`.
+2. **A caller must branch on this exact error** — declare it in that package's
+   `errors.go` as `errorx.<Builtin>.NewSubtype("…")`. You get a distinct type to
+   match while keeping `IsOfType` and the reported code. This is the only reason
+   the repo has typed errors today (`state.NotFoundError`, `helm.ErrNotFound`,
+   `principal.UserNotFoundError`, `daemon.ErrConfigNotFound`, `fsx.FileNotFound`,
+   `os.ErrSwapDeviceNotFound`); nothing branches on a built-in except `doctor`.
+3. **Already-namespaced packages stay as they are.** Adding reasons and hints is
+   orthogonal to renaming types, and a rename churns `IsOfType` call sites and
+   reported codes for no gain.
+
+`NewSubtype` inherits its parent's namespace, so the type reads
+`common.illegal_argument.invalid_identifier` — the name does not identify the
+package. If package-identifying type names ever matter more than the code, move
+`toErrorCode` onto `reasons.*` first, in its own PR; after that type identity
+stops mattering. Do not fold that into a package migration — the codes are
+operator-observable.
+
+### Deviations from issue #933
+
+Recorded here so ten migration PRs do not each re-derive them:
+
+- *"Package-level error types"* → reason codes, per the rule above.
+- *"Leverage `errx.Format()` for display"* → `doctor.OperatorMessage` plus
+  doctor's own numbered resolution block, which is richer than `Format`'s flat
+  output. `errx.Format` is unused.
+- *`errorx.Temporary()`* → **not adopted.** Nothing in solo-weaver retries, and
+  nothing reads the trait.
+
+---
+
+## Reason codes
+
+The shared vocabulary is `pkg/reasons` — PascalCase, so an error, a log line's
+`reason=` field and any `/status` output share one identifier. It is a **leaf
+package** (imports only `errx`); it cannot live in `pkg/models`, which already
+depends on `pkg/sanity`.
+
+Reasons classify *what the operator must do*, not which package failed. **Prefer
+an existing constant** — a new one is earned only when some consumer (`doctor`, a
+log filter, an exit code) would treat it differently.
+
+### Target vocabulary
+
+The ~100 pre-errx hint sites were audited for #933 and their failure modes cluster
+into the rows below. Every migration PR picks its reason from here instead of
+inventing one. A constant is **declared in `pkg/reasons` only in the PR that first
+uses it** — reserved rows live in this table until their package migrates. If a
+failure mode genuinely fits no row, add a row in the same PR that declares the
+constant.
+
+| Reason | Meaning (operator's view) | Status |
+|---|---|---|
+| `InvalidArgument` | A flag value, flag combination or positional argument was rejected | **declared** — `pkg/sanity` |
+| `FileMissing` | A required file, directory, binary or unit file does not exist and will not be created | **declared** — `pkg/sanity` |
+| `Internal` | An invariant breach or bug in solo-weaver, not an operator error | **declared** — `pkg/sanity` |
+| `PermissionDenied` | Superuser privilege required, or file/resource ownership or access denied | **declared** — `pkg/sanity` |
+| `NotInstalled` | A component is absent; the operator must run its install command first | **declared** — `internal/workflows`; reserved for `internal/bll` handlers, `internal/network` ("run `… create` first") |
+| `Unreachable` | An endpoint did not respond: K8s API server, daemon socket, block-node health | reserved — `internal/kube`, daemon steps, `internal/blocknode` |
+| `K8sAPIFailed` | A Kubernetes API operation failed (ConfigMaps, ServiceAccounts, …) | reserved — `internal/kube`, cluster steps |
+| `HelmOperationFailed` | A Helm install/upgrade/uninstall/render failed | reserved — `pkg/helm`, workflow steps |
+| `ServiceOperationFailed` | A systemd unit operation failed, or a unit is in the wrong state | reserved — `pkg/os`, daemon/service steps |
+| `DownloadFailed` | An artifact download failed: network error, HTTP status, truncated body — retrying is reasonable | reserved — `pkg/software` |
+| `IntegrityCheckFailed` | A checksum, signature or tamper check failed on a downloaded or installed artifact — do **not** retry; report it | reserved — `pkg/software`, `pkg/helm` |
+| `PreflightFailed` | A hardware/OS validation floor was not met (memory, storage, OS version) | reserved — `internal/workflows` preflight, `pkg/hardware` |
+| `ResourceNotReady` | A Kubernetes resource did not converge in time (pod/CRD/PVC); the API call itself succeeded | reserved — `internal/kube`, `internal/blocknode`, workflow steps |
+| `StateOperationFailed` | Reading, writing, refreshing or migrating the application state file failed | reserved — `internal/state`, `internal/rsl`, `internal/bll` |
+| `ConfigInvalid` | A configuration **file's contents** are malformed or incomplete (`config.yaml`, `daemon.yaml`) — not a flag value | reserved — `pkg/config`, `cmd/daemon` |
+| `PreconditionNotMet` | The system is in the wrong state for this command (already installed, service already running, resource still referenced); change the state or use a different verb | **declared** — `internal/workflows`; reserved for `internal/bll`, daemon/service steps |
+
+Two mapping calls settled during the #933 audit, recorded so they stay uniform:
+a requested version/platform absent from the embedded catalog is
+`InvalidArgument` (the operator picked a value we don't ship), not
+`NotInstalled`; and "already installed / already running" is
+`PreconditionNotMet` — there is deliberately no `AlreadyInstalled` twin.
+
+**Never rename or remove a shipped reason.** The strings appear in operator logs
+and possibly in scripts that grep for them, so a rename silently reclassifies
+every existing call site. Add the better name and leave the old constant in place.
+
+For a genuinely subsystem-specific failure mode, declare a package-local reason
+rather than widening the shared set — they work everywhere a shared one does:
+
+```go
+// internal/blocknode/reasons.go
+const ReasonStorageLayoutMismatch errx.Reason = "BlockNodeStorageLayoutMismatch"
+```
+
+---
+
+## How a reason reaches the operator
+
+`Diagnose` surfaces the reason as `ErrorDiagnosis.Reason` (printed in the `-V`
+panel); `CheckErr` writes it as a `reason=` field on the failure log line, with
+any attached hints alongside as a `hints=` array — the log file alone carries
+the remediation steps. Hints on the panel are resolved by `findResolution`,
+which returns the attached hints or falls back to the `errorx`-namespace text.
+
+`errx.PropertyReason` is registered **printable**, so `err.Error()` renders
+`… bad flag value {reason: InvalidArgument}`. That is wanted in a log line and is
+noise on a human surface, hence the split:
+
+| Surface | Renders | Reason inline? |
+|---|---|---|
+| log line, `%+v` dump | `err.Error()` | yes |
+| TUI step/phase failure line | `doctor.OperatorMessage(err)` | no |
+| panel `Cause:` line | `doctor.OperatorMessage(err)` | no |
+| panel `Reason:` line (`-V`) | `ErrorDiagnosis.Reason` | it *is* the reason |
+
+`OperatorMessage` is `err.Error()` minus every reason pair along the cause chain;
+the message, the `errorx` type, other printable properties, the `(hidden: …)`
+underlying error and the cause chain are untouched. **Render errors on a new human
+surface through it, not through `err.Error()`.** The removal is textual because
+`errorx` cannot render a message minus one printable property; the real fix is
+upstream in `errx`, after which `OperatorMessage` collapses to `err.Error()`.
+
+It walks the chain the same way `errx` does — `errorx` causes then
+`errors.Unwrap` — so it strips a nested reason left by stacked decoration, but not
+one attached to a `WithUnderlyingErrors` operand, which `errx.ReasonOf` cannot see
+either. One known gap remains: the default (non-`-V`) panel strips the reason
+without printing it anywhere.
+
+There is **no reason-to-exit-code mapping** — `CheckErr` exits 1 for every
+failure. Adding one is a separate change, since operator scripts observe the
+current value.
+
+---
+
+## One hint channel
+
+Remediation reaches the operator by **one** route: hints attached to the error,
+read back by `findResolution` into `ErrorDiagnosis.Resolution`, rendered as the
+numbered `Resolution:` block by both the compact and the `-V` panel.
+
+`CheckErr(ctx, err)` takes no hints beside the error, and nothing reads an
+`"instructions"` key out of a report's `Metadata`. Two earlier channels did:
+
+- a variadic `instructions ...string` blob on `CheckErr`, and
+- `automa.WithMetadata(map[string]string{"instructions": …})` on a failure report.
+
+Both were removed. They were not merely redundant: hints round-tripped
+`[]string` → `strings.Join("\n")` → `strings.Split("\n")` on the way to the
+panel, and the same hints rendered **numbered** through `Resolution` but
+**unnumbered** through the blob, decided by nothing more than which channel a
+given call site happened to populate. The blob also invited a printf mistake the
+signature could not reject — `CheckErr(ctx, err, "failed to set flag %s", name)`
+printed the format string verbatim and dropped `name`.
+
+A step that wants the operator to see a command therefore decorates the error it
+reports, and writes only genuine key/value facts into `Metadata`:
+
+```go
+return automa.FailureReport(stp,
+    automa.WithError(errx.Decorate(
+        errorx.IllegalState.New("weaver owner group %q has incorrect GID: expected %s, got %s",
+            name, want, got),
+        reasons.PreconditionNotMet,
+        fmt.Sprintf("sudo groupmod -g %s %s", want, name),
+        "Re-run this command once the GID matches.")),
+    automa.WithMetadata(meta))
+```
+
+Note the split the removal forces, and which is worth keeping on its own:
+**observed-vs-expected facts belong in the message, commands belong in the
+hints.** The blobs interleaved the two, so every fact was stated twice.
+
+`CheckReportErr` finds that error with `doctor.DeepestFailureError`, which
+descends to the leaf failed step: automa replaces an enclosing step's error with
+a fresh `workflow "X" completed with N step failures` wrapper that carries
+neither reason nor hints, so diagnosing the top-level error would silently drop
+both. `cmd/cli/commands/common` uses the same helper to pick the error it returns
+from `RunE`, so the panel and the returned error agree.
+
+---
+
+## Testing decoration
+
+A package that decorates its boundary errors carries a table test asserting it —
+see `TestValidatorsAreDecorated` in `pkg/sanity/errors_test.go`: one row per
+boundary, each asserting the expected reason and a distinctive fragment of the
+hint. Decoration is a large, mechanical diff, and a table a reviewer can read in a
+minute is the only practical way to check it without auditing every call site.
+Also pin that decoration changed neither the message nor the `errorx` namespace.
+
+---
+
+## Compatibility during the migration
+
+`models.ErrPropertyResolution` and `models.ErrPropertyReason` are **aliases** of
+`errx.PropertyResolution` / `errx.PropertyReason`, not independent registrations.
+`errorx` compares properties **by pointer, not by label**, so a second property
+also labelled `"resolution"` would be a distinct key that `errx.Hints` cannot see,
+silently dropping every pre-existing hint. `TestPropertyIdentity` pins it. Because
+of the aliasing, the ~100 legacy `WithProperty(ErrPropertyResolution, …)` sites and
+new `errx.WithHints` calls write to the same place.
+
+**New code must attach a `[]string`, never a bare `string`** — `errx.Hints`
+type-asserts to `[]string` and silently returns "no hints" for anything else. 14
+legacy sites still pass a bare string (`internal/bll/blocknode`, `internal/rsl`,
+`internal/workflows`, `cmd/cli`); each is rewritten to `errx.Decorate` by its own
+package's migration PR rather than converted upfront, which would only pre-touch
+files those PRs rewrite. Until then the coercion branch in `resolutionHints` is
+load-bearing, and it stays afterwards because `ErrPropertyResolution` is exported.
+
+Read every property through `doctor.extractProperty`, which follows the `errorx`
+cause chain **and** `errors.Unwrap` — exactly what `errx.extract` does. A reader
+that walks only the `errorx` chain stops at a plain `%w` wrapper and then
+disagrees with `errx` about whether an error carries hints at all.
+`TestExtractPropertyMatchesErrx` pins that parity — including the shared blind
+spot below, so a traversal fix must land in `errx` first, or in both at once.
+
+**Neither traversal sees inside `errors.Join`.** A joined error exposes its
+children through `Unwrap() []error`, which `errors.Unwrap` does not follow, so a
+reason or hints attached to a join *operand* are invisible to `errx.ReasonOf`,
+`errx.Hints` and the doctor alike (upstream errx v1.0.0 limitation). Never
+decorate an operand of `errors.Join`. Decorate on top of the join, using a
+transparent `errorx.Decorate` as the property carrier so `errors.Is` still
+reaches the sentinel:
+
+```go
+// wrong — the reason and hints vanish at the join
+return errors.Join(ErrAborted, errx.Decorate(cause, reasons.X, "hint"))
+
+// right — metadata outermost, sentinel still matchable with errors.Is
+return errx.Decorate(
+    errorx.Decorate(errors.Join(ErrAborted, cause), "context for the operator"),
+    reasons.X, "hint",
+)
+```
+
+(`errorx.<Type>.Wrap` is not a substitute for `errorx.Decorate` here — it wraps
+opaquely, which severs `errors.Is` from the sentinel.) `TestJoinHidesDecoration`
+pins both halves; when errx learns to traverse joins, its failure message says
+what to update.
+
+Parity is over **traversal**, not the value check: `resolutionHints` deliberately
+coerces a bare string to a one-element slice, and reports "no hints" for an empty
+`[]string` so the namespace fallback fires. `TestFindResolution` pins both.
+
+---
+
+## Quick reference
+
+| Task | Call |
+|---|---|
+| Build a typed error | `errorx.<Type>.New(…)` / `.Wrap(err, …)` |
+| Classify it at a boundary | `errx.WithReason(err, reasons.…)` |
+| Add operator hints | `errx.WithHints(err, "step", …)` |
+| Both at once | `errx.Decorate(err, reason, hints…)` |
+| Read the reason / hints | `errx.ReasonOf(err)` / `errx.Hints(err)` |
+| Render + exit (CLI) | `doctor.CheckErr(ctx, err)` |
+| Render a message on a human surface | `doctor.OperatorMessage(err)` |
+
+## See also
+
+- `.claude/skills/errorx-conventions/SKILL.md` — which `errorx` namespace to pick
+- `pkg/reasons` — the shared reason vocabulary
+- `internal/doctor/diagnose.go` — how a failure becomes operator-facing output

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/automa-saga/automa v0.11.0
 	github.com/automa-saga/daemonkit v0.1.0
+	github.com/automa-saga/errx v1.0.0
 	github.com/automa-saga/logx v0.5.0
 	github.com/automa-saga/version v1.0.0
 	github.com/bluet/syspkg v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/automa-saga/automa v0.11.0 h1:uc8T4syrLhM4FEKqfhmZ1GwsC9MXfsUJPRgUv4W
 github.com/automa-saga/automa v0.11.0/go.mod h1:pXFvdJeabtZmpDVcZNE64ijwS8WSpkUKa3kyjBfO7zI=
 github.com/automa-saga/daemonkit v0.1.0 h1:/ph77RqJnBAsx79oROEmlgZ63/aFNg0Tiy5GsdckI4M=
 github.com/automa-saga/daemonkit v0.1.0/go.mod h1:SljBxNkAAfJMfnC2hurv+NRZzwC2LRf2QZJR/waHwQA=
+github.com/automa-saga/errx v1.0.0 h1:2VDWBD2toBp3YmGF8P9+RTR1aaevkLMbB3qm2yzktBs=
+github.com/automa-saga/errx v1.0.0/go.mod h1:b2x9NigWF35P0Nnv6QtY5lmHGFmGY7/DallDeZCgscI=
 github.com/automa-saga/logx v0.5.0 h1:yuFC7JlEQRbEKr+6t9eg1kXAvRIIgzdu9Bz7a0gSJYo=
 github.com/automa-saga/logx v0.5.0/go.mod h1:8S9d499t8uro8yO3blI1hruXLEYWzrBp9ndCI/Ik/88=
 github.com/automa-saga/version v1.0.0 h1:3asMlA3P/Yr3CgctHGdV+hbKOof+9eexMXa046wBzmQ=

--- a/internal/doctor/diagnose.go
+++ b/internal/doctor/diagnose.go
@@ -4,6 +4,7 @@ package doctor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/automa-saga/automa"
+	"github.com/automa-saga/errx"
 	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/models"
 
@@ -40,6 +42,9 @@ type ErrorDiagnosis struct {
 	ProfilingSnapshots map[string]string `yaml:"ProfilingSnapshots" json:"profilingSnapshots"`
 	Resolution         []string          `yaml:"steps" json:"steps"`
 	WhyFloor           string            `yaml:"whyFloor" json:"whyFloor"`
+
+	// Reason is the errx reason code, "" when the call site is not decorated.
+	Reason string `yaml:"reason" json:"reason"`
 }
 
 func toErrorCode(err error) int {
@@ -60,30 +65,64 @@ func toErrorMessage(err error) (string, string) {
 		return err.Error(), ""
 	}
 
-	cause := ""
-	if e.Cause() != nil {
-		cause = fmt.Sprintf("%s", e.Cause())
+	return e.Message(), OperatorMessage(e.Cause())
+}
+
+// OperatorMessage renders err for a human surface (the TUI failure line, the
+// panel's Cause line): err.Error() minus errx's reason code, which those surfaces
+// already show separately. Log lines keep it inline — see docs/dev/error-handling.md.
+func OperatorMessage(err error) string {
+	if err == nil {
+		return ""
 	}
 
-	return e.Message(), cause
+	// err.Error() renders the whole cause chain, so every reason along it leaks —
+	// not just the outermost one errx.ReasonOf reports.
+	msg := err.Error()
+	for _, reason := range reasonsInChain(err) {
+		msg = stripPrintableProperty(msg, "reason", reason)
+	}
+
+	return msg
+}
+
+// reasonsInChain returns each distinct reason value attached along err's chain,
+// outermost first. Shares walkChain's blind spot: a reason on an underlying
+// error still renders, exactly as errx.ReasonOf cannot see one.
+func reasonsInChain(err error) []string {
+	var out []string
+	seen := map[string]bool{}
+
+	walkChain(err, func(e error) bool {
+		if v, ok := errorx.ExtractProperty(e, errx.PropertyReason); ok {
+			if s, ok := v.(string); ok && !seen[s] {
+				seen[s] = true
+				out = append(out, s)
+			}
+		}
+		return true
+	})
+
+	return out
+}
+
+// stripPrintableProperty removes one "<label>: <value>" pair from the "{...}" group
+// errorx renders printable properties into, dropping a group left empty.
+func stripPrintableProperty(msg, label, value string) string {
+	pair := label + ": " + value
+
+	msg = strings.ReplaceAll(msg, pair+", ", "")
+	msg = strings.ReplaceAll(msg, ", "+pair, "")
+	msg = strings.ReplaceAll(msg, " {"+pair+"}", "")
+	msg = strings.ReplaceAll(msg, "{"+pair+"}", "")
+
+	return strings.TrimSpace(msg)
 }
 
 func findResolution(err error) []string {
-	// Walk the full cause chain first: a resolution hint attached to an inner
-	// error must not be lost when outer layers (e.g. illegal_state wrappers in
-	// root.go) do not carry the property themselves.
-	for e := err; e != nil; {
-		if resolution, ok := errorx.ExtractProperty(e, ErrPropertyResolution); ok {
-			if resSteps, ok := resolution.([]string); ok {
-				return resSteps
-			}
-			return []string{fmt.Sprintf("%s", resolution)}
-		}
-		ex := errorx.Cast(e)
-		if ex == nil {
-			break
-		}
-		e = ex.Cause()
+	// Covers errx.WithHints and direct property attachments alike.
+	if hints, ok := resolutionHints(err); ok {
+		return hints
 	}
 
 	switch {
@@ -106,16 +145,55 @@ func findResolution(err error) []string {
 	}
 }
 
-func findWhyFloor(err error) string {
+// walkChain calls fn for each error in err's chain, outermost first, until fn
+// returns false. Mirrors errx.extract (unexported): walks the errorx causes and
+// errors.Unwrap, so it cannot see less than errx.Hints / errx.ReasonOf do.
+func walkChain(err error, fn func(error) bool) {
 	for e := err; e != nil; {
-		if why, ok := errorx.ExtractProperty(e, models.ErrPropertyWhyFloor); ok {
-			return fmt.Sprintf("%s", why)
+		if !fn(e) {
+			return
 		}
-		ex := errorx.Cast(e)
-		if ex == nil {
-			break
+		if ex := errorx.Cast(e); ex != nil {
+			e = ex.Cause()
+			continue
 		}
-		e = ex.Cause()
+		e = errors.Unwrap(e)
+	}
+}
+
+// extractProperty returns key's value from anywhere in err's chain, outermost first.
+func extractProperty(err error, key errorx.Property) (any, bool) {
+	var value any
+	var found bool
+
+	walkChain(err, func(e error) bool {
+		value, found = errorx.ExtractProperty(e, key)
+		return !found
+	})
+
+	return value, found
+}
+
+// resolutionHints returns the hints attached anywhere in err's chain, outermost
+// first. New code attaches []string; the bare-string branch carries the legacy
+// sites still awaiting their package's migration — see docs/dev/error-handling.md.
+func resolutionHints(err error) ([]string, bool) {
+	resolution, ok := extractProperty(err, ErrPropertyResolution)
+	if !ok {
+		return nil, false
+	}
+	if steps, ok := resolution.([]string); ok {
+		return steps, len(steps) > 0
+	}
+	if s, ok := resolution.(string); ok {
+		return []string{s}, s != ""
+	}
+	return []string{fmt.Sprintf("%s", resolution)}, true
+}
+
+func findWhyFloor(err error) string {
+	if why, ok := extractProperty(err, models.ErrPropertyWhyFloor); ok {
+		return fmt.Sprintf("%s", why)
 	}
 	return ""
 }
@@ -254,6 +332,9 @@ func Diagnose(ctx context.Context, ex error) *ErrorDiagnosis {
 
 	msg, cause := toErrorMessage(ex)
 	vinfo := version.Get()
+
+	reason, _ := errx.ReasonOf(ex)
+
 	return &ErrorDiagnosis{
 		Error:      ex,
 		ErrorType:  errorx.GetTypeName(ex),
@@ -268,6 +349,7 @@ func Diagnose(ctx context.Context, ex error) *ErrorDiagnosis {
 		Logfile:    config.Get().Log.Filename,
 		Resolution: findResolution(ex),
 		WhyFloor:   findWhyFloor(ex),
+		Reason:     reason.String(),
 	}
 }
 
@@ -276,25 +358,37 @@ func Diagnose(ctx context.Context, ex error) *ErrorDiagnosis {
 // error panel is shown and details are written only to the log file.
 var VerboseLevel int
 
-// CheckErr prints diagnosis and exit with error code 1
-// Optional instructions can be provided to give additional context to the user
-func CheckErr(ctx context.Context, err error, instructions ...string) {
-	// Always log the full stacktrace to the log file (not to console)
-	logx.As().Error().Msgf("%+v", err)
+// CheckErr prints diagnosis and exit with error code 1.
+//
+// Remediation steps come from the error itself — attach them with
+// errx.Decorate / errx.WithHints at the boundary that returns err. There is
+// deliberately no way to pass them alongside: a second channel renders the same
+// hints differently depending on which one happened to be populated.
+func CheckErr(ctx context.Context, err error) {
+	// Full stacktrace to the log file only, with the reason and hints as
+	// structured fields so the log alone carries the remediation steps.
+	ev := logx.As().Error()
+	if reason, ok := errx.ReasonOf(err); ok {
+		ev = ev.Str("reason", reason.String())
+	}
+	if hints, ok := resolutionHints(err); ok {
+		ev = ev.Strs("hints", hints)
+	}
+	ev.Msgf("%+v", err)
 
 	resp := Diagnose(ctx, err)
 
 	if VerboseLevel >= 1 {
-		checkErrVerbose(resp, instructions...)
+		checkErrVerbose(resp)
 	} else {
-		checkErrCompact(resp, instructions...)
+		checkErrCompact(resp)
 	}
 
 	os.Exit(1)
 }
 
 // checkErrCompact prints a concise, human-friendly error panel to stderr.
-func checkErrCompact(resp *ErrorDiagnosis, instructions ...string) {
+func checkErrCompact(resp *ErrorDiagnosis) {
 	fmt.Fprintf(os.Stderr, "\n  %s%s✗ Error:%s %s\n", Bold, Red, Reset, resp.Message)
 	if resp.Cause != "" {
 		fmt.Fprintf(os.Stderr, "  %s  Cause:%s %s\n", White, Reset, resp.Cause)
@@ -304,16 +398,7 @@ func checkErrCompact(resp *ErrorDiagnosis, instructions ...string) {
 	}
 
 	// Print resolution
-	if len(instructions) > 0 && instructions[0] != "" {
-		fmt.Fprintf(os.Stderr, "\n  %s%sResolution:%s\n", Bold, Yellow, Reset)
-		for _, line := range strings.Split(instructions[0], "\n") {
-			if line == "" {
-				fmt.Fprintln(os.Stderr)
-			} else {
-				fmt.Fprintf(os.Stderr, "    %s\n", line)
-			}
-		}
-	} else if len(resp.Resolution) > 0 {
+	if len(resp.Resolution) > 0 {
 		fmt.Fprintf(os.Stderr, "\n  %s%sResolution:%s\n", Bold, Yellow, Reset)
 		for i, r := range resp.Resolution {
 			fmt.Fprintf(os.Stderr, "    %d. %s\n", i+1, r)
@@ -332,7 +417,7 @@ func checkErrCompact(resp *ErrorDiagnosis, instructions ...string) {
 }
 
 // checkErrVerbose prints the full legacy error output with stacktrace and profiling.
-func checkErrVerbose(resp *ErrorDiagnosis, instructions ...string) {
+func checkErrVerbose(resp *ErrorDiagnosis) {
 	fmt.Printf("\n%s%s************************************** Error Stacktrace ******************************************%s\n", Bold, Gray, Reset)
 	fmt.Printf("\n%+v\n", resp.Error) // Print full error with stack trace
 
@@ -343,6 +428,10 @@ func checkErrVerbose(resp *ErrorDiagnosis, instructions ...string) {
 	}
 	fmt.Printf("\t%sError Type:%s %s\n", Bold+White, Reset, resp.ErrorType)
 	fmt.Printf("\t%sError Code:%s %d\n", Bold+White, Reset, resp.Code)
+	if resp.Reason != "" {
+		// Bare, to grep against the log's reason= field.
+		fmt.Printf("\t%sReason:%s %s\n", Bold+White, Reset, resp.Reason)
+	}
 	fmt.Printf("\t%sCommit:%s %s\n", Gray, Reset, resp.Commit)
 	fmt.Printf("\t%sPid:%s %d\n", Gray, Reset, resp.Pid)
 	fmt.Printf("\t%sTraceId:%s %s\n", Gray, Reset, resp.TraceId)
@@ -360,23 +449,8 @@ func checkErrVerbose(resp *ErrorDiagnosis, instructions ...string) {
 
 	fmt.Printf("\n%s%s****************************************** Resolution *********************************************%s\n", Bold, Yellow, Reset)
 
-	// Print custom instructions first if provided
-	if len(instructions) > 0 && instructions[0] != "" {
-		for _, line := range strings.Split(instructions[0], "\n") {
-			if line == "" {
-				fmt.Println()
-			} else {
-				fmt.Printf("\t%s\n", Bold+White+line+Reset)
-			}
-		}
-		if len(resp.Resolution) > 0 {
-			fmt.Println()
-		}
-	} else {
-		// Print default resolution steps
-		for _, r := range resp.Resolution {
-			fmt.Printf("\t%s\n", White+r+Reset)
-		}
+	for i, r := range resp.Resolution {
+		fmt.Printf("\t%s\n", White+fmt.Sprintf("%d. %s", i+1, r)+Reset)
 	}
 }
 
@@ -387,48 +461,41 @@ func CheckReportErr(ctx context.Context, report *automa.Report) {
 	}
 
 	if report.Error != nil {
-		// pick the first error when scanning step reports
-		rootErr := report.Error
-		var errStepReport *automa.Report
-		for _, stepReport := range report.StepReports {
-			if stepReport != nil && stepReport.Error != nil {
-				rootErr = stepReport.Error
-				errStepReport = stepReport
-				break
-			}
+		// Diagnose the leaf error, not automa's "completed with N failures"
+		// wrapper: the hints and reason are attached where the step failed.
+		rootErr := DeepestFailureError(report)
+		if rootErr == nil {
+			rootErr = report.Error
 		}
 
-		// Check for instructions in any nested reports before showing error
-		instructions := GetInstructionsFromReport(errStepReport)
-
-		CheckErr(ctx, rootErr, instructions)
+		CheckErr(ctx, rootErr)
 	}
 }
 
-// GetInstructionsFromReport recursively searches for instructions in report metadata.
-// Returns the first non-empty instructions found in the report tree, or an empty string if none exist.
-func GetInstructionsFromReport(report *automa.Report) string {
-	if report == nil {
-		return ""
+// DeepestFailureError descends through nested StepReports to return the
+// leaf-level failed step's Error, so that errx hints and reasons attached on a
+// deeply nested step (e.g. the preflight superuser check, the weaver
+// installation check) are not masked by automa's workflow-level
+// "completed with N failures" wrapper. Returns nil when no step failed.
+//
+// Failure is automa's own IsFailed predicate — a failed status *or* an attached
+// error — so a step that reports an error without setting the status still gets
+// its hints rendered.
+func DeepestFailureError(r *automa.Report) error {
+	if r == nil {
+		return nil
 	}
-
-	// Check if this report has instructions
-	if instructions, ok := report.Metadata["instructions"]; ok {
-		return instructions
-	}
-
-	if resolution, ok := errorx.ExtractProperty(report.Error, ErrPropertyResolution); ok {
-		return fmt.Sprintf("%s", resolution)
-	}
-
-	// Recursively check nested step reports
-	for _, stepReport := range report.StepReports {
-		if instructions := GetInstructionsFromReport(stepReport); instructions != "" {
-			return instructions
-		} else if resolution, ok := errorx.ExtractProperty(stepReport.Error, ErrPropertyResolution); ok {
-			return fmt.Sprintf("%s", resolution)
+	for _, sr := range r.StepReports {
+		if sr == nil || !sr.IsFailed() {
+			continue
 		}
+		if deeper := DeepestFailureError(sr); deeper != nil {
+			return deeper
+		}
+		if sr.Error != nil {
+			return sr.Error
+		}
+		return errorx.IllegalState.New("step %q failed", sr.Id)
 	}
-
-	return ""
+	return nil
 }

--- a/internal/doctor/diagnose_test.go
+++ b/internal/doctor/diagnose_test.go
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package doctor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/automa-saga/errx"
+	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/hashgraph/solo-weaver/pkg/reasons"
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/require"
+)
+
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// capturePanel runs fn with stdout and stderr redirected and returns the output
+// with ANSI colour codes stripped, so assertions can match the plain text.
+func capturePanel(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	// Drain concurrently: output past the pipe buffer would block fn() forever.
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		_, copyErr := io.Copy(&buf, r)
+		done <- copyErr
+	}()
+
+	origOut, origErr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = w, w
+	fn()
+	os.Stdout, os.Stderr = origOut, origErr
+	require.NoError(t, w.Close())
+
+	require.NoError(t, <-done)
+	return ansiRE.ReplaceAllString(buf.String(), "")
+}
+
+// TestToErrorCode_NamespaceChoice is the guardrail behind the "declare a typed
+// error as a subtype of the built-in" rule in docs/dev/error-handling.md. A fresh
+// namespace severs IsOfType against the built-in, which silently reclassifies the
+// operator-visible error code. If this test has to change, the codes changed —
+// make that deliberate rather than a side effect of a package migration.
+func TestToErrorCode_NamespaceChoice(t *testing.T) {
+	subtype := errorx.IllegalArgument.NewSubtype("namespace_choice_subtype")
+	freshNS := errorx.NewNamespace("namespace_choice_fresh")
+	freshType := freshNS.NewType("rejected")
+	traitNS := errorx.NewNamespace("namespace_choice_trait", errorx.NotFound())
+
+	t.Run("built-in namespace", func(t *testing.T) {
+		require.Equal(t, 10400, toErrorCode(errorx.IllegalArgument.New("bad flag")))
+	})
+
+	t.Run("subtype of a built-in keeps the code", func(t *testing.T) {
+		err := subtype.New("bad flag")
+		require.True(t, errorx.IsOfType(err, errorx.IllegalArgument),
+			"a subtype must still match its parent")
+		require.True(t, errorx.IsOfType(err, subtype),
+			"and must be matchable as itself — the whole point of declaring it")
+		require.Equal(t, 10400, toErrorCode(err))
+	})
+
+	t.Run("fresh namespace loses the code", func(t *testing.T) {
+		err := freshType.New("bad flag")
+		require.False(t, errorx.IsOfType(err, errorx.IllegalArgument),
+			"precondition: a fresh namespace does not inherit a built-in")
+		require.Equal(t, 10500, toErrorCode(err),
+			"10400 -> 10500 is the regression the subtype rule exists to prevent")
+	})
+
+	t.Run("traits survive a fresh namespace", func(t *testing.T) {
+		// Only parent-type identity is lost, so a NotFound namespace still maps.
+		require.Equal(t, 10404, toErrorCode(traitNS.NewType("missing").New("gone")))
+	})
+
+	t.Run("the namespace fallback degrades too", func(t *testing.T) {
+		require.Equal(t,
+			[]string{"Ensure all required arguments are provided with valid values."},
+			findResolution(subtype.New("bad flag")))
+		require.Equal(t,
+			[]string{"Check error message for details or contact support"},
+			findResolution(freshType.New("bad flag")))
+	})
+}
+
+// TestPropertyIdentity pins the aliasing: errorx compares properties by pointer, so
+// re-registering either label would hide every legacy hint and reason from errx.
+// Asserts the behaviour rather than the alias — require.Equal would accept a copy.
+func TestPropertyIdentity(t *testing.T) {
+	err := errorx.IllegalState.New("boom").
+		WithProperty(models.ErrPropertyResolution, []string{"legacy step"}).
+		WithProperty(models.ErrPropertyReason, reasons.FileMissing.String())
+
+	hints, ok := errx.Hints(err)
+	require.True(t, ok, "legacy hints must be visible to errx.Hints")
+	require.Equal(t, []string{"legacy step"}, hints)
+
+	reason, ok := errx.ReasonOf(err)
+	require.True(t, ok, "legacy reason must be visible to errx.ReasonOf")
+	require.Equal(t, reasons.FileMissing, reason)
+}
+
+// TestOperatorMessage pins the reason-surface split: log lines keep "{reason: X}"
+// inline, human surfaces drop it. Nothing else about the message may change.
+func TestOperatorMessage(t *testing.T) {
+	otherProp := errorx.RegisterPrintableProperty("operator_message_test_prop")
+
+	t.Run("drops the reason group", func(t *testing.T) {
+		err := errx.Decorate(errorx.IllegalArgument.New("bad flag value"), reasons.InvalidArgument)
+		require.Contains(t, err.Error(), "{reason: InvalidArgument}", "precondition: errx renders it")
+		require.Equal(t, "common.illegal_argument: bad flag value", OperatorMessage(err))
+	})
+
+	t.Run("keeps other printable properties", func(t *testing.T) {
+		err := errx.WithReason(
+			errorx.IllegalArgument.New("bad flag value").WithProperty(otherProp, "kept"),
+			reasons.InvalidArgument)
+		got := OperatorMessage(err)
+		require.Contains(t, got, "{operator_message_test_prop: kept}")
+		require.NotContains(t, got, "reason")
+	})
+
+	t.Run("keeps the underlying error and the cause chain", func(t *testing.T) {
+		underlying := errorx.ExternalError.New("permission denied")
+		inner := errorx.IllegalState.New("cannot read /opt/solo").WithUnderlyingErrors(underlying)
+		err := errx.WithReason(errorx.InternalError.Wrap(inner, "preflight"), reasons.Internal)
+
+		got := OperatorMessage(err)
+		require.NotContains(t, got, "reason")
+		require.Contains(t, got, "preflight")
+		require.Contains(t, got, "cannot read /opt/solo")
+		require.Contains(t, got, "hidden: ")
+		require.Contains(t, got, "permission denied")
+	})
+
+	t.Run("drops a reason nested in the cause chain", func(t *testing.T) {
+		// err.Error() renders every cause, so stripping only the outermost reason
+		// (what errx.ReasonOf reports) leaks the inner one onto the panel.
+		inner := errx.Decorate(errorx.IllegalArgument.New("inner"), reasons.InvalidArgument)
+		err := errx.Decorate(errorx.InternalError.Wrap(inner, "outer"), reasons.Internal)
+
+		require.Equal(t,
+			"common.internal_error: outer, cause: common.illegal_argument: inner",
+			OperatorMessage(err))
+	})
+
+	t.Run("keeps other printable properties on a nested error", func(t *testing.T) {
+		inner := errx.WithReason(
+			errorx.IllegalArgument.New("inner").WithProperty(otherProp, "kept"),
+			reasons.InvalidArgument)
+		err := errx.Decorate(errorx.InternalError.Wrap(inner, "outer"), reasons.Internal)
+
+		got := OperatorMessage(err)
+		require.Contains(t, got, "{operator_message_test_prop: kept}",
+			"only the reason pair leaves the nested group")
+		require.NotContains(t, got, "reason")
+	})
+
+	t.Run("undecorated error is unchanged", func(t *testing.T) {
+		err := errorx.IllegalState.New("boom")
+		require.Equal(t, err.Error(), OperatorMessage(err))
+	})
+
+	t.Run("nil and non-errorx errors", func(t *testing.T) {
+		require.Equal(t, "", OperatorMessage(nil))
+		require.Equal(t, "EOF", OperatorMessage(io.EOF), "sanity: a plain error renders verbatim")
+	})
+}
+
+// TestToErrorMessage_CauseDropsReason covers the panel's Cause line, which renders
+// the cause in full and so would otherwise repeat the reason.
+func TestToErrorMessage_CauseDropsReason(t *testing.T) {
+	t.Run("single reason", func(t *testing.T) {
+		inner := errx.Decorate(errorx.IllegalArgument.New("bad flag value"), reasons.InvalidArgument)
+		msg, cause := toErrorMessage(errorx.IllegalState.Wrap(inner, "preflight failed"))
+
+		require.Equal(t, "preflight failed", msg)
+		require.Equal(t, "common.illegal_argument: bad flag value", cause)
+	})
+
+	t.Run("a reason at every level of the cause chain", func(t *testing.T) {
+		inner := errx.Decorate(errorx.IllegalArgument.New("bad flag value"), reasons.InvalidArgument)
+		mid := errx.Decorate(errorx.ExternalError.Wrap(inner, "probe"), reasons.Internal)
+		msg, cause := toErrorMessage(errorx.IllegalState.Wrap(mid, "preflight failed"))
+
+		require.Equal(t, "preflight failed", msg)
+		require.Equal(t,
+			"common.external_error: probe, cause: common.illegal_argument: bad flag value",
+			cause)
+	})
+}
+
+// TestExtractPropertyMatchesErrx pins the traversal contract: the doctor's reader
+// must see exactly what errx sees, including through non-errorx wrappers. Parity
+// covers blind spots too — in the join cases both sides agree the hints are NOT
+// found (errors.Unwrap does not follow Unwrap() []error); what is lost and why
+// is pinned separately by TestJoinHidesDecoration.
+func TestExtractPropertyMatchesErrx(t *testing.T) {
+	chains := map[string]error{
+		"direct":           errx.WithHints(errorx.IllegalState.New("boom"), "fix it"),
+		"errorx wrap":      errorx.IllegalState.Wrap(errx.WithHints(errorx.ExternalError.New("refused"), "fix it"), "probe"),
+		"plain %w wrapper": fmt.Errorf("probe: %w", errx.WithHints(errorx.ExternalError.New("refused"), "fix it")),
+		"errors.Join":      errors.Join(errx.WithHints(errorx.ExternalError.New("refused"), "fix it")),
+		"wrap over a join": errorx.IllegalState.Wrap(errors.Join(errx.WithHints(errorx.ExternalError.New("refused"), "fix it")), "probe"),
+		"nothing attached": errorx.IllegalState.New("boom"),
+	}
+
+	for name, err := range chains {
+		t.Run(name, func(t *testing.T) {
+			want, wantOK := errx.Hints(err)
+			got, gotOK := resolutionHints(err)
+
+			require.Equal(t, wantOK, gotOK, "doctor and errx disagree on whether hints are present")
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+// TestJoinHidesDecoration pins the errx v1.0.0 blind spot documented in
+// docs/dev/error-handling.md: errors.Join exposes its children via
+// Unwrap() []error, which neither errx nor the doctor's traversal follows, so
+// decoration on a join operand is silently lost. Hence the rule: decorate on
+// top of the join, never an operand. If the "lost" subtest starts failing, errx
+// has learned to traverse joins — flip its assertions and drop the join warning
+// from the doc.
+func TestJoinHidesDecoration(t *testing.T) {
+	sentinel := errorx.RejectedOperation.New("aborted by user")
+
+	t.Run("a decorated join operand is lost", func(t *testing.T) {
+		err := errors.Join(sentinel,
+			errx.Decorate(errorx.ExternalError.New("boom"), reasons.FileMissing, "fix it"))
+
+		require.True(t, errors.Is(err, sentinel), "identity matching is what the join is for")
+
+		_, ok := errx.ReasonOf(err)
+		require.False(t, ok,
+			"errx now traverses joins — flip this test and update docs/dev/error-handling.md")
+		_, ok = errx.Hints(err)
+		require.False(t, ok)
+		_, ok = resolutionHints(err)
+		require.False(t, ok, "the doctor must not disagree with errx, even about a blind spot")
+	})
+
+	t.Run("decorating on top of the join survives", func(t *testing.T) {
+		err := errx.Decorate(
+			errorx.Decorate(errors.Join(sentinel, errorx.ExternalError.New("boom")), "aborting install"),
+			reasons.FileMissing, "fix it")
+
+		require.True(t, errors.Is(err, sentinel),
+			"errorx.Decorate wraps transparently, so errors.Is still reaches the sentinel")
+
+		reason, ok := errx.ReasonOf(err)
+		require.True(t, ok)
+		require.Equal(t, reasons.FileMissing, reason)
+
+		hints, ok := resolutionHints(err)
+		require.True(t, ok)
+		require.Equal(t, []string{"fix it"}, hints)
+	})
+}
+
+func TestFindResolution(t *testing.T) {
+	t.Run("hints attached via errx", func(t *testing.T) {
+		err := errx.WithHints(errorx.IllegalState.New("boom"), "step one", "step two")
+		require.Equal(t, []string{"step one", "step two"}, findResolution(err))
+	})
+
+	t.Run("hints attached via errx.Decorate", func(t *testing.T) {
+		err := errx.Decorate(errorx.IllegalState.New("boom"), reasons.FileMissing, "step one")
+		require.Equal(t, []string{"step one"}, findResolution(err))
+	})
+
+	t.Run("errx hints deep in the cause chain", func(t *testing.T) {
+		inner := errx.WithHints(errorx.ExternalError.New("refused"), "check the firewall")
+		outer := errorx.IllegalState.Wrap(errorx.InternalError.Wrap(inner, "probe"), "preflight")
+		require.Equal(t, []string{"check the firewall"}, findResolution(outer))
+	})
+
+	t.Run("legacy []string hints", func(t *testing.T) {
+		err := errorx.IllegalState.New("boom").
+			WithProperty(models.ErrPropertyResolution, []string{"legacy step"})
+		require.Equal(t, []string{"legacy step"}, findResolution(err))
+	})
+
+	t.Run("legacy bare-string hints", func(t *testing.T) {
+		err := errorx.IllegalState.New("boom").
+			WithProperty(models.ErrPropertyResolution, "use 'block node install'")
+		require.Equal(t, []string{"use 'block node install'"}, findResolution(err))
+	})
+
+	t.Run("undecorated error keeps the namespace fallback", func(t *testing.T) {
+		require.Equal(t,
+			[]string{"Ensure provided data is in correct format."},
+			findResolution(errorx.IllegalFormat.New("bad yaml")))
+	})
+
+	t.Run("empty bare-string hint falls back", func(t *testing.T) {
+		err := errorx.IllegalFormat.New("bad yaml").
+			WithProperty(models.ErrPropertyResolution, "")
+		require.Equal(t,
+			[]string{"Ensure provided data is in correct format."},
+			findResolution(err))
+	})
+
+	t.Run("empty hint slice falls back", func(t *testing.T) {
+		err := errorx.IllegalFormat.New("bad yaml").
+			WithProperty(models.ErrPropertyResolution, []string{})
+		require.Equal(t,
+			[]string{"Ensure provided data is in correct format."},
+			findResolution(err))
+	})
+}
+
+func TestDiagnose_Reason(t *testing.T) {
+	t.Run("surfaces the reason and hints of a decorated error", func(t *testing.T) {
+		err := errx.Decorate(errorx.IllegalState.New("boom"), reasons.FileMissing, "do the thing")
+		d := Diagnose(context.Background(), err)
+		require.Equal(t, "FileMissing", d.Reason)
+		require.Equal(t, []string{"do the thing"}, d.Resolution)
+	})
+
+	t.Run("leaves Reason empty for an undecorated error", func(t *testing.T) {
+		// Empty, not "unknown": checkErrVerbose omits the Reason line entirely.
+		d := Diagnose(context.Background(), errorx.IllegalState.New("boom"))
+		require.Equal(t, "", d.Reason)
+	})
+}
+
+// TestCheckErrVerbose_Reason pins the verbose panel's reason line, printed bare so
+// it greps against the log's reason= field.
+func TestCheckErrVerbose_Reason(t *testing.T) {
+	t.Run("a decorated error renders the reason", func(t *testing.T) {
+		d := Diagnose(context.Background(),
+			errx.Decorate(errorx.IllegalState.New("boom"), reasons.FileMissing, "do the thing"))
+		out := capturePanel(t, func() { checkErrVerbose(d) })
+		require.Contains(t, out, "Reason: FileMissing")
+	})
+
+	t.Run("an undecorated error omits the line entirely", func(t *testing.T) {
+		d := Diagnose(context.Background(), errorx.IllegalState.New("boom"))
+		out := capturePanel(t, func() { checkErrVerbose(d) })
+		require.NotContains(t, out, "Reason:", "an empty reason must not render an empty line")
+	})
+}
+
+// TestPanelResolutionIsTheOnlyHintChannel pins the single-channel contract: both
+// panels number the hints attached to the error, and there is no second channel
+// that could render the same hints a different way.
+func TestPanelResolutionIsTheOnlyHintChannel(t *testing.T) {
+	decorated := func() *ErrorDiagnosis {
+		return Diagnose(context.Background(), errx.Decorate(
+			errorx.IllegalState.New("boom"), reasons.FileMissing, "first step", "second step"))
+	}
+
+	t.Run("compact panel numbers the hints", func(t *testing.T) {
+		out := capturePanel(t, func() { checkErrCompact(decorated()) })
+		require.Contains(t, out, "1. first step")
+		require.Contains(t, out, "2. second step")
+	})
+
+	t.Run("verbose panel numbers them identically", func(t *testing.T) {
+		out := capturePanel(t, func() { checkErrVerbose(decorated()) })
+		require.Contains(t, out, "1. first step")
+		require.Contains(t, out, "2. second step")
+	})
+
+	t.Run("legacy []string hints are numbered too", func(t *testing.T) {
+		d := Diagnose(context.Background(), errorx.IllegalState.New("boom").
+			WithProperty(models.ErrPropertyResolution, []string{"step one", "step two"}))
+		out := capturePanel(t, func() { checkErrCompact(d) })
+		require.Contains(t, out, "1. step one")
+		require.Contains(t, out, "2. step two")
+		require.NotContains(t, out, "[step one", "must not render the Go slice literal")
+	})
+
+	t.Run("an undecorated error still gets the namespace fallback", func(t *testing.T) {
+		d := Diagnose(context.Background(), errorx.IllegalState.New("boom"))
+		out := capturePanel(t, func() { checkErrCompact(d) })
+		require.Contains(t, out, "1. ", "the fallback must render as a numbered step")
+	})
+}

--- a/internal/ui/handler.go
+++ b/internal/ui/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/automa-saga/automa"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/hashgraph/solo-weaver/internal/doctor"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
 )
 
@@ -71,10 +72,7 @@ func NewTUIHandler(program *tea.Program) *notify.Handler {
 
 		PhaseFailure: func(ctx context.Context, stp automa.Step, report *automa.Report, msg string, args ...interface{}) {
 			name := fmt.Sprintf(msg, args...)
-			errMsg := ""
-			if report.Error != nil {
-				errMsg = report.Error.Error()
-			}
+			errMsg := doctor.OperatorMessage(report.Error)
 			if VerboseLevel >= 1 {
 				program.Println(fmt.Sprintf("  %s %s", failedIcon, phaseNameStyle.Render(name)))
 			}
@@ -100,10 +98,7 @@ func NewTUIHandler(program *tea.Program) *notify.Handler {
 
 		StepFailure: func(ctx context.Context, stp automa.Step, report *automa.Report, msg string, args ...interface{}) {
 			name := fmt.Sprintf(msg, args...)
-			errMsg := ""
-			if report.Error != nil {
-				errMsg = report.Error.Error()
-			}
+			errMsg := doctor.OperatorMessage(report.Error)
 			printProgressHeader()
 			if VerboseLevel >= 1 {
 				indent := stepIndent()

--- a/internal/workflows/preflight.go
+++ b/internal/workflows/preflight.go
@@ -14,9 +14,11 @@ import (
 	"github.com/hashgraph/solo-weaver/pkg/config"
 
 	"github.com/automa-saga/automa"
+	"github.com/automa-saga/errx"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/pkg/hardware"
 	"github.com/hashgraph/solo-weaver/pkg/models"
+	"github.com/hashgraph/solo-weaver/pkg/reasons"
 	"github.com/joomcode/errorx"
 )
 
@@ -125,91 +127,71 @@ func CheckWeaverUserStep() automa.Builder {
 			weaverGroup, groupErr := user.LookupGroup(weaverGroupName)
 			groupExists := groupErr == nil
 
-			// Collect validation errors for user and group before returning
-			var errors []error
-			var instructions string
+			uidWrong := userExists && weaverUser.Uid != weaverUserId
+			gidWrong := groupExists && weaverGroup.Gid != weaverGroupId
 
-			// Track mismatches in meta
-			if userExists && weaverUser.Uid != weaverUserId {
+			// The message carries the observed vs expected IDs; the hints carry
+			// only the commands that fix them.
+			var mismatches []string
+
+			if uidWrong {
 				meta["user_exists"] = "true"
 				meta["user_id_mismatch"] = "true"
 				meta["expected_user_id"] = weaverUserId
 				meta["actual_user_id"] = weaverUser.Uid
-				errors = append(errors, errorx.IllegalState.New("provisioner user exists with incorrect UID: expected %s, got %s", weaverUserId, weaverUser.Uid))
-				instructions += fmt.Sprintf("User '%s' exists but has incorrect UID.\n", weaverUsername)
-				instructions += fmt.Sprintf("Expected: %s, Found: %s\n\n", weaverUserId, weaverUser.Uid)
+				mismatches = append(mismatches, fmt.Sprintf(
+					"user %q has UID %s, expected %s", weaverUsername, weaverUser.Uid, weaverUserId))
 			}
 
-			if groupExists && weaverGroup.Gid != weaverGroupId {
+			if gidWrong {
 				meta["group_exists"] = "true"
 				meta["group_id_mismatch"] = "true"
 				meta["expected_group_id"] = weaverGroupId
 				meta["actual_group_id"] = weaverGroup.Gid
-				errors = append(errors, errorx.IllegalState.New("provisioner group exists with incorrect GID: expected %s, got %s", weaverGroupId, weaverGroup.Gid))
-				instructions += fmt.Sprintf("Group '%s' exists but has incorrect GID.\n", weaverGroupName)
-				instructions += fmt.Sprintf("Expected: %s, Found: %s\n\n", weaverGroupId, weaverGroup.Gid)
+				mismatches = append(mismatches, fmt.Sprintf(
+					"group %q has GID %s, expected %s", weaverGroupName, weaverGroup.Gid, weaverGroupId))
 			}
 
-			// If there are any errors, provide combined instructions
-			if len(errors) > 0 {
-				instructions += "Please update the user and/or group IDs as follows:\n\n"
-				// Suggest groupmod if group exists but has wrong GID
-				if groupExists && weaverGroup.Gid != weaverGroupId {
-					instructions += fmt.Sprintf("  sudo groupmod -g %s %s\n", weaverGroupId, weaverGroupName)
+			if len(mismatches) > 0 {
+				var hints []string
+				// groupmod first: the usermod -g below needs the target GID to exist.
+				if gidWrong {
+					hints = append(hints, fmt.Sprintf("sudo groupmod -g %s %s", weaverGroupId, weaverGroupName))
 				}
-				// Suggest usermod if user exists but has wrong UID
-				if userExists && weaverUser.Uid != weaverUserId {
-					instructions += fmt.Sprintf("  sudo usermod -u %s -g %s %s\n", weaverUserId, weaverGroupId, weaverUsername)
+				if uidWrong {
+					hints = append(hints, fmt.Sprintf("sudo usermod -u %s -g %s %s", weaverUserId, weaverGroupId, weaverUsername))
 				}
-				instructions += "\nNote: After changing user/group IDs, you may need to update file ownerships accordingly.\n"
-				meta["instructions"] = instructions
-
-				// Combine errors into one error message
-				var errMsg string
-				for i, err := range errors {
-					if i > 0 {
-						errMsg += "; "
-					}
-					errMsg += err.Error()
-				}
+				hints = append(hints, "Update file ownerships under the provisioner directories to match the new IDs.")
 
 				return automa.FailureReport(stp,
-					automa.WithError(errorx.IllegalState.New("%s", errMsg)),
+					automa.WithError(errx.Decorate(
+						errorx.IllegalState.New("provisioner service account has incorrect IDs: %s",
+							strings.Join(mismatches, "; ")),
+						reasons.PreconditionNotMet, hints...)),
 					automa.WithMetadata(meta))
 			}
 
-			// If either user or group doesn't exist, provide creation instructions
+			// The service account is provisioned by the installer, so a missing
+			// user or group is a "not installed" state, not something to fix by hand.
 			if !userExists || !groupExists {
 				meta["user_exists"] = fmt.Sprintf("%t", userExists)
 				meta["group_exists"] = fmt.Sprintf("%t", groupExists)
 
-				if !userExists && !groupExists {
-					instructions = fmt.Sprintf("The weaver service account ('%s'/'%s') has not been provisioned on this host.\n", weaverUsername, weaverGroupName)
-					instructions += "Run the installer to set it up:\n\n"
-					instructions += "  sudo solo-provisioner install"
-				} else if !userExists {
-					instructions = fmt.Sprintf("The weaver user '%s' does not exist.\n", weaverUsername)
-					instructions += "The service account is provisioned by the installer — run:\n\n"
-					instructions += "  sudo solo-provisioner install"
-				} else {
-					instructions = fmt.Sprintf("The weaver group '%s' does not exist.\n", weaverGroupName)
-					instructions += "The service account is provisioned by the installer — run:\n\n"
-					instructions += "  sudo solo-provisioner install"
-				}
-
-				meta["instructions"] = instructions
-
 				var errMsg string
-				if !userExists && !groupExists {
-					errMsg = fmt.Sprintf("provisioner user '%s' and group '%s' do not exist", weaverUsername, weaverGroupName)
-				} else if !userExists {
-					errMsg = fmt.Sprintf("provisioner user '%s' does not exist", weaverUsername)
-				} else {
-					errMsg = fmt.Sprintf("provisioner group '%s' does not exist", weaverGroupName)
+				switch {
+				case !userExists && !groupExists:
+					errMsg = fmt.Sprintf("provisioner user %q and group %q do not exist", weaverUsername, weaverGroupName)
+				case !userExists:
+					errMsg = fmt.Sprintf("provisioner user %q does not exist", weaverUsername)
+				default:
+					errMsg = fmt.Sprintf("provisioner group %q does not exist", weaverGroupName)
 				}
 
 				return automa.FailureReport(stp,
-					automa.WithError(errorx.IllegalState.New("%s", errMsg)),
+					automa.WithError(errx.Decorate(
+						errorx.IllegalState.New("%s", errMsg),
+						reasons.NotInstalled,
+						"sudo solo-provisioner install")),
 					automa.WithMetadata(meta))
 			}
 

--- a/internal/workflows/steps/step_ensure_hedera_owner.go
+++ b/internal/workflows/steps/step_ensure_hedera_owner.go
@@ -8,9 +8,11 @@ import (
 	"strconv"
 
 	"github.com/automa-saga/automa"
+	"github.com/automa-saga/errx"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
 	"github.com/hashgraph/solo-weaver/pkg/config"
+	"github.com/hashgraph/solo-weaver/pkg/reasons"
 	"github.com/hashgraph/solo-weaver/pkg/security/principal"
 	"github.com/joomcode/errorx"
 )
@@ -51,15 +53,14 @@ func EnsureHederaOwnerStep() *automa.StepBuilder {
 			} else {
 				// Group exists — verify GID matches.
 				if hederaGroup.Gid() != hederaGroupId {
-					instructions := fmt.Sprintf(
-						"Group %q exists with GID %s but GID %s is required.\n"+
-							"Fix it with: sudo groupmod -g %s %s",
-						hederaGroupName, hederaGroup.Gid(), hederaGroupId, hederaGroupId, hederaGroupName)
 					return automa.FailureReport(stp,
-						automa.WithError(errorx.IllegalState.New(
-							"hedera owner group %q has incorrect GID: expected %s, got %s",
-							hederaGroupName, hederaGroupId, hederaGroup.Gid())),
-						automa.WithMetadata(map[string]string{"instructions": instructions}))
+						automa.WithError(errx.Decorate(
+							errorx.IllegalState.New(
+								"hedera owner group %q has incorrect GID: expected %s, got %s",
+								hederaGroupName, hederaGroupId, hederaGroup.Gid()),
+							reasons.PreconditionNotMet,
+							fmt.Sprintf("sudo groupmod -g %s %s", hederaGroupId, hederaGroupName),
+							"Re-run this command once the GID matches.")))
 				}
 				meta["hedera_group_created"] = "false"
 			}
@@ -81,29 +82,27 @@ func EnsureHederaOwnerStep() *automa.StepBuilder {
 			} else {
 				// User exists — verify UID matches.
 				if hederaUser.Uid() != hederaUserId {
-					instructions := fmt.Sprintf(
-						"User %q exists with UID %s but UID %s is required.\n"+
-							"Fix it with: sudo usermod -u %s %s",
-						hederaUserName, hederaUser.Uid(), hederaUserId, hederaUserId, hederaUserName)
 					return automa.FailureReport(stp,
-						automa.WithError(errorx.IllegalState.New(
-							"hedera owner user %q has incorrect UID: expected %s, got %s",
-							hederaUserName, hederaUserId, hederaUser.Uid())),
-						automa.WithMetadata(map[string]string{"instructions": instructions}))
+						automa.WithError(errx.Decorate(
+							errorx.IllegalState.New(
+								"hedera owner user %q has incorrect UID: expected %s, got %s",
+								hederaUserName, hederaUserId, hederaUser.Uid()),
+							reasons.PreconditionNotMet,
+							fmt.Sprintf("sudo usermod -u %s %s", hederaUserId, hederaUserName),
+							"Re-run this command once the UID matches.")))
 				}
 				meta["hedera_user_created"] = "false"
 			}
 
 			// Add weaver to the hedera group so it can write to setgid block-node storage dirs.
 			if err := pm.AddUserToGroup(weaverUserName, hederaGroupName); err != nil {
-				instructions := fmt.Sprintf(
-					"Could not add %q to group %q.\n"+
-						"Fix it with: sudo usermod -aG %s %s",
-					weaverUserName, hederaGroupName, hederaGroupName, weaverUserName)
 				return automa.FailureReport(stp,
-					automa.WithError(errorx.IllegalState.Wrap(err,
-						"failed to add %s to group %s", weaverUserName, hederaGroupName)),
-					automa.WithMetadata(map[string]string{"instructions": instructions}))
+					automa.WithError(errx.Decorate(
+						errorx.IllegalState.Wrap(err,
+							"failed to add %s to group %s", weaverUserName, hederaGroupName),
+						reasons.PreconditionNotMet,
+						fmt.Sprintf("sudo usermod -aG %s %s", hederaGroupName, weaverUserName),
+						"Re-run this command once the membership is in place.")))
 			}
 			logx.As().Info().Msgf("Ensured %s is a member of group %s", weaverUserName, hederaGroupName)
 			meta["weaver_in_hedera_group"] = "true"

--- a/internal/workflows/steps/step_ensure_weaver_owner.go
+++ b/internal/workflows/steps/step_ensure_weaver_owner.go
@@ -9,10 +9,12 @@ import (
 	"strconv"
 
 	"github.com/automa-saga/automa"
+	"github.com/automa-saga/errx"
 	"github.com/automa-saga/logx"
 	"github.com/hashgraph/solo-weaver/internal/workflows/notify"
 	"github.com/hashgraph/solo-weaver/pkg/config"
 	"github.com/hashgraph/solo-weaver/pkg/fsx"
+	"github.com/hashgraph/solo-weaver/pkg/reasons"
 	"github.com/hashgraph/solo-weaver/pkg/security/principal"
 	"github.com/joomcode/errorx"
 )
@@ -50,15 +52,14 @@ func EnsureWeaverOwnerStep() *automa.StepBuilder {
 				meta["weaver_group_created"] = "true"
 			} else {
 				if weaverGroup.Gid() != weaverGroupId {
-					instructions := fmt.Sprintf(
-						"Group %q exists with GID %s but GID %s is required.\n"+
-							"Fix it with: sudo groupmod -g %s %s",
-						weaverGroupName, weaverGroup.Gid(), weaverGroupId, weaverGroupId, weaverGroupName)
 					return automa.FailureReport(stp,
-						automa.WithError(errorx.IllegalState.New(
-							"weaver owner group %q has incorrect GID: expected %s, got %s",
-							weaverGroupName, weaverGroupId, weaverGroup.Gid())),
-						automa.WithMetadata(map[string]string{"instructions": instructions}))
+						automa.WithError(errx.Decorate(
+							errorx.IllegalState.New(
+								"weaver owner group %q has incorrect GID: expected %s, got %s",
+								weaverGroupName, weaverGroupId, weaverGroup.Gid()),
+							reasons.PreconditionNotMet,
+							fmt.Sprintf("sudo groupmod -g %s %s", weaverGroupId, weaverGroupName),
+							"Re-run this command once the GID matches.")))
 				}
 				meta["weaver_group_created"] = "false"
 			}
@@ -78,15 +79,14 @@ func EnsureWeaverOwnerStep() *automa.StepBuilder {
 				meta["weaver_user_created"] = "true"
 			} else {
 				if weaverUser.Uid() != weaverUserId {
-					instructions := fmt.Sprintf(
-						"User %q exists with UID %s but UID %s is required.\n"+
-							"Fix it with: sudo usermod -u %s %s",
-						weaverUserName, weaverUser.Uid(), weaverUserId, weaverUserId, weaverUserName)
 					return automa.FailureReport(stp,
-						automa.WithError(errorx.IllegalState.New(
-							"weaver owner user %q has incorrect UID: expected %s, got %s",
-							weaverUserName, weaverUserId, weaverUser.Uid())),
-						automa.WithMetadata(map[string]string{"instructions": instructions}))
+						automa.WithError(errx.Decorate(
+							errorx.IllegalState.New(
+								"weaver owner user %q has incorrect UID: expected %s, got %s",
+								weaverUserName, weaverUserId, weaverUser.Uid()),
+							reasons.PreconditionNotMet,
+							fmt.Sprintf("sudo usermod -u %s %s", weaverUserId, weaverUserName),
+							"Re-run this command once the UID matches.")))
 				}
 				meta["weaver_user_created"] = "false"
 			}

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -2,19 +2,19 @@
 
 package models
 
-import "github.com/joomcode/errorx"
+import (
+	"github.com/automa-saga/errx"
+	"github.com/joomcode/errorx"
+)
 
 var (
-	// ErrPropertyResolution is the errorx property key used to attach remediation
-	// hints to precondition errors — mirrors doctor.ErrPropertyResolution without
-	// creating a circular import.
-	ErrPropertyResolution = errorx.RegisterProperty("resolution")
+	// ErrPropertyResolution holds remediation hints. Must alias errx's property —
+	// errorx compares properties by pointer, so a re-registration is invisible to errx.Hints.
+	ErrPropertyResolution = errx.PropertyResolution
 
-	// ErrPropertyReason is the errorx property key used to attach a stable,
-	// machine-readable reason code to an error (e.g. "UpgradeDirOwnershipCheckFailed").
-	// Mirrors the log-line reason= field convention so structured tooling can
-	// correlate /status JSON output with journal entries.
-	ErrPropertyReason = errorx.RegisterProperty("reason")
+	// ErrPropertyReason holds the machine-readable reason code. Prefer errx.WithReason
+	// or errx.Decorate over setting it directly. Printable: it renders in err.Error().
+	ErrPropertyReason = errx.PropertyReason
 
 	// ErrPropertyWhyFloor is the errorx property key used to attach the rule
 	// attribution string ("Why:") that produced the binding hardware floor for a

--- a/pkg/reasons/reasons.go
+++ b/pkg/reasons/reasons.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package reasons holds the shared errx reason vocabulary. It is a leaf package
+// (errx only) so that any package can import it without creating a cycle.
+package reasons
+
+import "github.com/automa-saga/errx"
+
+// Reason codes with live call sites, read back via errx.ReasonOf.
+const (
+	// InvalidArgument - a flag value, flag combination or positional argument was rejected.
+	InvalidArgument errx.Reason = "InvalidArgument"
+
+	// FileMissing - a required file or directory does not exist and we will not create it.
+	FileMissing errx.Reason = "FileMissing"
+
+	// PermissionDenied - superuser privilege required, or file/resource access denied.
+	PermissionDenied errx.Reason = "PermissionDenied"
+
+	// Internal - an invariant breach or a bug in solo-weaver, not an operator error.
+	Internal errx.Reason = "Internal"
+
+	// NotInstalled - a component is absent; the operator must run its install command first.
+	NotInstalled errx.Reason = "NotInstalled"
+
+	// PreconditionNotMet - the system is in the wrong state for this command; change the
+	// state or use a different verb.
+	PreconditionNotMet errx.Reason = "PreconditionNotMet"
+)

--- a/pkg/sanity/errors.go
+++ b/pkg/sanity/errors.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package sanity
+
+import (
+	"github.com/automa-saga/errx"
+	"github.com/hashgraph/solo-weaver/pkg/reasons"
+	"github.com/joomcode/errorx"
+)
+
+// Remediation hints, one per validated domain: each states the accepted form.
+const (
+	hintIdentifier  = "Use only letters, digits, underscore or hyphen ([A-Za-z0-9_-])."
+	hintDNSName     = "Use a hostname of letters, digits, dots and hyphens, e.g. node1.example.com."
+	hintHexToken    = "Supply the token exactly as issued: hex digits only (0-9, a-f, A-F), at most 4096 characters."
+	hintHostPort    = "Use host or host:port, e.g. teleport.example.com:3080 — no scheme, no path."
+	hintUsername    = "Use an existing Linux account name ([A-Za-z0-9_.-]), e.g. hedera or first.last."
+	hintOperationID = "Use only letters, digits, dot, underscore or hyphen, e.g. upgrade-v0.76.0-20060102T150405Z."
+	hintPath        = "Use an absolute path with no '..' segments or shell metacharacters, e.g. /opt/solo/weaver."
+	hintVersion     = "Use a semantic version, e.g. 1.2.3, 1.2.3-beta.1."
+	hintChartRef    = "Use oci://registry/path/chart, an https:// chart URL, or repo/chart-name."
+	hintStorageSize = "Use a Kubernetes quantity greater than zero with unit Gi, Mi or Ti, e.g. 500Gi."
+	hintCIDR        = "Use CIDR notation with an explicit prefix length, e.g. 10.0.0.0/8."
+	hintIPv4CIDR    = "Use an IPv4 CIDR, e.g. 10.0.0.0/8 — IPv6 is not supported here."
+	hintPort        = "Use a TCP/UDP port number between 1 and 65535."
+	hintInputFile   = "Check the path and that the file exists and is a regular file."
+
+	// Split because ValidateURL's accepted schemes depend on opts.AllowHTTP.
+	hintURL        = "Use a full URL with an ASCII hostname, e.g. https://registry.example.com/path."
+	hintURLHTTPS   = "Use an https:// URL."
+	hintURLPlainOK = "Use an http:// or https:// URL."
+	hintFileDenied = "Check the permissions on the file and its parent directories, or re-run with sudo."
+)
+
+// ErrInvalidName is returned by Sanitize* helpers when the input contains
+// no valid characters and would otherwise sanitize to an empty string.
+var ErrInvalidName = errx.Decorate(
+	errorx.IllegalArgument.New("invalid name"),
+	reasons.InvalidArgument,
+	hintIdentifier,
+)
+
+// invalidArgf builds the standard rejection: IllegalArgument + InvalidArgument reason + hint.
+func invalidArgf(hint, format string, args ...any) error {
+	return errx.Decorate(
+		errorx.IllegalArgument.New(format, args...),
+		reasons.InvalidArgument,
+		hint,
+	)
+}
+
+// invalidArgWrapf is invalidArgf over a cause, whose hint it shadows.
+func invalidArgWrapf(hint string, cause error, format string, args ...any) error {
+	return errx.Decorate(
+		errorx.IllegalArgument.Wrap(cause, format, args...),
+		reasons.InvalidArgument,
+		hint,
+	)
+}

--- a/pkg/sanity/errors_test.go
+++ b/pkg/sanity/errors_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package sanity
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/automa-saga/errx"
+	"github.com/hashgraph/solo-weaver/pkg/reasons"
+	"github.com/joomcode/errorx"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidatorsAreDecorated asserts every exported validator attaches a reason and a hint.
+func TestValidatorsAreDecorated(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantReason errx.Reason
+		hintPart   string
+	}{
+		{"ValidateIdentifier empty", ValidateIdentifier(""), reasons.InvalidArgument, "underscore or hyphen"},
+		{"ValidateIdentifier bad char", ValidateIdentifier("bad name"), reasons.InvalidArgument, "underscore or hyphen"},
+		{"ValidateDNSName", ValidateDNSName("bad_host!"), reasons.InvalidArgument, "node1.example.com"},
+		{"ValidateHexToken", ValidateHexToken("zzz"), reasons.InvalidArgument, "hex digits only"},
+		{"ValidateHostPort", ValidateHostPort("host/path"), reasons.InvalidArgument, "no scheme, no path"},
+		{"ValidateUsername", ValidateUsername("bad user"), reasons.InvalidArgument, "Linux account name"},
+		{"ValidateOperationID", ValidateOperationID("bad id"), reasons.InvalidArgument, "upgrade-v0.76.0"},
+		{"ValidateURL", ValidateURL("ftp://x.example.com", nil), reasons.InvalidArgument, "Use an https:// URL"},
+		{"ValidateURL AllowHTTP", ValidateURL("ftp://x.example.com", &ValidateURLOptions{AllowHTTP: true}),
+			reasons.InvalidArgument, "Use an http:// or https:// URL"},
+		{"ValidateURL bad host", ValidateURL("https://", nil), reasons.InvalidArgument, "ASCII hostname"},
+		{"ValidateVersion", ValidateVersion("not-a-version"), reasons.InvalidArgument, "semantic version"},
+		{"ValidateChartReference", ValidateChartReference("bad chart"), reasons.InvalidArgument, "oci://registry"},
+		{"ValidateStorageSize", ValidateStorageSize("5GB"), reasons.InvalidArgument, "Gi, Mi or Ti"},
+		{"ValidateStorageSize zero", ValidateStorageSize("0Gi"), reasons.InvalidArgument, "Gi, Mi or Ti"},
+		{"ValidateCIDR", ValidateCIDR("10.0.0.0"), reasons.InvalidArgument, "explicit prefix length"},
+		{"ValidateIPv4CIDR on IPv6", ValidateIPv4CIDR("2001:db8::/32"), reasons.InvalidArgument, "IPv6 is not supported"},
+		{"ValidatePort", ValidatePort("99999"), reasons.InvalidArgument, "between 1 and 65535"},
+		{"ValidatePort empty", ValidatePort(""), reasons.InvalidArgument, "between 1 and 65535"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, tt.err)
+
+			reason, ok := errx.ReasonOf(tt.err)
+			require.True(t, ok, "no reason attached")
+			require.Equal(t, tt.wantReason, reason)
+
+			hints, ok := errx.Hints(tt.err)
+			require.True(t, ok, "no hints attached")
+			require.Len(t, hints, 1)
+			require.Contains(t, hints[0], tt.hintPart)
+		})
+	}
+}
+
+func TestSanitizersAreDecorated(t *testing.T) {
+	// All three Sanitize* helpers return the shared ErrInvalidName sentinel.
+	for name, err := range map[string]error{
+		"SanitizeIdentifier": second(SanitizeIdentifier("!!!")),
+		"SanitizeFilename":   second(SanitizeFilename("!!!")),
+		"SanitizeModuleName": second(SanitizeModuleName("!!!")),
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrInvalidName, "sentinel identity must survive decoration")
+
+			reason, ok := errx.ReasonOf(err)
+			require.True(t, ok)
+			require.Equal(t, reasons.InvalidArgument, reason)
+
+			hints, ok := errx.Hints(err)
+			require.True(t, ok)
+			require.NotEmpty(t, hints)
+		})
+	}
+}
+
+func TestSanitizePathIsDecorated(t *testing.T) {
+	_, err := SanitizePath("../etc/passwd")
+	require.Error(t, err)
+
+	reason, ok := errx.ReasonOf(err)
+	require.True(t, ok)
+	require.Equal(t, reasons.InvalidArgument, reason)
+
+	hints, ok := errx.Hints(err)
+	require.True(t, ok)
+	require.Contains(t, hints[0], "absolute path")
+}
+
+func TestValidateInputFile_Reasons(t *testing.T) {
+	t.Run("missing file is FileMissing, not InvalidArgument", func(t *testing.T) {
+		_, err := ValidateInputFile("/nonexistent/solo-weaver-test-file")
+		require.Error(t, err)
+
+		reason, ok := errx.ReasonOf(err)
+		require.True(t, ok)
+		require.Equal(t, reasons.FileMissing, reason)
+	})
+
+	t.Run("an unreadable file is PermissionDenied, not Internal", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory permissions")
+		}
+
+		dir := t.TempDir()
+		target := filepath.Join(dir, "secret.txt")
+		require.NoError(t, os.WriteFile(target, []byte("x"), 0o600))
+		// Clear +x on the parent so stat on the child fails with EACCES.
+		require.NoError(t, os.Chmod(dir, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+		_, err := ValidateInputFile(target)
+		require.Error(t, err)
+
+		reason, ok := errx.ReasonOf(err)
+		require.True(t, ok)
+		require.Equal(t, reasons.PermissionDenied, reason,
+			"an unreadable path is the operator's to fix, not a solo-weaver bug")
+
+		hints, ok := errx.Hints(err)
+		require.True(t, ok, "PermissionDenied is actionable and must carry a hint")
+		require.Contains(t, hints[0], "sudo")
+	})
+
+	t.Run("empty path is InvalidArgument", func(t *testing.T) {
+		_, err := ValidateInputFile("")
+		require.Error(t, err)
+
+		reason, ok := errx.ReasonOf(err)
+		require.True(t, ok)
+		require.Equal(t, reasons.InvalidArgument, reason)
+	})
+
+	t.Run("a rejected path keeps SanitizePath's inner hint", func(t *testing.T) {
+		// ValidateInputFile wraps without re-decorating; the inner hint must survive.
+		_, err := ValidateInputFile("../etc/passwd")
+		require.Error(t, err)
+
+		hints, ok := errx.Hints(err)
+		require.True(t, ok, "inner hint must not be lost through the wrap")
+		require.Contains(t, hints[0], "absolute path")
+	})
+}
+
+// TestErrorMessageRendering pins that decoration preserves the original text and
+// namespace, and appends the printable reason to err.Error() — deliberate, for log
+// correlation; doctor.OperatorMessage strips it again on human surfaces.
+func TestErrorMessageRendering(t *testing.T) {
+	err := ValidateIdentifier("bad name")
+	require.Contains(t, err.Error(), "identifier contains invalid characters: bad name",
+		"decoration must preserve the original message text")
+	require.Contains(t, err.Error(), "{reason: InvalidArgument}",
+		"the printable reason property must render in the message")
+	require.True(t, errorx.IsOfType(err, errorx.IllegalArgument),
+		"decoration must preserve the errorx namespace")
+}
+
+func second(_ string, err error) error { return err }

--- a/pkg/sanity/sanity.go
+++ b/pkg/sanity/sanity.go
@@ -11,13 +11,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/automa-saga/errx"
+	"github.com/hashgraph/solo-weaver/pkg/reasons"
 	"github.com/joomcode/errorx"
-)
-
-var (
-	// ErrInvalidName is returned by Sanitize* helpers when the input contains
-	// no valid characters and would otherwise sanitize to an empty string.
-	ErrInvalidName = errorx.IllegalArgument.New("invalid name")
 )
 
 // Security validation patterns for paths
@@ -136,13 +132,13 @@ func SanitizeModuleName(s string) (string, error) {
 // Use this when you need to ensure the input is already clean and reject invalid input.
 func ValidateIdentifier(s string) error {
 	if s == "" {
-		return errorx.IllegalArgument.New("identifier cannot be empty")
+		return invalidArgf(hintIdentifier, "identifier cannot be empty")
 	}
 
 	// Check if all characters are valid
 	for i := 0; i < len(s); i++ {
 		if !isValidIdentifierChar(s[i]) {
-			return errorx.IllegalArgument.New("identifier contains invalid characters: %s", s)
+			return invalidArgf(hintIdentifier, "identifier contains invalid characters: %s", s)
 		}
 	}
 
@@ -156,11 +152,11 @@ func ValidateIdentifier(s string) error {
 // Use this for values that may be FQDNs, such as cluster names derived from hostnames.
 func ValidateDNSName(s string) error {
 	if s == "" {
-		return errorx.IllegalArgument.New("DNS name cannot be empty")
+		return invalidArgf(hintDNSName, "DNS name cannot be empty")
 	}
 
 	if !hostPattern.MatchString(s) {
-		return errorx.IllegalArgument.New("DNS name contains invalid characters: %s", s)
+		return invalidArgf(hintDNSName, "DNS name contains invalid characters: %s", s)
 	}
 
 	return nil
@@ -174,20 +170,20 @@ func ValidateDNSName(s string) error {
 //  3. Have a reasonable maximum length (4096 characters) to prevent buffer overflow attacks
 func ValidateHexToken(s string) error {
 	if s == "" {
-		return errorx.IllegalArgument.New("token cannot be empty")
+		return invalidArgf(hintHexToken, "token cannot be empty")
 	}
 
 	// Check length - enforce a reasonable upper bound to prevent buffer overflow attacks
 	// No minimum length since token formats may vary
 	if len(s) > 4096 {
-		return errorx.IllegalArgument.New("token exceeds maximum length of 4096 characters, got %d", len(s))
+		return invalidArgf(hintHexToken, "token exceeds maximum length of 4096 characters, got %d", len(s))
 	}
 
 	// Check if all characters are valid hex digits
 	for i := 0; i < len(s); i++ {
 		c := s[i]
 		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
-			return errorx.IllegalArgument.New("token contains non-hexadecimal characters: %s", s)
+			return invalidArgf(hintHexToken, "token contains non-hexadecimal characters: %s", s)
 		}
 	}
 
@@ -206,27 +202,27 @@ func ValidateHexToken(s string) error {
 //   - URLs (use ValidateURL for those)
 func ValidateHostPort(s string) error {
 	if s == "" {
-		return errorx.IllegalArgument.New("host:port cannot be empty")
+		return invalidArgf(hintHostPort, "host:port cannot be empty")
 	}
 
 	// Check for path traversal
 	if strings.Contains(s, "..") || strings.Contains(s, "/") {
-		return errorx.IllegalArgument.New("host:port cannot contain path components: %s", s)
+		return invalidArgf(hintHostPort, "host:port cannot contain path components: %s", s)
 	}
 
 	// Check for shell metacharacters
 	if shellMetachars.MatchString(s) {
-		return errorx.IllegalArgument.New("host:port contains invalid characters: %s", s)
+		return invalidArgf(hintHostPort, "host:port contains invalid characters: %s", s)
 	}
 
 	hostPort := strings.Split(s, ":")
 	if len(hostPort) > 2 || len(hostPort) < 1 {
-		return errorx.IllegalArgument.New("invalid host:port format: %s", s)
+		return invalidArgf(hintHostPort, "invalid host:port format: %s", s)
 	}
 
 	// Validate host - must match hostname/IP pattern (alphanumeric, dots, hyphens)
 	if !hostPattern.MatchString(hostPort[0]) {
-		return errorx.IllegalArgument.New("invalid host format: %s", hostPort[0])
+		return invalidArgf(hintHostPort, "invalid host format: %s", hostPort[0])
 	}
 
 	// Validate port if present
@@ -234,10 +230,10 @@ func ValidateHostPort(s string) error {
 		portStr := hostPort[1]
 		port, err := strconv.Atoi(portStr)
 		if err != nil {
-			return errorx.IllegalArgument.New("invalid port number: %s", portStr)
+			return invalidArgf(hintPort, "invalid port number: %s", portStr)
 		}
 		if port < 1 || port > 65535 {
-			return errorx.IllegalArgument.New("port must be between 1 and 65535, got %d", port)
+			return invalidArgf(hintPort, "port must be between 1 and 65535, got %d", port)
 		}
 	}
 
@@ -261,23 +257,23 @@ func ValidateHostPort(s string) error {
 // Returns nil when the input is safe; the caller can then use s as-is.
 func ValidateUsername(s string) error {
 	if s == "" {
-		return errorx.IllegalArgument.New("username cannot be empty")
+		return invalidArgf(hintUsername, "username cannot be empty")
 	}
 
 	// Check for path traversal attempts
 	if strings.Contains(s, "..") {
-		return errorx.IllegalArgument.New("username contains path traversal sequences: %s", s)
+		return invalidArgf(hintUsername, "username contains path traversal sequences: %s", s)
 	}
 
 	// Check for shell metacharacters
 	if shellMetachars.MatchString(s) {
-		return errorx.IllegalArgument.New("username contains shell metacharacters: %s", s)
+		return invalidArgf(hintUsername, "username contains shell metacharacters: %s", s)
 	}
 
 	// Every byte must be a valid username character
 	for i := 0; i < len(s); i++ {
 		if !isValidUsernameChar(s[i]) {
-			return errorx.IllegalArgument.New("username contains invalid characters: %s", s)
+			return invalidArgf(hintUsername, "username contains invalid characters: %s", s)
 		}
 	}
 
@@ -294,23 +290,23 @@ func ValidateUsername(s string) error {
 // strings (e.g. "upgrade-v0.76.0-20060102T150405Z").
 func ValidateOperationID(s string) error {
 	if s == "" {
-		return errorx.IllegalArgument.New("operationId cannot be empty")
+		return invalidArgf(hintOperationID, "operationId cannot be empty")
 	}
 
 	// Check for path traversal attempts before the per-char loop.
 	if strings.Contains(s, "..") {
-		return errorx.IllegalArgument.New("operationId contains path traversal sequences: %s", s)
+		return invalidArgf(hintOperationID, "operationId contains path traversal sequences: %s", s)
 	}
 
 	// Check for shell metacharacters (narrower, more specific message).
 	if shellMetachars.MatchString(s) {
-		return errorx.IllegalArgument.New("operationId contains shell metacharacters: %s", s)
+		return invalidArgf(hintOperationID, "operationId contains shell metacharacters: %s", s)
 	}
 
 	// Every byte must be a valid operationId character.
 	for i := 0; i < len(s); i++ {
 		if !isValidOperationIDChar(s[i]) {
-			return errorx.IllegalArgument.New("operationId contains invalid characters: %s", s)
+			return invalidArgf(hintOperationID, "operationId contains invalid characters: %s", s)
 		}
 	}
 
@@ -329,7 +325,7 @@ func ValidateOperationID(s string) error {
 // Returns the sanitized (cleaned) absolute path, or an error if the input is invalid or unsafe.
 func SanitizePath(path string) (string, error) {
 	if path == "" {
-		return "", errorx.IllegalArgument.New("path cannot be empty")
+		return "", invalidArgf(hintPath, "path cannot be empty")
 	}
 
 	// Check for path traversal patterns BEFORE cleaning
@@ -338,7 +334,7 @@ func SanitizePath(path string) (string, error) {
 	// Check for ".." as a path segment
 	for _, segment := range strings.Split(path, "/") {
 		if segment == ".." {
-			return "", errorx.IllegalArgument.New("path cannot contain '..' segments: %s", path)
+			return "", invalidArgf(hintPath, "path cannot contain '..' segments: %s", path)
 		}
 	}
 
@@ -348,18 +344,18 @@ func SanitizePath(path string) (string, error) {
 		var err error
 		absPath, err = filepath.Abs(path)
 		if err != nil {
-			return "", errorx.IllegalArgument.Wrap(err, "failed to resolve file path: %s", path)
+			return "", invalidArgWrapf(hintPath, err, "failed to resolve file path: %s", path)
 		}
 	}
 
 	// Check for shell metacharacters in the original path
 	if shellMetachars.MatchString(absPath) {
-		return "", errorx.IllegalArgument.New("path contains shell metacharacters: %s", path)
+		return "", invalidArgf(hintPath, "path contains shell metacharacters: %s", path)
 	}
 
 	// Check for valid characters in the original path
 	if !validPathChars.MatchString(absPath) {
-		return "", errorx.IllegalArgument.New("path contains invalid characters: %s", path)
+		return "", invalidArgf(hintPath, "path contains invalid characters: %s", path)
 	}
 
 	return filepath.Clean(absPath), nil
@@ -385,46 +381,46 @@ type ValidateURLOptions struct {
 // Returns an error if the URL is invalid or unsafe.
 func ValidateURL(rawURL string, opts *ValidateURLOptions) error {
 	if rawURL == "" {
-		return errorx.IllegalArgument.New("URL cannot be empty")
+		return invalidArgf(hintURL, "URL cannot be empty")
 	}
 
 	// Check for ASCII-only characters to prevent homograph attacks
 	if !isASCII(rawURL) {
-		return errorx.IllegalArgument.New("URL must contain only ASCII characters")
+		return invalidArgf(hintURL, "URL must contain only ASCII characters")
 	}
 
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
-		return errorx.IllegalArgument.New("invalid URL: %s", err.Error())
+		return invalidArgf(hintURL, "invalid URL: %s", err.Error())
 	}
 
 	// Check scheme
 	allowHTTP := opts != nil && opts.AllowHTTP
 	if allowHTTP {
 		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-			return errorx.IllegalArgument.New("URL scheme must be http or https, got: %s", parsedURL.Scheme)
+			return invalidArgf(hintURLPlainOK, "URL scheme must be http or https, got: %s", parsedURL.Scheme)
 		}
 	} else {
 		if parsedURL.Scheme != "https" {
-			return errorx.IllegalArgument.New("URL scheme must be https for security, got: %s", parsedURL.Scheme)
+			return invalidArgf(hintURLHTTPS, "URL scheme must be https for security, got: %s", parsedURL.Scheme)
 		}
 	}
 
 	// Ensure host is not empty
 	if parsedURL.Host == "" {
-		return errorx.IllegalArgument.New("URL must have a valid host")
+		return invalidArgf(hintURL, "URL must have a valid host")
 	}
 
 	// Extract hostname without port
 	hostname := parsedURL.Hostname()
 	if hostname == "" {
-		return errorx.IllegalArgument.New("URL must have a valid hostname")
+		return invalidArgf(hintURL, "URL must have a valid hostname")
 	}
 
 	// Validate against allowed domains if provided
 	if opts != nil && len(opts.AllowedDomains) > 0 {
 		if !isAllowedDomain(hostname, opts.AllowedDomains) {
-			return errorx.IllegalArgument.New("URL host %s is not in the allowed domain list", hostname)
+			return invalidArgf(hintURL, "URL host %s is not in the allowed domain list", hostname)
 		}
 	}
 
@@ -489,11 +485,11 @@ func isAllowedDomain(hostname string, allowedDomains []string) bool {
 // Returns the sanitized path or an error if the path is outside the base directory.
 func ValidatePathWithinBase(basePath, targetPath string) (string, error) {
 	if basePath == "" {
-		return "", errorx.IllegalArgument.New("base path cannot be empty")
+		return "", invalidArgf(hintPath, "base path cannot be empty")
 	}
 
 	if targetPath == "" {
-		return "", errorx.IllegalArgument.New("target path cannot be empty")
+		return "", invalidArgf(hintPath, "target path cannot be empty")
 	}
 
 	// Sanitize the target path
@@ -513,7 +509,7 @@ func ValidatePathWithinBase(basePath, targetPath string) (string, error) {
 
 	// Check if the clean target starts with the clean base
 	if !strings.HasPrefix(cleanTarget+string(filepath.Separator), cleanBase) {
-		return "", errorx.IllegalArgument.New("path '%s' is outside the allowed base directory '%s'", cleanTarget, basePath)
+		return "", invalidArgf(hintPath, "path '%s' is outside the allowed base directory '%s'", cleanTarget, basePath)
 	}
 
 	return cleanTarget, nil
@@ -534,7 +530,7 @@ func ValidatePathWithinBase(basePath, targetPath string) (string, error) {
 // Returns the sanitized absolute path or an error if validation fails.
 func ValidateInputFile(filePath string) (string, error) {
 	if filePath == "" {
-		return "", errorx.IllegalArgument.New("file path cannot be empty")
+		return "", invalidArgf(hintInputFile, "file path cannot be empty")
 	}
 
 	// Sanitize the path to prevent path traversal and shell injection attacks
@@ -547,16 +543,27 @@ func ValidateInputFile(filePath string) (string, error) {
 	fileInfo, err := os.Stat(sanitizedPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", errorx.IllegalArgument.New("file does not exist: %s", sanitizedPath)
+			return "", errx.Decorate(
+				errorx.IllegalArgument.New("file does not exist: %s", sanitizedPath),
+				reasons.FileMissing, hintInputFile)
 		}
-		return "", errorx.InternalError.Wrap(err, "failed to stat file: %s", sanitizedPath)
+		// An unreadable path is the operator's to fix; only an unexplained stat
+		// failure is Internal.
+		if os.IsPermission(err) {
+			return "", errx.Decorate(
+				errorx.ExternalError.Wrap(err, "cannot access file: %s", sanitizedPath),
+				reasons.PermissionDenied, hintFileDenied)
+		}
+		return "", errx.WithReason(
+			errorx.InternalError.Wrap(err, "failed to stat file: %s", sanitizedPath),
+			reasons.Internal)
 	}
 
 	// Ensure it's a regular file (not a directory, device, socket, etc.).
 	// Symlinks are followed; symlinks to regular files are allowed.
 	// This prevents attacks using special files like /dev/zero or named pipes.
 	if !fileInfo.Mode().IsRegular() {
-		return "", errorx.IllegalArgument.New("path is not a regular file: %s", sanitizedPath)
+		return "", invalidArgf(hintInputFile, "path is not a regular file: %s", sanitizedPath)
 	}
 
 	return sanitizedPath, nil
@@ -568,14 +575,14 @@ func ValidateInputFile(filePath string) (string, error) {
 // From the bottom of the page at https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 func ValidateVersion(version string) error {
 	if version == "" {
-		return errorx.IllegalArgument.New("version cannot be empty")
+		return invalidArgf(hintVersion, "version cannot be empty")
 	}
 
 	// Semantic version pattern: digits, dots, hyphens, and alphanumeric for pre-release/build metadata
 	// Examples: 1.0.0, 1.0.0-alpha, 1.0.0-beta.1, 1.0.0+build.123
 	validVersionPattern := regexp.MustCompile(`^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 	if !validVersionPattern.MatchString(version) {
-		return errorx.IllegalArgument.New("version contains invalid characters: %s", version)
+		return invalidArgf(hintVersion, "version contains invalid characters: %s", version)
 	}
 
 	return nil
@@ -589,14 +596,14 @@ func ValidateVersion(version string) error {
 //   - Simple chart names: my-chart, repo/chart-name
 func ValidateChartReference(chart string) error {
 	if chart == "" {
-		return errorx.IllegalArgument.New("chart reference cannot be empty")
+		return invalidArgf(hintChartRef, "chart reference cannot be empty")
 	}
 
 	// Check for dangerous shell metacharacters that could enable command injection
 	// Note: We allow some characters like : / @ for valid OCI and URL references
 	dangerousChars := regexp.MustCompile(`[;&|$\x60<>(){}[\]*?~\s]`)
 	if dangerousChars.MatchString(chart) {
-		return errorx.IllegalArgument.New("chart reference contains invalid characters: %s", chart)
+		return invalidArgf(hintChartRef, "chart reference contains invalid characters: %s", chart)
 	}
 
 	// If it's an OCI reference, validate the OCI URL format
@@ -609,7 +616,7 @@ func ValidateChartReference(chart string) error {
 		// Parse as URL to ensure it's well-formed
 		_, err := url.Parse(chart)
 		if err != nil {
-			return errorx.IllegalArgument.Wrap(err, "invalid chart URL: %s", chart)
+			return invalidArgWrapf(hintChartRef, err, "invalid chart URL: %s", chart)
 		}
 		return nil
 	}
@@ -618,7 +625,7 @@ func ValidateChartReference(chart string) error {
 	// Allow alphanumeric, hyphens, underscores, dots, and forward slashes
 	validChartPattern := regexp.MustCompile(`^[a-zA-Z0-9.\-_/]+$`)
 	if !validChartPattern.MatchString(chart) {
-		return errorx.IllegalArgument.New("chart name contains invalid characters: %s", chart)
+		return invalidArgf(hintChartRef, "chart name contains invalid characters: %s", chart)
 	}
 
 	return nil
@@ -629,7 +636,7 @@ func validateOCIReference(ociRef string) error {
 	// Remove the oci:// prefix for validation
 	ref := strings.TrimPrefix(ociRef, "oci://")
 	if ref == "" {
-		return errorx.IllegalArgument.New("OCI reference missing registry path")
+		return invalidArgf(hintChartRef, "OCI reference missing registry path")
 	}
 
 	// OCI reference format: registry.example.com[:port]/path/to/chart[:tag][@digest]
@@ -639,19 +646,19 @@ func validateOCIReference(ociRef string) error {
 	// Basic structure check: should have at least a registry and path
 	parts := strings.Split(ref, "/")
 	if len(parts) < 2 {
-		return errorx.IllegalArgument.New("OCI reference must include registry and path: %s", ociRef)
+		return invalidArgf(hintChartRef, "OCI reference must include registry and path: %s", ociRef)
 	}
 
 	// Validate the registry part (first component)
 	registry := parts[0]
 	if registry == "" {
-		return errorx.IllegalArgument.New("OCI reference missing registry: %s", ociRef)
+		return invalidArgf(hintChartRef, "OCI reference missing registry: %s", ociRef)
 	}
 
 	// Registry should be alphanumeric with dots, hyphens, and optional :port
 	validRegistryPattern := regexp.MustCompile(`^[a-zA-Z0-9.\-]+(:[0-9]+)?$`)
 	if !validRegistryPattern.MatchString(registry) {
-		return errorx.IllegalArgument.New("invalid OCI registry format: %s", registry)
+		return invalidArgf(hintChartRef, "invalid OCI registry format: %s", registry)
 	}
 
 	return nil
@@ -664,7 +671,7 @@ func validateOCIReference(ociRef string) error {
 // The numeric value must be greater than zero.
 func ValidateStorageSize(size string) error {
 	if size == "" {
-		return errorx.IllegalArgument.New("storage size cannot be empty")
+		return invalidArgf(hintStorageSize, "storage size cannot be empty")
 	}
 
 	// Kubernetes storage size pattern: number followed by unit (Gi, Mi, or Ti)
@@ -672,7 +679,7 @@ func ValidateStorageSize(size string) error {
 	validStorageSizePattern := regexp.MustCompile(`^([0-9]+)(Gi|Mi|Ti)$`)
 	matches := validStorageSizePattern.FindStringSubmatch(size)
 	if matches == nil {
-		return errorx.IllegalArgument.New("storage size must be in format '<number>(Gi|Mi|Ti)', got: %s", size)
+		return invalidArgf(hintStorageSize, "storage size must be in format '<number>(Gi|Mi|Ti)', got: %s", size)
 	}
 
 	// Extract the numeric part (first capture group)
@@ -689,7 +696,7 @@ func ValidateStorageSize(size string) error {
 	}
 
 	if allZeros {
-		return errorx.IllegalArgument.New("storage size must be greater than zero, got: %s", size)
+		return invalidArgf(hintStorageSize, "storage size must be greater than zero, got: %s", size)
 	}
 
 	return nil
@@ -714,17 +721,17 @@ func Contains[T comparable](item T, slice []T) bool {
 // explicit about the mask.
 func ValidateCIDR(s string) error {
 	if s == "" {
-		return errorx.IllegalArgument.New("CIDR cannot be empty")
+		return invalidArgf(hintCIDR, "CIDR cannot be empty")
 	}
 
 	// Defensive: net.ParseCIDR already rejects these, but fail with a specific
 	// message so the operator sees "invalid characters" rather than a parser dump.
 	if shellMetachars.MatchString(s) {
-		return errorx.IllegalArgument.New("CIDR contains invalid characters: %s", s)
+		return invalidArgf(hintCIDR, "CIDR contains invalid characters: %s", s)
 	}
 
 	if _, _, err := net.ParseCIDR(s); err != nil {
-		return errorx.IllegalArgument.New("invalid CIDR: %s", s)
+		return invalidArgf(hintCIDR, "invalid CIDR: %s", s)
 	}
 
 	return nil
@@ -743,7 +750,7 @@ func ValidateIPv4CIDR(s string) error {
 	}
 	ip, _, _ := net.ParseCIDR(s)
 	if ip.To4() == nil {
-		return errorx.IllegalArgument.New(
+		return invalidArgf(hintIPv4CIDR,
 			"invalid CIDR %q: IPv6 CIDRs are not yet supported; the inet weaver-host-firewall table uses ipv4_addr sets", s)
 	}
 	return nil
@@ -771,16 +778,16 @@ func CIDRIsIPv6(s string) (bool, error) {
 // before they are rendered into the `inet weaver-host-firewall` nftables ruleset.
 func ValidatePort(s string) error {
 	if s == "" {
-		return errorx.IllegalArgument.New("port cannot be empty")
+		return invalidArgf(hintPort, "port cannot be empty")
 	}
 
 	port, err := strconv.Atoi(s)
 	if err != nil {
-		return errorx.IllegalArgument.New("invalid port number: %s", s)
+		return invalidArgf(hintPort, "invalid port number: %s", s)
 	}
 
 	if port < 1 || port > 65535 {
-		return errorx.IllegalArgument.New("port must be between 1 and 65535, got %d", port)
+		return invalidArgf(hintPort, "port must be between 1 and 65535, got %d", port)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds pkg/reasons, the shared errx reason vocabulary - a leaf package (errx only) any package can import without a cycle
- Decorates the foundation call sites with a reason code plus operator-actionable hints: the preflight service-account check, the weaver/hedera owner steps, and flag registration
- Migrates pkg/sanity onto invalidArgf/invalidArgWrapf with a per-domain hint constant for each validator, so every rejection states the accepted form
- Makes doctor walk the full error chain, so a reason or hint attached to an inner error survives a non-decorating errorx.Wrap, and coerces a legacy bare-string hint to a one-element list
- Surfaces Reason as its own -V panel field and structured log field, and adds doctor.OperatorMessage so the printable {reason: X} stays in logs and off human surfaces
- Collapses the three remediation channels into one: drops CheckErr's instructions parameter and GetInstructionsFromReport, and exports DeepestFailureError so a nested step's error is no longer masked by automa's workflow-level wrapper
- Aliases models.ErrProperty{Resolution,Reason} to errx's properties - errorx compares properties by pointer, so a re-registration is invisible to errx.Hints
- Documents the contract in docs/dev/error-handling.md, with the conventions summarised in CLAUDE.md and the errorx-conventions skill

### Related Issues

There will be more PRs related to this issue:
- Closes #933

### UAT steps

```sh
# Host
task vm:start && task vm:sync && task vm:ssh
```

```sh
# VM
SP=/opt/solo/weaver/bin/solo-provisioner
LOG=/opt/solo/weaver/logs/solo-provisioner.log
```

1. FileMissing - Cause: has no {reason: …}; Resolution = input-file hint; -V adds bare Reason: FileMissing; log has "reason", "hints":[…], and keeps {reason: …} inline.
```sh
sudo $SP block node install --profile local --values /nonexistent/values.yaml --non-interactive; echo "exit=$?"
sudo $SP block node install --profile local --values /nonexistent/values.yaml --non-interactive -V
sudo grep "file does not exist" $LOG | tail -1
```

2. Path traversal - Reason: InvalidArgument + the absolute-path hint once on the panel.
```sh
sudo $SP block node install --profile local --values '../etc/passwd' --non-interactive -V
```

3. Hint survives a non-decorating wrap  - Reason: InvalidArgument + Use only letters, digits, underscore or hyphen ([A-Za-z0-9_-])., surviving two wraps (invalid user inputs → invalid namespace → identifier contains invalid characters).
```sh
sudo $SP block node install --profile local --namespace 'bad ns' --non-interactive -V
```

4. not a regular file - Reason: InvalidArgument, path is not a regular file: /opt, input-file hint.
```sh
sudo $SP block node install --profile local --values /opt --non-interactive -V
```

5. Undecorated fallback - Check error message for details or contact support, no Reason: line.
```sh
sudo $SP block node install --profile bogus --non-interactive -V
```

6. Bare-string hint - Reason: line. This is the root gate, not CheckPrivilegesStep — that one is unreachable from the CLI.
```sh
$SP block node install --profile local --non-interactive
```

7. second bare-string site - Full installation or re-installation required remediation on the panel; one-element hints=[…] in the log.
```sh
sudo /mnt/solo-weaver/bin/solo-provisioner-linux-arm64 block node install --profile local --non-interactive
```

8. Wrong IDs, dependency order - Reason: PreconditionNotMet; both IDs in the message; hints 1. groupmod, 2. usermod, 3. owneract and -V; log has reason + all three hints; leaf step's message, never completed with 1 step failures.
```sh
ps -u weaver                                   # must be empty
sudo groupmod -g 2501 weaver; sudo usermod -u 2501 weaver
sudo $SP block node check --profile local      # compact
sudo $SP block node check --profile local -V   # verbose
sudo grep "incorrect IDs" $LOG | tail -1
sudo usermod -u 2500 weaver; sudo groupmod -g 2500 weaver
getent passwd weaver; getent group weaver      # expect 2500:2500 / 2500
sudo $SP block node check --profile local      # validate-weaver-user … status=success
```


9. Static checks Every CheckErr takes a single error, no trailing args; second grep returns nothing.
```sh
grep -rn "doctor.CheckErr" cmd internal --include="*.go" | grep -v _test
grep -rn 'Metadata\["instructions"\]\|"instructions"' cmd internal --include="*.go" | grep -v _test
```