### PR TITLE
fix(daemon/shaper): wake the statusz poll loop on endpoint discovery

### DIFF
--- a/docs/dev/daemon/traffic-shaper-statusz.md
+++ b/docs/dev/daemon/traffic-shaper-statusz.md
@@ -154,11 +154,22 @@ until a ready BN pod is observed the poll loop idles quietly and starts polling
 as soon as one appears.
 
 **Using pod discovery without `base_url`:** after a daemon restart or host
-reboot, the entry reconcile fires immediately but skips if no URL has been
-discovered yet. Convergence then waits until the pod watcher observes a ready
-BN pod, after which the next ticker tick (up to one poll interval) triggers
-the reconcile. For the lowest post-reboot convergence latency, set `base_url`
-to a stable statusz endpoint (e.g. a node-local port-forward).
+reboot, the entry reconcile fires immediately and skips if no URL has been
+discovered yet — the pod watcher runs concurrently, so on a cold start it has
+usually not recorded an endpoint yet. Convergence is **not** deferred to the next
+tick in that case: the watcher signals the poll loop as soon as it records an
+endpoint, and the loop wakes on that signal as well as on the ticker. Both paths
+therefore converge as fast as the BN statusz endpoint responds — bounded by BN
+startup time, not by `poll_interval`.
+
+The same signal fires when a rescheduled pod changes the endpoint, and when the
+owning pod is deleted (the loop wakes, observes an empty URL, and logs the loss
+promptly instead of up to one interval later).
+
+> Before #1000 convergence on this path was bounded by *pod discovery plus up to
+> one poll interval*, because the ticker was the loop's only wake-up source.
+> Setting `base_url` was the documented workaround; it is no longer needed to get
+> prompt convergence.
 
 ### Enablement at install time
 

--- a/docs/dev/traffic-shaper.md
+++ b/docs/dev/traffic-shaper.md
@@ -279,7 +279,7 @@ fill in the parts that are deliberately **not** persisted (see below).
 | Artifact | Persisted at boot? | Rebuilt by |
 |---|---|---|
 | nft tables, chains, rules (both tables) | Yes — replayed from the `.nft` files via `nft -f` | — |
-| nft **set elements** (the CIDR membership of `bn-*` sets) | **No** | daemon statusz poll loop — entry reconcile fires immediately on daemon start; bounded by BN startup time when `base_url` is set, or by pod readiness + up to one poll interval with pod discovery |
+| nft **set elements** (the CIDR membership of `bn-*` sets) | **No** | daemon statusz poll loop — entry reconcile fires immediately on daemon start, and the pod watcher wakes the loop the moment it discovers the endpoint, so convergence is bounded by BN startup time on both the `base_url` and pod-discovery paths |
 | `$EGRESS` HTB hierarchy | Yes — the `solo-provisioner-bandwidth-shaper.sh` script | — |
 | `$VETH` (per-pod) HTB hierarchy | **No** | daemon pod-lifecycle watcher, on the next pod-create event |
 

--- a/internal/daemon/blocknode/pod_watcher.go
+++ b/internal/daemon/blocknode/pod_watcher.go
@@ -222,13 +222,23 @@ func (m *TrafficShaperMonitor) handlePodDelete(ctx context.Context, pod *corev1.
 	// Drop the discovered statusz endpoint only if this is the pod that set it, so
 	// a stale delete for some other pod cannot blank a still-valid endpoint. The
 	// poll loop then idles until another ready BN pod is observed.
-	if m.discoveredStatuszPod == pod.UID {
+	endpointCleared := m.discoveredStatuszPod == pod.UID
+	if endpointCleared {
 		m.discoveredStatuszURL = ""
 		m.discoveredStatuszPod = ""
 	}
 	veth, ok := m.attached[pod.UID]
 	delete(m.attached, pod.UID)
 	m.mu.Unlock()
+
+	// Wake the poll loop so it logs the endpoint loss promptly instead of up to a
+	// full interval later. The woken reconcile is a no-op while the URL is empty.
+	// Signalled after the unlock, and before the early return below so a pod with
+	// no recorded veth still reports the loss.
+	if endpointCleared {
+		m.signalURLChanged()
+	}
+
 	if !ok {
 		return
 	}
@@ -282,6 +292,9 @@ func (m *TrafficShaperMonitor) recordDiscoveredStatusz(pod *corev1.Pod) {
 			Str("pod", pod.Namespace+"/"+pod.Name).
 			Str("statusz_url", url).
 			Msg("discovered BN statusz endpoint from pod")
+		// Wake the poll loop so membership converges now instead of at the next
+		// tick. Sent after the unlock above — never while holding m.mu.
+		m.signalURLChanged()
 	}
 }
 

--- a/internal/daemon/blocknode/pod_watcher_test.go
+++ b/internal/daemon/blocknode/pod_watcher_test.go
@@ -65,10 +65,11 @@ func (f *fakeDelegator) ReconcileShaperCheck(context.Context, string) (string, e
 
 func newTestMonitor(r vethResolver, d *fakeDelegator) *TrafficShaperMonitor {
 	return &TrafficShaperMonitor{
-		resolver:  r,
-		delegator: d,
-		attached:  make(map[types.UID]string),
-		inflight:  make(map[types.UID]bool),
+		resolver:   r,
+		delegator:  d,
+		attached:   make(map[types.UID]string),
+		inflight:   make(map[types.UID]bool),
+		urlChanged: make(chan struct{}, 1),
 	}
 }
 
@@ -303,6 +304,56 @@ func TestHandlePodDelete_ClearsDiscoveredStatuszForOwningPod(t *testing.T) {
 	m.handlePodDelete(context.Background(), pod)
 	require.Empty(t, m.discoveredStatuszURL, "owning pod delete clears the discovered endpoint")
 	require.Equal(t, types.UID(""), m.discoveredStatuszPod)
+}
+
+// signalled reports whether a wake-up is pending, consuming it so successive
+// assertions in one test observe only new signals.
+func signalled(m *TrafficShaperMonitor) bool {
+	select {
+	case <-m.urlChanged:
+		return true
+	default:
+		return false
+	}
+}
+
+// TestRecordDiscoveredStatusz_SignalsOnlyOnChange verifies the poll loop is woken
+// when the endpoint actually changes, and is left alone when a repeat event
+// records the same URL — otherwise every watch event would cost a probe (#1000).
+func TestRecordDiscoveredStatusz_SignalsOnlyOnChange(t *testing.T) {
+	m := newTestMonitor(&fakeResolver{results: []resolveResult{{veth: "lxc1"}}}, &fakeDelegator{})
+	pod := readyPodWithNet("u1", "bn-0", "10.1.2.3",
+		corev1.ContainerPort{Name: bnHealthPortName, ContainerPort: 40983})
+
+	m.recordDiscoveredStatusz(pod)
+	require.True(t, signalled(m), "first discovery wakes the poll loop")
+
+	m.recordDiscoveredStatusz(pod)
+	require.False(t, signalled(m), "an unchanged endpoint must not wake the loop")
+
+	// A rescheduled pod on a new IP is a change and must wake the loop so the
+	// roster is re-read against the new endpoint.
+	moved := readyPodWithNet("u2", "bn-0", "10.1.2.9",
+		corev1.ContainerPort{Name: bnHealthPortName, ContainerPort: 40983})
+	m.recordDiscoveredStatusz(moved)
+	require.True(t, signalled(m), "a changed endpoint wakes the poll loop")
+}
+
+// TestHandlePodDelete_SignalsWhenEndpointCleared verifies losing the endpoint also
+// wakes the loop, so the endpoint-lost transition is logged promptly rather than
+// up to a full poll interval later. An unrelated pod delete must stay silent.
+func TestHandlePodDelete_SignalsWhenEndpointCleared(t *testing.T) {
+	m := newTestMonitor(&fakeResolver{results: []resolveResult{{veth: "lxc1"}}}, &fakeDelegator{})
+	pod := readyPodWithNet("u1", "bn-0", "10.1.2.3",
+		corev1.ContainerPort{Name: bnHealthPortName, ContainerPort: 40983})
+	m.recordDiscoveredStatusz(pod)
+	require.True(t, signalled(m), "drain the discovery signal")
+
+	m.handlePodDelete(context.Background(), readyPod("u2", "bn-1"))
+	require.False(t, signalled(m), "an unrelated pod delete must not wake the loop")
+
+	m.handlePodDelete(context.Background(), pod)
+	require.True(t, signalled(m), "clearing the endpoint wakes the loop")
 }
 
 func TestHandlePodDelete_KeepsDiscoveredStatuszForOtherPod(t *testing.T) {

--- a/internal/daemon/blocknode/traffic_shaper_monitor.go
+++ b/internal/daemon/blocknode/traffic_shaper_monitor.go
@@ -89,6 +89,21 @@ type TrafficShaperMonitor struct {
 	// a delete only clears the endpoint when it is that pod (not some other pod in
 	// a multi-pod window) that went away.
 	discoveredStatuszPod types.UID
+
+	// urlChanged wakes the statusz poll loop when the pod watcher discovers,
+	// changes, or loses the statusz endpoint, so convergence is not deferred to
+	// the next ticker tick. The two responsibilities start concurrently, so the
+	// entry reconcile usually runs before the watcher's initial list has recorded
+	// an endpoint; without this signal the loop would sleep a full poll interval
+	// with a ready pod and a reachable statusz (#1000).
+	//
+	// Capacity 1 with a non-blocking send is load-bearing: it makes the signal
+	// order-independent. A send that lands before the loop reaches its select is
+	// retained in the buffer and returns immediately on arrival, whereas an
+	// unbuffered send would find no receiver, drop, and reintroduce the race it
+	// exists to close. Extra wake-ups are harmless — the digest gate skips the
+	// privileged apply when the desired state has not changed.
+	urlChanged chan struct{}
 }
 
 // NewTrafficShaperMonitor constructs a TrafficShaperMonitor. resolver and client
@@ -107,6 +122,27 @@ func NewTrafficShaperMonitor(resolver *VethResolver, client kubernetes.Interface
 		pollInterval: pollInterval,
 		attached:     make(map[types.UID]string),
 		inflight:     make(map[types.UID]bool),
+		urlChanged:   make(chan struct{}, 1),
+	}
+}
+
+// signalURLChanged wakes the statusz poll loop after the discovered endpoint
+// changed. The send is non-blocking: when a signal is already buffered the loop
+// has not consumed the previous one yet and will observe the latest URL when it
+// wakes, so coalescing loses nothing. Safe to call with no loop running (e.g.
+// while runStatuszPoll is restarting after a fault) — the buffered signal is
+// consumed by the next loop, costing one extra reconcile, which is idempotent.
+//
+// Never call this while holding m.mu: the send must not be able to interleave
+// with a reader of the discovered-statusz fields.
+func (m *TrafficShaperMonitor) signalURLChanged() {
+	if m.urlChanged == nil {
+		// Zero-value monitor (unit-test scaffolding); nothing to wake.
+		return
+	}
+	select {
+	case m.urlChanged <- struct{}{}:
+	default:
 	}
 }
 
@@ -335,11 +371,12 @@ func (m *TrafficShaperMonitor) runStatuszPoll(ctx context.Context) error {
 	// error and superviseResponsibility retries with back-off — convergence is
 	// bounded by BN startup time, not the poll interval.
 	//
-	// Pod-discovery caveat: when base_url is not configured, effectiveStatuszURL
-	// returns "" until the pod watcher observes a ready BN pod. In that case this
-	// entry reconcile is a silent no-op (not an error), and convergence after a
-	// restart waits for pod discovery plus up to one poll interval for the next
-	// tick. Set base_url for guaranteed immediate convergence after a reboot.
+	// Pod-discovery path: when base_url is not configured, effectiveStatuszURL
+	// returns "" until the pod watcher observes a ready BN pod, so this entry
+	// reconcile is a silent no-op (not an error) on a cold start. Convergence is
+	// not deferred to the next tick in that case — the watcher signals urlChanged
+	// as soon as it records an endpoint and the select below wakes on it, so both
+	// the discovery and base_url paths converge as fast as statusz responds.
 	if err := runReconcile(); err != nil {
 		return err
 	}
@@ -349,6 +386,13 @@ func (m *TrafficShaperMonitor) runStatuszPoll(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
+			if err := runReconcile(); err != nil {
+				return err
+			}
+		case <-m.urlChanged:
+			// The pod watcher discovered, changed, or lost the endpoint. Reconcile
+			// now rather than waiting out the interval. reconcile() no-ops when the
+			// URL is empty (endpoint lost), so a teardown signal costs nothing.
 			if err := runReconcile(); err != nil {
 				return err
 			}

--- a/internal/daemon/blocknode/traffic_shaper_monitor_test.go
+++ b/internal/daemon/blocknode/traffic_shaper_monitor_test.go
@@ -78,6 +78,7 @@ func newPollMonitor(d *pollFakeDelegator, statuszURL string, interval time.Durat
 		delegator:    d,
 		statuszURL:   statuszURL,
 		pollInterval: interval,
+		urlChanged:   make(chan struct{}, 1),
 	}
 }
 
@@ -140,6 +141,90 @@ func TestRunStatuszPoll_ReconcilesOnceDiscovered(t *testing.T) {
 	d.mu.Lock()
 	require.Equal(t, "http://10.1.2.3:40983", d.lastURL, "reconciled against the discovered URL")
 	d.mu.Unlock()
+}
+
+// TestSignalURLChanged_RetainsSignalForLateReceiver pins the buffering guarantee
+// that closes #1000. The pod watcher and the poll loop start concurrently, so
+// discovery routinely signals before the loop reaches its select. With capacity 1
+// the signal waits in the buffer; an unbuffered channel would drop it for want of
+// a receiver and the loop would sleep a full poll interval with a ready pod.
+func TestSignalURLChanged_RetainsSignalForLateReceiver(t *testing.T) {
+	m := &TrafficShaperMonitor{urlChanged: make(chan struct{}, 1)}
+
+	m.signalURLChanged() // no receiver is waiting yet
+
+	select {
+	case <-m.urlChanged:
+	default:
+		t.Fatal("signal dropped with no receiver waiting — the poll loop would sleep a full interval (#1000)")
+	}
+}
+
+// TestSignalURLChanged_CoalescesAndNeverBlocks verifies repeated signals with no
+// reader neither block nor queue: extra wake-ups are redundant because the loop
+// re-reads the current URL when it wakes. Also covers the zero-value monitor,
+// where the channel is nil (unit-test scaffolding constructs monitors directly).
+func TestSignalURLChanged_CoalescesAndNeverBlocks(t *testing.T) {
+	m := &TrafficShaperMonitor{urlChanged: make(chan struct{}, 1)}
+	for range 100 {
+		m.signalURLChanged() // must not block once the buffer is full
+	}
+	require.Len(t, m.urlChanged, 1, "signals coalesce into a single pending wake-up")
+
+	require.NotPanics(t, (&TrafficShaperMonitor{}).signalURLChanged,
+		"a monitor with no channel wired must be safe to signal")
+}
+
+// TestRunStatuszPoll_DiscoverySignalWakesLoopBeforeNextTick is the regression test
+// for #1000. The poll interval is an hour, so the ticker cannot account for any
+// reconcile: the only way the loop can converge is by waking on the discovery
+// signal. Before the fix this test would hang until the deadline.
+func TestRunStatuszPoll_DiscoverySignalWakesLoopBeforeNextTick(t *testing.T) {
+	d := &pollFakeDelegator{digests: []string{"D1"}}
+	m := newPollMonitor(d, "", time.Hour) // no base_url override; tick is unreachable
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- m.runStatuszPoll(ctx) }()
+
+	// The entry reconcile runs with no endpoint and must stay quiet.
+	time.Sleep(20 * time.Millisecond)
+	require.Zero(t, d.checkCalls.Load(), "no exec while the endpoint is undiscovered")
+
+	// The pod watcher records an endpoint and signals, as recordDiscoveredStatusz does.
+	m.mu.Lock()
+	m.discoveredStatuszURL = "http://10.1.2.3:40983"
+	m.mu.Unlock()
+	m.signalURLChanged()
+
+	waitForCount(t, d.applyCalls.Load, 1)
+	cancel()
+	require.NoError(t, <-done)
+
+	d.mu.Lock()
+	require.Equal(t, "http://10.1.2.3:40983", d.lastURL, "reconciled against the newly discovered URL")
+	d.mu.Unlock()
+}
+
+// TestRunStatuszPoll_EndpointLossSignalIsHarmless verifies a teardown signal (the
+// owning pod went away, so the URL is now empty) wakes the loop without exec'ing
+// anything — it only lets the endpoint-lost transition be logged promptly.
+func TestRunStatuszPoll_EndpointLossSignalIsHarmless(t *testing.T) {
+	d := &pollFakeDelegator{digests: []string{"D1"}}
+	m := newPollMonitor(d, "", time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- m.runStatuszPoll(ctx) }()
+
+	m.signalURLChanged() // endpoint still empty, as after a pod delete
+	time.Sleep(20 * time.Millisecond)
+	require.Zero(t, d.checkCalls.Load(), "a wake-up with no endpoint must not exec")
+
+	cancel()
+	require.NoError(t, <-done)
 }
 
 // TestRunStatuszPoll_InertWhenUnset verifies that with no statusz base_url the


### PR DESCRIPTION
## Description

After `block node install --traffic-shaping-enabled`, the `inet weaver-workload-policy` sets stayed
empty for a **full poll interval (5 min default)** — even though the BN pod was `ContainersReady` and
statusz was serving the correct roster the whole time. Same on `reconfigure`, host reboot, and
`systemctl restart solo-provisioner-daemon`.

Measured on a local ENV-2 install **before** this change:

| Time | Event | Source |
|---|---|---|
| 23:08:36 | BN pod reaches `ContainersReady=True` | pod-condition poll (2 s) |
| 23:08:37 | `block node install` workflow completes | `setup_report_20260812_230837.yaml` |
| 23:08:38 | daemon install completes (802 ms) → daemon starts | `setup_report_20260812_230838.yaml` |
| **23:13:39** | `bn-publisher` / `bn-partner-out` / `bn-backfill` populate | nft poll (2 s) |

**Δ = 5 min 01 s — exactly one poll interval.** Note the pod was ready *two seconds before the daemon
started*, so this was never "waiting for the pod": everything the daemon needed was in place at `T₀`,
and statusz answered `200` with the right roster throughout.

### Root cause

`Run` starts the pod watcher and the poll loop concurrently (`traffic_shaper_monitor.go:126-136`), so
on a cold start the entry reconcile (`:343`) normally runs *before* the watcher's initial
`pods.List()` (`pod_watcher.go:72`) has recorded an endpoint. Then:

1. `effectiveStatuszURL()` returns `""`.
2. The empty-URL branch returns `nil`, **not an error** — so `superviseResponsibility` does not retry
   it with the 5 s→5 min back-off.
3. The loop parks on `select { <-ctx.Done(); <-ticker.C }`. **`ticker.C` was the only wake-up source**,
   so nothing told it the endpoint appeared moments later.

A few milliseconds of startup race cost a full interval of convergence.

### Why the buffer is load-bearing — the main thing to review

`urlChanged` is `make(chan struct{}, 1)` with a **non-blocking** send. That is not incidental: it is
what makes the signal order-independent. The watcher frequently signals *before* the poll loop reaches
its `select`. With capacity 1 the signal waits in the buffer and the `select` returns immediately; an
**unbuffered** send would find no receiver, drop silently, and reintroduce the exact race this closes —
just moved a few lines. `TestSignalURLChanged_RetainsSignalForLateReceiver` pins this property
directly, with no timing dependence.

### Relationship to #964 — this is a composition regression

#964 §3 documented the caveat as accepted: *"When using pod discovery only (no `base_url`) … convergence
is then bounded by up to one poll interval after discovery."* Two changes five days apart made that bite:

| Date | Change | Effect |
|---|---|---|
| 2026-07-30 | #936 (issue #918) — discover the endpoint from the BN pod instead of a fixed `base_url` (enabled by hiero-ledger/hiero-block-node#3316) | Moved every default install **off** the `base_url` path onto the pod-discovery path. Cost then: ~5 s |
| 2026-08-04 | #965 (issue #964) — default poll interval 5 s → 5 min | Same latent race now costs **5 min** — 60× |

Before #936, operators set `base_url` explicitly in the install TUI, which returns immediately from
`effectiveStatuszURL()` and never consults the watcher — which is why the guarantee held in practice and
this race went unnoticed. **Deliberately not reverting to `base_url`:** discovery follows the pod across
restarts, reschedules and IP changes, which a fixed URL cannot. This PR gives the discovery path the
startup convergence `base_url` already had.

The caveat also *understated* the trigger — it describes waiting for the pod to *become* ready, but here
the pod was ready before the daemon started. The race is against the watcher's initial list, not pod
readiness.

### Files changed

| File | Change |
|---|---|
| `internal/daemon/blocknode/traffic_shaper_monitor.go` | Add `urlChanged` (cap 1) + `signalURLChanged()`; `select` on it alongside `ticker.C`; rewrite the entry-reconcile caveat comment |
| `internal/daemon/blocknode/pod_watcher.go` | Signal on endpoint discovery/change (`recordDiscoveredStatusz`) and on clear-by-delete (`handlePodDelete`) |
| `internal/daemon/blocknode/traffic_shaper_monitor_test.go` | 4 tests: buffering guarantee, coalescing/nil-safety, signal-wakes-before-tick, loss signal is harmless |
| `internal/daemon/blocknode/pod_watcher_test.go` | 2 tests: signals only on change, signals when the endpoint is cleared |
| `docs/dev/daemon/traffic-shaper-statusz.md` | Rewrite the pod-discovery paragraph — convergence no longer bounded by `poll_interval` |
| `docs/dev/traffic-shaper.md` | Reboot table no longer says "pod readiness + up to one poll interval" |

No informer is involved — `runPodWatcher` is a raw `List` + `Watch`, so the `WaitForCacheSync` wording in
issue #1000's proposed fix was not implementable as written. It also turned out unnecessary: with the
buffered channel the entry reconcile does not need to observe a URL at all.

### Review guide

**Checklist**

- [ ] `traffic_shaper_monitor.go` — `urlChanged` is created with capacity **1**; a change to `0` silently
      restores the bug (only the new unit test would catch it)
- [ ] `signalURLChanged()` uses `select { case ch <- struct{}{}: default: }` — must never block, since it
      is called from the watch-event path
- [ ] Nil-channel guard is present: unit-test scaffolding constructs `TrafficShaperMonitor` directly, and a
      nil channel in `select` blocks forever rather than panicking (so a missing guard would be silent)
- [ ] `pod_watcher.go:279` — signal is sent **after** `m.mu.Unlock()`, never while holding the mutex
- [ ] `handlePodDelete` — signal is sent after the unlock **and before** the `if !ok { return }` early
      return, so a pod with no recorded veth still reports the loss
- [ ] `handlePodDelete` only signals when `endpointCleared` — an unrelated pod's delete must stay silent
- [ ] No change to the digest gate: a `"" → url` transition already resets `lastDigest`/`lastApply`
      (`:256-275`), so the woken reconcile does a fresh apply rather than short-circuiting

**Test commands**

```bash
go test -race -count=1 ./internal/daemon/blocknode/...
go test -race -count=1 -run 'TestSignalURLChanged|TestRunStatuszPoll_DiscoverySignal|TestRecordDiscoveredStatusz_SignalsOnlyOnChange|TestHandlePodDelete_SignalsWhenEndpointCleared' ./internal/daemon/blocknode/
task vm:test:unit    # full suite; internal/mount is Linux-only so macOS cannot run it
task lint
```

`TestRunStatuszPoll_DiscoverySignalWakesLoopBeforeNextTick` uses a **1-hour** poll interval, so the ticker
cannot mask a missing signal. Verified it fails without the fix — replacing the new `select` case with a
never-ready channel produces `timed out waiting for count >= 1 (last: 0)`.

### Manual UAT

Requires a BN host with the plane installed and converged, and a BN whose statusz serves
`/statusz/inbound|outbound` (verify with `curl -s -o /dev/null -w '%{http_code}\n' http://<podIP>:40983/statusz/inbound`
→ `200`). Run the observer in one shell throughout:

```bash
sudo -v
while :; do
  R=$(kubectl -n block-node get pod -l app.kubernetes.io/name=block-node-server \
        -o jsonpath='{.items[0].status.conditions[?(@.type=="ContainersReady")].status}' 2>/dev/null)
  EL=$(sudo nft list set inet weaver-workload-policy bn-publisher 2>/dev/null \
        | tr -d '\n' | sed -n 's/.*elements = {\(.*\)}.*/\1/p')
  printf '%s ready=%-5s publisher={%s}\n' "$(date +%H:%M:%S)" "${R:-none}" "${EL:-EMPTY}"
  sleep 2
done
```

Set `STS=$(kubectl -n block-node get statefulset -o name | head -1)` for the cases below.

**UAT-1 — Fresh install (the reported bug).** Run `block node install --traffic-shaping-enabled …` with
the observer already running. Record pod-ready time, daemon start
(`systemctl show solo-provisioner-daemon -p ActiveEnterTimestamp`) and the first non-empty `publisher={…}`.

*Expected:* membership within **seconds** of pod-ready. *Before the fix:* pod-ready + ~5 min.

**UAT-2 — Daemon restart with no ready pod (fast loop, ~2 min).**

```bash
kubectl -n block-node scale $STS --replicas=0
kubectl -n block-node wait --for=delete pod -l app.kubernetes.io/name=block-node-server --timeout=120s
sudo systemctl restart solo-provisioner-daemon; echo "T0=$(date +%H:%M:%S)"
sudo nft flush set inet weaver-workload-policy bn-publisher
sudo nft flush set inet weaver-workload-policy bn-partner-out
kubectl -n block-node scale $STS --replicas=1
```

*Expected:* `publisher={…}` within seconds of `ready=True`, **not** at `T0 + 5 min`. This is the primary
gate — it forces the daemon to start with no endpoint, which is the race.

**UAT-3 — Control: convergence must stop tracking `poll_interval`.** Repeat UAT-2 with
`components.block_node.statusz.poll_interval` set to `30s`, then `5m`, in
`/opt/solo/weaver/config/daemon.yaml` (restart the daemon — there is no hot-reload).

*Expected:* convergence latency is **the same** in both runs and tracks pod-ready. *Before the fix* it
tracked the interval — that correlation was the diagnostic that proved the bug, so it disappearing is the
proof it is fixed.

**UAT-4 — Pod reschedule changes the endpoint.** With everything converged,
`kubectl -n block-node delete pod -l app.kubernetes.io/name=block-node-server`. The replacement usually
gets a new pod IP.

*Expected:* `journalctl -u solo-provisioner-daemon` shows `TrafficShaperStatuszDiscovered` with the new
`statusz_url`, then `TrafficShaperStatuszEndpointResolved` and a reconcile within seconds — not one
interval later. Membership re-populates. Also confirm the `$VETH` HTB re-attaches (`tc class show dev <veth>`).

**UAT-5 — `base_url` path unregressed.** Set `statusz.base_url` to the pod IP endpoint, restart the daemon,
repeat UAT-2.

*Expected:* unchanged prompt convergence. The override short-circuits `effectiveStatuszURL()` before the
discovered URL is read, so signals are inert on this path.

**UAT-6 — Endpoint loss is logged promptly.** `kubectl -n block-node scale $STS --replicas=0`.

*Expected:* `TrafficShaperStatuszEndpointLost` within seconds, not up to one interval later. No exec fires
(the woken reconcile no-ops on an empty URL) — confirm no `reconcile-shaper` invocation in the journal.

**UAT-7 — No signal storm / no redundant applies.** Leave the node idle and converged for ~15 min.

*Expected:* one `--check` probe per tick, and **no** privileged apply while the roster is unchanged (the
digest gate holds). Only the hourly force-resync should apply. Confirms extra wake-ups are cheap.

### Risks / rollback

- **Signal storm** — a pod flapping ready/not-ready could wake the loop repeatedly. Bounded by the
  capacity-1 buffer (coalescing) and the digest gate (no apply when unchanged), so the worst case is one
  unprivileged `--check` probe per distinct transition. UAT-7 covers this.
- **Send on nil / closed channel** — the channel is never closed and the send is non-blocking; the nil case
  is guarded for direct-construction in tests.
- **Rollback** — revert the commit. No on-disk format, config, or CLI surface changes; behaviour returns to
  waiting for the tick.

Not covered here: `GET /block_node/traffic_shaper/status` reports `{"monitor":{"state":"running"}}` even
while a responsibility is in permanent back-off — observed during this investigation and filed as field
evidence on #750, which already owns per-responsibility health reporting.

### Related Issues

* Closes #1000
