### PR TITLE
feat(cli): pin ESO version via infrastructure-catalog and remove --chart-version from eso operator install

### DIFF
--- a/cmd/cli/commands/common/flags_common.go
+++ b/cmd/cli/commands/common/flags_common.go
@@ -112,15 +112,6 @@ func FlagESONamespace() FlagDefinition[string] {
 	}
 }
 
-func FlagESOChartVersion() FlagDefinition[string] {
-	return FlagDefinition[string]{
-		Name:        "chart-version",
-		ShortName:   "",
-		Description: "External Secrets Operator chart version to install (must be declared in the infrastructure catalog; defaults to the catalog default)",
-		Default:     "",
-	}
-}
-
 func FlagESOSecretStore() FlagDefinition[string] {
 	return FlagDefinition[string]{
 		Name:        "store",

--- a/cmd/cli/commands/eso/operator/install.go
+++ b/cmd/cli/commands/eso/operator/install.go
@@ -10,40 +10,29 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/workflows"
 )
 
-var flagESOChartVersion string
-
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install the External Secrets Operator",
 	Long: `Install the External Secrets Operator (ESO) Helm chart into the cluster.
 
 The command is idempotent: when ESO is already installed in the target
-namespace, installation is skipped with a clear message.
+namespace, installation is skipped with a clear message. The chart version is
+pinned by the infrastructure catalog.
 
 Examples:
-  # Install ESO with defaults (namespace: external-secrets, catalog default version)
+  # Install ESO with defaults (namespace: external-secrets)
   solo-provisioner eso operator install
 
   # Install into a custom namespace
-  solo-provisioner eso operator install --namespace my-eso
-
-  # Pin a specific catalog-declared chart version
-  solo-provisioner eso operator install --chart-version 0.20.2`,
+  solo-provisioner eso operator install --namespace my-eso`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		l := logx.As()
 		l.Debug().
 			Strs("args", args).
 			Str("namespace", flagESONamespace).
-			Str("chartVersion", flagESOChartVersion).
 			Msg("Installing External Secrets Operator")
 
-		wb, err := workflows.NewESOInstallWorkflow(workflows.ESOInstallOptions{
-			Namespace: flagESONamespace,
-			Version:   flagESOChartVersion,
-		})
-		if err != nil {
-			return err
-		}
+		wb := workflows.NewESOInstallWorkflow(flagESONamespace)
 
 		if err := common.RunWorkflowBuilder(cmd.Context(), wb); err != nil {
 			return err
@@ -56,5 +45,4 @@ Examples:
 
 func init() {
 	common.FlagESONamespace().SetVar(installCmd, &flagESONamespace, false)
-	common.FlagESOChartVersion().SetVar(installCmd, &flagESOChartVersion, false)
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1028,17 +1028,14 @@ Manage the External Secrets Operator (ESO), which syncs secrets from external st
 
 #### Install External Secrets Operator
 
-Install the `external-secrets/external-secrets` Helm chart into the cluster. The command is idempotent: if ESO is already installed in the target namespace, installation is skipped with a clear message.
+Install the `external-secrets/external-secrets` Helm chart into the cluster. The command is idempotent: if ESO is already installed in the target namespace, installation is skipped with a clear message. The chart version is pinned by the infrastructure catalog.
 
 ```bash
-# Install with defaults (namespace: external-secrets, catalog default version)
+# Install with defaults (namespace: external-secrets)
 sudo solo-provisioner eso operator install
 
 # Install into a custom namespace
 sudo solo-provisioner eso operator install --namespace my-eso
-
-# Pin a specific catalog-declared chart version
-sudo solo-provisioner eso operator install --chart-version 0.20.2
 ```
 
 **Additional Flags**:
@@ -1046,7 +1043,6 @@ sudo solo-provisioner eso operator install --chart-version 0.20.2
 | Flag              | Default            | Description                                                                                                          |
 |-------------------|--------------------|----------------------------------------------------------------------------------------------------------------------|
 | `--namespace`     | `external-secrets` | Kubernetes namespace for the External Secrets Operator                                                               |
-| `--chart-version` | _(catalog default)_ | External Secrets Operator chart version to install (must be declared in the infrastructure catalog; defaults to the catalog default) |
 
 #### Uninstall External Secrets Operator
 
@@ -1700,7 +1696,7 @@ sudo solo-provisioner teleport cluster install --values=<file>
 sudo solo-provisioner teleport cluster uninstall
 
 # EXTERNAL SECRETS OPERATOR (ESO)
-sudo solo-provisioner eso operator install    [--namespace=<ns>] [--chart-version=<version>]
+sudo solo-provisioner eso operator install    [--namespace=<ns>]
 sudo solo-provisioner eso operator uninstall  [--namespace=<ns>]
 sudo solo-provisioner eso secret create       --store=<name> --name=<secret> --namespace=<ns> --set KEY=store/path[#field] [--refresh-interval=<interval>]
 

--- a/internal/workflows/eso.go
+++ b/internal/workflows/eso.go
@@ -7,15 +7,11 @@ import (
 	"github.com/hashgraph/solo-weaver/internal/workflows/steps"
 )
 
-// ESOInstallOptions aliases the steps-layer options so cmd callers need not
-// import internal/workflows/steps.
-type ESOInstallOptions = steps.ESOInstallOptions
-
 // NewESOInstallWorkflow creates a workflow to install the External Secrets
-// Operator (ESO) Helm chart into the cluster. It returns an error when the
-// requested version is not declared in the infrastructure catalog.
-func NewESOInstallWorkflow(opts ESOInstallOptions) (*automa.WorkflowBuilder, error) {
-	return steps.SetupExternalSecrets(opts)
+// Operator (ESO) Helm chart at the catalog default version. An empty namespace
+// selects the catalog default.
+func NewESOInstallWorkflow(namespace string) *automa.WorkflowBuilder {
+	return steps.SetupExternalSecrets(namespace)
 }
 
 // NewESOUninstallWorkflow creates a workflow to uninstall the External Secrets

--- a/internal/workflows/steps/catalog.go
+++ b/internal/workflows/steps/catalog.go
@@ -78,15 +78,6 @@ func chartSpec(name string) *helmChartSpec {
 // misconfigurations; production callers should prefer chartSpec, which crashes
 // loudly on the same impossible-in-practice conditions.
 func resolveCatalogChart(name string) (*helmChartSpec, error) {
-	return resolveCatalogChartVersion(name, "")
-}
-
-// resolveCatalogChartVersion is like resolveCatalogChart but resolves a specific
-// chart version; an empty version selects the catalog default. A non-empty
-// version must be declared under the component's `versions:` map (so PullAndVerify
-// has a checksum); otherwise it errors. This is the path user-supplied
-// --chart-version flags flow through.
-func resolveCatalogChartVersion(name, version string) (*helmChartSpec, error) {
 	catalog, err := software.LoadInfrastructureCatalog()
 	if err != nil {
 		return nil, errorx.IllegalFormat.Wrap(err, "load infrastructure catalog")
@@ -95,11 +86,9 @@ func resolveCatalogChartVersion(name, version string) (*helmChartSpec, error) {
 	if err != nil {
 		return nil, errorx.IllegalArgument.Wrap(err, "catalog")
 	}
-	if version == "" {
-		version, err = meta.GetDefaultVersion()
-		if err != nil {
-			return nil, errorx.IllegalFormat.Wrap(err, "catalog")
-		}
+	version, err := meta.GetDefaultVersion()
+	if err != nil {
+		return nil, errorx.IllegalFormat.Wrap(err, "catalog")
 	}
 	sum, ok := meta.Versions[software.Version(version)]
 	if !ok {

--- a/internal/workflows/steps/step_external_secrets.go
+++ b/internal/workflows/steps/step_external_secrets.go
@@ -25,21 +25,13 @@ const (
 	UninstallExternalSecretsStepId = "uninstall-external-secrets"
 )
 
-// ESOInstallOptions parameterizes the External Secrets Operator install workflow.
-// Empty fields select the catalog default namespace and version.
-type ESOInstallOptions struct {
-	Namespace string
-	Version   string
-}
-
-// SetupExternalSecrets returns a workflow builder that installs the External Secrets Operator.
-func SetupExternalSecrets(opts ESOInstallOptions) (*automa.WorkflowBuilder, error) {
-	spec, err := resolveCatalogChartVersion("external-secrets", opts.Version)
-	if err != nil {
-		return nil, err
-	}
-	if opts.Namespace != "" {
-		spec.Namespace = opts.Namespace
+// SetupExternalSecrets returns a workflow builder that installs the External
+// Secrets Operator at the catalog default version. An empty namespace selects
+// the catalog default namespace.
+func SetupExternalSecrets(namespace string) *automa.WorkflowBuilder {
+	spec := chartSpec("external-secrets")
+	if namespace != "" {
+		spec.Namespace = namespace
 	}
 
 	return automa.NewWorkflowBuilder().WithId(SetupExternalSecretsStepId).Steps(
@@ -55,7 +47,7 @@ func SetupExternalSecrets(opts ESOInstallOptions) (*automa.WorkflowBuilder, erro
 		}).
 		WithOnCompletion(func(ctx context.Context, stp automa.Step, rpt *automa.Report) {
 			notify.As().StepCompletion(ctx, stp, rpt, "External Secrets Operator setup successfully")
-		}), nil
+		})
 }
 
 // TeardownExternalSecrets returns a workflow builder that uninstalls the External

--- a/internal/workflows/steps/step_external_secrets_test.go
+++ b/internal/workflows/steps/step_external_secrets_test.go
@@ -172,30 +172,3 @@ func Test_uninstallESOChart_UninstallChartError(t *testing.T) {
 	require.ErrorIs(t, err, wantErr)
 	assert.False(t, uninstalled)
 }
-
-func Test_SetupExternalSecrets_VersionResolution(t *testing.T) {
-	t.Run("default version", func(t *testing.T) {
-		def, err := resolveCatalogChart("external-secrets")
-		require.NoError(t, err)
-
-		spec, err := resolveCatalogChartVersion("external-secrets", "")
-		require.NoError(t, err)
-		assert.Equal(t, def.Version, spec.Version)
-	})
-
-	t.Run("declared version accepted", func(t *testing.T) {
-		def, err := resolveCatalogChart("external-secrets")
-		require.NoError(t, err)
-
-		spec, err := resolveCatalogChartVersion("external-secrets", def.Version)
-		require.NoError(t, err)
-		assert.Equal(t, def.Version, spec.Version)
-		assert.NotEmpty(t, spec.Checksum)
-	})
-
-	t.Run("undeclared version rejected", func(t *testing.T) {
-		_, err := SetupExternalSecrets(ESOInstallOptions{Version: "0.0.0-nonexistent"})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "0.0.0-nonexistent")
-	})
-}


### PR DESCRIPTION
## Description

Removes `--chart-version` from `eso operator install`: the ESO chart version now resolves
exclusively from the infrastructure catalog's `default:` (`0.20.2`), matching how every other
cluster-infra installer works (metallb, cilium, metrics-server, alloy — none expose a version
flag). For a privileged, cluster-wide singleton, version selection belongs to a
solo-provisioner release (a catalog edit), not a runtime flag.

What it does:

* Drops the `--chart-version` flag, its definition (`FlagESOChartVersion`), and the
  version-threading through the install workflow.
* Simplifies `SetupExternalSecrets` to `(namespace string) *automa.WorkflowBuilder` — it was
  the ONLY `Setup*` in the steps package returning an error, and that error existed solely to
  report an undeclared user-supplied version. It now exactly mirrors
  `TeardownExternalSecrets(namespace string)` and the 15 peer installers, resolving via
  `chartSpec("external-secrets")`. (Slight deviation from the issue's touch-point table,
  which suggested keeping a one-field options struct — the plain signature is the stronger
  match for acceptance criterion "behavior matches metallb/cilium/alloy".)
* Collapses `resolveCatalogChartVersion` back into `resolveCatalogChart` (the issue offered
  this as reviewer's discretion). #670 added the two-arg helper solely to resolve a
  caller-supplied `--chart-version`; with that flag gone nothing passes a non-default version,
  so the helper had no caller. The now-orphaned unit test is removed with it.
* Adds a one-line breadcrumb to the install help and quickstart: "The chart version is
  pinned by the infrastructure catalog."

### Review guide

* **Why the signature change is in scope** — the error return and options struct existed only
  to carry the user version; with it gone, keeping either would leave ESO the lone outlier
  among the cluster-infra installers for no benefit. Install/Teardown are now symmetric.
* **Why `resolveCatalogChartVersion` is collapsed** — once `--chart-version` is removed,
  nothing calls the two-arg helper; it's orphaned. There's no current or foreseeable feature
  that needs to resolve a non-default version, so it's folded back into `resolveCatalogChart`,
  which still resolves the catalog default exactly as before (metallb/cilium/alloy, which
  share it, are unaffected). If some future feature ever needs a specific version, re-adding
  the parameter is trivial.
* **Block node keeps `--chart-version` deliberately** — data-plane component with an
  operator-driven version as persisted state and a dedicated `upgrade` command; the asymmetry
  is principled.

### Manual UAT

Run on a VM/host with a reachable cluster (requires `sudo`).

```bash
# 1. Flag surface: --chart-version is gone; help shows the catalog-pinned line
sudo solo-provisioner eso operator install --help
# -> no --chart-version flag; Long text contains "pinned by the infrastructure catalog"
sudo solo-provisioner eso operator install --chart-version 0.20.2
# -> Error: unknown flag: --chart-version (non-zero exit, nothing runs)

# 2. Fresh install resolves the catalog default (uninstall first if ESO is present)
sudo solo-provisioner eso operator uninstall
sudo solo-provisioner eso operator install
sudo KUBECONFIG=/etc/kubernetes/admin.conf helm list -n external-secrets
# -> CHART column shows external-secrets-0.20.2 (the catalog default)

# 3. Idempotency unchanged: re-run skips
sudo solo-provisioner eso operator install
# -> "already installed, skipping" path, exit 0

# 4. --namespace still works (R3)
sudo solo-provisioner eso operator uninstall
sudo solo-provisioner eso operator install --namespace my-eso
sudo KUBECONFIG=/etc/kubernetes/admin.conf helm list -n my-eso
# -> release present in my-eso at 0.20.2
sudo solo-provisioner eso operator uninstall --namespace my-eso   # cleanup
```

### Related Issues

* Closes #894
* Part of #377